### PR TITLE
NFS exports combiner and parser improvements

### DIFF
--- a/docs/shared_combiners_catalog/nfs_exports.rst
+++ b/docs/shared_combiners_catalog/nfs_exports.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.combiners.nfs_exports
+   :members:
+   :show-inheritance:

--- a/insights/combiners/nfs_exports.py
+++ b/insights/combiners/nfs_exports.py
@@ -40,7 +40,7 @@ class AllNFSExports(object):
     Combiner for accessing all the NFS export configuration files.
 
     Exports are allowed to be listed multiple times, with all duplicate
-    host after the first causing `exportfs` to emit a warning and ignore
+    host after the first causing ``exportfs`` to emit a warning and ignore
     the host.  So we combine the raw lines and ignored exports into structures
     listing the source file for each
 

--- a/insights/combiners/nfs_exports.py
+++ b/insights/combiners/nfs_exports.py
@@ -1,0 +1,114 @@
+"""
+Combined NFS exports
+====================
+
+The NFS exports files are normally available to rules from both a single
+NFSExports object and zero or more NFSExportsD objects.  This combiner turns
+those into one set of data.
+
+Examples:
+    >>> type(all_nfs)
+    <class 'insights.combiners.nfs_exports.AllNFSExports'>
+    >>> all_nfs.files  # List of files exporting NFS shares
+    ['/etc/exports', '/etc/exports.d/mnt.exports']
+    >>> '/home/redhat' in all_nfs.exports  # All exports stored by path
+    True
+    >>> sorted(all_nfs.exports['/home/redhat'].keys())  # Each path is a dictionary of host specs and flags.
+    ['@rhtttttttttttt', 'ins1.redhat.com', 'ins2.redhat.com', 'ins3.redhat.com']
+    >>> all_nfs.exports['/home/redhat']['ins3.redhat.com']  # Each host contains a list of flags.
+    ['rw', 'sync', 'no_root_squash']
+    >>> '/home/redhat' in all_nfs.ignored_exports  # Ignored exports are remembered within one file
+    True
+    >>> all_nfs.ignored_exports['/home/redhat'].keys()  # Each ignored export is then stored by source file...
+    ['/etc/exports']
+    >>> all_nfs.ignored_exports['/home/redhat']['/etc/exports'].keys()  # ... and then by host spec...
+    ['ins2.redhat.com']
+    >>> all_nfs.ignored_exports['/home/redhat']['/etc/exports']['ins2.redhat.com']  # ... holding the values that were duplicated
+    ['rw', 'sync', 'no_root_squash']
+    >>> '/home/insights/shared/rw'  in all_nfs.ignored_exports  # Ignored exports are remembered across files
+    True
+
+"""
+
+from insights.core.plugins import combiner
+from insights.parsers.nfs_exports import NFSExports, NFSExportsD
+
+
+@combiner(NFSExports, NFSExportsD)
+class AllNFSExports(object):
+    """
+    Combiner for accessing all the NFS export configuration files.
+
+    Exports are allowed to be listed multiple times, with all duplicate
+    host after the first causing `exportfs` to emit a warning and ignore
+    the host.  So we combine the raw lines and ignored exports into structures
+    listing the source file for each
+
+    Attributes:
+        files (list): the list of source files that contained NFS export
+            definitions.
+
+        exports (dict of dicts): the NFS exports stored by export path, with
+            each path storing a dictionary of host flag lists.
+
+        ignored_exports (dict): A dictionary of exported paths that have
+            host definitions that conflicted with a previous definition,
+            stored by export path and then path of the file that defined it.
+
+        raw_lines (dict of dicts): A dictionary of raw lines that define each
+            exported path, with the lines stored by defining file.
+
+    """
+    def __init__(self, nfsexports, nfsexportsd):
+        self.files = []
+        self.exports = {}
+        self.ignored_exports = {}
+        self.raw_lines = {}
+
+        sources = [nfsexports]
+        # Make sure exports are stored in the order they're parsed -
+        # alphabetically by file name
+        sources.extend(sorted(nfsexportsd, key=lambda f: f.file_path))
+
+        def add_paths_to_dict(src_path, src_dict, dest_dict):
+            # Because ignored_exports and raw_lines are stored by path, we
+            # keep that and add the paths in them piecewise, stored by the
+            # path of this source file.
+            for path, value in src_dict.iteritems():
+                if path not in dest_dict:
+                    dest_dict[path] = {src_path: value}
+                else:
+                    dest_dict[path][src_path] = value
+
+        for source in sources:
+            self.files.append(source.file_path)
+            # Add all raw lines from the source to raw lines.
+            add_paths_to_dict(source.file_path, source.raw_lines, self.raw_lines)
+            # Likewise all the ignored exports from this file.
+            add_paths_to_dict(source.file_path, source.ignored_exports, self.ignored_exports)
+            # For exports though we have to preserve existing host definitions
+            # and ignore repeated host specs.
+            for path, hosts in source.data.iteritems():
+                if path in self.exports:
+                    # Check whether the host specification has been listed
+                    # more than once across different files:
+                    for host, flags in hosts.iteritems():
+                        if host in self.exports[path]:
+                            # Add this to the ignored_exports list.  But
+                            # because we know that this path-host tuple isn't
+                            # duplicated in this file (it's already in
+                            # ignored_exports if it does), then we can assume
+                            # that the file isn't in the common ignored_exports
+                            # already.
+                            if path in self.ignored_exports:
+                                self.ignored_exports[path][host] = flags
+                            else:
+                                self.ignored_exports[path] = {host: flags}
+                        else:
+                            # A new host spec - add as is.
+                            self.exports[path][host] = flags
+                else:
+                    # No exports for this path so far, add them all
+                    self.exports[path] = hosts
+
+        super(AllNFSExports, self).__init__()

