### PR TITLE
Catalina_out parser add get_after for 1.x branch

### DIFF
--- a/insights/parsers/catalina_out.py
+++ b/insights/parsers/catalina_out.py
@@ -2,45 +2,6 @@
 CatalinaOut - ``catalina.out`` logs for Tomcat
 ==============================================
 
-This parser reads all ``catalina.out`` files in the ``/var/log/tomcat*``
-directories.
-
-It uses the LogFileOutput base class.
-
-Note that the standard format of Catalina log lines spreads the information
-over two lines::
-
-    Nov 10, 2015 8:52:38 AM org.apache.jk.common.MsgAjp processHeader
-    SEVERE: BAD packet signature 18245
-    Nov 10, 2015 8:52:38 AM org.apache.jk.common.ChannelSocket processConnection
-    SEVERE: Error, processing connection
-    SEVERE: BAD packet signature 18245
-    Nov 10, 2015 8:52:38 AM org.apache.jk.common.ChannelSocket processConnection
-    SEVERE: Error, processing connection
-    INFO: Pausing Coyote HTTP/1.1 on http-8080
-    Nov 10, 2015 4:55:48 PM org.apache.coyote.http11.Http11Protocol pause
-
-However, this parser only recognises single lines.
-
-When using this parser, consider using a filter or a scan method, e.g.::
-
-    CatalinaOut.filters.append('BAD packet signature')
-    CatalinaOut.keep_scan('bad_signatures', 'BAD packet signature')
-
-Example:
-    >>> catalina = shared[CatalinaOut]
-    >>> catalina.file_path
-    '/var/log/tomcat/catalina.out'
-    >>> catalina.file_name
-    'catalina.out'
-    >>> len(catalina.lines.get('SEVERE'))
-    4
-    >>> 'Http11Protocol pause' in catalina
-    True
-    >>> catalina.lines[0]
-    'Nov 10, 2015 8:52:38 AM org.apache.jk.common.MsgAjp processHeader'
-    >>> catalina.bad_signatures
-    ['SEVERE: BAD packet signature 18245', 'SEVERE: BAD packet signature 18245']
 """
 
 from .. import LogFileOutput, parser
@@ -49,10 +10,64 @@ from .. import LogFileOutput, parser
 @parser('catalina.out')
 class CatalinaOut(LogFileOutput):
     """
-    Catalina log file reader class.  Import this to read the catalina log
-    files::
+    This parser reads all ``catalina.out`` files in the ``/var/log/tomcat*``
+    directories.
 
-        from insights.core.parsers.catalina_out import CatalinaOut
+    It uses the LogFileOutput base class.
 
+    Note that the standard format of Catalina log lines spreads the information
+    over two lines::
+
+        Nov 10, 2015 8:52:38 AM org.apache.jk.common.MsgAjp processHeader
+        SEVERE: BAD packet signature 18245
+        Nov 10, 2015 8:52:38 AM org.apache.jk.common.ChannelSocket processConnection
+        SEVERE: Error, processing connection
+        SEVERE: BAD packet signature 18245
+        Nov 10, 2015 8:52:38 AM org.apache.jk.common.ChannelSocket processConnection
+        SEVERE: Error, processing connection
+        Nov 10, 2015 4:55:48 PM org.apache.coyote.http11.Http11Protocol pause
+        INFO: Pausing Coyote HTTP/1.1 on http-8080
+
+    However, this parser only recognises single lines.
+
+    When using this parser, consider using a filter or a scan method, e.g.::
+
+        CatalinaOut.filters.append('BAD packet signature')
+        CatalinaOut.keep_scan('bad_signatures', 'BAD packet signature')
+
+    Example:
+        >>> catalina = shared[CatalinaOut]
+        >>> catalina.file_path
+        '/var/log/tomcat/catalina.out'
+        >>> catalina.file_name
+        'catalina.out'
+        >>> len(catalina.lines.get('SEVERE'))
+        4
+        >>> 'Http11Protocol pause' in catalina
+        True
+        >>> catalina.lines[0]
+        'Nov 10, 2015 8:52:38 AM org.apache.jk.common.MsgAjp processHeader'
+        >>> catalina.bad_signatures
+        ['SEVERE: BAD packet signature 18245', 'SEVERE: BAD packet signature 18245']
+        >>> from datetime import datetime
+        >>> catalina.get_after(datetime(2015, 11, 10, 12, 00, 00))
+        ['Nov 10, 2015 4:55:48 PM org.apache.coyote.http11.Http11Protocol pause',
+         'INFO: Pausing Coyote HTTP/1.1 on http-8080']
     """
-    pass
+    def get_after(self, timestamp, lines=None):
+        """
+        Get a list of lines after the given time stamp.
+
+        Parameters:
+            timestamp(datetime.datetime): log lines after this time are
+                returned.
+            lines(list): the list of log lines to search (e.g. from a get).
+                If not supplied, all available lines are searched.
+
+        Returns:
+            (list): The list of log lines with time stamps after the given
+            date and time.  Lines after the time stamped lines are considered
+            to be continuations of the previous line and are included if the
+            previous line's timestamp is after the given timestamp.
+        """
+        return super(CatalinaOut, self).get_after(timestamp, lines, '%b %d, %Y %I:%M:%S %p')

--- a/insights/parsers/catalina_out.py
+++ b/insights/parsers/catalina_out.py
@@ -64,10 +64,11 @@ class CatalinaOut(LogFileOutput):
             lines(list): the list of log lines to search (e.g. from a get).
                 If not supplied, all available lines are searched.
 
-        Returns:
-            (list): The list of log lines with time stamps after the given
-            date and time.  Lines after the time stamped lines are considered
-            to be continuations of the previous line and are included if the
-            previous line's timestamp is after the given timestamp.
+        Yields:
+            Log lines with time stamps after the given date and time, in the
+            same format they were supplied.  Lines after the time stamped
+            lines are considered to be continuations of the previous line and
+            are included if the previous line's timestamp is after the given
+            timestamp.
         """
         return super(CatalinaOut, self).get_after(timestamp, lines, '%b %d, %Y %I:%M:%S %p')

