### PR TITLE
Add parser entry to sos_archieve.py

### DIFF
--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -1,7 +1,7 @@
 from functools import partial
 from insights.specs import Specs
 from insights.core.context import SosArchiveContext
-from insights.core.spec_factory import simple_file, first_of, first_file, glob_file
+from insights.core.spec_factory import simple_file, simple_command, first_of, first_file, glob_file
 
 first_file = partial(first_file, context=SosArchiveContext)
 glob_file = partial(glob_file, context=SosArchiveContext)
@@ -10,6 +10,10 @@ simple_file = partial(simple_file, context=SosArchiveContext)
 
 class SosSpecs(Specs):
     blkid = simple_file("sos_commands/block/blkid_-c_.dev.null")
+    candlepin_log = first_of([
+        simple_file("/var/log/candlepin/candlepin.log"),
+        simple_file("sos_commands/foreman/foreman-debug/var/log/candlepin/candlepin.log")
+    ])
     candlepin_error_log = first_of([
         simple_file("var/log/candlepin/error.log"),
         simple_file(r"sos_commands/foreman/foreman-debug/var/log/candlepin/error.log")
@@ -33,8 +37,10 @@ class SosSpecs(Specs):
     ethtool_i = glob_file("sos_commands/networking/ethtool_-i_*")
     ethtool_k = glob_file("sos_commands/networking/ethtool_-k_*")
     fdisk_l_sos = glob_file(r"sos_commands/filesys/fdisk_-l_*")
-    foreman_production_log = first_file(["var/log/foreman/production.log",
-                                         r"sos_commands/foreman-debug/var/log/foreman/sos_production.log"])
+    foreman_production_log = first_of([simple_file("/var/log/foreman/production.log"), simple_file("sos_commands/foreman/foreman-debug/var/log/foreman/production.log")])
+    foreman_proxy_conf = first_of([simple_file("/etc/foreman-proxy/settings.yml"), simple_file("sos_commands/foreman/foreman-debug/etc/foreman-proxy/settings.yml")])
+    foreman_proxy_log = first_of([simple_file("/var/log/foreman-proxy/proxy.log"), simple_file("sos_commands/foreman/foreman-debug/var/log/foreman-proxy/proxy.log")])
+    foreman_satellite_log = first_of([simple_file("/var/log/foreman-installer/satellite.log"), simple_file("sos_commands/foreman/foreman-debug/var/log/foreman-installer/satellite.log")])
     foreman_ssl_access_ssl_log = first_file(["var/log/httpd/foreman-ssl_access_ssl.log", r"sos_commands/foreman/foreman-debug/var/log/httpd/foreman-ssl_access_ssl.log"])
     getcert_list = simple_file("sos_commands/ipa/ipa-getcert_list")
     hostname = first_of([simple_file("sos_commands/general/hostname_-f"), simple_file("sos_commands/general/hostname")])
@@ -59,8 +65,20 @@ class SosSpecs(Specs):
     ps_auxww = first_file(["sos_commands/process/ps_auxwww", "sos_commands/process/ps_aux", "sos_commands/process/ps_auxcww"])
     puppet_ssl_cert_ca_pem = simple_file("sos_commands/foreman/foreman-debug/var/lib/puppet/ssl/certs/ca.pem")
     pvs = simple_file("sos_commands/lvm2/pvs_-a_-v_-o_pv_mda_free_pv_mda_size_pv_mda_count_pv_mda_used_count_pe_start_--config_global_locking_type_0")
-    qpid_stat_q = simple_file("sos_commands/foreman/foreman-debug/qpid-stat-q")
-    qpid_stat_u = simple_file("sos_commands/foreman/foreman-debug/qpid-stat-u")
+    qpid_stat_q = first_of([
+        simple_command("/usr/bin/qpid-stat -q --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671"),
+        simple_file("qpid_stat_queues"),
+        simple_file("qpid-stat-q"),
+        simple_file("sos_commands/foreman/foreman-debug/qpid_stat_queues"),
+        simple_file("sos_commands/foreman/foreman-debug/qpid-stat-q")
+    ])
+    qpid_stat_u = first_of([
+        simple_command("/usr/bin/qpid-stat -u --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671"),
+        simple_file("qpid_stat_subscriptions"),
+        simple_file("qpid-stat-u"),
+        simple_file("sos_commands/foreman/foreman-debug/qpid_stat_subscriptions"),
+        simple_file("sos_commands/foreman/foreman-debug/qpid-stat-u")
+    ])
     root_crontab = simple_file("sos_commands/cron/root_crontab")
     route = simple_file("sos_commands/networking/route_-n")
     sestatus = simple_file("sos_commands/selinux/sestatus_-b")

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -1,7 +1,7 @@
 from functools import partial
 from insights.specs import Specs
 from insights.core.context import SosArchiveContext
-from insights.core.spec_factory import simple_file, simple_command, first_of, first_file, glob_file
+from insights.core.spec_factory import simple_file, first_of, first_file, glob_file
 
 first_file = partial(first_file, context=SosArchiveContext)
 glob_file = partial(glob_file, context=SosArchiveContext)
@@ -66,14 +66,12 @@ class SosSpecs(Specs):
     puppet_ssl_cert_ca_pem = simple_file("sos_commands/foreman/foreman-debug/var/lib/puppet/ssl/certs/ca.pem")
     pvs = simple_file("sos_commands/lvm2/pvs_-a_-v_-o_pv_mda_free_pv_mda_size_pv_mda_count_pv_mda_used_count_pe_start_--config_global_locking_type_0")
     qpid_stat_q = first_of([
-        simple_command("/usr/bin/qpid-stat -q --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671"),
         simple_file("qpid_stat_queues"),
         simple_file("qpid-stat-q"),
         simple_file("sos_commands/foreman/foreman-debug/qpid_stat_queues"),
         simple_file("sos_commands/foreman/foreman-debug/qpid-stat-q")
     ])
     qpid_stat_u = first_of([
-        simple_command("/usr/bin/qpid-stat -u --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671"),
         simple_file("qpid_stat_subscriptions"),
         simple_file("qpid-stat-u"),
         simple_file("sos_commands/foreman/foreman-debug/qpid_stat_subscriptions"),


### PR DESCRIPTION
Following parser entries are updated:

`candlepin_log`
`foreman_production_log`
`foreman_proxy_conf`
`foreman_proxy_log`
`foreman_satellite_log`
`qpid_stat_q`
`qpid_stat_u`