### PR TITLE
delete `a` and `R` in the ls command, as it may collected unexpected …

### DIFF
--- a/insights/parsers/ls_var_tmp.py
+++ b/insights/parsers/ls_var_tmp.py
@@ -1,8 +1,8 @@
 """
-LsVarTmp - command ``ls -lanR /var/tmp``
-========================================
+LsVarTmp - command ``ls -ln /var/tmp``
+======================================
 
-The ``ls -lanR /var/tmp`` command provides information for the listing of the
+The ``ls -ln /var/tmp`` command provides information for the listing of the
 ``/var/tmp`` directory.
 
 Sample input is shown in the Examples. See ``FileListing`` class for
@@ -12,50 +12,18 @@ Sample directory list::
 
     /var/tmp:
     total 20
-    drwxrwxrwt.  5 0 0 4096 Apr 28  2018 .
-    drwxr-xr-x. 24 0 0 4096 Oct 15  2015 ..
     drwxr-xr-x.  2 0 0 4096 Mar 26 02:25 a1
     drwxr-xr-x.  2 0 0 4096 Mar 26 02:25 a2
     drwxr-xr-x.  2 0 0 4096 Apr 28  2018 foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad
-
-    /var/tmp/a1:
-    total 8
-    drwxr-xr-x. 2 0 0 4096 Mar 26 02:25 .
-    drwxrwxrwt. 5 0 0 4096 Apr 28  2018 ..
-
-    /var/tmp/a2:
-    total 8
-    drwxr-xr-x. 2 0 0 4096 Mar 26 02:25 .
-    drwxrwxrwt. 5 0 0 4096 Apr 28  2018 ..
-
-    /var/tmp/foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad:
-    total 36
-    drwxr-xr-x. 3 0 0  4096 Apr  3 02:50 .
-    drwxrwxrwt. 5 0 0  4096 Apr 28  2018 ..
-    drwxr-xr-x. 2 0 0  4096 Apr  3 02:50 dir1
-    -rw-r--r--. 1 0 0     2 Apr 28  2018 exit_code
-    -rw-r--r--. 1 0 0 15606 Apr 28  2018 output
-    -rwxr-xr-x. 1 0 0    14 Apr 28  2018 script
-    -rw-r--r--. 1 0 0     0 Apr  3 02:50 test
-
-    /var/tmp/foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad/dir1:
-    total 8
-    drwxr-xr-x. 2 0 0 4096 Apr  3 02:50 .
-    drwxr-xr-x. 3 0 0 4096 Apr  3 02:50 ..
-
 
 Examples:
 
     >>> "a1" in ls_var_tmp
     False
-    >>> "/var/tmp/a1" in ls_var_tmp
+    >>> "/var/tmp" in ls_var_tmp
     True
-    >>> ls_var_tmp.files_of("/var/tmp/foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad")
-    ['exit_code', 'output', 'script', 'test']
-    >>> ls_var_tmp.dirs_of("/var/tmp/foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad")
-    ['.', '..', 'dir1']
-    >>> ls_var_tmp.total_of("/var/tmp/foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad")
-    36
+    >>> ls_var_tmp.dir_entry('/var/tmp', 'a1')['type']
+    'd'
 """
 
 
@@ -67,5 +35,5 @@ from .. import parser
 
 @parser(Specs.ls_var_tmp)
 class LsVarTmp(FileListing):
-    """Parses output of ``ls -lanR /var/tmp`` command."""
+    """Parses output of ``ls -ln /var/tmp`` command."""
     pass