--- a/insights/combiners/nfs_exports.py
+++ b/insights/combiners/nfs_exports.py
@@ -11,19 +11,19 @@ Examples:
     <class 'insights.combiners.nfs_exports.AllNFSExports'>
     >>> all_nfs.files  # List of files exporting NFS shares
     ['/etc/exports', '/etc/exports.d/mnt.exports']
-    >>> '/home/redhat' in all_nfs.exports  # All exports stored by path
+    >>> '/home/example' in all_nfs.exports  # All exports stored by path
     True
-    >>> sorted(all_nfs.exports['/home/redhat'].keys())  # Each path is a dictionary of host specs and flags.
-    ['@rhtttttttttttt', 'ins1.redhat.com', 'ins2.redhat.com', 'ins3.redhat.com']
-    >>> all_nfs.exports['/home/redhat']['ins3.redhat.com']  # Each host contains a list of flags.
+    >>> sorted(all_nfs.exports['/home/example'].keys())  # Each path is a dictionary of host specs and flags.
+    ['@group', 'ins1.example.com', 'ins2.example.com']
+    >>> all_nfs.exports['/home/example']['ins2.example.com']  # Each host contains a list of flags.
     ['rw', 'sync', 'no_root_squash']
-    >>> '/home/redhat' in all_nfs.ignored_exports  # Ignored exports are remembered within one file
+    >>> '/home/example' in all_nfs.ignored_exports  # Ignored exports are remembered within one file
     True
-    >>> all_nfs.ignored_exports['/home/redhat'].keys()  # Each ignored export is then stored by source file...
+    >>> all_nfs.ignored_exports['/home/example'].keys()  # Each ignored export is then stored by source file...
     ['/etc/exports']
-    >>> all_nfs.ignored_exports['/home/redhat']['/etc/exports'].keys()  # ... and then by host spec...
-    ['ins2.redhat.com']
-    >>> all_nfs.ignored_exports['/home/redhat']['/etc/exports']['ins2.redhat.com']  # ... holding the values that were duplicated
+    >>> all_nfs.ignored_exports['/home/example']['/etc/exports'].keys()  # ... and then by host spec...
+    ['ins2.example.com']
+    >>> all_nfs.ignored_exports['/home/example']['/etc/exports']['ins2.example.com']  # ... holding the values that were duplicated
     ['rw', 'sync', 'no_root_squash']
     >>> '/home/insights/shared/rw'  in all_nfs.ignored_exports  # Ignored exports are remembered across files
     True

--- a/insights/combiners/nfs_exports.py
+++ b/insights/combiners/nfs_exports.py
@@ -34,7 +34,7 @@ from insights.core.plugins import combiner
 from insights.parsers.nfs_exports import NFSExports, NFSExportsD
 
 
