### PR TITLE
Update unordered_compare to use keys() to traverse AttributeDicts correctly

### DIFF
--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -42,7 +42,7 @@ def unordered_compare(result, expected):
             unordered_compare(left_item, right_item)
     elif isinstance(result, dict):
         assert len(result) == len(expected)
-        for item_key in result:
+        for item_key in result.keys():
             unordered_compare(result[item_key], expected[item_key])
     else:
         assert result == expected


### PR DESCRIPTION
AttributeDicts implement `__iter__` as if it were `iteritems`, which causes problems in iterators over dictionaries that expect it to simply iterate through the keys.