### PR TITLE
Parser doc heading fixes

### DIFF
--- a/insights/parsers/fstab.py
+++ b/insights/parsers/fstab.py
@@ -1,5 +1,5 @@
 """
-fstab - file ``/etc/fstab``
+FSTab - file ``/etc/fstab``
 ===========================
 
 Parse the ``/etc/fstab`` file into a list of lines.  Each line is a dictionary
@@ -52,7 +52,8 @@ Typical content of the ``fstab`` looks like::
 
 Examples:
 
-    >>> fstab = shared[FSTab]
+    >>> type(fstab)
+    <class 'insights.parsers.fstab.FSTab'>
     >>> len(fstab)
     9
     >>> fstab.data[0]['fs_spec'] # Note that data is a list not a dict here

--- a/insights/parsers/installed_rpms.py
+++ b/insights/parsers/installed_rpms.py
@@ -1,11 +1,12 @@
 """
-installed RPMs - Command ``rpm -qa``
-====================================
-The ``InstalledRpms`` class parses the output of the ``rpm -qa`` command.  Each line
-is parsed and stored in an ``InstalledRpm`` object.  The ``rpm -qa`` command may
-output data in different formats and each format can be handled by the parsing
-routines of this class. The basic format of command is the package and is shown
-in the Examples.
+InstalledRpms - Command ``rpm -qa``
+===================================
+
+The ``InstalledRpms`` class parses the output of the ``rpm -qa`` command.
+Each line is parsed and stored in an ``InstalledRpm`` object.  The ``rpm
+-qa`` command may output data in different formats and each format can be
+handled by the parsing routines of this class. The basic format of command is
+the package and is shown in the Examples.
 
 Sample input data::
 
@@ -26,18 +27,8 @@ Sample input data::
 
 
 Examples:
-    >>> from insights.parsers.installed_rpms import InstalledRpms
-    >>> from insights.tests import context_wrap
-    >>> content = '''
-    ... openjpeg-libs-1.3-9.el6_3.x86_64
-    ... openldap-2.4.23-31.el6.x86_64
-    ... openobex-1.4-7.el6.x86_64
-    ... openssh-server-5.3p1-104.el6.x86_64
-    ... openssh-askpass-5.3p1-84.1.el6.x86_64
-    ... openssl-1.0.0-27.el6.x86_64
-    ... '''
-    >>> shared = {InstalledRpms: InstalledRpms(context_wrap(content))}
-    >>> rpms = shared[InstalledRpms]
+    >>> type(rpms)
+    <class 'insights.parsers.installed_rpms.InstalledRpms'>
     >>> 'openjpeg-libs' in rpms
     True
     >>> rpms.corrupt

--- a/insights/parsers/ipaupgrade_log.py
+++ b/insights/parsers/ipaupgrade_log.py
@@ -1,6 +1,7 @@
 """
-IpaupgradeLog - ``/var/log/ipaupgrade.log`` log File for IPA upgrade
-====================================================================
+IpaupgradeLog - file ``/var/log/ipaupgrade.log``
+================================================
+
 This file records the information of IPA server upgrade process while
 executing command ``ipa-server-upgrade``
 """

--- a/insights/parsers/jboss_domain_log.py
+++ b/insights/parsers/jboss_domain_log.py
@@ -1,6 +1,6 @@
 """
 JbossDomainServerLog - file ``$JBOSS_SERVER_LOG_DIR/server.log*``
------------------------------------------------------------------
+=================================================================
 
 Parser for the JBoss Domain Server Log File.
 """

--- a/insights/parsers/jboss_domain_log.py
+++ b/insights/parsers/jboss_domain_log.py
@@ -1,12 +1,8 @@
 """
-JBoss Domain Log Files
-======================
+JbossDomainServerLog - file ``$JBOSS_SERVER_LOG_DIR/server.log*``
+-----------------------------------------------------------------
 
-Parsers provided by this module:
-
-JbossDomainServerLog - JBoss Domain Server Log File ``$JBOSS_SERVER_LOG_DIR/server.log*``
------------------------------------------------------------------------------------------
-
+Parser for the JBoss Domain Server Log File.
 """
 
 from .. import LogFileOutput, parser

--- a/insights/parsers/libkeyutils.py
+++ b/insights/parsers/libkeyutils.py
@@ -2,14 +2,14 @@
 Parsers for detection of Linux/Ebury 1.6 malware indicators
 ===========================================================
 
