### PR TITLE
Test example code in documentation for 1.x branch

### DIFF
--- a/docs/docs_guidelines.rst
+++ b/docs/docs_guidelines.rst
@@ -34,7 +34,7 @@ only moving the documentation down into each parser when it is specific to the p
 For instance if there is only one parser in a module then almost all of the documentation
 will be in the module section.  If there are multiple parsers that are very similar then
 most of the documentation will be in the module section and only the unique details will
-be in each parser's class.  
+be in each parser's class.
 
 Look at the example code in this article and also review the source files for
 these parsers and see how the documentation has been organized.
@@ -94,7 +94,7 @@ in code contributed to the insights-core project:
        >>> "0d:00.0" in pci_info
        True
    """
-   from .. import LogFileOutput, parser 
+   from .. import LogFileOutput, parser
 
 
    @parser('lspci')
@@ -128,7 +128,7 @@ The second line is the name of the module and a descriptive phrase.  In this cas
 the file is **lspci.py**, the module is **lspci** and it is a command.  An example
 of a file parser would be file **fstab.py**, module name **fstab** and descriptive
 phrase'File /etc/fstab'.  The module
-name line is followed by a line of ``=`` characters that is the same length as the 
+name line is followed by a line of ``=`` characters that is the same length as the
 entire module line.  A blank line follows the module information.
 
 Description
@@ -155,7 +155,7 @@ Description
    whether a particular string is in the ``lspci`` output.  Other methods/operators
    are also supported, see the :py:class:`insights.core.LogFileOutput` class for more information.
 
-Next comes the description of the module. 
+Next comes the description of the module.
 Since this description is the first thing a developer will see when viewing
 the documentation it is important that the description is clear, concise and useful.
 Include elements of the module that would not be obvious from looking at the code.
@@ -226,14 +226,15 @@ refer to the input samples provide in the *Examples* section from the comments.
 Testing Your Docstring
 ======================
 
-Once you have implemented a parser with the recommended documentation style you will
-need to include it in the insights-core documentation.  You can do this by creating a file
-in the directory ``insights-core/docs/shared_parsers_catalog/`` that has the same name
-as your parser
-module name, except with a ``.rst`` extension instead of a ``.py`` extension.  For
-example if your parser module is named ``your_parser.py`` then create a file
-``insights-core/docs/shared_parsers_catalog/your_parser.rst`` and include the following
-three lines in the file::
+Once you have implemented a parser with the recommended documentation style
+you will need to include it in the insights-core documentation.  You can do
+this by creating a file in the directory
+``insights-core/docs/shared_parsers_catalog/`` that has the same name as your
+parser module name, except with a ``.rst`` extension instead of a ``.py``
+extension.  For example if your parser module is named ``your_parser.py``
+then create a file
+``insights-core/docs/shared_parsers_catalog/your_parser.rst`` and include the
+following three lines in the file::
 
    .. automodule:: insights.parsers.your_parser
       :members:
@@ -269,6 +270,26 @@ port 8000::
 Once you have verified that the documentation was created correctly, check in your
 code and the ``.rst`` file and submit a pull request.
 
+Testing the code in your Docstring
+----------------------------------
+
+The code in the ``Examples`` section of your docstring can be automatically
+tested against the input data given in an indented section preceded by the
+``::`` Sphinx directive.  To do this, you need the following code in your
+test module:
+
+.. code-block:: python
+
+    from insights.tests import doc_test_examples
+    from insights.parsers import {your_module}
+
+    def test_documentation():
+        doc_test_examples({your_module})
+
+More documentation on how this works can be found in the
+:py:func:`insights.tests.doc_test_examples` and
+:py:func:`insights.tests.doc_test_examples_in` functions.
+
 Rendered HTML
 =============
 
@@ -280,7 +301,7 @@ The following show how the ``lspci`` module documentation is rendered as HTML.
 References
 ==========
 * `Sphinx Docs`_
-* List of Docstring headings supported by Sphinx Napoleon `Sphinx Section Names`_ 
+* List of Docstring headings supported by Sphinx Napoleon `Sphinx Section Names`_
 * `reStructuredText Docs`_
 * `Google Docstring Style`_
 * `Python Doctest Docs`_

--- a/insights/parsers/tests/test_netstat.py
+++ b/insights/parsers/tests/test_netstat.py
@@ -1,9 +1,10 @@
 from insights.parsers.netstat import Netstat, NetstatAGN, NetstatS, Netstat_I, SsTULPN
-from insights.tests import context_wrap
+from insights.tests import context_wrap, doc_test_examples
 from insights.parsers import netstat
 from ...parsers import ParseException
 
 import pytest
+
 
 NETSTAT_S = '''
 Ip:
@@ -120,6 +121,9 @@ class TestNetstats():
     def test_netstat_s(self):
         info = NetstatS(context_wrap(NETSTAT_S)).data
 
+        assert sorted(info.keys()) == [
+            'icmp', 'icmpmsg', 'ip', 'ipext', 'tcp', 'tcpext', 'udp', 'udplite',
+        ]
         assert info['ip'] == {'total_packets_received': '3405107',
                               'forwarded': '0',
                               'incoming_packets_discarded': '0',
@@ -524,3 +528,7 @@ def test_ss_tulpn_get_port():
     exp02 = [{'Netid': 'udp', 'Process': 'users:(("rpc.statd",pid=29559,fd=10))', 'Peer-Address-Port': ':::12345', 'Send-Q': '0', 'Local-Address-Port': ':::37968', 'State': 'UNCONN', 'Recv-Q': '0'}]
     assert ss.get_peerport("12345") == exp02
     assert ss.get_port("12345") == exp02
+
+
+def test_netstat_docs():
+    doc_test_examples(netstat)

--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -480,9 +480,15 @@ def doc_test_examples_in(parser, docs):
             if line.strip() == '':
                 # Input data is surrounded with blanks - ignore them.
                 continue
-            elif get_indent(line) > input_data_indent:
+            elif get_indent(line) >= input_data_indent:
                 # Indented line - collect.
-                input_data.append(line.strip())
+                # We need to only strip as much space as the indent.  We could
+                # just assume eight spaces here, but instead we'll try to be
+                # clever and detect it.  We take the indent of the first line
+                # (i.e. input_data is empty) and strip only that much off.
+                if input_data == []:
+                    input_data_indent = get_indent(line)
+                input_data.append(line[len(input_data_indent):])
             else:
                 # Back to previous indent.
                 input_data_indent = 'not in input data'
@@ -496,6 +502,7 @@ def doc_test_examples_in(parser, docs):
                 continue
             elif get_indent(line) > examples_indent:
                 # Indented line - collect.
+                # Here we always ignore surrounding spaces - easier.
                 examples.append(line.strip())
             else:
                 # Back to previous indent.

--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -431,7 +431,7 @@ def redhat_release(major, minor=""):
         raise Exception("invalid major version: %s" % major)
 
 
-def test_examples_in_doc_of(parser, docs):
+def doc_test_examples_in(parser, docs):
     """
     This function looks in the documentation given for an indented block
     (following a ``\:\:``) and an `Examples\:` section.  The indented block