-@combiner(NFSExports, NFSExportsD)
+@combiner(NFSExports, optional=[NFSExportsD])
 class AllNFSExports(object):
     """
     Combiner for accessing all the NFS export configuration files.

--- a/insights/combiners/nfs_exports.py
+++ b/insights/combiners/nfs_exports.py
@@ -33,6 +33,8 @@ Examples:
 from insights.core.plugins import combiner
 from insights.parsers.nfs_exports import NFSExports, NFSExportsD
 
+import collections
+
 
 @combiner(NFSExports, optional=[NFSExportsD])
 class AllNFSExports(object):
@@ -67,8 +69,9 @@ class AllNFSExports(object):
 
         sources = [nfsexports]
         # Make sure exports are stored in the order they're parsed -
-        # alphabetically by file name
-        sources.extend(sorted(nfsexportsd, key=lambda f: f.file_path))
+        # alphabetically by file name.  Ignore it if nfsexportsd isn't valid.
+        if isinstance(nfsexportsd, collections.Iterable):
+            sources.extend(sorted(nfsexportsd, key=lambda f: f.file_path))
 
         def add_paths_to_dict(src_path, src_dict, dest_dict):
             # Because ignored_exports and raw_lines are stored by path, we

--- a/insights/combiners/tests/test_nfs_exports.py
+++ b/insights/combiners/tests/test_nfs_exports.py
@@ -1,0 +1,58 @@
+from insights.parsers.nfs_exports import NFSExports, NFSExportsD
+from insights.parsers.tests.test_nfs_exports import EXPORTS
+from insights.combiners import nfs_exports
+from insights.tests import context_wrap
+
+from doctest import testmod
+
+EXPORTS_D_EXTRAS = """
+/mnt/work       *(rw,sync)
+/mnt/backup     10.0.0.0/24(rw,sync,no_root_squash)
+# We expect the following to be stored in the ignored_exports property
+# as it has a duplicate host declaration for this path.
+/home/insights/shared/rw ins1.redhat.com(rw,sync,no_root_squash)
+"""
+
+# Set up combined test environment for docs and for more thorough functional
+# testing.
+nfs_exportsf = NFSExports(
+    context_wrap(EXPORTS, path="/etc/exports")
+)
+nfs_exportsd = [NFSExportsD(
+    context_wrap(EXPORTS_D_EXTRAS, path="/etc/exports.d/mnt.exports")
+)]
+combined = nfs_exports.AllNFSExports(nfs_exportsf, nfs_exportsd)
+
+
+def test_nfs_exports_docs():
+    failed, total = testmod(nfs_exports, globs={'all_nfs': combined})
+    assert failed == 0
+
+
+def test_nfs_export_combiner():
+    assert combined
+    assert hasattr(combined, 'exports')
+    assert isinstance(combined.exports, dict)
+    assert combined.exports
+    assert len(combined.exports) == 7
+    assert sorted(combined.exports.keys()) == sorted([
+        '/home/utcs/shared/ro', '/home/insights/shared/rw',
+        '/home/insights/shared/special/all/mail',
+        '/home/insights/ins/special/all/config', '/home/redhat', '/mnt/work',
+        '/mnt/backup'
+    ])
+    for path, hosts in nfs_exportsf.data.iteritems(:
+        assert hosts == combined.exports[path]
+
+    assert hasattr(combined, 'ignored_exports')
+    assert isinstance(combined.ignored_exports, dict)
+    assert combined.ignored_exports
+    assert len(combined.ignored_exports) == 2
+    print combined.ignored_exports.keys()
+    assert sorted(combined.ignored_exports.keys()) == sorted([
+        '/home/insights/shared/rw', '/home/redhat'
+    ])
+
+    assert hasattr(combined, 'raw_lines')
+    assert isinstance(combined.raw_lines, dict)
+    assert combined.raw_lines

--- a/insights/combiners/tests/test_nfs_exports.py
+++ b/insights/combiners/tests/test_nfs_exports.py
@@ -8,9 +8,12 @@ from doctest import testmod
 EXPORTS_D_EXTRAS = """
 /mnt/work       *(rw,sync)
 /mnt/backup     10.0.0.0/24(rw,sync,no_root_squash)
+# This is a duplicate share but a new host, so it should be stored
+/home/insights/shared/rw ins4.example.com(rw,sync,no_root_squash)
 # We expect the following to be stored in the ignored_exports property
 # as it has a duplicate host declaration for this path.
