### PR TITLE
WIP: Support old specs

### DIFF
--- a/insights/client/archive.py
+++ b/insights/client/archive.py
@@ -14,7 +14,6 @@ from insights_spec import InsightsFile, InsightsCommand
 
 logger = logging.getLogger(__name__)
 
-
 class InsightsArchive(object):
 
     """
@@ -168,6 +167,7 @@ class InsightsArchive(object):
         output = spec.get_output()
         if output:
             write_data_to_file(output, archive_path)
+            return output
 
     def add_metadata_to_archive(self, metadata, meta_path):
         '''

--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -429,7 +429,6 @@ def collect(rc=0):
             logger.debug("Inferring target_type '%s' for SPEC collection", target_type)
             logger.debug("Inferred from '%s'", t['type'])
             dc = DataCollector(archive,
-                               config,
                                mountpoint=mp,
                                target_name=t['name'],
                                target_type=target_type)

--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -31,14 +31,13 @@ class DataCollector(object):
     '''
     Run commands and collect files
     '''
-    def __init__(self, archive_=None, config=None, mountpoint=None, target_name='', target_type='host'):
+    def __init__(self, archive_=None, mountpoint=None, target_name='', target_type='host'):
         self.archive = archive_ if archive_ else archive.InsightsArchive()
         self.mountpoint = '/'
         if mountpoint:
             self.mountpoint = mountpoint
         self.target_name = target_name
         self.target_type = target_type
-        self.config = config
 
     def _get_meta_path(self, specname, conf):
         # should really never need these
@@ -201,7 +200,7 @@ class DataCollector(object):
                     else:
                         cmd_specs = self._parse_command_spec(spec, conf['pre_commands'])
                         for s in cmd_specs:
-                            cmd_spec = InsightsCommand(s, exclude, self.mountpoint, self.target_name, self.config)
+                            cmd_spec = InsightsCommand(s, exclude, self.mountpoint, self.target_name)
                             self.archive.add_to_archive(cmd_spec)
         else:
             logger.debug('Spec metadata type "%s" not found in spec.', metadata_spec)
@@ -260,7 +259,7 @@ class DataCollector(object):
                         else:
                             cmd_specs = self._parse_command_spec(spec, conf['pre_commands'])
                             for s in cmd_specs:
-                                cmd_spec = InsightsCommand(s, exclude, self.mountpoint, self.target_name, self.config)
+                                cmd_spec = InsightsCommand(s, exclude, self.mountpoint, self.target_name)
                                 self.archive.add_to_archive(cmd_spec)
             except LookupError:
                 logger.debug('Target type %s not found in spec %s. Skipping...', self.target_type, specname)

--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -210,7 +210,7 @@ class DataCollector(object):
         '''
         Run specs and collect all the data
         '''
-        logger.debug('Beginning to run collection spec...')
+        logger.info('Beginning to run collection spec...')
         exclude = None
         if rm_conf:
             try:
@@ -226,7 +226,9 @@ class DataCollector(object):
                 logger.debug('Finished running specific spec %s', specific_spec)
             return
 
+        out = {}
         for specname in conf['specs']:
+            logger.info(specname)
             try:
                 # spec group for a s
                 spec_group = conf['specs'][specname]
@@ -242,7 +244,7 @@ class DataCollector(object):
                             file_specs = self._parse_file_spec(spec)
                             for s in file_specs:
                                 file_spec = InsightsFile(s, exclude, self.mountpoint, self.target_name)
-                                self.archive.add_to_archive(file_spec)
+                                out[specname] = self.archive.add_to_archive(file_spec)
                     elif 'glob' in spec:
                         glob_specs = self._parse_glob_spec(spec)
                         for g in glob_specs:
@@ -251,7 +253,7 @@ class DataCollector(object):
                                 continue
                             else:
                                 glob_spec = InsightsFile(g, exclude, self.mountpoint, self.target_name)
-                                self.archive.add_to_archive(glob_spec)
+                                out[specname] = self.archive.add_to_archive(glob_spec)
                     elif 'command' in spec:
                         if rm_conf and 'commands' in rm_conf and spec['command'] in rm_conf['commands']:
                             logger.warn("WARNING: Skipping command %s", spec['command'])
@@ -260,11 +262,12 @@ class DataCollector(object):
                             cmd_specs = self._parse_command_spec(spec, conf['pre_commands'])
                             for s in cmd_specs:
                                 cmd_spec = InsightsCommand(s, exclude, self.mountpoint, self.target_name)
-                                self.archive.add_to_archive(cmd_spec)
+                                out[specname] = self.archive.add_to_archive(cmd_spec)
             except LookupError:
                 logger.debug('Target type %s not found in spec %s. Skipping...', self.target_type, specname)
                 continue
         logger.debug('Spec collection finished.')
+        print json.dumps(out, indent=4)
 
         # collect metadata
         logger.debug('Collecting metadata...')

--- a/insights/client/insights_spec.py
+++ b/insights/client/insights_spec.py
@@ -30,7 +30,7 @@ class InsightsCommand(InsightsSpec):
     '''
     A command spec
     '''
-    def __init__(self, spec, exclude, mountpoint, target_name, config=None):
+    def __init__(self, spec, exclude, mountpoint, target_name):
         InsightsSpec.__init__(self, spec, exclude)
         # substitute mountpoint for collection
         # have to use .replace instead of .format because there are other
@@ -49,7 +49,6 @@ class InsightsCommand(InsightsSpec):
         if not six.PY3:
             self.command = self.command.encode('utf-8', 'ignore')
         self.black_list = ['rm', 'kill', 'reboot', 'shutdown']
-        self.config = config
 
     def _mangle_command(self, command, name_max=255):
         """

--- a/insights/client/insights_spec.py
+++ b/insights/client/insights_spec.py
@@ -6,6 +6,7 @@ import logging
 import six
 from subprocess import Popen, PIPE, STDOUT
 from tempfile import NamedTemporaryFile
+from insights.util import mangle
 
 from constants import InsightsConstants as constants
 from config import CONFIG as config
@@ -23,7 +24,10 @@ class InsightsSpec(object):
         # pattern for spec collection
         self.pattern = spec['pattern'] if spec['pattern'] else None
         # absolute destination inside the archive for this spec
-        self.archive_path = spec['archive_file_name']
+        if 'command' in spec:
+            self.archive_path = mangle.mangle_command(spec['command'])
+        else:  # 'file'
+            self.archive_path = spec['file']
 
 
 class InsightsCommand(InsightsSpec):

--- a/test_collector.py
+++ b/test_collector.py
@@ -1,0 +1,16 @@
+from insights.client.collection_rules import InsightsConfig
+from insights.client.data_collector import DataCollector
+import logging
+
+logging.basicConfig()
+logging.root.level = logging.INFO
+
+BRANCH_INFO = {"remote_branch": -1, "remote_leaf": -1}
+
+config = InsightsConfig()
+config.collection_rules_file = "/home/klape/insights/frontend-assets/uploader.json"
+config.gpg = False
+uploader_json, rm_conf = config.get_conf(False)
+
+dc = DataCollector()
+dc.run_collection(uploader_json, rm_conf, BRANCH_INFO)


### PR DESCRIPTION
The code is still in "debug mode", meaning I modified the actual execution of `InsightsSpec` objects to just print the command that would have been executed.  You can see the test running I wrote in `test_collector.py`.

The current state is that it properly reads `files` and `commands`, but it does not do anything with the mountpoint yet.

Testing should be done against https://github.com/RedHatInsights/insights-frontend-assets/blob/symbolic_names/uploader.json