### PR TITLE
Hostname parser raises ParseException on invalid data

### DIFF
--- a/insights/combiners/tests/test_hostname.py
+++ b/insights/combiners/tests/test_hostname.py
@@ -112,6 +112,6 @@ def test_get_all_hostname():
 
 
 def test_hostname_raise():
-    hn = Hostname(context_wrap(""))
     with pytest.raises(Exception):
+        hn = Hostname(context_wrap(""))
         hostname(hn, None, None)

--- a/insights/parsers/hostname.py
+++ b/insights/parsers/hostname.py
@@ -19,6 +19,7 @@ Examples:
 
 """
 
+from . import ParseException
 from .. import Parser, parser
 from insights.specs import Specs
 
@@ -35,9 +36,10 @@ class Hostname(Parser):
     """
     def parse_content(self, content):
         content = filter(None, content)
-        raw = None
-        if len(content) == 1:
-            raw = content[0].strip()
+        if len(content) != 1:
+            msg = "hostname data contains multiple non-empty lines"
+            raise ParseException(msg)
+        raw = content[0].strip()
         self.fqdn = raw
         self.hostname = raw.split(".")[0] if raw else None
         self.domain = ".".join(raw.split(".")[1:]) if raw else None

--- a/insights/parsers/tests/test_hostname.py
+++ b/insights/parsers/tests/test_hostname.py
@@ -1,3 +1,4 @@
+import pytest
 from insights.parsers.hostname import Hostname
 from insights.tests import context_wrap
 
@@ -12,30 +13,36 @@ rhel7
 """
 
 
-def test_hostname():
+def test_full_hostname():
     data = Hostname(context_wrap(HOSTNAME))
     assert data.fqdn == "rhel7.example.com"
     assert data.hostname == "rhel7"
     assert data.domain == "example.com"
     assert "{0}".format(data) == "<hostname: rhel7, domain: example.com>"
 
+
+def test_full_multiline_hostname():
     data = Hostname(context_wrap(HOSTNAME_MULTILINE, strip=False))
     assert data.fqdn == "rhel7.example.com"
     assert data.hostname == "rhel7"
     assert data.domain == "example.com"
     assert "{0}".format(data) == "<hostname: rhel7, domain: example.com>"
 
+
+def test_short_hostname():
     data = Hostname(context_wrap(HOSTNAME_SHORT))
     assert data.fqdn == "rhel7"
     assert data.hostname == "rhel7"
     assert data.domain == ""
 
+
+def test_short_multiline_hostname():
     data = Hostname(context_wrap(HOSTNAME_SHORT_MULTILINE, strip=False))
     assert data.fqdn == "rhel7"
     assert data.hostname == "rhel7"
     assert data.domain == ""
 
-    data = Hostname(context_wrap(""))
-    assert data.fqdn is None
-    assert data.hostname is None
-    assert data.domain is None
+
+def test_empty_hostname():
+    with pytest.raises(Exception):
+        Hostname(context_wrap(""))


### PR DESCRIPTION
Change the `Hostname` parser to raise a `ParseException` if its content has more than one non-empty line. It previously just defaulted its attributes to `None` and fell through. #1113