-/home/insights/shared/rw ins1.redhat.com(rw,sync,no_root_squash)
+/home/insights/shared/rw ins1.example.com(rw,sync,no_root_squash)
+/home/insights/shared/rw ins2.example.com(rw,sync,no_root_squash)
 """
 
 # Set up combined test environment for docs and for more thorough functional
@@ -38,11 +41,14 @@ def test_nfs_export_combiner():
     assert sorted(combined.exports.keys()) == sorted([
         '/home/utcs/shared/ro', '/home/insights/shared/rw',
         '/home/insights/shared/special/all/mail',
-        '/home/insights/ins/special/all/config', '/home/redhat', '/mnt/work',
+        '/home/insights/ins/special/all/config', '/home/example', '/mnt/work',
         '/mnt/backup'
     ])
-    for path, hosts in nfs_exportsf.data.iteritems(:
+    for path, hosts in nfs_exportsf.data.iteritems():
         assert hosts == combined.exports[path]
+    assert sorted(combined.exports['/home/insights/shared/rw'].keys()) == sorted([
+        '@group', 'ins1.example.com', 'ins2.example.com', 'ins4.example.com'
+    ])
 
     assert hasattr(combined, 'ignored_exports')
     assert isinstance(combined.ignored_exports, dict)
@@ -50,7 +56,7 @@ def test_nfs_export_combiner():
     assert len(combined.ignored_exports) == 2
     print combined.ignored_exports.keys()
     assert sorted(combined.ignored_exports.keys()) == sorted([
-        '/home/insights/shared/rw', '/home/redhat'
+        '/home/insights/shared/rw', '/home/example'
     ])
 
     assert hasattr(combined, 'raw_lines')

--- a/insights/parsers/nfs_exports.py
+++ b/insights/parsers/nfs_exports.py
@@ -25,95 +25,32 @@ NFSExports - file ``nfs_exports``
 NFSExportsD - files in the ``nfs_exports.d`` directory
 ------------------------------------------------------
 
-Sample input is shown in the Examples.
+Sample content of the ``/etc/exports`` file::
+
+    /home/utcs/shared/ro                    @group(ro,sync)   ins1.example.com(rw,sync,no_root_squash) ins2.example.com(rw,sync,no_root_squash)
+    /home/insights/shared/rw                @group(rw,sync)   ins1.example.com(rw,sync,no_root_squash) ins2.example.com(ro,sync,no_root_squash)
+    /home/insights/shared/special/all/mail  @group(rw,sync,no_root_squash)
+    /home/insights/ins/special/all/config   @group(ro,sync,no_root_squash)  ins1.example.com(rw,sync,no_root_squash)
+    #/home/insights                          ins1.example.com(rw,sync,no_root_squash)
+    /home/example                           @group(rw,sync,root_squash) ins1.example.com(rw,sync,no_root_squash) ins2.example.com(rw,sync,no_root_squash)
+    # A duplicate host for this exported path
+    /home/example                           ins2.example.com(rw,sync,no_root_squash)
 
 Examples:
-    >>> EXPORTS='''
-    ... /home/utcs/shared/ro @rht(ro,sync)   ins1.example.com(rw,sync,no_root_squash) ins2.example.com(rw,sync,no_root_squash)
-    ... /home/insights/shared/rw @rht(rw,sync)   ins1.example.com(rw,sync,no_root_squash) ins2.example.com(ro,sync,no_root_squash)
-    ... /home/insights/shared/special/all/mail   @rht(rw,sync,no_root_squash)
-    ... /home/insights/ins/special/all/config   @rht(ro,sync,no_root_squash)  ins1.example.com(rw,sync,no_root_squash)
-    ... #/home/insights ins1.example.com(rw,sync,no_root_squash)
-    ... /home/example           @rht(rw,sync,root_squash) ins1.example.com(rw,sync,no_root_squash) ins2.example.com(rw,sync,no_root_squash)
-    ... /home/example           ins3.example.com(rw,sync,no_root_squash)
-    ... '''
-    >>> print json.dumps(nfs_exports.data, indent=4)
-    {
-        "/home/insights/shared/rw": {
-            "@rht": [
-                "rw",
-                "sync"
-            ],
-            "ins1.example.com": [
-                "rw",
-                "sync",
-                "no_root_squash"
-            ],
-            "ins2.example.com": [
-                "ro",
-                "sync",
-                "no_root_squash"
-            ]
-        },
-        "/home/insights/ins/special/all/config": {
-            "@rht": [
-                "ro",
-                "sync",
-                "no_root_squash"
-            ],
-            "ins1.example.com": [
-                "rw",
-                "sync",
-                "no_root_squash"
-            ]
-        },
-        "/home/insights/shared/special/all/mail": {
-            "@rht": [
-                "rw",
-                "sync",
-                "no_root_squash"
-            ]
-        },
-        "/home/example": {
-            "@rht": [
-                "rw",
-                "sync",
-                "root_squash"
-            ],
-            "ins1.example.com": [
-                "rw",
-                "sync",
-                "no_root_squash"
-            ],
-            "ins2.example.com": [
-                "rw",
-                "sync",
-                "no_root_squash"
-            ]
-        },
-        "/home/utcs/shared/ro": {
-            "@rht": [
-                "ro",
-                "sync"
-            ],
-            "ins1.example.com": [
-                "rw",
-                "sync",
-                "no_root_squash"
-            ],
-            "ins2.example.com": [
-                "rw",
-                "sync",
-                "no_root_squash"
-            ]
-        }
-    }
-    >>> nfs_exports.ignored_lines
-    ['/home/example           ins3.example.com(rw,sync,no_root_squash)']
-    >>> nfs_exports.all_options()
-    set(['ro', 'no_root_squash', 'rw', 'sync', 'root_squash'])
-    >>> nfs_exports.export_paths()
-    set(['/home/insights/shared/rw', '/home/insights/ins/special/all/config', '/home/insights/shared/special/all/mail', '/home/example', '/home/utcs/shared/ro'])
+    >>> type(exports)
+    <class 'insights.parsers.nfs_exports.NFSExports'>
+    >>> type(exports.data)
+    <type 'dict'>
+    >>> exports.raw_lines['/home/insights/shared/rw']  # List of lines that define this path
+    ['/home/insights/shared/rw                @group(rw,sync)   ins1.example.com(rw,sync,no_root_squash) ins2.example.com(ro,sync,no_root_squash)']
+    >>> exports.raw_lines['/home/example']  # Lines are stored even if they contain duplicate hosts
+    ['/home/example                           @group(rw,sync,root_squash) ins1.example.com(rw,sync,no_root_squash) ins2.example.com(rw,sync,no_root_squash)', '/home/example                           ins2.example.com(rw,sync,no_root_squash)']
+    >>> exports.ignored_exports
+    {'/home/example': {'ins2.example.com': ['rw', 'sync', 'no_root_squash']}}
+    >>> sorted(list(exports.all_options()))
+    ['no_root_squash', 'ro', 'root_squash', 'rw', 'sync']
+    >>> sorted(list(exports.export_paths()))
+    ['/home/example', '/home/insights/ins/special/all/config', '/home/insights/shared/rw', '/home/insights/shared/special/all/mail', '/home/utcs/shared/ro']
 """
 
 from itertools import chain
