### PR TITLE
Modify setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ entry_points = {
 
 runtime = {
     'pyyaml>=3.10,<=3.12',
-    'python-setuptools',
-    'python-requests'
+    'setuptools',
+    'requests'
 }
 
 develop = {


### PR DESCRIPTION
Pip install was failing due to setuptools and requests having python
prefixed onto them. Seems to work properly if 'python-' is removed.