### PR TITLE
Subscription-manager list parser for 1.x branch

### DIFF
--- a/docs/shared_parsers_catalog/subscription_manager_list.rst
+++ b/docs/shared_parsers_catalog/subscription_manager_list.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.subscription_manager_list
+   :members:
+   :show-inheritance:

--- a/insights/config/specs.py
+++ b/insights/config/specs.py
@@ -398,6 +398,8 @@ static_specs = {
     "sshd_config_perms"         : CommandSpec("/bin/ls -l /etc/ssh/sshd_config"),
     "sssd_config"               : SimpleFileSpec("etc/sssd/sssd.conf"),
     "sssd_logs"                 : PatternSpec(r"var/log/sssd/.*\.log$"),
+    "subscription_manager_list_consumed": CommandSpec("/usr/bin/subscription-manager list --consumed"),
+    "subscription_manager_list_installed": CommandSpec("/usr/bin/subscription-manager list --installed"),
     "swift_object_expirer_conf" : SimpleFileSpec("etc/swift/object-expirer.conf"),
     "swift_proxy_server_conf"   : SimpleFileSpec("etc/swift/proxy-server.conf"),
     "sysconfig_chronyd"         : SimpleFileSpec("etc/sysconfig/chronyd"),

--- a/insights/parsers/subscription_manager_list.py
+++ b/insights/parsers/subscription_manager_list.py
@@ -10,7 +10,7 @@ SubscriptionManagerListConsumed - command ``subscription-manager list --consumed
 ----------------------------------------------------------------------------------
 
 SubscriptionManagerListInstalled - command ``subscription-manager list --installed``
-----------------------------------------------------------------------------------
+------------------------------------------------------------------------------------
 
 """
 
@@ -91,6 +91,12 @@ class SubscriptionManagerList(Parser):
         :func:`insights.parsers.keyword_search` function for more details
         on usage.
 
+        Arguments:
+            **kwargs: Key-value pairs of search parameters.
+
+        Returns:
+            (list): A list of records that matched the search criteria.
+
         >>> consumed = shared[SubscriptionManagerListConsumed]
         >>> len(consumed.search(Service_Level='PREMIUM'))
         1
@@ -159,8 +165,8 @@ class SubscriptionManagerListConsumed(SubscriptionManagerList):
     @property
     def all_current(self):
         """
-        Does every subscription record have the Status Details value set to
-        'Subscription is current'?
+        (bool) Does every subscription record have the Status Details value
+        set to 'Subscription is current'?
         """
         return all(
             sub['Status Details'] == 'Subscription is current'
@@ -216,7 +222,7 @@ class SubscriptionManagerListInstalled(SubscriptionManagerList):
     @property
     def all_subscribed(self):
         """
-        Does every product record have the Status value set to
+        (bool) Does every product record have the Status value set to
         'Subscribed'?
         """
         return all(

--- a/insights/parsers/subscription_manager_list.py
+++ b/insights/parsers/subscription_manager_list.py
@@ -1,0 +1,225 @@
+"""
+Subscription manager list outputs - command ``subscription-manager list``
+=========================================================================
+
+This module provides parsers for various list outputs of ``subscription-manager``.
+
+Parsers provided by this module are:
+
+SubscriptionManagerListConsumed - command ``subscription-manager list --consumed``
+----------------------------------------------------------------------------------
+
+SubscriptionManagerListInstalled - command ``subscription-manager list --installed``
+----------------------------------------------------------------------------------
+
+"""
+
+from .. import Parser, parser
+from . import keyword_search
+from datetime import date
+import re
+
+
+class SubscriptionManagerList(Parser):
+    """
+    A general object for parsing the output of ``subscription-manager list``.
+    This should be subclassed to read the specific output - e.g. ``--consumed``
+    or ``--installed``.
+    """
+    def parse_content(self, content):
+        self.records = []
+        current_record = {}
+        record_start_key = ''
+        key = ''  # The key currently in use
+
+        key_val_re = re.compile('^(?P<key>\w[\w\s]+\w):\s+(?P<value>\w.*)$')
+        cont_val_re = re.compile('^\s+(?P<value>\w.*)$')
+        mdy_re = re.compile('(?P<month>0\d|1[012])/(?P<day>[012]\d|3[01])/(?P<year>\d+)')
+
+        # The first line that matches the key_val_re is treated as the start
+        # of a record.  The header doesn't match because it doesn't have a
+        # colon.  Once that's read, if the record start key is seen again
+        # it starts a new record.
+
+        for line in content:
+            # Check for match of key/value line
+            match = key_val_re.search(line)
+            if match:
+                key, value = match.group('key', 'value')
+                if not record_start_key:
+                    record_start_key = key
+                # Have we started a new record
+                if key == record_start_key:
+                    # If we have an existing record, save it
+                    if current_record:
+                        self.records.append(current_record)
+                    current_record = {}
+                current_record[key] = value
+                # Do some type conversions and add-ons
+                if key == 'Active' and value in ('True', 'False'):
+                    current_record[key] = (value == 'True')
+                elif key in ('Starts', 'Ends'):
+                    date_match = mdy_re.search(value)
+                    if date_match:
+                        current_record[key + ' timestamp'] = date(
+                            year=int(date_match.group('year')) + 2000,
+                            month=int(date_match.group('month')),
+                            day=int(date_match.group('day')),
+                        )
+            elif not record_start_key:
+                # Ignore any lines before the first record key.
+                continue
+            # Check for value continuations
+            match = cont_val_re.search(line)
+            if match:
+                # Add this value to the current key:
+                if isinstance(current_record[key], str):
+                    # Convert the single string into a list
+                    current_record[key] = [
+                        current_record[key], match.group('value')
+                    ]
+                else:
+                    current_record[key].append(match.group('value'))
+
+        # Save the last read record if we had one.
+        if current_record:
+            self.records.append(current_record)
+
+    def search(self, *args, **kwargs):
+        """
+        Search for records that match the given keys and values.  See the
+        :func:`insights.parsers.keyword_search` function for more details
+        on usage.
+
+        >>> consumed = shared[SubscriptionManagerListConsumed]
+        >>> len(consumed.search(Service_Level='PREMIUM'))
+        1
+        >>> consumed.search(Provides__contains='Red Hat Enterprise Virtualization')
+        []
+        """
+        return keyword_search(self.records, **kwargs)
+
+
+@parser('subscription_manager_list_consumed')
+class SubscriptionManagerListConsumed(SubscriptionManagerList):
+    """
+    Read the output of ``subscription-manager list --consumed``.
+
+    Sample input file::
+
+        +-------------------------------------------+
+           Consumed Subscriptions
+        +-------------------------------------------+
+        Subscription Name: Red Hat Enterprise Linux Server, Premium (1-2 sockets) (Up to 1 guest)
+        Provides:          Oracle Java (for RHEL Server)
+                           Red Hat Software Collections Beta (for RHEL Server)
+                           Red Hat Enterprise Linux Server
+                           Red Hat Beta
+        SKU:               RH0155783S
+        Contract:          12345678
+        Account:           1000001
+        Serial:            0102030405060708090
+        Pool ID:           8a85f981477e5284014783abaf5d4dcd
+        Active:            True
+        Quantity Used:     1
+        Service Level:     PREMIUM
+        Service Type:      L1-L3
+        Status Details:    Subscription is current
+        Subscription Type: Standard
+        Starts:            11/14/14
+        Ends:              07/06/15
+        System Type:       Physical
+
+    Examples:
+        >>> consumed = shared[SubscriptionManagerListConsumed]
+        >>> type(consumed)
+        <class 'insights.parsers.subscription_manager_list.SubscriptionManagerListConsumed'>
+        >>> len(consumed.records)
+        1
+        >>> sub1 = consumed.records[0]
+        >>> sub1['SKU']
+        'RH0155783S'
+        >>> sub1['Active']  # Type conversion on Active field
+        True
+        >>> sub1['Status Details']  # Keys appear as given
+        'Subscription is current'
+        >>> type(sub1['Provides'])  # Provides lines as a list
+        <type 'list'>
+        >>> sub1['Provides'][1]
+        'Red Hat Software Collections Beta (for RHEL Server)'
+        >>> sub1['Starts']  # Basic field as text - note month/day/year
+        '11/14/14'
+        >>> type(sub1['Starts timestamp'])  # Converted to date
+        <type 'datetime.date'>
+        >>> sub1['Starts timestamp'].year
+        2014
+        >>> consumed.all_current  # Are all subscriptions listed as current?
+        True
+    """
+    @property
+    def all_current(self):
+        """
+        Does every subscription record have the Status Details value set to
+        'Subscription is current'?
+        """
+        return all(
+            sub['Status Details'] == 'Subscription is current'
+            for sub in self.records
+        )
+
+
+@parser('subscription_manager_list_installed')
+class SubscriptionManagerListInstalled(SubscriptionManagerList):
+    """
+    Read the output of ``subscription-manager list --installed``.
+
+    Sample input file::
+
+        +-------------------------------------------+
+        Installed Product Status
+        +-------------------------------------------+
+        Product Name:   Red Hat Software Collections (for RHEL Server)
+        Product ID:     201
+        Version:        2
+        Arch:           x86_64
+        Status:         Subscribed
+        Status Details:
+        Starts:         04/27/15
+        Ends:           04/27/16
+
+        Product Name:   Red Hat Enterprise Linux Server
+        Product ID:     69
+        Version:        7.1
+        Arch:           x86_64
+        Status:         Subscribed
+        Status Details:
+        Starts:         04/27/15
+        Ends:           04/27/16
+
+    Examples:
+        >>> installed = shared[SubscriptionManagerListInstalled]
+        >>> type(installed)
+        <class 'insights.parsers.subscription_manager_list.SubscriptionManagerListInstalled'>
+        >>> len(installed.records)
+        2
+        >>> prod1 = installed.records[0]
+        >>> prod1['Product ID']  # Note - not converted to number
+        '201'
+        >>> prod1['Starts']  # String date as is
+        '04/27/15'
+        >>> prod1['Starts timestamp'].year  # Extra converted to date
+        2015
+        >>> installed.all_subscribed
+        True
+
+    """
+    @property
+    def all_subscribed(self):
+        """
+        Does every product record have the Status value set to
+        'Subscribed'?
+        """
+        return all(
+            sub['Status'] == 'Subscribed'
+            for sub in self.records
+        )

--- a/insights/parsers/tests/test_subscription_manager_list.py
+++ b/insights/parsers/tests/test_subscription_manager_list.py
@@ -1,0 +1,101 @@
+from ...parsers import subscription_manager_list
+from ...tests import context_wrap
+
+import doctest
+
+subscription_manager_list_consumed_in_docs = '''
++-------------------------------------------+
+   Consumed Subscriptions
++-------------------------------------------+
+Subscription Name: Red Hat Enterprise Linux Server, Premium (1-2 sockets) (Up to 1 guest)
+Provides:          Oracle Java (for RHEL Server)
+                   Red Hat Software Collections Beta (for RHEL Server)
+                   Red Hat Enterprise Linux Server
+                   Red Hat Beta
+SKU:               RH0155783S
+Contract:          12345678
+Account:           1000001
+Serial:            0102030405060708090
+Pool ID:           8a85f981477e5284014783abaf5d4dcd
+Active:            True
+Quantity Used:     1
+Service Level:     PREMIUM
+Service Type:      L1-L3
+Status Details:    Subscription is current
+Subscription Type: Standard
+Starts:            11/14/14
+Ends:              07/06/15
+System Type:       Physical
+'''
+
+subscription_manager_list_installed_in_docs = '''
++-------------------------------------------+
+Installed Product Status
++-------------------------------------------+
+Product Name:   Red Hat Software Collections (for RHEL Server)
+Product ID:     201
+Version:        2
+Arch:           x86_64
+Status:         Subscribed
+Status Details:
+Starts:         04/27/15
+Ends:           04/27/16
+
+Product Name:   Red Hat Enterprise Linux Server
+Product ID:     69
+Version:        7.1
+Arch:           x86_64
+Status:         Subscribed
+Status Details:
+Starts:         04/27/15
+Ends:           04/27/16
+'''
+
+
+def test_subscription_manager_list_docs():
+    env = {
+        'SubscriptionManagerListConsumed': subscription_manager_list.SubscriptionManagerListConsumed,
+        'SubscriptionManagerListInstalled': subscription_manager_list.SubscriptionManagerListInstalled,
+        'shared': {
+            subscription_manager_list.SubscriptionManagerListConsumed: subscription_manager_list.SubscriptionManagerListConsumed(
+                context_wrap(subscription_manager_list_consumed_in_docs)
+            ),
+            subscription_manager_list.SubscriptionManagerListInstalled: subscription_manager_list.SubscriptionManagerListInstalled(
+                context_wrap(subscription_manager_list_installed_in_docs)
+            )
+        },
+    }
+    failed, total = doctest.testmod(subscription_manager_list, globs=env)
+    assert failed == 0
+
+
+subscription_manager_list_test_data = '''
++-------------------------------------------+
+   Consumed Subscriptions
++-------------------------------------------+
+Subscription Name: Red Hat Enterprise Linux Server, Premium (1-2 sockets) (Up to 1 guest)
+Subscription Type: Standard
+Starts:            17/2
+'''
+
+subscription_manager_list_no_installed_products = '''
+No installed products to list
+'''
+
+
+def test_subscription_manager_list_exceptions():
+    sml = subscription_manager_list.SubscriptionManagerListConsumed(
+        context_wrap(subscription_manager_list_test_data)
+    )
+    assert len(sml.records) == 1
+    rec0 = sml.records[0]
+    assert 'Subscription Name' in rec0
+    assert 'Subscription Type' in rec0
+    assert 'Starts' in rec0
+    assert rec0['Starts'] == '17/2'
+    assert 'Starts timestamp' not in rec0
+
+    sml = subscription_manager_list.SubscriptionManagerListInstalled(
+        context_wrap(subscription_manager_list_no_installed_products)
+    )
+    assert sml.records == []


### PR DESCRIPTION
This module provides a base class for parsing the output of ``subscription-manager list``, with a variety of tools to make it useful.

Documentation and complete testing is provided.