### PR TITLE
Pulp worker defaults for master branch

### DIFF
--- a/docs/shared_parsers_catalog/pulp_worker_defaults.rst
+++ b/docs/shared_parsers_catalog/pulp_worker_defaults.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.pulp_worker_defaults
+   :members:
+   :show-inheritance:

--- a/insights/parsers/pulp_worker_defaults.py
+++ b/insights/parsers/pulp_worker_defaults.py
@@ -1,0 +1,43 @@
+"""
+PulpWorkerDefaults - file ``/etc/default/pulp_workers``
+=======================================================
+
+The PulpWorkerDefaults parser reads the shell options set in the
+``/etc/default/pulp_worker`` file.  These are made available using the
+:class:`insights.core.SysconfigOptions` class methods.
+
+Sample file contents::
+
+    # Configuration file for Pulp's Celery workers
+
+    # Define the number of worker nodes you wish to have here. This defaults to the number of processors
+    # that are detected on the system if left commented here.
+    PULP_CONCURRENCY=1
+
+    # Configure Python's encoding for writing all logs, stdout and stderr
+    PYTHONIOENCODING="UTF-8"
+
+Examples:
+    >>> pulp_defs = shared[PulpWorkerDefaults]
+    >>> type(pulp_defs)
+    <class 'insights.parsers.pulp_worker_defaults.PulpWorkerDefaults'>
+    >>> 'PULP_CONCURRENCY' in pulp_defs
+    True
+    >>> pulp_defs['PULP_CONCURRENCY']  # Note string return value
+    '1'
+    >>> 'PULP_MAX_TASKS_PER_CHILD' in pulp_defs
+    False
+    >>> pulp_defs['PYTHONIOENCODING']  # Values are dequoted as per bash
+    'UTF-8'
+
+"""
+
+from .. import parser, SysconfigOptions
+
+
+@parser('etc/default/pulp_workers')
+class PulpWorkerDefaults(SysconfigOptions):
+    """
+    Parse the ``/etc/default/pulp_workers`` file.
+    """
+    pass

--- a/insights/parsers/pulp_worker_defaults.py
+++ b/insights/parsers/pulp_worker_defaults.py
@@ -33,9 +33,10 @@ Examples:
 """
 
 from .. import parser, SysconfigOptions
+from insights.specs import Specs
 
 
-@parser('etc/default/pulp_workers')
+@parser(Specs.pulp_worker_defaults)
 class PulpWorkerDefaults(SysconfigOptions):
     """
     Parse the ``/etc/default/pulp_workers`` file.

--- a/insights/parsers/tests/test_pulp_worker_defaults.py
+++ b/insights/parsers/tests/test_pulp_worker_defaults.py
@@ -1,0 +1,28 @@
+from ...parsers import pulp_worker_defaults
+from ...tests import context_wrap
+
+import doctest
+
+pulp_worker_defaults_in_docs = '''
+# Configuration file for Pulp's Celery workers
+
+# Define the number of worker nodes you wish to have here. This defaults to the number of processors
+# that are detected on the system if left commented here.
+PULP_CONCURRENCY=1
+
+# Configure Python's encoding for writing all logs, stdout and stderr
+PYTHONIOENCODING="UTF-8"
+'''
+
+
+def test_pulp_worker_defaults_docs():
+    env = {
+        'PulpWorkerDefaults': pulp_worker_defaults.PulpWorkerDefaults,
+        'shared': {
+            pulp_worker_defaults.PulpWorkerDefaults: pulp_worker_defaults.PulpWorkerDefaults(
+                context_wrap(pulp_worker_defaults_in_docs)
+            )
+        },
+    }
+    failed, total = doctest.testmod(pulp_worker_defaults, globs=env)
+    assert failed == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -284,6 +284,7 @@ class Specs(SpecSet):
     ps_aux = RegistryPoint()
     ps_auxcww = RegistryPoint()
     ps_auxww = RegistryPoint()
+    pulp_worker_defaults = RegistryPoint()
     puppet_ssl_cert_ca_pem = RegistryPoint()
     pvs_noheadings = RegistryPoint()
     pvs = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -449,6 +449,7 @@ class DefaultSpecs(Specs):
     prev_uploader_log = simple_file("var/log/redhat-access-insights/redhat-access-insights.log.1")
     proc_snmp_ipv4 = simple_file("proc/net/snmp")
     proc_snmp_ipv6 = simple_file("proc/net/snmp6")
+    pulp_worker_defaults = simple_file("etc/default/pulp_workers")
     puppet_ssl_cert_ca_pem = None
     pvs = simple_command('/sbin/pvs -a -v -o +pv_mda_free,pv_mda_size,pv_mda_count,pv_mda_used_count,pe_count --config="global{locking_type=0}"')
     pvs_noheadings = simple_command("/sbin/pvs --nameprefixes --noheadings --separator='|' -a -o pv_all,vg_name --config=\"global{locking_type=0}\"")


### PR DESCRIPTION
A simple parser to read the `/etc/default/pulp_workers` file using the `SysconfigOptions` parser class.

This is the master branch version of #950 