### PR TITLE
Ease hostname restrictions by filtering blank lines. Fix #1055.

### DIFF
--- a/insights/parsers/hostname.py
+++ b/insights/parsers/hostname.py
@@ -34,6 +34,7 @@ class Hostname(Parser):
         domain: The domain get from the fqdn.
     """
     def parse_content(self, content):
+        content = filter(None, content)
         raw = None
         if len(content) == 1:
             raw = content[0].strip()

--- a/insights/parsers/tests/test_hostname.py
+++ b/insights/parsers/tests/test_hostname.py
@@ -2,7 +2,14 @@ from insights.parsers.hostname import Hostname
 from insights.tests import context_wrap
 
 HOSTNAME = "rhel7.example.com"
+HOSTNAME_MULTILINE = """
+rhel7.example.com
+"""
+
 HOSTNAME_SHORT = "rhel7"
+HOSTNAME_SHORT_MULTILINE = """
+rhel7
+"""
 
 
 def test_hostname():
@@ -12,7 +19,18 @@ def test_hostname():
     assert data.domain == "example.com"
     assert "{0}".format(data) == "<hostname: rhel7, domain: example.com>"
 
+    data = Hostname(context_wrap(HOSTNAME_MULTILINE, strip=False))
+    assert data.fqdn == "rhel7.example.com"
+    assert data.hostname == "rhel7"
+    assert data.domain == "example.com"
+    assert "{0}".format(data) == "<hostname: rhel7, domain: example.com>"
+
     data = Hostname(context_wrap(HOSTNAME_SHORT))
+    assert data.fqdn == "rhel7"
+    assert data.hostname == "rhel7"
+    assert data.domain == ""
+
+    data = Hostname(context_wrap(HOSTNAME_SHORT_MULTILINE, strip=False))
     assert data.fqdn == "rhel7"
     assert data.hostname == "rhel7"
     assert data.domain == ""

--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -77,9 +77,12 @@ def context_wrap(lines,
                  release=DEFAULT_RELEASE,
                  version="-1.-1",
                  machine_id="machine_id",
+                 strip=True,
                  **kwargs):
     if isinstance(lines, basestring):
-        lines = lines.strip().splitlines()
+        if strip:
+            lines = lines.strip()
+        lines = lines.splitlines()
     return Context(content=lines,
                    path=path, hostname=hostname,
                    release=release, version=version.split("."),


### PR DESCRIPTION
sos_commands/general/hostname sometimes contains the hostname with a newline at the end, which results in a file with two lines. The hostname parser specifically checks for one line but doesn't gracefully handle the problem.

I changed it to filter blank lines before parsing.

Also updated context_wrap with an optional parameter to skip whitespace stripping of content before splitting into lines. The strip was hiding this problem in unit tests.