### PR TITLE
Update AttributeDict

### DIFF
--- a/insights/combiners/grub_conf.py
+++ b/insights/combiners/grub_conf.py
@@ -103,7 +103,7 @@ class GrubConf(object):
                 None by default.
 
         Returns:
-            A list of :class:`insights.core.AttributeDict` objects for each
+            A list of `insights.parsers.grub_conf.BootEntry` objects for each
             boot entry in which the `cmdline` contains the `search_text`.
         """
         if search_text is None:

--- a/insights/combiners/grub_conf.py
+++ b/insights/combiners/grub_conf.py
@@ -103,8 +103,8 @@ class GrubConf(object):
                 None by default.
 
         Returns:
-            A list of `insights.parsers.grub_conf.BootEntry` objects for each
-            boot entry in which the `cmdline` contains the `search_text`.
+            A list of :class:`insights.parsers.grub_conf.BootEntry` objects for
+            each boot entry in which the `cmdline` contains the `search_text`.
         """
         if search_text is None:
             return [entry for entry in self.grub.boot_entries]

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -1289,7 +1289,10 @@ class FileListing(Parser):
 
 class AttributeDict(dict):
     """
-    Class to convert the access to the keys in ``attrs`` dictionary as attributes.
+    Class to convert the access to each item in a dict as attribute.
+
+    .. warning::
+        Deprecated class, please set attributes explicitly.
 
     Examples:
         >>> data = {
@@ -1297,52 +1300,23 @@ class AttributeDict(dict):
         ... "fact2":"fact 2"
         ... "fact3":"fact 3"
         ... }
-        >>> d_obj = AttributeDict(data, attrs={'fact0': 'fact 0', 'fact1': ''})
-        {'fact0': 'fact 0', fact1': 'fact 1', 'fact2': 'fact 2', 'fact3': 'fact 3'}
-        >>> d_obj.fact0             # There is such an attribute: 'fact0'
-        'fact 0'
-        >>> 'fact0' in d_obj        # But 'fact0' is not in the dictionary
-        False
-        >>> d_obj.get('fact0')
-        None
-        >>> d_obj.fact1             # There is such an attribute: 'fact1'
-        'fact 1'
-        >>> 'fact1' in d_obj        # And 'fact1' is in the dictionary
-        True
+        >>> d_obj = AttributeDict(data)
+        {'fact1': 'fact 1', 'fact2': 'fact 2', 'fact3': 'fact 3'}
         >>> d_obj['fact1']
         'fact 1'
-        >>> hasattr(d_obj, 'fact2') # No such attribute 'fact2'
-        False
-        >>> 'fact2' in d_obj        # But 'fact2' is in the dictionary
+        >>> d_obj.get('fact1')
+        'fact 1'
+        >>> d_obj.fact1
+        'fact 1'
+        >>> 'fact2' in d_obj
         True
-        >>> d_obj['fact2']
-        'fact 2'
-
-    Arguments:
-        data (dict): The base dictionary will work on
-        attrs (dict): The key-value pairs that will be fixed as attributes.
-            The key is the attribute and the value is the default value of the
-            attribute when there is no such key in ``data``.
-
-    Raises:
-        ValueError: When no or an empty ``attrs`` is passed
-
+        >>> d_obj.get('fact3', default='no fact')
+        'fact 3'
+        >>> d_obj.get('fact4', default='no fact')
+        'no fact'
     """
 
-    def __init__(self, data={}, attrs={}):
-        if not attrs:
-            raise ValueError("Argument 'attrs' must be specified as a dict and cannot be empty.")
-
-        for k, v in attrs.items():
-            setattr(self, k, data.get(k, v))
-
-        super(AttributeDict, self).__init__(data)
-
-    def __iter__(self):
-        """
-        .. warning::
-            Deprecated method, please use `items()`
-        """
-        deprecated(AttributeDict.__iter__, "Please use 'items()'.")
-        for k, v in self.__dict__.items():
-            yield k, v
+    def __init__(self, *args, **kwargs):
+        deprecated(AttributeDict, "Please set attributes explicitly.")
+        super(AttributeDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -1296,7 +1296,7 @@ class AttributeDict(dict):
         ... "fact2":"fact 2"
         ... "fact3":"fact 3"
         ... }
-        >>> d_obj = AttributeDict(data=data, attrs={'fact0': 'fact 0', 'fact1': ''})
+        >>> d_obj = AttributeDict(data, attrs={'fact0': 'fact 0', 'fact1': ''})
         {'fact0': 'fact 0', fact1': 'fact 1', 'fact2': 'fact 2', 'fact3': 'fact 3'}
         >>> d_obj.fact0             # There is such an attribute: 'fact0'
         'fact 0'

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -1288,8 +1288,7 @@ class FileListing(Parser):
 
 class AttributeDict(dict):
     """
-    Class to convert the access to the keys in ``fixed_attrs`` dictionary as
-    attributes.
+    Class to convert the access to the keys in ``attrs`` dictionary as attributes.
 
     Examples:
         >>> data = {
@@ -1297,52 +1296,46 @@ class AttributeDict(dict):
         ... "fact2":"fact 2"
         ... "fact3":"fact 3"
         ... }
-        >>> d_obj = AttributeDict(data, fixed_attrs={'fact0': 'fact 0', 'fact1': ''})
+        >>> d_obj = AttributeDict(data=data, attrs={'fact0': 'fact 0', 'fact1': ''})
         {'fact0': 'fact 0', fact1': 'fact 1', 'fact2': 'fact 2', 'fact3': 'fact 3'}
-        >>> 'fact0' in d_obj
-        True
-        >>> d_obj['fact0']
+        >>> d_obj.fact0             # There is such an attribute: 'fact0'
         'fact 0'
-        >>> d_obj.get('fact1')
-        'fact 1'
-        >>> d_obj.fact0
-        'fact 0'
-        >>> d_obj.fact1
-        'fact 1'
-        >>> 'fact2' in d_obj
-        True
-        >>> hasattr(d_obj, 'fact2')
+        >>> 'fact0' in d_obj        # But 'fact0' is not in the dictionary
         False
+        >>> d_obj.get('fact0')
+        None
+        >>> d_obj.fact1             # There is such an attribute: 'fact1'
+        'fact 1'
+        >>> 'fact1' in d_obj        # And 'fact1' is in the dictionary
+        True
+        >>> d_obj['fact1']
+        'fact 1'
+        >>> hasattr(d_obj, 'fact2') # No such attribute 'fact2'
+        False
+        >>> 'fact2' in d_obj        # But 'fact2' is in the dictionary
+        True
+        >>> d_obj['fact2']
+        'fact 2'
 
     Arguments:
-        (dict): The base dictionary will work on
-        fixed_attrs (dict): The fixed keys should be specified in this directory
-            with the values in type :class:`type_info`
+        data (dict): The base dictionary will work on
+        attrs (dict): The key-value pairs that will be fixed as attributes.
+            The key is the attribute and the value is the default value of the
+            attribute when there is no such key in ``data``.
 
     Raises:
-        TypeError: When more than one directories are passed
-        ValueError: When no or an empty 'fixed_attrs' is passed
+        ValueError: When no or an empty ``attrs`` is passed
 
     """
-    type_info = namedtuple('type_info', field_names=['type', 'default'])
-    """namedtuple: Type for the values of the ``fixed_attrs`` dictionary"""
-    def __init__(self, *args, **kwargs):
-        if len(args) > 1:
-            raise TypeError(
-                "AttributeDict takes at most 1 argument ({n} given)".format(
-                    n=len(args)
-                )
-            )
 
-        fixed_attrs = kwargs.pop('fixed_attrs', {})
-        if not fixed_attrs:
-            raise ValueError("The 'fixed_attrs' must be specified")
+    def __init__(self, data={}, attrs={}):
+        if not attrs:
+            raise ValueError("Argument 'attrs' must be specified as a dict and cannot be empty.")
 
-        data = args[0] if args else {}
-        for k, v in fixed_attrs.items():
+        for k, v in attrs.items():
             setattr(self, k, data.get(k, v))
 
-        super(AttributeDict, self).__init__(*args, **kwargs)
+        super(AttributeDict, self).__init__(data)
 
     def __iter__(self):
         """

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -11,7 +11,6 @@ from insights.contrib.ConfigParser import RawConfigParser
 
 from insights.parsers import ParseException
 from insights.core.serde import deserializer, serializer
-from insights.util import deprecated
 
 import sys
 # Since XPath expression is not supported by the ElementTree in Python 2.6,
@@ -1286,7 +1285,7 @@ class FileListing(Parser):
         return self.listings[directory]['raw_list']
 
 
-class AttributeDict(LegacyItemAccess):
+class AttributeDict(dict):
     """
     Class to convert the access to the item listed in ``fixed_attrs`` as
     attribute.
@@ -1297,7 +1296,7 @@ class AttributeDict(LegacyItemAccess):
         ... "fact2":"fact 2"
         ... "fact3":"fact 3"
         ... }