-Libkeyutils
------------
+Libkeyutils - command ``find -L /lib /lib64 -name 'libkeyutils.so*'``
+---------------------------------------------------------------------
 
 Parses output of command ``find -L /lib /lib64 -name 'libkeyutils.so*'`` to find all potentially
 affected libraries.
 
-LibkeyutilsObjdumps
--------------------
+LibkeyutilsObjdumps - command ``find -L /lib /lib64 -name libkeyutils.so.1 -exec objdump -x "{}" \;``
+-----------------------------------------------------------------------------------------------------
 
 Parses output of command ``find -L /lib /lib64 -name libkeyutils.so.1 -exec objdump -x "{}" \;`` to
 verify linked libraries.

--- a/insights/parsers/nginx_conf.py
+++ b/insights/parsers/nginx_conf.py
@@ -1,11 +1,11 @@
 """
-NginxConf - nginx configuration files
-=====================================
-Parse the keyword-and-value of an Nginx configuration
-file.
+NginxConf - file ``/etc/nginx/nginx.conf`` and other Nginx configuration files
+==============================================================================
 
-Generally, each line is split on the first space into
-key and value, leading and trailing space being ignored.
+Parse the keyword-and-value of an Nginx configuration file.
+
+Generally, each line is split on the first space into key and value, leading
+and trailing space being ignored.
 
 Example nginx.conf file::
 

--- a/insights/parsers/ntp_sources.py
+++ b/insights/parsers/ntp_sources.py
@@ -9,6 +9,18 @@ The parsers here provide information about the time sources used by
 There is also a parser for parsing the output of ``ntpq -c 'rv 0 leap'``
 command to give leap second status.
 
+Parsers in this module are:
+
+ChronycSources - command ``/usr/bin/chronyc sources``
+-----------------------------------------------------
+
+NtpqLeap - command ``/usr/sbin/ntpq -c 'rv 0 leap'``
+----------------------------------------------------
+
+NtpqPn - command ``/usr/sbin/ntpq -pn``
+---------------------------------------
+
+
 """
 
 import re
@@ -93,7 +105,8 @@ class NtpqLeap(Parser):
 @parser(Specs.ntpq_pn)
 class NtpqPn(Parser):
     """
-    Get source and flag for each NTP time source from the output of `ntpq -pn`.
+    Get source and flag for each NTP time source from the output of
+    ``/usr/sbin/ntpq -pn``.
 
     Currently, this only captures the source IP address and the 'flag'
     character in the first column at this stage.  Therefore it will need

--- a/insights/parsers/smbstatus.py
+++ b/insights/parsers/smbstatus.py
@@ -2,8 +2,14 @@
 Samba status commands
 =====================
 
-This module provides processing for the ``smbstatus`` command.
+This module provides processing for the ``smbstatus`` command using the
+following parsers:
 
+SmbstatusS - command ``/usr/bin/smbstatus -S``
+----------------------------------------------
+
+Smbstatusp - command ``/usr/bin/smbstatus -p``
+----------------------------------------------
 """
 
 from .. import parser, Parser, get_active_lines

--- a/insights/parsers/tomcat_xml.py
+++ b/insights/parsers/tomcat_xml.py
@@ -2,10 +2,16 @@
 tomcat_xml - XML files for Tomcat
 =================================
 
-Classes to parse Tomcat XML configuration files.
+Classes to parse Tomcat XML configuration files:
+
+TomcatWebXml - files from ``/etc/tomcat*/web.xml`` and ``/conf/tomcat/tomcat*/web.xml``
+---------------------------------------------------------------------------------------
+
+TomcatServerXml - files from ``(tomcat base directory)/conf/server.xml`` or ``conf/tomcat/tomcat*/server.xml``
+--------------------------------------------------------------------------------------------------------------
 
 .. note::
-    The tomcat XML files are gotten from the directory specified in the java
+    The tomcat XML files are found in the directory specified in the java
     commands
 
 """


### PR DESCRIPTION
Just a few minor fixes to parser documentation headings
* FStab - put class in heading name, remove old shared dictionary
* Installed RPMS - put class in heading name, remove old shared dictionary
* IPA upgrade log - standardise to `parser - file path` format.
* Jboss domain log - standardise to `parser - file path` format.
* Libkeyutils - add contained parsers in subheadings
* NginxConf - add file to heading
* NTP sources - add contained parsers in subheadings
* Samba status - add contained parsers in subheadings
* Tomcat XML files - add contained parsers in subheadings