### PR TITLE
Add auto generated file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ man
 pylint.out
 cover/
 docs/plugin_catalog/*.rst
+docs/components.rst
 build/
 .idea*
 dist/


### PR DESCRIPTION
* docs/components.rst is autogenerated during doc build and it should
  not be added to any commits.