@@ -127,14 +64,20 @@ class NFSExportsBase(Parser):
     """
     Class to parse ``/etc/exports`` and ``/etc/exports.d/*.exports``.
 
+    Exports are stored keyed on the path of the export, and then the host
+    definition.  The flags are stored as a list.  NFS allows the same path
+    to be listed on multiple lines and in multiple files, but an exported
+    path can only have one definition for a given host.
+
     Attributes:
         data (dict): Key is export path, value is a dict, where the key is the
             client host and the value is a list of options.
 
-        ignored_lines (list): List of lines that are not used by ``nfsd``.
+        ignored_exports (dict): A dictionary of exported paths that have host
+            definitions that conflicted with a previous definition.
 
-        raw_lines (dict): Key is export path, value is raw line (though it is
-            transformed via ``get_active_lines``)
+        raw_lines (dict of lists): The list of the raw lines that define each
+            exported path, including any lines that may have ignored exports.
     """
 
     def _parse_host(self, content):
@@ -151,28 +94,32 @@ class NFSExportsBase(Parser):
         return path, hosts
 
     def parse_content(self, content):
-        # Reversing order of lines because only the first line for a given path
-        # is parsed; all others are ignored.  Thus reversing enables us to
-        # utilize dict overrides.
-        active_lines = get_active_lines(content)
-        line_gen = (self._parse_line(l) for l in reversed(active_lines))
-        self.data = dict((path, hosts) for path, hosts in line_gen)
-        self.ignored_lines = list(self._find_ignored_lines(active_lines))
-        self.raw_lines = dict((l.split()[0], l) for l in active_lines)
+        # Exports can be duplicated, but the path-host tuple cannot: the
+        # first read will be stored and all later path-host tuples cause
+        # `exportfs` to generate a warning when setting up the export.
+        self.data = {}
+        self.ignored_exports = {}
+        self.raw_lines = {}
 