-        >>> d = AttributeDict(data, fixed_attrs={'fact0': 'fact 0', 'fact1': ''})
+        >>> d_obj = AttributeDict(data, fixed_attrs={'fact0': 'fact 0', 'fact1': ''})
         {'fact0': 'fact 0', fact1': 'fact 1', 'fact2': 'fact 2', 'fact3': 'fact 3'}
         >>> 'fact0' in d_obj
         True
@@ -1319,22 +1318,11 @@ class AttributeDict(LegacyItemAccess):
     """
     type_info = namedtuple('type_info', field_names=['type', 'default'])
     """namedtuple: Type for the ``fixed_attrs``"""
-    def __init__(self, data, fixed_attrs={}):
-        self.data = data
+    def __init__(self, *args, **kwargs):
+        data = args[0]
+        fixed_attrs = kwargs.pop('fixed_attrs', {})
         for k, v in fixed_attrs.items():
             if k not in data:
                 data[k] = v
             setattr(self, k, data.get(k))
-
-    def iteritems(self):
-        """
-        .. warning::
-            Deprecated method, please use :func:`__iter__` instead.
-        """
-        deprecated(AttributeDict.iteritems, "Please use `__iter__`.")
-        for k, v in self.data.items():
-            yield k, v
-
-    def __iter__(self):
-        for k in self.data:
-            yield k
+        super(AttributeDict, self).__init__(*args, **kwargs)

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -1328,7 +1328,11 @@ class AttributeDict(dict):
     """namedtuple: Type for the values of the ``fixed_attrs`` dictionary"""
     def __init__(self, *args, **kwargs):
         if len(args) > 1:
-            raise TypeError("AttributeDict takes at most 1 argument ({} given)".format(len(args)))
+            raise TypeError(
+                "AttributeDict takes at most 1 argument ({n} given)".format(
+                    n=len(args)
+                )
+            )
 
         fixed_attrs = kwargs.pop('fixed_attrs', {})
         if not fixed_attrs:

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -1288,8 +1288,8 @@ class FileListing(Parser):
 
 class AttributeDict(dict):
     """
-    Class to convert the access to the item listed in ``fixed_attrs`` as
-    attribute.
+    Class to convert the access to the keys in ``fixed_attrs`` dictionary as
+    attributes.
 
     Examples:
         >>> data = {
@@ -1314,18 +1314,32 @@ class AttributeDict(dict):
         >>> hasattr(d_obj, 'fact2')
         False
 
-    Attributes:
-        data (dict): All required specific properties can be included in data
+    Arguments:
+        (dict): The base dictionary will work on
+        fixed_attrs (dict): The fixed keys should be specified in this directory
+            with the values in type :class:`type_info`
+
+    Raises:
+        TypeError: When more than one directories are passed
+        ValueError: When no or an empty 'fixed_attrs' is passed
+
     """
     type_info = namedtuple('type_info', field_names=['type', 'default'])
-    """namedtuple: Type for the ``fixed_attrs``"""
+    """namedtuple: Type for the values of the ``fixed_attrs`` dictionary"""
     def __init__(self, *args, **kwargs):
-        data = args[0]
+        if len(args) > 1:
+            raise TypeError("AttributeDict takes at most 1 argument ({} given)".format(len(args)))
+
         fixed_attrs = kwargs.pop('fixed_attrs', {})
+        if not fixed_attrs:
+            raise ValueError("The 'fixed_attrs' must be specified")
+
+        data = args[0] if args else {}
         for k, v in fixed_attrs.items():
             if k not in data:
                 data[k] = v
             setattr(self, k, data.get(k))
+
         super(AttributeDict, self).__init__(*args, **kwargs)
 
     def __iter__(self):

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -7,6 +7,7 @@ import re
 import shlex
 import yaml
 import six
+
 from insights.contrib.ConfigParser import RawConfigParser
 
 from insights.parsers import ParseException

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -11,6 +11,7 @@ from insights.contrib.ConfigParser import RawConfigParser
 
 from insights.parsers import ParseException
 from insights.core.serde import deserializer, serializer
+from insights.util import deprecated
 
 import sys
 # Since XPath expression is not supported by the ElementTree in Python 2.6,
@@ -1326,3 +1327,12 @@ class AttributeDict(dict):
                 data[k] = v
             setattr(self, k, data.get(k))
         super(AttributeDict, self).__init__(*args, **kwargs)
+
+    def __iter__(self):
+        """
+        .. warning::
+            Deprecated method, please use `items()`
+        """
+        deprecated(AttributeDict.__iter__, "Please use 'items()'.")
+        for k, v in self.__dict__.items():
+            yield k, v

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -1340,9 +1340,7 @@ class AttributeDict(dict):
 
         data = args[0] if args else {}
         for k, v in fixed_attrs.items():
-            if k not in data:
-                data[k] = v
-            setattr(self, k, data.get(k))
+            setattr(self, k, data.get(k, v))
 
         super(AttributeDict, self).__init__(*args, **kwargs)
 

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -7,7 +7,6 @@ import re
 import shlex
 import yaml
 import six
-
 from insights.contrib.ConfigParser import RawConfigParser
 
 from insights.parsers import ParseException

--- a/insights/parsers/fstab.py
+++ b/insights/parsers/fstab.py
@@ -37,9 +37,8 @@ This data, as above, is available in the ``data`` property:
 * ``noquota`` - Disk quotas are enforced or not
 
 For instance, the option ``rw`` in ``rw,dmode=0500`` may be accessed as
-``mnt_row_info.rw`` with the value ``True``, but the ``dmode`` can only be
-accessed as ``mnt_row_info.get('dmode')`` or ``mnt_row_info['dmode']`` with the
-value ``0500``.
+``mnt_row_info.rw`` with the value ``True``, and the ``dmode`` can be accessed
+as ``mnt_row_info.dmode`` with the value ``0500``.
 
 The :class:`FSTabEntry` for each mount point is also available via the
 :attr:`FSTab.mounted_on` property; the data is the same as that stored in the

--- a/insights/parsers/fstab.py
+++ b/insights/parsers/fstab.py
@@ -106,7 +106,6 @@ class FSTabEntry(AttributeDict):
         'fs_passno': AttributeDict.type_info(int, 0),
         'raw': AttributeDict.type_info(str, ''),
     }
-    """fixed_attrs (dict): The fixed attributes for FSTabEntry."""
 
     def __init__(self, data):
         super(FSTabEntry, self).__init__(data, fixed_attrs=FSTabEntry.fixed_attrs)

--- a/insights/parsers/fstab.py
+++ b/insights/parsers/fstab.py
@@ -22,7 +22,7 @@ option's value set to True so it can be conveniently searched.
 
 This data, as above, is available in the ``data`` property:
 
-* As wrapped as an FSTabEntry, each column can also be accessed as a property
+* As wrapped as an :class:`FSTabEntry`, each column can also be accessed as a property
   with the same name.
 * The mount options are a dictionary object with keys corresponding to the
   common mount options.
@@ -84,7 +84,7 @@ FS_HEADINGS = "fs_spec                               fs_file                 fs_
 class FSTabEntry(AttributeDict):
     """
     An object representing an entry in ``/etc/fstab``.  Each entry is a
-    :class:`insights.core.AttributeDict` object with below fixed properties:
+    :class:`insights.core.AttributeDict` object with below fixed attributes:
 
     Attributes:
         fs_spec (str): the device to mount
@@ -106,6 +106,7 @@ class FSTabEntry(AttributeDict):
         'fs_passno': AttributeDict.type_info(int, 0),
         'raw': AttributeDict.type_info(str, ''),
     }
+    """fixed_attrs (dict): The fixed attributes for FSTabEntry."""
 
     def __init__(self, data):
         super(FSTabEntry, self).__init__(data, fixed_attrs=FSTabEntry.fixed_attrs)
@@ -125,9 +126,8 @@ class FSTab(Parser):
         >>>         print fs.raw
 
     Attributes:
-        data (list): a list of parsed fstab entries as FSTabEntry objects.
-        mounted_on (dict): a dictionary of FSTabEntry objects keyed on mount
-            point.
+        data (list): a list of parsed fstab entries as :class:`FSTabEntry` objects.
+        mounted_on (dict): a dictionary of :class:`FSTabEntry` objects keyed on mount point.
     """
 
     def __len__(self):

--- a/insights/parsers/fstab.py
+++ b/insights/parsers/fstab.py
@@ -89,7 +89,7 @@ Examples:
 """
 
 
-from .. import Parser, parser, get_active_lines, AttributeDict
+from .. import Parser, parser, get_active_lines, LegacyItemAccess
 from ..parsers import optlist_to_dict, parse_delimited_table, keyword_search
 from ..parsers.mount import MountOpts
 from insights.specs import Specs
@@ -97,10 +97,10 @@ from insights.specs import Specs
 FS_HEADINGS = "fs_spec                               fs_file                 fs_vfstype raw_fs_mntops    fs_freq fs_passno"
 
 
-class FSTabEntry(AttributeDict):
+class FSTabEntry(LegacyItemAccess):
     """
-    An object representing an entry in ``/etc/fstab``.  Each entry is a
-    :class:`insights.core.AttributeDict` object with below fixed attributes:
+    An object representing an entry in ``/etc/fstab``.  Each entry contains
+    below fixed attributes:
 
     Attributes:
         fs_spec (str): the device to mount
@@ -124,7 +124,20 @@ class FSTabEntry(AttributeDict):
     }
 
     def __init__(self, data={}):
-        super(FSTabEntry, self).__init__(data, attrs=FSTabEntry.attrs)
+        self.data = data
+        for k, v in FSTabEntry.attrs.items():
+            if k not in data:
+                setattr(self, k, v)
+        for k, v in data.items():
+            setattr(self, k, v)
+
+    def items(self):
+        """
+        To keep backward compatibility and let it can be iterated as a
+        dictionary.
+        """
+        for k, v in self.data.items():
+            yield k, v
 
 
 @parser(Specs.fstab)

--- a/insights/parsers/fstab.py
+++ b/insights/parsers/fstab.py
@@ -22,10 +22,10 @@ option's value set to True so it can be conveniently searched.
 
 This data, as above, is available in the ``data`` property:
 
-* As wrapped as an :class:`FSTabEntry`, each column can also be accessed as a
+* Wrapped as an :class:`FSTabEntry`, each column can also be accessed as a
   property with the same name.
-* The `` fs_mntops`` is wrpped as a :class:`insights.parsers.mount.MountOpts`
-  object contains below fixed attributes:
+* The ``fs_mntops`` is wrapped as a :class:`insights.parsers.mount.MountOpts`
+  which contains below fixed attributes:
 
 * ``rw`` - Read write
 * ``ro`` - Read only
@@ -112,19 +112,19 @@ class FSTabEntry(AttributeDict):
         fs_passno (int): check the filesystem on reboot in this pass number
         raw (str): the RAW line which is useful to front-end
     """
-    fixed_attrs = {
-        'fs_spec': AttributeDict.type_info(str, ''),
-        'fs_file': AttributeDict.type_info(str, ''),
-        'fs_vfstype': AttributeDict.type_info(str, ''),
-        'raw_fs_mntops': AttributeDict.type_info(str, ''),
-        'fs_mntops': AttributeDict.type_info(MountOpts, MountOpts({})),
-        'fs_freq': AttributeDict.type_info(int, 0),
-        'fs_passno': AttributeDict.type_info(int, 0),
-        'raw': AttributeDict.type_info(str, ''),
+    attrs = {
+        'fs_spec': '',
+        'fs_file': '',
+        'fs_vfstype': '',
+        'raw_fs_mntops': '',
+        'fs_mntops': MountOpts(),
+        'fs_freq': 0,
+        'fs_passno': 0,
+        'raw': '',
     }
 
-    def __init__(self, data):
-        super(FSTabEntry, self).__init__(data, fixed_attrs=FSTabEntry.fixed_attrs)
+    def __init__(self, data={}):
+        super(FSTabEntry, self).__init__(data, attrs=FSTabEntry.attrs)
 
 
 @parser(Specs.fstab)

--- a/insights/parsers/grub_conf.py
+++ b/insights/parsers/grub_conf.py
@@ -73,8 +73,8 @@ GRUB_INITRDS = 'grub_initrds'
 class BootEntry(AttributeDict):
     """
     An object representing an entry in the output of ``mount`` command.  Each
-    entry is a :class:`insights.core.AttributeDict` object with below
-    properties:
+    entry is a :class:`insights.core.AttributeDict` object with below fixed
+    attributes:
 
     Attributes:
         name (str): Name of the boot entry

--- a/insights/parsers/grub_conf.py
+++ b/insights/parsers/grub_conf.py
@@ -85,7 +85,7 @@ class BootEntry(AttributeDict):
             'cmdline': '',
     }
 
-    def __init__(self, data):
+    def __init__(self, data={}):
         super(BootEntry, self).__init__(data, attrs=BootEntry.attrs)
 
 

--- a/insights/parsers/grub_conf.py
+++ b/insights/parsers/grub_conf.py
@@ -70,7 +70,7 @@ GRUB_KERNELS = 'grub_kernels'
 GRUB_INITRDS = 'grub_initrds'
 
 
-class BootEntry(object):
+class BootEntry(LegacyItemAccess):
     """
     An object representing an entry in the output of ``mount`` command.  Each
     entry contains below fixed attributes:
@@ -79,17 +79,18 @@ class BootEntry(object):
         name (str): Name of the boot entry
         cmdline (str): Cmdline of the boot entry
     """
-    attrs = {
-            'name': '',
-            'cmdline': '',
-    }
-
     def __init__(self, data={}):
-        for k, v in BootEntry.attrs.items():
-            if k not in data:
-                setattr(self, k, v)
+        self.data = data
         for k, v in data.items():
             setattr(self, k, v)
+
+    def items(self):
+        """
+        To keep backward compatibility and let it can be iterated as a
+        dictionary.
+        """
+        for k, v in self.data.items():
+            yield k, v
 
 
 class GrubConfig(LegacyItemAccess, Parser):

--- a/insights/parsers/grub_conf.py
+++ b/insights/parsers/grub_conf.py
@@ -147,7 +147,6 @@ class GrubConfig(LegacyItemAccess, Parser):
             self.data.pop('configs')
 
         for line_full in self.data.get('title', []) + self.data.get('menuentry', []):
-            entry = []
             for name, line in line_full:
                 if name == 'menuentry_name' or name == 'title_name':
                     entry = {}

--- a/insights/parsers/grub_conf.py
+++ b/insights/parsers/grub_conf.py
@@ -80,13 +80,13 @@ class BootEntry(AttributeDict):
         name (str): Name of the boot entry
         cmdline (str): Cmdline of the boot entry
     """
-    fixed_attrs = {
-            'name': AttributeDict.type_info(str, ''),
-            'cmdline': AttributeDict.type_info(str, ''),
+    attrs = {
+            'name': '',
+            'cmdline': '',
     }
 
     def __init__(self, data):
-        super(BootEntry, self).__init__(data, fixed_attrs=BootEntry.fixed_attrs)
+        super(BootEntry, self).__init__(data, attrs=BootEntry.attrs)
 
 
 class GrubConfig(LegacyItemAccess, Parser):

--- a/insights/parsers/grub_conf.py
+++ b/insights/parsers/grub_conf.py
@@ -62,7 +62,7 @@ Grub2EFIConfig - file ``/boot/efi/EFI/redhat/grub.cfg``
 -------------------------------------------------------
 """
 
-from .. import Parser, parser, get_active_lines, defaults, LegacyItemAccess, AttributeDict
+from .. import Parser, parser, get_active_lines, defaults, LegacyItemAccess
 from insights.specs import Specs
 
 IOMMU = "intel_iommu=on"
@@ -70,11 +70,10 @@ GRUB_KERNELS = 'grub_kernels'
 GRUB_INITRDS = 'grub_initrds'
 
 
-class BootEntry(AttributeDict):
+class BootEntry(object):
     """
     An object representing an entry in the output of ``mount`` command.  Each
-    entry is a :class:`insights.core.AttributeDict` object with below fixed
-    attributes:
+    entry contains below fixed attributes:
 
     Attributes:
         name (str): Name of the boot entry
@@ -86,7 +85,11 @@ class BootEntry(AttributeDict):
     }
 
     def __init__(self, data={}):
-        super(BootEntry, self).__init__(data, attrs=BootEntry.attrs)
+        for k, v in BootEntry.attrs.items():
+            if k not in data:
+                setattr(self, k, v)
+        for k, v in data.items():
+            setattr(self, k, v)
 
 
 class GrubConfig(LegacyItemAccess, Parser):

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -21,8 +21,8 @@ are listed in the same order as in the command output:
  * ``mount_label`` - Only present if optional label is present
  * ``mount_clause`` - Full string from command output
 
-The `` mount_options`` is stored as a :class:`MountOpts` object contains below
-fixed attributes:
+The ``mount_options`` is wrapped as a :class:`MountOpts` object which contains
+below fixed attributes:
 
 * ``rw`` - Read write
 * ``ro`` - Read only
@@ -94,19 +94,19 @@ class MountOpts(AttributeDict):
         inode64 (bool): "inode64" is enabled or not
         noquota (bool): Disk quotas are enforced or not
     """
-    fixed_attrs = {
-        'rw': AttributeDict.type_info(bool, False),
-        'ro': AttributeDict.type_info(bool, False),
-        'defaults': AttributeDict.type_info(bool, False),
-        'relatime': AttributeDict.type_info(bool, False),
-        'seclabel': AttributeDict.type_info(bool, False),
-        'attr2': AttributeDict.type_info(bool, False),
-        'inode64': AttributeDict.type_info(bool, False),
-        'noquota': AttributeDict.type_info(bool, False)
+    attrs = {
+        'rw': False,
+        'ro': False,
+        'defaults': False,
+        'relatime': False,
+        'seclabel': False,
+        'attr2': False,
+        'inode64': False,
+        'noquota': False
     }
 
-    def __init__(self, data):
-        super(MountOpts, self).__init__(data, fixed_attrs=MountOpts.fixed_attrs)
+    def __init__(self, data={}):
+        super(MountOpts, self).__init__(data, attrs=MountOpts.attrs)
 
 
 class MountEntry(AttributeDict):
@@ -122,16 +122,16 @@ class MountEntry(AttributeDict):
         mount_type (str): Name of filesystem type
         mount_options (MountOpts): Mount options as a :class:`insights.parsers.mount.MountOpts` object
     """
-    fixed_attrs = {
-            'mount_clause': AttributeDict.type_info(str, ''),
-            'filesystem': AttributeDict.type_info(str, ''),
-            'mount_point': AttributeDict.type_info(str, ''),
-            'mount_type': AttributeDict.type_info(str, ''),
-            'mount_options': AttributeDict.type_info(MountOpts, MountOpts({})),
+    attrs = {
+            'mount_clause': '',
+            'filesystem': '',
+            'mount_point': '',
+            'mount_type': '',
+            'mount_options': MountOpts(),
     }
 
-    def __init__(self, data):
-        super(MountEntry, self).__init__(data, fixed_attrs=MountEntry.fixed_attrs)
+    def __init__(self, data={}):
+        super(MountEntry, self).__init__(data, attrs=MountEntry.attrs)
 
 
 @parser(Specs.mount)

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -10,8 +10,8 @@ implements parsing for the ``mount`` command output which looks like::
     /dev/mapper/HostVG-Config on /etc/shadow type ext4 (rw,noatime,seclabel,stripe=256,data=ordered)
     dev/sr0 on /run/media/root/VMware Tools type iso9660 (ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2) [VMware Tools]
 
-The information is stored as a list of ``MountEntry`` objects.  Each
-``MountEntry`` object contains attributes for the following information that
+The information is stored as a list of :class:`MountEntry` objects.  Each
+`:class:`MountEntry` object contains attributes for the following information that
 are listed in the same order as in the command output::
 
     - filesystem: (str) Name of filesystem
@@ -31,7 +31,6 @@ MountEntry lines are also available in a ``mounts`` property, keyed on the
 mount point.
 
 Examples:
-    >>> mnt_info = shared[Mount]
     >>> mnt_info
     <insights.parsers.mount.Mount at 0x7fd4a7d3bbd0>
     >>> len(mnt_info)
@@ -95,7 +94,7 @@ class Mount(Parser):
     """Class of information for all output from ``mount`` command.
 
     Attributes:
-        rows (list of MountEntry): List of `MountEntry` objects for
+        rows (list of MountEntry): List of :class:`MountEntry` objects for
             each row of the command output.
 
     Raises:

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -67,8 +67,8 @@ from .. import Parser, parser, get_active_lines, AttributeDict
 class MountEntry(AttributeDict):
     """
     An object representing an entry in the output of ``mount`` command.  Each
-    entry is a :class:`insights.core.AttributeDict` object with below
-    properties:
+    entry is a :class:`insights.core.AttributeDict` object with below fixed
+    attributes:
 
     Attributes:
         mount_clause (str): Full string from command output

--- a/insights/parsers/proc_limits.py
+++ b/insights/parsers/proc_limits.py
@@ -17,7 +17,7 @@ HEADER_SUBSTITUTE = [('Soft Limit', 'Soft_Limit'), ('Hard Limit', 'Hard_Limit')]
 class Limits(AttributeDict):
     """
     An object representing a line in the ``/proc/limits``.  Each entry is a
-    :class:`insights.core.AttributeDict` object with below properties:
+    :class:`insights.core.AttributeDict` object with below fixed attributes:
 
     Attributes:
         hard_limit(str): Hard limit

--- a/insights/parsers/proc_limits.py
+++ b/insights/parsers/proc_limits.py
@@ -7,17 +7,17 @@ directory.
 
 """
 
-from .. import Parser, parser, AttributeDict
+from .. import Parser, parser
 from ..parsers import parse_fixed_table, ParseException
 from insights.specs import Specs
 
 HEADER_SUBSTITUTE = [('Soft Limit', 'Soft_Limit'), ('Hard Limit', 'Hard_Limit')]
 
 
-class Limits(AttributeDict):
+class Limits(object):
     """
-    An object representing a line in the ``/proc/limits``.  Each entry is a
-    :class:`insights.core.AttributeDict` object with below fixed attributes:
+    An object representing a line in the ``/proc/limits``.  Each entry contains
+    below fixed attributes:
 
     Attributes:
         hard_limit(str): Hard limit
@@ -31,7 +31,11 @@ class Limits(AttributeDict):
     }
 
     def __init__(self, data={}):
-        super(Limits, self).__init__(data, attrs=Limits.attrs)
+        for k, v in Limits.attrs.items():
+            if k not in data:
+                setattr(self, k, v)
+        for k, v in data.items():
+            setattr(self, k, v)
 
 
 class ProcLimits(Parser):

--- a/insights/parsers/proc_limits.py
+++ b/insights/parsers/proc_limits.py
@@ -24,14 +24,14 @@ class Limits(AttributeDict):
         soft_limit(str): Soft limit
         units(str): Unit of the limit value
     """
-    fixed_attrs = {
-            'hard_limit': AttributeDict.type_info(str, ''),
-            'soft_limit': AttributeDict.type_info(str, ''),
-            'units': AttributeDict.type_info(str, ''),
+    attrs = {
+            'hard_limit': '',
+            'soft_limit': '',
+            'units': ''
     }
 
     def __init__(self, data):
-        super(Limits, self).__init__(data, fixed_attrs=Limits.fixed_attrs)
+        super(Limits, self).__init__(data, attrs=Limits.attrs)
 
 
 class ProcLimits(Parser):

--- a/insights/parsers/proc_limits.py
+++ b/insights/parsers/proc_limits.py
@@ -7,11 +7,21 @@ directory.
 
 """
 
-from .. import Parser, parser, AttributeDict
+from collections import namedtuple
+from .. import Parser, parser
 from ..parsers import parse_fixed_table, ParseException
 from insights.specs import Specs
 
 HEADER_SUBSTITUTE = [('Soft Limit', 'Soft_Limit'), ('Hard Limit', 'Hard_Limit')]
+
+ProcLimit = namedtuple(
+        'ProcLimit',
+        field_names=['hard_limit', 'soft_limit', 'units']
+)
+"""
+namedtuple: Type for storing the corresponding limits: ``hard_limit``,
+            ``soft_limit`` and ``units``.
+"""
 
 
 class ProcLimits(Parser):
@@ -31,8 +41,8 @@ class ProcLimits(Parser):
     is converted to lowercase and joined the words with underline '_'.  If not
     sure about whether an attribute is exist or not, check it via the
     '__contains__' method before fetching it.
-    The attribute value is set to a :py:class:`insights.core.AttributeDict`
-    which wraps the corresponding ``hard_limit``, ``soft_limit`` and ``units``.
+    The attribute value is set to a `ProcLimit` which wraps the
+    corresponding ``hard_limit``, ``soft_limit`` and ``units``.
 
     Typical content looks like::
 
@@ -91,9 +101,7 @@ class ProcLimits(Parser):
         for row in self.data:
             row['Limit'] = row['Limit'].lower().replace(' ', '_')
             setattr(self, row['Limit'],
-                    AttributeDict({'hard_limit': row['Hard_Limit'],
-                                   'soft_limit': row['Soft_Limit'],
-                                   'units': row['Units']}))
+                    ProcLimit(row['Hard_Limit'], row['Soft_Limit'], row['Units']))
 
 
 @parser(Specs.httpd_limits)

--- a/insights/parsers/proc_limits.py
+++ b/insights/parsers/proc_limits.py
@@ -7,14 +7,14 @@ directory.
 
 """
 
-from .. import Parser, parser
+from .. import Parser, parser, LegacyItemAccess
 from ..parsers import parse_fixed_table, ParseException
 from insights.specs import Specs
 
 HEADER_SUBSTITUTE = [('Soft Limit', 'Soft_Limit'), ('Hard Limit', 'Hard_Limit')]
 
 
-class Limits(object):
+class Limits(LegacyItemAccess):
     """
     An object representing a line in the ``/proc/limits``.  Each entry contains
     below fixed attributes:
@@ -24,18 +24,19 @@ class Limits(object):
         soft_limit(str): Soft limit
         units(str): Unit of the limit value
     """
-    attrs = {
-            'hard_limit': '',
-            'soft_limit': '',
-            'units': ''
-    }
 
     def __init__(self, data={}):
-        for k, v in Limits.attrs.items():
-            if k not in data:
-                setattr(self, k, v)
+        self.data = data
         for k, v in data.items():
             setattr(self, k, v)
+
+    def items(self):
+        """
+        To keep backward compatibility and let it can be iterated as a
+        dictionary.
+        """
+        for k, v in self.data.items():
+            yield k, v
 
 
 class ProcLimits(Parser):

--- a/insights/parsers/proc_limits.py
+++ b/insights/parsers/proc_limits.py
@@ -30,7 +30,7 @@ class Limits(AttributeDict):
             'units': ''
     }
 
-    def __init__(self, data):
+    def __init__(self, data={}):
         super(Limits, self).__init__(data, attrs=Limits.attrs)
 
 

--- a/insights/parsers/proc_limits.py
+++ b/insights/parsers/proc_limits.py
@@ -51,7 +51,7 @@ class ProcLimits(Parser):
     is converted to lowercase and joined the words with underline '_'.  If not
     sure about whether an attribute is exist or not, check it via the
     '__contains__' method before fetching it.
-    The attribute value is set to a `ProcLimit` which wraps the
+    The attribute value is set to a :class:`Limits` which wraps the
     corresponding ``hard_limit``, ``soft_limit`` and ``units``.
 
     Typical content looks like::
@@ -75,7 +75,6 @@ class ProcLimits(Parser):
         Max realtime timeout      unlimited            unlimited            us
 
     Examples:
-        >>> proc_limits = shared[ProcLimits]
         >>> len(proc_limits)
         16
         >>> proc_limits.max_processes.hard_limit

--- a/insights/parsers/tests/test_fstab.py
+++ b/insights/parsers/tests/test_fstab.py
@@ -61,8 +61,8 @@ def test_fstab():
     assert sdb1 is not None
     assert sdb1.fs_file == "/hdfs/data1"
     assert sdb1.fs_vfstype == "xfs"
-    assert 'rw' in sdb1.fs_mntops
-    assert 'relatime' in sdb1.fs_mntops
+    assert sdb1.fs_mntops.rw
+    assert sdb1.fs_mntops.relatime
     assert 'noquota' in sdb1.fs_mntops
     assert sdb1.fs_freq == 0
     assert sdb1.fs_passno == 0
@@ -71,15 +71,15 @@ def test_fstab():
     assert nfs_host.fs_spec == "nfs_hostname.example.com:/nfs_share/data"
     assert nfs_host.fs_file == "/srv/rdu/data/000"
     assert nfs_host.fs_vfstype == "nfs"
-    assert 'ro' in nfs_host.fs_mntops
-    assert 'hard' in nfs_host.fs_mntops
+    assert nfs_host.fs_mntops.ro
+    assert nfs_host.fs_mntops['hard']
     assert 'bg' in nfs_host.fs_mntops
     assert nfs_host.fs_mntops['rsize'] == "32768"
     assert nfs_host.fs_freq == 0
     assert nfs_host.fs_passno == 0
-    assert dev_vg0.fs_mntops.get('data') == 'writeback'
+    assert dev_vg0.fs_mntops['data'] == 'writeback'
     assert dev_vg0.raw == '/dev/mapper/vg0-lv2 /test1             ext4 defaults,data=writeback     1 1'
-    for opt, v in dev_vg0.fs_mntops.items():
+    for opt, v in dev_vg0.fs_mntops:
         if opt.startswith('data'):
             assert v == 'writeback'
 

--- a/insights/parsers/tests/test_fstab.py
+++ b/insights/parsers/tests/test_fstab.py
@@ -72,12 +72,12 @@ def test_fstab():
     assert nfs_host.fs_file == "/srv/rdu/data/000"
     assert nfs_host.fs_vfstype == "nfs"
     assert nfs_host.fs_mntops.ro
-    assert nfs_host.fs_mntops['hard']
+    assert nfs_host.fs_mntops.hard
     assert 'bg' in nfs_host.fs_mntops
-    assert nfs_host.fs_mntops['rsize'] == "32768"
+    assert nfs_host.fs_mntops.rsize == "32768"
     assert nfs_host.fs_freq == 0
     assert nfs_host.fs_passno == 0
-    assert dev_vg0.fs_mntops['data'] == 'writeback'
+    assert dev_vg0.fs_mntops.data == 'writeback'
     assert dev_vg0.raw == '/dev/mapper/vg0-lv2 /test1             ext4 defaults,data=writeback     1 1'
     for opt, v in dev_vg0.fs_mntops.items():
         if opt.startswith('data'):

--- a/insights/parsers/tests/test_fstab.py
+++ b/insights/parsers/tests/test_fstab.py
@@ -61,8 +61,8 @@ def test_fstab():
     assert sdb1 is not None
     assert sdb1.fs_file == "/hdfs/data1"
     assert sdb1.fs_vfstype == "xfs"
-    assert sdb1.fs_mntops.rw
-    assert sdb1.fs_mntops.relatime
+    assert 'rw' in sdb1.fs_mntops
+    assert 'relatime' in sdb1.fs_mntops
     assert 'noquota' in sdb1.fs_mntops
     assert sdb1.fs_freq == 0
     assert sdb1.fs_passno == 0
@@ -71,15 +71,15 @@ def test_fstab():
     assert nfs_host.fs_spec == "nfs_hostname.example.com:/nfs_share/data"
     assert nfs_host.fs_file == "/srv/rdu/data/000"
     assert nfs_host.fs_vfstype == "nfs"
-    assert nfs_host.fs_mntops.ro
-    assert nfs_host.fs_mntops.hard
+    assert 'ro' in nfs_host.fs_mntops
+    assert 'hard' in nfs_host.fs_mntops
     assert 'bg' in nfs_host.fs_mntops
-    assert nfs_host.fs_mntops.rsize == "32768"
+    assert nfs_host.fs_mntops['rsize'] == "32768"
     assert nfs_host.fs_freq == 0
     assert nfs_host.fs_passno == 0
-    assert dev_vg0.fs_mntops.data == 'writeback'
+    assert dev_vg0.fs_mntops.get('data') == 'writeback'
     assert dev_vg0.raw == '/dev/mapper/vg0-lv2 /test1             ext4 defaults,data=writeback     1 1'
-    for opt, v in dev_vg0.fs_mntops:
+    for opt, v in dev_vg0.fs_mntops.items():
         if opt.startswith('data'):
             assert v == 'writeback'
 

--- a/insights/parsers/tests/test_fstab.py
+++ b/insights/parsers/tests/test_fstab.py
@@ -79,7 +79,7 @@ def test_fstab():
     assert nfs_host.fs_passno == 0
     assert dev_vg0.fs_mntops['data'] == 'writeback'
     assert dev_vg0.raw == '/dev/mapper/vg0-lv2 /test1             ext4 defaults,data=writeback     1 1'
-    for opt, v in dev_vg0.fs_mntops:
+    for opt, v in dev_vg0.fs_mntops.items():
         if opt.startswith('data'):
             assert v == 'writeback'
 

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -53,6 +53,7 @@ def test_mount():
     assert 'rw' in sda1['mount_options']
     assert 'seclabel' in sda1['mount_options']
     assert sda1['mount_options']['data'] == 'ordered'
+    assert sda1.mount_options.data == 'ordered'
     assert 'mount_label' not in sda1
 
     # Test iteration

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -43,7 +43,6 @@ def test_mount():
     assert sr0.get('does not exist', 'failure') == 'failure'
     assert sr0['mount_type'] == 'iso9660'
     assert 'ro' in sr0['mount_options']
-    assert sr0.mount_options.ro
     assert 'relatime' in sr0['mount_options']
     assert sr0['mount_options']['uhelper'] == 'udisks2'
     assert sr0['mount_label'] == 'VMware Tools'
@@ -53,7 +52,6 @@ def test_mount():
     assert 'rw' in sda1['mount_options']
     assert 'seclabel' in sda1['mount_options']
     assert sda1['mount_options']['data'] == 'ordered'
-    assert sda1.mount_options.data == 'ordered'
     assert 'mount_label' not in sda1
 
     # Test iteration
@@ -85,9 +83,11 @@ def test_mount():
     assert errors is not None
     assert len(errors) == 2
     assert not hasattr(errors[0], 'parse_error')
+    assert 'parse_error' not in errors[0]
     assert errors[0].filesystem == 'tmpfs'
-    assert hasattr(errors[1], 'parse_error')
-    assert errors[1].parse_error == 'Unable to parse line'
+    assert not hasattr(errors[0], 'parse_error')
+    assert 'parse_error' in errors[1]
+    assert errors[1].get('parse_error') == 'Unable to parse line'
 
     # Test search
     assert results.search(filesystem='/dev/sr0') == [sr0]

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -43,6 +43,7 @@ def test_mount():
     assert sr0.get('does not exist', 'failure') == 'failure'
     assert sr0['mount_type'] == 'iso9660'
     assert 'ro' in sr0['mount_options']
+    assert sr0.mount_options.ro
     assert 'relatime' in sr0['mount_options']
     assert sr0['mount_options']['uhelper'] == 'udisks2'
     assert sr0['mount_label'] == 'VMware Tools'
@@ -83,11 +84,9 @@ def test_mount():
     assert errors is not None
     assert len(errors) == 2
     assert not hasattr(errors[0], 'parse_error')
-    assert 'parse_error' not in errors[0]
     assert errors[0].filesystem == 'tmpfs'
-    assert not hasattr(errors[0], 'parse_error')
-    assert 'parse_error' in errors[1]
-    assert errors[1].get('parse_error') == 'Unable to parse line'
+    assert not hasattr(errors[1], 'parse_error')
+    assert errors[1]['parse_error'] == 'Unable to parse line'
 
     # Test search
     assert results.search(filesystem='/dev/sr0') == [sr0]

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -85,8 +85,8 @@ def test_mount():
     assert len(errors) == 2
     assert not hasattr(errors[0], 'parse_error')
     assert errors[0].filesystem == 'tmpfs'
-    assert not hasattr(errors[1], 'parse_error')
-    assert errors[1]['parse_error'] == 'Unable to parse line'
+    assert hasattr(errors[1], 'parse_error')
+    assert errors[1].parse_error == 'Unable to parse line'
 
     # Test search
     assert results.search(filesystem='/dev/sr0') == [sr0]

--- a/insights/tests/test_attribute_dict.py
+++ b/insights/tests/test_attribute_dict.py
@@ -1,46 +1,19 @@
 # -*- coding: UTF-8 -*-
 from insights.core import AttributeDict
-import pytest
 
 DICT = {'dmode': '0500', 'relatime': True, 'uid': '0',
         'iocharset': 'utf8', 'gid': '0', 'mode': '0400', 'ro': True,
         'nosuid': True, 'uhelper': 'udisks2', 'nodev': True}
 
-DICT_DOC = {"fact1": "fact 1", "fact2": "fact 2", "fact3": "fact 3"}
 
-
-def test_attribute_dict_exp():
-    with pytest.raises(ValueError) as ve:
-        AttributeDict(DICT)
-    assert "Argument 'attrs' must be specified as a dict and cannot be empty." in str(ve)
-    with pytest.raises(ValueError) as ve:
-        AttributeDict(attrs={})
-    assert "Argument 'attrs' must be specified as a dict and cannot be empty." in str(ve)
-
-
-def test_attribute_dict_with_fixed_attributes():
-    attrs = {'nosuid': False, 'mode': '', 'xmode': 'TEST'}
-    d_obj = AttributeDict(DICT, attrs=attrs)
+def test_attribute_dict():
+    d_obj = AttributeDict(DICT)
     assert d_obj['dmode'] == '0500'
     assert d_obj.get('relatime') is True
+    assert d_obj.nosuid is True
     assert 'uid' in d_obj
     assert d_obj.get('mode', None) == '0400'
-    assert 'mode' in d_obj
-    assert 'xmode' not in d_obj
-    assert 'nosuid' in d_obj
-    assert d_obj.mode == '0400'
-    assert d_obj.xmode == 'TEST'
-    assert d_obj.nosuid is True
-
-
-def test_attribute_dict_doc_examples():
-    d_obj = AttributeDict(data=DICT_DOC, attrs={'fact0': 'fact 0', 'fact1': ''})
-    assert d_obj.fact0 == 'fact 0'
-    assert 'fact0' not in d_obj
-    assert d_obj.get('fact0') is None
-    assert d_obj.fact1 == 'fact 1'
-    assert 'fact1' in d_obj
-    assert d_obj['fact1'] == 'fact 1'
-    assert 'fact2' in d_obj
-    assert not hasattr(d_obj, 'fact2')
-    assert d_obj.get('fact2') == 'fact 2'
+    assert d_obj.get('xmode', None) is None
+    for d, v in d_obj.items():
+        if d.startswith('nod'):
+            assert v is True

--- a/insights/tests/test_attribute_dict.py
+++ b/insights/tests/test_attribute_dict.py
@@ -6,7 +6,7 @@ DICT = {'dmode': '0500', 'relatime': True, 'uid': '0',
         'iocharset': 'utf8', 'gid': '0', 'mode': '0400', 'ro': True,
         'nosuid': True, 'uhelper': 'udisks2', 'nodev': True}
 
-DICT_DOC = {"fact1":"fact 1", "fact2":"fact 2", "fact3":"fact 3"}
+DICT_DOC = {"fact1": "fact 1", "fact2": "fact 2", "fact3": "fact 3"}
 
 
 def test_attribute_dict_exp():
@@ -32,8 +32,8 @@ def test_attribute_dict_with_fixed_attributes():
     assert d_obj.xmode == 'TEST'
     assert d_obj.nosuid is True
 
+
 def test_attribute_dict_doc_examples():
-    attrs = {'nosuid': False, 'mode': '', 'xmode': 'TEST'}
     d_obj = AttributeDict(data=DICT_DOC, attrs={'fact0': 'fact 0', 'fact1': ''})
     assert d_obj.fact0 == 'fact 0'
     assert 'fact0' not in d_obj

--- a/insights/tests/test_attribute_dict.py
+++ b/insights/tests/test_attribute_dict.py
@@ -6,21 +6,21 @@ DICT = {'dmode': '0500', 'relatime': True, 'uid': '0',
         'iocharset': 'utf8', 'gid': '0', 'mode': '0400', 'ro': True,
         'nosuid': True, 'uhelper': 'udisks2', 'nodev': True}
 
+DICT_DOC = {"fact1":"fact 1", "fact2":"fact 2", "fact3":"fact 3"}
+
 
 def test_attribute_dict_exp():
-    fixed_attrs = {'nosuid': False, 'mode': '', 'xmode': 'TEST'}
-    with pytest.raises(TypeError) as te:
-        AttributeDict(DICT, DICT, fixed_attrs=fixed_attrs)
-    assert "AttributeDict takes at most 1 argument (2 given)" in str(te)
-
     with pytest.raises(ValueError) as ve:
-        AttributeDict(DICT, fixed_attrs={})
-    assert "'fixed_attrs' must be specified" in str(ve)
+        AttributeDict(DICT)
+    assert "Argument 'attrs' must be specified as a dict and cannot be empty." in str(ve)
+    with pytest.raises(ValueError) as ve:
+        AttributeDict(attrs={})
+    assert "Argument 'attrs' must be specified as a dict and cannot be empty." in str(ve)
 
 
 def test_attribute_dict_with_fixed_attributes():
-    fixed_attrs = {'nosuid': False, 'mode': '', 'xmode': 'TEST'}
-    d_obj = AttributeDict(DICT, fixed_attrs=fixed_attrs)
+    attrs = {'nosuid': False, 'mode': '', 'xmode': 'TEST'}
+    d_obj = AttributeDict(DICT, attrs=attrs)
     assert d_obj['dmode'] == '0500'
     assert d_obj.get('relatime') is True
     assert 'uid' in d_obj
@@ -31,3 +31,16 @@ def test_attribute_dict_with_fixed_attributes():
     assert d_obj.mode == '0400'
     assert d_obj.xmode == 'TEST'
     assert d_obj.nosuid is True
+
+def test_attribute_dict_doc_examples():
+    attrs = {'nosuid': False, 'mode': '', 'xmode': 'TEST'}
+    d_obj = AttributeDict(data=DICT_DOC, attrs={'fact0': 'fact 0', 'fact1': ''})
+    assert d_obj.fact0 == 'fact 0'
+    assert 'fact0' not in d_obj
+    assert d_obj.get('fact0') is None
+    assert d_obj.fact1 == 'fact 1'
+    assert 'fact1' in d_obj
+    assert d_obj['fact1'] == 'fact 1'
+    assert 'fact2' in d_obj
+    assert not hasattr(d_obj, 'fact2')
+    assert d_obj.get('fact2') == 'fact 2'

--- a/insights/tests/test_attribute_dict.py
+++ b/insights/tests/test_attribute_dict.py
@@ -1,18 +1,21 @@
 # -*- coding: UTF-8 -*-
 from insights.core import AttributeDict
+import pytest
 
 DICT = {'dmode': '0500', 'relatime': True, 'uid': '0',
         'iocharset': 'utf8', 'gid': '0', 'mode': '0400', 'ro': True,
         'nosuid': True, 'uhelper': 'udisks2', 'nodev': True}
 
 
-def test_attribute_dict_without_fixed_attributes():
-    d_obj = AttributeDict(DICT)
-    assert d_obj['dmode'] == '0500'
-    assert d_obj.get('relatime') is True
-    assert 'uid' in d_obj
-    assert d_obj.get('mode', None) == '0400'
-    assert d_obj.get('xmode', None) is None
+def test_attribute_dict_exp():
+    fixed_attrs = {'nosuid': False, 'mode': '', 'xmode': 'TEST'}
+    with pytest.raises(TypeError) as te:
+        AttributeDict(DICT, DICT, fixed_attrs=fixed_attrs)
+    assert "AttributeDict takes at most 1 argument (2 given)" in str(te)
+
+    with pytest.raises(ValueError) as ve:
+        AttributeDict(DICT, fixed_attrs={})
+    assert "'fixed_attrs' must be specified" in str(ve)
 
 
 def test_attribute_dict_with_fixed_attributes():

--- a/insights/tests/test_attribute_dict.py
+++ b/insights/tests/test_attribute_dict.py
@@ -26,7 +26,7 @@ def test_attribute_dict_with_fixed_attributes():
     assert 'uid' in d_obj
     assert d_obj.get('mode', None) == '0400'
     assert 'mode' in d_obj
-    assert 'xmode' in d_obj
+    assert 'xmode' not in d_obj
     assert 'nosuid' in d_obj
     assert d_obj.mode == '0400'
     assert d_obj.xmode == 'TEST'

--- a/insights/tests/test_attribute_dict.py
+++ b/insights/tests/test_attribute_dict.py
@@ -6,14 +6,25 @@ DICT = {'dmode': '0500', 'relatime': True, 'uid': '0',
         'nosuid': True, 'uhelper': 'udisks2', 'nodev': True}
 
 
-def test_attribute_dict():
+def test_attribute_dict_without_fixed_attributes():
     d_obj = AttributeDict(DICT)
     assert d_obj['dmode'] == '0500'
     assert d_obj.get('relatime') is True
-    assert d_obj.nosuid is True
     assert 'uid' in d_obj
     assert d_obj.get('mode', None) == '0400'
     assert d_obj.get('xmode', None) is None
-    for d, v in d_obj:
-        if d.startswith('nod'):
-            assert v is True
+
+
+def test_attribute_dict_with_fixed_attributes():
+    fixed_attrs = {'nosuid': False, 'mode': '', 'xmode': 'TEST'}
+    d_obj = AttributeDict(DICT, fixed_attrs=fixed_attrs)
+    assert d_obj['dmode'] == '0500'
+    assert d_obj.get('relatime') is True
+    assert 'uid' in d_obj
+    assert d_obj.get('mode', None) == '0400'
+    assert 'mode' in d_obj
+    assert 'xmode' in d_obj
+    assert 'nosuid' in d_obj
+    assert d_obj.mode == '0400'
+    assert d_obj.xmode == 'TEST'
+    assert d_obj.nosuid is True


### PR DESCRIPTION
- Try not deprecate the AttributeDict to minimize the effect to plugins
- Only the `keys` included in `fixed_attrs` will be set as attributes
  Because of this, the tests of some rules in insights-plugins are broken, will fix them soon