### PR TITLE
Fix examples in httpd_M parser

### DIFF
--- a/insights/parsers/httpd_M.py
+++ b/insights/parsers/httpd_M.py
@@ -33,8 +33,12 @@ class HttpdM(LegacyItemAccess, Parser):
         <class 'insights.parsers.httpd_M.HttpdM'>
         >>> len(hm.loaded_modules)
         5
-        >>> hm.static_modules
-        ['core_module', 'http_module']
+        >>> len(hm.static_modules)
+        2
+        >>> 'core_module' in hm.static_modules
+        True
+        >>> 'http_module' in hm.static_modules
+        True
         >>> 'http_module' in hm
         True
         >>> 'http_module' in hm.shared_modules


### PR DESCRIPTION
* Examples had a list results that is generated by
  iterating over a dictionary so the list can be
  in a different order
* Eliminated this issue in the example by replacing
  the statement with equivalent statements
* If order matters then the parser needs to be fixed