-    @staticmethod
-    def _find_ignored_lines(lines):
-        """
-        Only the first line for a given export path is used; all others are
-        ignored
-        """
-        seen_paths = set()
-        for line in lines:
-            path = line.split()[0]
-            if path in seen_paths:
-                yield line
+        for line in get_active_lines(content):
+            path, hosts = self._parse_line(line)
+            if path not in self.data:
+                # New path, just add the hosts.
+                self.data[path] = hosts
+                self.raw_lines[path] = [line]
             else:
-                seen_paths.add(path)
+                # Add to raw lines even if some (or all) hosts are ignored.
+                self.raw_lines[path].append(line)
+                # Have to check each path-host tuple
+                for host, flags in hosts.iteritems():
+                    if host not in self.data[path]:
+                        # Only add if it doesn't already exist.
+                        self.data[path][host] = flags
+                    else:
+                        if path not in self.ignored_exports:
+                            self.ignored_exports[path] = {host: flags}
+                        else:
+                            self.ignored_exports[path][host] = flags
 
     def export_paths(self):
         """Returns the set of all export paths as strings"""
@@ -185,23 +132,6 @@ class NFSExportsBase(Parser):
 
     def __iter__(self):
         return self.data.iteritems()
-
-    @staticmethod
-    def reconstitute(path, d):
-        """
-        Reconstruct a line from its parsed value.  Original whitespace is not
-        maintained; instead two spaces (``"  "``) is used between each word.
-
-        Args:
-            path (str): The export path
-            d (dict): The dictionary that's the value of the exported path key
-                      in the parsed dict.
-
-        Returns:
-            str: The reconstituted line from the exports file
-        """
-        return "  ".join([path] + ["%s(%s)" % (host, ",".join(options))
-                         for host, options in d.iteritems()])
 
 
 @parser(Specs.nfs_exports)

--- a/insights/parsers/nfs_exports.py
+++ b/insights/parsers/nfs_exports.py
@@ -161,14 +161,8 @@ class NFSExportsBase(Parser):
             NFSExportsBase.reconstitute,
             'Please use the `raw_lines` dictionary property of the parser instance'
         )
-        return "{path}  {hosts}".format(
-            path=path,
-            hosts=' '.join((
-                '{host}({opts})'.format(
-                    host=h, opts=','.join(d[h]))
-                for h in sorted(d)
-            ))
-        )
+        return "  ".join([path] + ["%s(%s)" % (host, ",".join(options))
+                         for host, options in d.iteritems()])
 
 
 @parser(Specs.nfs_exports)

--- a/insights/parsers/tests/test_nfs_exports.py
+++ b/insights/parsers/tests/test_nfs_exports.py
@@ -100,13 +100,20 @@ def _do(nfs_exports):
 
 
 def test_reconstitute():
-    assert NFSExports.reconstitute(
+    # This is deprecated and will be removed in the future and is here for
+    # testing completeness.
+    recon = NFSExports.reconstitute(
         "/home/utcs/shared/ro", {
             "@group": ["ro", "sync"],
             "ins1.example.com": ["rw", "sync", "no_root_squash"],
             "ins2.example.com": ["rw", "sync", "no_root_squash"]
         }
-    ) == '/home/utcs/shared/ro  @group(ro,sync) ins1.example.com(rw,sync,no_root_squash) ins2.example.com(rw,sync,no_root_squash)'
+    )
+    # Because reconstitute uses iteritems, we can't test the order
+    # definitively.  We have to check that it's included each host definition.
+    assert recon.startswith('/home/utcs/shared/ro')
+    for host in ('@group', 'ins1.example.com', 'ins2.example.com'):
+        assert ' ' + host + '(' in recon
 
 
 NFS_EXPORTS_CORNER_CASES = '''


### PR DESCRIPTION
The NFS exports parser did not obey the semantics of duplicate exports, which is that a path can be listed multiple times but each host definition must be unique to a path.  Duplicate host definitions for a given path are ignored by `exportfs` after the first definition.  The NFS exports parser has been updated to obey these semantics.

This pull request also introduces an NFS exports combiner which reads all the NFS export parser objects and provides a unified interface to view all the paths exported in NFS on a system.