### PR TITLE
WIP - Support external component metadata and a new component for service requests

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import yaml
 import os
 import pkgutil
 from pprint import pprint
@@ -130,6 +131,7 @@ def run(component=None, root=None, print_summary=False,
         p.add_argument("-m", "--missing", help="Show missing requirements.", action="store_true")
         p.add_argument("-t", "--tracebacks", help="Show stack traces.", action="store_true")
         p.add_argument("-d", "--dropped", help="Show collected files that weren't processed.", action="store_true", default=False)
+        p.add_argument("-c", "--config", default=[], nargs="*", help="Configuration file for components.")
         p.add_argument("--rc", help="Run Context")
         p.add_argument("--ac", help="Archive Context")
         args = p.parse_args()
@@ -149,6 +151,10 @@ def run(component=None, root=None, print_summary=False,
             for c in dr.DELEGATES:
                 if c.__module__.startswith(plugins):
                     component.append(c)
+
+        for config in sorted(args.config):
+            with open(config) as cfg:
+                dr.apply_component_config(yaml.safe_load(cfg.read()))
 
     show_dropped = args.dropped if args else False
     if component:

--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -118,6 +118,17 @@ COMPONENT_NAME_CACHE = KeyPassingDefaultDict(_get_component)
 get_component = COMPONENT_NAME_CACHE.__getitem__
 
 
+def apply_component_config(doc):
+    for k, v in doc.items():
+        comp = get_component(k)
+        if "enabled" in v:
+            set_enabled(comp, v["enabled"])
+
+        delegate = get_delegate(comp)
+        if delegate:
+            delegate.metadata.update(v.get("metadata", {}))
+
+
 @defaults(None)
 def get_component_type(component):
     return get_delegate(component).type

--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -124,11 +124,15 @@ class StdTypes(dr.TypeSet):
     incident = dr.new_component_type()
     """ A component used by rules that allows automated statistical analysis."""
 
+    webservice = dr.new_component_type(type_metadata={"verify": False, "timeout": 5})
+    """ A component that fetches contents at URLs."""
+
 
 combiner = StdTypes.combiner
 rule = StdTypes.rule
 condition = StdTypes.condition
 incident = StdTypes.incident
+webservice = StdTypes.webservice
 
 
 def datasource(*args, **kwargs):

--- a/insights/tests/test_external_config.py
+++ b/insights/tests/test_external_config.py
@@ -1,0 +1,21 @@
+from insights.core import dr
+from insights.core.plugins import combiner
+
+
+@combiner()
+def void_combiner():
+    return None
+
+
+def test_external_config():
+    config = {
+        "insights.tests.test_external_config.void_combiner": {
+            "enabled": True,
+            "metadata": {
+                "knob": 42
+            }
+        }
+    }
+    dr.apply_component_config(config)
+    meta = dr.get_metadata(void_combiner)
+    assert meta["knob"] == 42


### PR DESCRIPTION
This PR enables external component configuration. You can enable or disable a component and provide arbitrary metadata for it to inspect at runtime.

For example, the following rule gets the RPM it should inspect from its metadata and falls back to a default if none is provided:
~~~python
#!/usr/bin/env python
# check_ovirt.py

from insights import dr, make_response, rule, run                               
from insights.parsers.installed_rpms import InstalledRpms                       

@rule(InstalledRpms)                                                            
def report(rpms):                                                               
    rpm = dr.get_metadata(report).get("rpm", "ovirt-hosted-engine-ha")          
    if rpm in rpms:                                                             
        return make_response("RUNNING", version=rpms.get_max(rpm).nvr)          
    return make_response("NOT_RUNNING")                                         
                                                                                
if __name__ == "__main__":                                                      
    run(report, print_summary=True)
~~~

It can be configured with a yaml file like this:
~~~yaml
check_ovirt.report:
    enabled: true
    metadata:
        rpm: bash
~~~
Run it with `python -m insights --config config.yml -p check_ovirt`

If multiple config files are passed, they are applied in sorted order.

Included in this PR is a new component type that takes advantage of the above functionality to encapsulate http(s) requests.

It includes a component type (`@webservice`)  and a base class `WebService` that automatically inspects subclass metdata to pass the following along to `requests.get`:
-  verify (bool), optional, default = False
-  timeout (int) seconds, optional, default = 5
-  username (string), optional
-  password (string), optional

`WebService` subclasses should provide a suitable API that delegates to the `WebService.get` method. Subclasses are responsible for defining appropriate URLs that back the service. They should be included in the service metadata.

