### PR TITLE
Enhance parser KDumpConf

### DIFF
--- a/insights/parsers/kdump.py
+++ b/insights/parsers/kdump.py
@@ -27,10 +27,10 @@ class KDumpConf(Parser):
     """
     A dictionary like object for the values of the kdump.conf file.
 
-    Attributes::
+    Attributes:
 
         lines (list): raw lines from the file, in order
-        data (dict): a dictionary of options set in the data.
+        data (dict): a dictionary of options set in the data
         comments(list): fully commented lines
         inline_comments(list): lines containing inline comments
         target(tuple): target line parsed as a (x, y) tuple if set, else None
@@ -125,7 +125,7 @@ class KDumpConf(Parser):
         self.data = items
         self.comments = comments
         self.inline_comments = inline_comments
-        self._check_target_conflict()
+        self.target = self._parse_target()
 
     def options(self, module):
         """
@@ -231,7 +231,7 @@ class KDumpConf(Parser):
         return not ('ssh' in self.data or 'net' in self.data or
                     'nfs' in self.data or 'nfs4' in self.data)
 
-    def _check_target_conflict(self):
+    def _parse_target(self):
         """
         More than one dump targets will lead to kudmp service start failure.
         Raise an exception here if more than one target is set here.
@@ -249,8 +249,7 @@ class KDumpConf(Parser):
                     raise ParseException("More than one target is configured.")
                 else:
                     target = (k, v)
-
-        self.target = target
+        return target
 
     def __getitem__(self, key):
         """

--- a/insights/parsers/kdump.py
+++ b/insights/parsers/kdump.py
@@ -237,10 +237,20 @@ class KDumpConf(Parser):
         """
         Return (fs_type, partation) as a tuple if set, else None.
         https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/kernel_administration_guide/kernel_crash_dump_guide#sect-supported-kdump-targets
+        If more than one target is configured, kudmp service fails to start.
         """
-        for t in self.SUPPORTED_FS_TYPES:
-            if t in self.data:
-                return (t, self.data[t])
+        targets = []
+        for fs in self.SUPPORTED_FS_TYPES:
+            if fs in self.data:
+                partation = self.data[fs]
+                if isinstance(partation, list):
+                    raise ParseException("More than one <partition> targets \
+                            are configured for %s type fs." % fs)
+                targets.append((fs, partation))
+        if len(targets) > 1:
+            raise ParseException("More than one <fs type> <partition> type of \
+                    targets are configured.")
+        return targets[0] if targets else None
 
     def __getitem__(self, key):
         """

--- a/insights/parsers/kdump.py
+++ b/insights/parsers/kdump.py
@@ -238,7 +238,7 @@ class KDumpConf(Parser):
         """
         used_targets = (self.is_ssh(), self.is_nfs(),
                         'raw' in self, bool(self.fs_and_partation))
-        if len([v for v in used_targets if v]) > 1:
+        if len(filter(None, used_targets)) > 1:
             raise ParseException("More than one target is configured.")
 
     def __getitem__(self, key):

--- a/insights/parsers/kdump.py
+++ b/insights/parsers/kdump.py
@@ -115,7 +115,18 @@ class KDumpConf(Parser):
         self.data = items
         self.comments = comments
         self.inline_comments = inline_comments
-        self._check_target_conflict()
+
+        def check_target_conflict():
+            """
+            More than one dump targets will lead to kudmp service start failure.
+            So raise an exception here if more than one target is set here.
+            """
+            used_targets = (self.is_ssh(), self.is_nfs(),
+                            'raw' in self, bool(self.fs_and_partation))
+            if len(filter(None, used_targets)) > 1:
+                raise ParseException("More than one target is configured.")
+
+        check_target_conflict()
 
     def options(self, module):
         """
@@ -230,16 +241,6 @@ class KDumpConf(Parser):
         for t in self.SUPPORTED_FS_TYPES:
             if t in self.data:
                 return (t, self.data[t])
-
-    def _check_target_conflict(self):
-        """
-        More than one dump targets will lead to kudmp service start failure.
-        So raise an exception here if more than one target is set here.
-        """
-        used_targets = (self.is_ssh(), self.is_nfs(),
-                        'raw' in self, bool(self.fs_and_partation))
-        if len(filter(None, used_targets)) > 1:
-            raise ParseException("More than one target is configured.")
 
     def __getitem__(self, key):
         """

--- a/insights/parsers/tests/test_kdump.py
+++ b/insights/parsers/tests/test_kdump.py
@@ -190,13 +190,32 @@ def test_fs_partation():
     assert kd['path'] == '/usr/local/cores'
 
 
-KDUMP_TARGET_CONFLICT = """
+KDUMP_TARGET_CONFLICT_1 = """
 net user@raw.server.com
 raw /dev/sda5
 """
 
+KDUMP_TARGET_CONFLICT_2 = """
+ext4 /dev/sdb1
+ext3 UUID=f15759be-89d4-46c4-9e1d-1b67e5b5da82
+"""
 
-def test_target_excptions():
+KDUMP_TARGET_CONFLICT_3 = """
+ext4 /dev/sdb1
+ext4 UUID=f15759be-89d4-46c4-9e1d-1b67e5b5da82
+"""
+
+
+def test_conflict_targets_excptions():
     with pytest.raises(ParseException) as e_info:
-        kdump.KDumpConf(context_wrap(KDUMP_TARGET_CONFLICT))
+        kdump.KDumpConf(context_wrap(KDUMP_TARGET_CONFLICT_1))
         assert "More than one target is configured" in str(e_info.value)
+
+    with pytest.raises(ParseException) as e_info:
+        kdump.KDumpConf(context_wrap(KDUMP_TARGET_CONFLICT_2))
+        assert "More than one <fs type> <partition> type" in str(e_info.value)
+
+    with pytest.raises(ParseException) as e_info:
+        kdump.KDumpConf(context_wrap(KDUMP_TARGET_CONFLICT_3))
+        assert "More than one <partition> targets" in str(e_info.value)
+        assert "ext4" in str(e_info.value)


### PR DESCRIPTION
  Fix the wrong logic of 'using_local_disk' property.
  Add two more properties to KDumpConf.
  Adjust the test-cases.