@@ -496,6 +496,7 @@ def test_examples_in_doc_of(parser, docs):
     # and asserting that they are equal.
     expression = ''
     output = ''
+
     def check_evaluation():
         # Output value should not need local environment.
         expval = eval(expression, {}, local_env)
@@ -531,7 +532,8 @@ def test_examples_in_doc_of(parser, docs):
     if expression and output:
         check_evaluation()
 
-def test_doc_examples(parser_module):
+
+def doc_test_examples(parser_module):
     """
     Test the example usage in a parser module and its parser classes against
     the sample output in the documentation.
@@ -551,9 +553,7 @@ def test_doc_examples(parser_module):
     ]
 
     if len(parsers) == 1:
-        print "testing one parser:", parsers[0]
-        test_examples_in_doc_of(parsers[0], parser_module.__doc__)
+        doc_test_examples_in(parsers[0], parser_module.__doc__)
     elif len(parsers) > 1:
-        for parser in parsers:
-            print "testing parser:", parser
-            test_examples_in_doc_of(parser, parser.__doc__)
+        for parser_ in parsers:
+            doc_test_examples_in(parser_, parser.__doc__)

--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -564,4 +564,4 @@ def doc_test_examples(parser_module):
         doc_test_examples_in(parsers[0], parser_module.__doc__)
     elif len(parsers) > 1:
         for parser_ in parsers:
-            doc_test_examples_in(parser_, parser.__doc__)
+            doc_test_examples_in(parser_, parser_.__doc__)

--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -522,22 +522,22 @@ def doc_test_examples_in(parser, docs):
     def check_evaluation():
         try:
             expval = eval(expression, {}, local_env)
-        except Exception as exc:
-            warnings.warn("Problem with evaluating expression '{e}': {exc}".format(
-                e=expression, exc=exc
+        except:
+            warnings.warn("In {p.__name__}, problem with evaluating expression '{e}': {exc}".format(
+                p=parser, e=expression, exc=sys.exc_info()[0]
             ))
             return
         # Output value should not need local environment.
         try:
             outval = eval(output)
-        except Exception as exc:
-            warnings.warn("Problem with evaluating expected output '{o}': {exc}".format(
-                o=output, exc=exc
+        except:
+            warnings.warn("In {p.__name__}, problem with evaluating expected output '{o}': {exc}".format(
+                p=parser, o=output, exc=sys.exc_info()[0]
             ))
             return
         if expval != outval:
-            warnings.warn("Documentation expression '{e}' does not match '{o}' (is actually '{ev}')".format(
-                e=expression, o=output, ev=expval, ov=outval
+            warnings.warn("In {p.__name__}, documentation expression '{e}' does not match '{o}' (is actually '{ev}')".format(
+                p=parser, e=expression, o=output, ev=expval, ov=outval
             ))
 
     for line in examples:

--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -524,12 +524,10 @@ def doc_test_examples_in(parser, docs):
             if expression:
                 if ' = ' in expression:
                     # variable = expression
-                    words = expression.split(None, 3)
+                    words = expression.split(None, 2)
                     assert words[1] == '='
                     local_env[words[0]] = eval(words[2], {}, local_env)
                 else:
-                    # expression by itself - compare to output
-                    # output should not rely on local environment
                     check_evaluation()
             # Store the new declaration
             expression = line[4:]

--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -434,17 +434,32 @@ def redhat_release(major, minor=""):
 def doc_test_examples_in(parser, docs):
     """
     This function looks in the documentation given for an indented block
