### PR TITLE
Fix nbsphinx version for RTD build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,4 @@ requests
 pyOpenSSL
 importlib
 Jinja2==2.9.6
-nbsphinx
+nbsphinx==0.3.1


### PR DESCRIPTION
Uses version 0.3.1 of nbsphinx because of bug introduced in to latest 0.3.2 version.