--- a/insights/parsers/nova_api_log.py
+++ b/insights/parsers/nova_api_log.py
@@ -1,17 +1,26 @@
+"""
+NovaApiLog - file ``/var/log/nova/nova-api.log``
+================================================
+"""
 from .. import LogFileOutput, parser
 
 
 @parser('nova-api_log')
 class NovaApiLog(LogFileOutput):
+    """Class for parsing the ``/var/log/nova/nova-api.log`` file.
+
+    Note:
+        Please refer to its super-class ``LogFileOutput``
+    """
     def get(self, keywords):
         """
-        Returns all lines that contain all keywords. keywords can be str or str list.
-        -- Sample --
-        keywords is a list. Example: ["WARNING","Could not find token", "404"]
-        ------------
-       2016-08-12 13:15:46.343 32386 WARNING nova.api.ec2.cloud [-] Deprecated: The in tree EC2 API is deprecated as
-        of Kilo release and may be removed in a future release. The stackforge ec2-api project
-        http://git.openstack.org/cgit/stackforge/ec2-api/ is the target replacement for this functionality.
+        Returns all lines that contain all keywords.
+
+        Parameters:
+            keywords(str or list): one or more strings to find in the lines.
+
+        Returns:
+            (list): The list of lines that contain all the keywords given.
         """
         r = []
         for l in self.lines:
@@ -20,3 +29,19 @@ class NovaApiLog(LogFileOutput):
             elif type(keywords) == str and keywords in l:
                 r.append(l)
         return r
+
+    def get_after(self, timestamp, lines=None):
+        """
+        Get a list of lines after the given time stamp.
+
+        Parameters:
+            timestamp(datetime.datetime): log lines after this time are
+                returned.
+            lines(list): the list of log lines to search (e.g. from a get).
+                If not supplied, all available lines are searched.
+
+        Yields:
+            Log lines with time stamps after the given date and time, in the
+            same format they were supplied.
+        """
+        return super(NovaApiLog, self).get_after(timestamp, lines, '%Y-%m-%d %H:%M:%S')

--- a/insights/parsers/tests/test_catalina_out.py
+++ b/insights/parsers/tests/test_catalina_out.py
@@ -1,6 +1,8 @@
 from insights.tests import context_wrap
 from insights.parsers.catalina_out import CatalinaOut
 
+from datetime import datetime
+
 OUT1 = """
 Nov 10, 2015 8:52:38 AM org.apache.jk.common.MsgAjp processHeader
 SEVERE: BAD packet signature 18245
@@ -110,3 +112,4 @@ def test_catalina_out():
     out_log = CatalinaOut(context_wrap(OUT1))
     assert "IETF RFC 4122 compliant UUID" in out_log
     assert len(out_log.get("SEVERE")) == 4
+    assert len(list(out_log.get_after(datetime(2015, 11, 10, 18, 38, 10)))) == 15

--- a/insights/parsers/tests/test_nova_api_log.py
+++ b/insights/parsers/tests/test_nova_api_log.py
@@ -1,13 +1,12 @@
 from insights.parsers.nova_api_log import NovaApiLog
 from insights.tests import context_wrap
 
+from datetime import datetime
+
 api_log = """
-2016-08-12 13:15:46.343 32386 WARNING nova.api.ec2.cloud [-] Deprecated: The in tree EC2 API is deprecated as of Kilo \
-release and may be removed in a future release. The stackforge ec2-api project http://git.openstack.org/cgit/stackforge\
-/ec2-api/ is the target replacement for this functionality.
+2016-08-12 13:15:46.343 32386 WARNING nova.api.ec2.cloud [-] Deprecated: The in tree EC2 API is deprecated as of Kilo release and may be removed in a future release. The stackforge ec2-api project http://git.openstack.org/cgit/stackforge/ec2-api/ is the target replacement for this functionality.
 2016-08-12 14:27:16.498 32499 WARNING keystonemiddleware.auth_token [-] Authorization failed for token
-2016-08-12 14:27:16.500 32499 WARNING keystonemiddleware.auth_token [-] Identity response: {"error": {"message": \
-"Could not find token: 786c3cee52d14baeae98262c6a2f3a4e", "code": 404, "title": "Not Found"}}
+2016-08-12 14:27:16.500 32499 WARNING keystonemiddleware.auth_token [-] Identity response: {"error": {"message": "Could not find token: 786c3cee52d14baeae98262c6a2f3a4e", "code": 404, "title": "Not Found"}}
 2016-08-12 14:27:16.502 32499 WARNING keystonemiddleware.auth_token [-] Authorization failed for token
 """""
 
@@ -17,3 +16,4 @@ def test_nova_api_log():
     assert len(log.get(["WARNING", "Authorization failed"])) == 2
     assert len(log.get("786c3cee52d14baeae98262c6a2f3a4e")) == 1
     assert len(log.get("Authorization failed")) == 2
+    assert len(list(log.get_after(datetime(2016, 8, 12, 14, 20, 0)))) == 3


### PR DESCRIPTION
Updating the parser to support the `get_after()` method.

This requires https://github.com/RedHatInsights/insights-core/pull/186 to fix the %p pattern.