-    (following a ``\:\:``) and an `Examples\:` section.  The indented block
+    (following a ``::``) and an ``Examples:`` section.  The indented block
     is stripped of leading space and read as test data, and put in a 'shared'
     dictionary against the given parser using the `'context_wrap'` function.
     This is stored in a dictionary of local declarations, to be used in later
     evaluation.
 
-    Each example line preceded by '`>>> `' is assumed to be a command and
-    `eval`uated, and the result is asserted to be equal to any non-'>>> '
-    indented lines (also `eval`'ed).  The `'variable' = shared['parser']`
-    declaration is used to set the given name in the local declarations
-    dictionary.
+    Each example line preceded by ``>>>`` is assumed to be a command and
+    ``eval``'ed, and the result is asserted to be equal to any non-``>>>``
+    indented lines (which are stripped, concantenated and then also
+    ``eval``'ed).  The ``'variable' = shared['parser']`` declaration is used
+    to set the given name in the local declarations dictionary.
+
+    Some attempt is made to set up the local evaluation environment but it is
+    not assumed to be a complete Python environment. In particular, other
+    statements that are not 'variable = value' or 'expression' are not
+    parsed. Only 'variable = value' statements update the local environment.
+
+    The local environment is set up to contain two things:
+
+     * the parser (in the way that the statement ``from
+       insights.parsers.parser_module import parser_class`` would)
+     * a 'shared' dictionary which has a reference to this parser by class
+       (in the same way that the 'shared' environment is provided to a rule).
+
+
+
     """
     if not (docs is not None and '::' in docs and 'Examples:' in docs):
         return
@@ -551,6 +566,17 @@ def doc_test_examples(parser_module):
     it is assumed to be in the parser module.  If there is more than one
     parser, the module documentation is ignored and the documentation of the
     parser itself is assumed to contain the input data and examples.
+
+    To use this you can include the following code in your test module:
+
+    .. code-block:: python
+
+        from insights.tests import doc_test_examples
+        from insights.parsers import {your_module}
+
+        def test_documentation():
+            doc_test_examples({your_module})
+
     """
     parsers = [
         decl

--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -498,17 +498,25 @@ def doc_test_examples_in(parser, docs):
     output = ''
 
     def check_evaluation():
+        try:
+            expval = eval(expression, {}, local_env)
+        except Exception as exc:
+            warnings.warn("Problem with evaluating expression '{e}': {exc}".format(
+                e=expression, exc=exc
+            ))
+            return
         # Output value should not need local environment.
-        expval = eval(expression, {}, local_env)
-        outval = eval(output)
+        try:
+            outval = eval(output)
+        except Exception as exc:
+            warnings.warn("Problem with evaluating expected output '{o}': {exc}".format(
+                o=output, exc=exc
+            ))
+            return
         if expval != outval:
-            warnings.warn("Documentation expression {e} does not match {o}".format(
+            warnings.warn("Documentation expression '{e}' does not match '{o}' (is actually '{ev}')".format(
                 e=expression, o=output, ev=expval, ov=outval
             ))
-        if outval is True or outval is False or outval is None:
-            assert eval(expression, {}, local_env) is outval
-        else:
-            assert eval(expression, {}, local_env) == outval
 
     for line in examples:
         if line.startswith('>>> '):


### PR DESCRIPTION
Test the documentation to make sure the example code works from the input data.

Insights parsers and combiners usually contain samples of the input data and code examples that are written as if a user had imported the parser or combiner and was trying commands out in an interpretive shell.  Not only is it useful to make sure that this code actually works and demonstrates the correct usage of the class under test, but the code also forms useful test code that should be checked by the test system.

We introduce the `doc_test_examples` function, which tests all the classes in a given module.  If the parser module given only contains one parser, the documentation for it is assumed to be in the parser module.  If there is more than one parser, the module documentation is ignored and the documentation of the parser itself is assumed to contain the input data and examples.

This work is done by the `doc_test_examples_in` function, which looks in the documentation given for an indented block (following a ``::``) and an `Examples:` section.  If these are not found, no testing is done.  Otherwise, the indented block is stripped of leading space and read as test data, and put in a 'shared' dictionary against the given parser using the `'context_wrap'` function.  This is stored in a dictionary of local declarations, to be used in later evaluation.

Each example line preceded by '`>>> `' is assumed to be an expression and `eval`uated, and the result is asserted to be equal to any non-'`>>> `' indented lines (which are concatenated together and then also `eval`'ed).  The `'variable' = shared['parser']` declaration is used to set the given name in the local declarations dictionary.  For example, the following example code:

```
>>> ns = shared[Netstat]
>>> hasattr(ns, 'data')
True
```
Will be interpreted in the following manner:

 * The 'ns' local variable will be set to the Netstat parser instance (which is populated from the input data given above).
 * The statement '`hasattr(ns, 'data')`' is evaluated and is checked against the value `True`.

Some attempt is made to set up the local evaluation environment but it is not assumed to be a complete Python environment.  In particular, other statements that are not 'variable = value' or 'expression' are not parsed.  Only 'variable = value' statements update the local environment.

To use this code, import the `doc_test_examples` function from the `insights.tests` module, and your parser module as itself, into your test module and then add the following code:

```python
def test_MODULE_docs():
    doc_test_examples(MODULE)
```

As an example, we have updated the `netstat` module parsers to use the correct format of documentation, and have verified that the documentation matches the parser output usage.