### PR TITLE
Explicitly mark commands for inclusion for image analysis

### DIFF
--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -185,7 +185,7 @@ class DataCollector(object):
         for c in conf['commands']:
             if c['command'] in rm_conf.get('commands', []):
                 logger.warn("WARNING: Skipping command %s", c['command'])
-            else:
+            elif self.mountpoint == "/" or c.get("image"):
                 cmd_specs = self._parse_command_spec(c, conf['pre_commands'])
                 for s in cmd_specs:
                     cmd_spec = InsightsCommand(s, exclude, self.mountpoint)


### PR DESCRIPTION
This expects specs in uploader.json to be marked with an `"image": true` key/value pair.