--- a/insights/parsers/tests/test_ls_var_tmp.py
+++ b/insights/parsers/tests/test_ls_var_tmp.py
@@ -7,47 +7,16 @@ from insights.tests import context_wrap
 LS_VAR_TMP = """
 /var/tmp:
 total 20
-drwxrwxrwt.  5 0 0 4096 Apr 28  2018 .
-drwxr-xr-x. 24 0 0 4096 Oct 15  2015 ..
 drwxr-xr-x.  2 0 0 4096 Mar 26 02:25 a1
 drwxr-xr-x.  2 0 0 4096 Mar 26 02:25 a2
 drwxr-xr-x.  3 0 0 4096 Apr  3 02:50 foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad
-
-/var/tmp/a1:
-total 8
-drwxr-xr-x. 2 0 0 4096 Mar 26 02:25 .
-drwxrwxrwt. 5 0 0 4096 Apr 28  2018 ..
-
-/var/tmp/a2:
-total 8
-drwxr-xr-x. 2 0 0 4096 Mar 26 02:25 .
-drwxrwxrwt. 5 0 0 4096 Apr 28  2018 ..
-
-/var/tmp/foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad:
-total 36
-drwxr-xr-x. 3 0 0  4096 Apr  3 02:50 .
-drwxrwxrwt. 5 0 0  4096 Apr 28  2018 ..
-drwxr-xr-x. 2 0 0  4096 Apr  3 02:50 dir1
--rw-r--r--. 1 0 0     2 Apr 28  2018 exit_code
--rw-r--r--. 1 0 0 15606 Apr 28  2018 output
--rwxr-xr-x. 1 0 0    14 Apr 28  2018 script
--rw-r--r--. 1 0 0     0 Apr  3 02:50 test
-
-/var/tmp/foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad/dir1:
-total 8
-drwxr-xr-x. 2 0 0 4096 Apr  3 02:50 .
-drwxr-xr-x. 3 0 0 4096 Apr  3 02:50 ..
 """
 
 
 def test_ls_var_tmp():
     ls_var_tmp = LsVarTmp(context_wrap(LS_VAR_TMP))
-    assert "/var/tmp/foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad" in ls_var_tmp
-    assert len(ls_var_tmp.files_of("/var/tmp/foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad")) == 4
-    assert ls_var_tmp.files_of("/var/tmp/foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad") == ['exit_code', 'output', 'script', 'test']
-    assert ls_var_tmp.dirs_of("/var/tmp/foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad") == ['.', '..', 'dir1']
-    assert ls_var_tmp.total_of("/var/tmp/foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad") == 36
-    foreman = ls_var_tmp.dir_entry("/var/tmp", "foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad")
+    assert ls_var_tmp.dirs_of('/var/tmp') == ['a1', 'a2', 'foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad']
+    foreman = ls_var_tmp.dir_entry('/var/tmp', 'foreman-ssh-cmd-fc3f65c9-2b35-480d-87e3-1d971433d6ad')
     assert foreman is not None
     assert foreman == {
         'group': '0',

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -322,7 +322,7 @@ class DefaultSpecs(Specs):
     ls_etc = simple_command("/bin/ls -lanR /etc")
     ls_sys_firmware = simple_command("/bin/ls -lanR /sys/firmware")
     ls_var_log = simple_command("/bin/ls -la /var/log /var/log/audit")
-    ls_var_tmp = simple_command("/bin/ls -lanR /var/tmp")
+    ls_var_tmp = simple_command("/bin/ls -ln /var/tmp")
     ls_var_www = simple_command("/bin/ls -la /dev/null /var/www")  # https://github.com/RedHatInsights/insights-core/issues/827
     lvdisplay = simple_command("/sbin/lvdisplay")
     lvm_conf = simple_file("/etc/lvm/lvm.conf")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -97,7 +97,7 @@ class InsightsArchiveSpecs(Specs):
     ls_sys_firmware = simple_file("insights_commands/ls_-lanR_.sys.firmware")
     ls_var_log = simple_file("insights_commands/ls_-la_.var.log_.var.log.audit")
     ls_var_www = simple_file("insights_commands/ls_-la_.dev.null_.var.www")
-    ls_var_tmp = simple_file("insights_commands/ls_-lanR_.var.tmp")
+    ls_var_tmp = simple_file("insights_commands/ls_-ln_.var.tmp")
     lsblk = simple_file("insights_commands/lsblk")
     lsblk_pairs = simple_file("insights_commands/lsblk_-P_-o_NAME_KNAME_MAJ_MIN_FSTYPE_MOUNTPOINT_LABEL_UUID_RA_RO_RM_MODEL_SIZE_STATE_OWNER_GROUP_MODE_ALIGNMENT_MIN-IO_OPT-IO_PHY-SEC_LOG-SEC_ROTA_SCHED_RQ-SIZE_TYPE_DISC-ALN_DISC-GRAN_DISC-MAX_DISC-ZERO")
     lscpu = simple_file("insights_commands/lscpu")


### PR DESCRIPTION
delete 'a' and 'R' from the `ls` command, as it may collect unexpected large data