### PR TITLE
fail more gracefully on unreachable Docker

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -282,7 +282,10 @@ def collect(rc=0):
         logger.debug("Scanning for matching container/image.")
 
         from containers import get_targets
-        target = get_targets()[0]
+        targets = get_targets()
+        if len(targets) == 0:
+            sys.exit(constants.sig_kill_bad)
+        target = targets[0]
 
     # the host
     else:


### PR DESCRIPTION
I introduced a small bug when I removed much of the old code. We need to run `get_targets` once and check its length before accessing an index, otherwise the process will fail with a traceback when an image scan is attempted when Docker is missing or unreachable. 

Future enhancements should refactor the `get_targets` functions so this check is unnecessary. The empty array returned by the default function is a holdover from the old multi-target/uber-archive schema and is no longer needed.