### PR TITLE
[WIP] Cluster support

### DIFF
--- a/cluster_rules/bash_version.py
+++ b/cluster_rules/bash_version.py
@@ -2,17 +2,17 @@
 from insights import run
 from insights.parsers.installed_rpms import InstalledRpms
 from insights.combiners.hostname import hostname
-from insights.core.plugins import cluster_fact, cluster_rule
+from insights.core.plugins import fact, cluster_rule
 
 
-@cluster_fact(InstalledRpms)
+@fact(InstalledRpms)
 def bash_version(rpms):
     rpm = rpms.get_max("bash")
     return {"name": rpm.name, "version": rpm.nvr}
 
 
 # bet there'll be a bunch of these
-@cluster_fact(hostname)
+@fact(hostname)
 def get_hostname(hn):
     return {"hostname": hn.fqdn}
 

--- a/cluster_rules/bash_version.py
+++ b/cluster_rules/bash_version.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+from insights import run
+from insights.parsers.installed_rpms import InstalledRpms
+from insights.combiners.hostname import hostname
+from insights.core.plugins import cluster_fact, cluster_rule
+
+
+@cluster_fact(InstalledRpms)
+def bash_version(rpms):
+    rpm = rpms.get_max("bash")
+    return {"name": rpm.name, "version": rpm.nvr}
+
+
+# bet there'll be a bunch of these
+@cluster_fact(hostname)
+def get_hostname(hn):
+    return {"hostname": hn.fqdn}
+
+
+@cluster_rule(bash_version, get_hostname)
+def bash_rule(bash, hn):
+    print(bash)
+    print(hn)
+
+
+if __name__ == "__main__":
+    run(bash_version, print_summary=True)

--- a/cluster_rules/bash_version.py
+++ b/cluster_rules/bash_version.py
@@ -2,7 +2,7 @@
 from insights import run
 from insights.parsers.installed_rpms import InstalledRpms
 from insights.combiners.hostname import hostname
-from insights.core.plugins import fact, cluster_rule
+from insights.core.plugins import fact, rule
 
 
 @fact(InstalledRpms)
@@ -11,16 +11,14 @@ def bash_version(rpms):
     return {"name": rpm.name, "version": rpm.nvr}
 
 
-# bet there'll be a bunch of these
 @fact(hostname)
 def get_hostname(hn):
     return {"hostname": hn.fqdn}
 
 
-@cluster_rule(bash_version, get_hostname)
+@rule(bash_version, get_hostname, cluster=True)
 def bash_rule(bash, hn):
-    print(bash)
-    print(hn)
+    pass
 
 
 if __name__ == "__main__":

--- a/cluster_rules/ntp_compare.py
+++ b/cluster_rules/ntp_compare.py
@@ -1,11 +1,11 @@
 from insights import make_response
 from insights.specs import Specs
 from insights.core.cluster import ClusterMeta
-from insights.core.plugins import cluster_fact, cluster_rule
+from insights.core.plugins import fact, cluster_rule
 from insights.util.fs import sha256
 
 
-@cluster_fact(Specs.ntp_conf)
+@fact(Specs.ntp_conf)
 def ntp_sha256(ntp):
     return {"sha": sha256(ntp.path)}
 

--- a/cluster_rules/ntp_compare.py
+++ b/cluster_rules/ntp_compare.py
@@ -1,0 +1,21 @@
+from insights import make_response
+from insights.specs import Specs
+from insights.core.cluster import ClusterMeta
+from insights.core.plugins import cluster_fact, cluster_rule
+from insights.util.fs import sha256
+
+
+@cluster_fact(Specs.ntp_conf)
+def ntp_sha256(ntp):
+    return {"sha": sha256(ntp.path)}
+
+
+@cluster_rule(ntp_sha256, ClusterMeta)
+def report(shas, meta):
+    if len(shas) != meta.num_members or len(shas.sha.unique()) != 1:
+        return make_response("DISTINCT_NTP_CONFS")
+
+
+if __name__ == "__main__":
+    from insights import run
+    run(report, print_summary=True)

--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -7,12 +7,14 @@ from .core import FileListing, LegacyItemAccess, SysconfigOptions  # noqa: F401
 from .core import YAMLParser, JSONParser, XMLParser, CommandParser  # noqa: F401
 from .core import AttributeDict  # noqa: F401
 from .core import Syslog  # noqa: F401
-from .core.archives import extract  # noqa: F401
+from .core.archives import COMPRESSION_TYPES, extract  # noqa: F401
 from .core import dr  # noqa: F401
-from .core.context import HostContext, HostArchiveContext  # noqa: F401
+from .core.cluster import process_cluster
+from .core.context import ClusterArchiveContext, HostContext, HostArchiveContext  # noqa: F401
 from .core.dr import SkipComponent  # noqa: F401
 from .core.hydration import create_context
 from .core.plugins import combiner, metadata, parser, rule  # noqa: F401
+from .core.plugins import cluster_fact, cluster_rule  # noqa: F401
 from .core.plugins import datasource, condition, incident  # noqa: F401
 from .core.plugins import make_response, make_metadata, make_fingerprint  # noqa: F401
 from .core.filters import add_filter, apply_filters, get_filters  # noqa: F401
@@ -51,7 +53,7 @@ def add_status(name, nvr, commit):
 
 
 def _run(graph=None, root=None, run_context=HostContext,
-         archive_context=HostArchiveContext, show_dropped=False):
+         archive_context=None, show_dropped=False, use_pandas=False):
     """
     run is a general interface that is meant for stand alone scripts to use
     when executing insights components.
@@ -76,7 +78,13 @@ def _run(graph=None, root=None, run_context=HostContext,
         return dr.run(graph, broker=broker)
 
     if os.path.isdir(root):
-        broker[archive_context] = create_context(root, archive_context)
+        ctx = create_context(root, archive_context)
+
+        if isinstance(ctx, ClusterArchiveContext):
+            archives = [f for f in ctx.all_files if f.endswith(COMPRESSION_TYPES)]
+            return process_cluster(archives, use_pandas=use_pandas)
+
+        broker[ctx.__class__] = ctx
         return dr.run(graph, broker=broker)
 
     with extract(root) as ex:
@@ -111,7 +119,7 @@ def _load_context(path):
 
 
 def run(component=None, root=None, print_summary=False,
-        run_context=HostContext, archive_context=None):
+        run_context=HostContext, archive_context=None, use_pandas=False):
 
     from .core import dr
     dr.load_components("insights.specs.default")
@@ -127,16 +135,19 @@ def run(component=None, root=None, print_summary=False,
         p.add_argument("-p", "--plugins", default=[], nargs="*",
                        help="package(s) or module(s) containing plugins to run.")
         p.add_argument("-v", "--verbose", help="Verbose output.", action="store_true")
+        p.add_argument("-q", "--quiet", help="Error output only.", action="store_true")
         p.add_argument("-m", "--missing", help="Show missing requirements.", action="store_true")
         p.add_argument("-t", "--tracebacks", help="Show stack traces.", action="store_true")
         p.add_argument("-d", "--dropped", help="Show collected files that weren't processed.", action="store_true", default=False)
+        p.add_argument("--pandas", action="store_true", help="Use pandas dataframes with cluster_rules")
         p.add_argument("--rc", help="Run Context")
         p.add_argument("--ac", help="Archive Context")
         args = p.parse_args()
 
-        logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+        logging.basicConfig(level=logging.DEBUG if args.verbose else logging.ERROR if args.quiet else logging.INFO)
         run_context = _load_context(args.rc) or run_context
         archive_context = _load_context(args.ac) or archive_context
+        use_pandas = args.pandas or use_pandas
 
         root = args.archive or root
 
@@ -160,7 +171,8 @@ def run(component=None, root=None, print_summary=False,
     else:
         graph = dr.COMPONENTS[dr.GROUPS.single]
 
-    broker = _run(graph, root, run_context=run_context, archive_context=archive_context, show_dropped=show_dropped)
+    broker = _run(graph, root, run_context=run_context, archive_context=archive_context, show_dropped=show_dropped, use_pandas=use_pandas)
+
     if print_summary:
         broker.describe(show_missing=args.missing, show_tracebacks=args.tracebacks)
     return broker

--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -13,8 +13,7 @@ from .core.cluster import process_cluster
 from .core.context import ClusterArchiveContext, HostContext, HostArchiveContext  # noqa: F401
 from .core.dr import SkipComponent  # noqa: F401
 from .core.hydration import create_context
-from .core.plugins import combiner, metadata, parser, rule  # noqa: F401
-from .core.plugins import fact, cluster_rule  # noqa: F401
+from .core.plugins import combiner, fact, metadata, parser, rule  # noqa: F401
 from .core.plugins import datasource, condition, incident  # noqa: F401
 from .core.plugins import make_response, make_metadata, make_fingerprint  # noqa: F401
 from .core.filters import add_filter, apply_filters, get_filters  # noqa: F401
@@ -139,7 +138,7 @@ def run(component=None, root=None, print_summary=False,
         p.add_argument("-m", "--missing", help="Show missing requirements.", action="store_true")
         p.add_argument("-t", "--tracebacks", help="Show stack traces.", action="store_true")
         p.add_argument("-d", "--dropped", help="Show collected files that weren't processed.", action="store_true", default=False)
-        p.add_argument("--pandas", action="store_true", help="Use pandas dataframes with cluster_rules")
+        p.add_argument("--pandas", action="store_true", help="Use pandas dataframes with cluster rules")
         p.add_argument("--rc", help="Run Context")
         p.add_argument("--ac", help="Archive Context")
         args = p.parse_args()

--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -14,7 +14,7 @@ from .core.context import ClusterArchiveContext, HostContext, HostArchiveContext
 from .core.dr import SkipComponent  # noqa: F401
 from .core.hydration import create_context
 from .core.plugins import combiner, metadata, parser, rule  # noqa: F401
-from .core.plugins import cluster_fact, cluster_rule  # noqa: F401
+from .core.plugins import fact, cluster_rule  # noqa: F401
 from .core.plugins import datasource, condition, incident  # noqa: F401
 from .core.plugins import make_response, make_metadata, make_fingerprint  # noqa: F401
 from .core.filters import add_filter, apply_filters, get_filters  # noqa: F401

--- a/insights/core/archives.py
+++ b/insights/core/archives.py
@@ -10,6 +10,9 @@ from insights.util.content_type import from_file
 logger = logging.getLogger(__name__)
 
 
+COMPRESSION_TYPES = ("zip", "tar", "gz", "bz2", "xz")
+
+
 class InvalidArchive(Exception):
     def __init__(self, msg):
         super(InvalidArchive, self).__init__(msg)
@@ -24,7 +27,6 @@ class InvalidContentType(InvalidArchive):
 
 
 class ZipExtractor(object):
-
     def __init__(self, timeout=None):
         self.content_type = "application/zip"
         self.timeout = timeout

--- a/insights/core/cluster.py
+++ b/insights/core/cluster.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+import itertools
+from collections import defaultdict
+
+from insights.core import dr, plugins
+from insights.core.archives import extract
+from insights.core.hydration import create_context
+from insights.specs import Specs
+
+
+MACHINE_IDS = itertools.count()
+
+
+class ClusterMeta(object):
+    def __init__(self, num_members, **kwargs):
+        self.num_members = num_members
+        self.kwargs = kwargs
+
+
+@plugins.combiner(optional=[Specs.machine_id, Specs.hostname])
+def machine_id(mid, hn):
+    ds = mid or hn
+    if ds:
+        return ds.content[0].strip()
+    return str(next(MACHINE_IDS))
+
+
+def attach_machine_id(result, mid):
+    key = "machine_id"
+    if isinstance(result, list):
+        for r in result:
+            r[key] = mid
+    else:
+        result[key] = mid
+    return result
+
+
+def process_archives(archives):
+    for archive in archives:
+        with extract(archive) as ex:
+            ctx = create_context(ex.tmp_dir)
+            broker = dr.Broker()
+            broker[ctx.__class__] = ctx
+            yield dr.run(broker=broker)
+
+
+def extract_cluster_facts(brokers):
+    results = defaultdict(list)
+    for b in brokers:
+        mid = b[machine_id]
+        for k in b.instances:
+            if not plugins.is_type(k, plugins.cluster_fact):
+                continue
+            r = attach_machine_id(b[k], mid)
+            if isinstance(r, list):
+                results[k].extend(r)
+            else:
+                results[k].append(r)
+    return results
+
+
+def process_cluster_facts(facts, meta, use_pandas=False):
+    if use_pandas:
+        import pandas as pd
+
+    broker = dr.Broker()
+    broker[ClusterMeta] = meta
+    for k, v in facts.items():
+        broker[k] = pd.DataFrame(v) if use_pandas else v
+    return dr.run(dr.COMPONENTS[dr.GROUPS.cluster], broker=broker)
+
+
+def process_cluster(archives, use_pandas=False):
+    brokers = process_archives(archives)
+    facts = extract_cluster_facts(brokers)
+    meta = ClusterMeta(len(archives))
+    return process_cluster_facts(facts, meta, use_pandas=use_pandas)

--- a/insights/core/context.py
+++ b/insights/core/context.py
@@ -170,11 +170,7 @@ class SosArchiveContext(ExecutionContext):
 
 @fs_root
 class ClusterArchiveContext(ExecutionContext):
-    def __init__(self, root, paths, stored_command_prefix="insights_commands"):
-        self.root = root
-        self.paths = paths
-        self.stored_command_prefix = stored_command_prefix
-        super(ClusterArchiveContext, self).__init__()
+    pass
 
 
 @fs_root

--- a/insights/core/hydration.py
+++ b/insights/core/hydration.py
@@ -11,29 +11,34 @@ from insights.core.evaluators import SingleEvaluator
 log = logging.getLogger(__name__)
 
 
-def create_context(path, context=None):
-    if context is None and any(f.endswith(COMPRESSION_TYPES) for f in os.listdir(path)):
-        context = ClusterArchiveContext
-
+def get_all_files(path):
     all_files = []
     for f in archives.get_all_files(path):
         if os.path.isfile(f) and not os.path.islink(f):
             all_files.append(f)
-            if context is None:
-                if "insights_commands" in f:
-                    context = HostArchiveContext
-                elif "sos_commands" in f:
-                    context = SosArchiveContext
-                elif "JBOSS_HOME" in f:
-                    context = JDRContext
+    return all_files
 
-    context = context or HostArchiveContext
+
+def determine_context(common_path, files):
+    if any(f.endswith(COMPRESSION_TYPES) for f in os.listdir(common_path)):
+        return ClusterArchiveContext
+
+    for f in files:
+        if "insights_commands" in f:
+            return HostArchiveContext
+        elif "sos_commands" in f:
+            return SosArchiveContext
+        elif "JBOSS_HOME" in f:
+            return JDRContext
+
+    return HostArchiveContext
+
+
+def create_context(path, context=None):
+    all_files = get_all_files(path)
     common_path = os.path.commonprefix(all_files)
-    if context is not ClusterArchiveContext:
-        real_root = os.path.join(path, common_path)
-    else:
-        real_root = path
-    return context(real_root, all_files=all_files)
+    context = determine_context(common_path, all_files)
+    return context(common_path, all_files=all_files)
 
 
 def hydrate_new_dir(path, broker=None):

--- a/insights/core/hydration.py
+++ b/insights/core/hydration.py
@@ -36,7 +36,7 @@ def determine_context(common_path, files):
 
 def create_context(path, context=None):
     all_files = get_all_files(path)
-    common_path = os.path.commonprefix(all_files)
+    common_path = os.path.dirname(os.path.commonprefix(all_files))
     context = determine_context(common_path, all_files)
     return context(common_path, all_files=all_files)
 

--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -125,11 +125,17 @@ class StdTypes(dr.TypeSet):
     incident = dr.new_component_type()
     """ A component used by rules that allows automated statistical analysis."""
 
+    cluster_fact = dr.new_component_type()
+
+    cluster_rule = make_rule_type(group=dr.GROUPS.cluster)
+
 
 combiner = StdTypes.combiner
 rule = StdTypes.rule
 condition = StdTypes.condition
 incident = StdTypes.incident
+cluster_fact = StdTypes.cluster_fact
+cluster_rule = StdTypes.cluster_rule
 
 
 def datasource(*args, **kwargs):

--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -125,7 +125,7 @@ class StdTypes(dr.TypeSet):
     incident = dr.new_component_type()
     """ A component used by rules that allows automated statistical analysis."""
 
-    cluster_fact = dr.new_component_type()
+    fact = dr.new_component_type()
 
     cluster_rule = make_rule_type(group=dr.GROUPS.cluster)
 
@@ -134,7 +134,7 @@ combiner = StdTypes.combiner
 rule = StdTypes.rule
 condition = StdTypes.condition
 incident = StdTypes.incident
-cluster_fact = StdTypes.cluster_fact
+fact = StdTypes.fact
 cluster_rule = StdTypes.cluster_rule
 
 

--- a/insights/util/fs.py
+++ b/insights/util/fs.py
@@ -1,7 +1,41 @@
 import errno
+import hashlib
 import os
 
 from insights.util import subproc
+
+
+def read_in_chunks(file_object, chunk_size=1024):
+    while True:
+        data = file_object.read(chunk_size)
+        if not data:
+            break
+        yield data
+
+
+def touch(fname, times=None):
+    with open(fname, 'a'):
+        os.utime(fname, times)
+
+
+def hash_bytestr_iter(bytesiter, hasher):
+    for block in bytesiter:
+        hasher.update(block)
+    return hasher.hexdigest()
+
+
+def file_as_blockiter(afile, blocksize=65536):
+    block = afile.read(blocksize)
+    while len(block) > 0:
+        yield block
+        block = afile.read(blocksize)
+
+
+def sha256(path):
+    with open(path, "rb") as f:
+        block_iter = file_as_blockiter(f)
+        hasher = hashlib.sha256()
+        return hash_bytestr_iter(block_iter, hasher)
 
 
 def remove(path, chmod=False):

--- a/sample_script.py
+++ b/sample_script.py
@@ -2,15 +2,20 @@
 from insights.core.plugins import make_response, rule
 from insights.parsers.redhat_release import RedhatRelease
 
+CONTENT = {
+    "IS_FEDORA": "This machine runs {{product}}.",
+    "IS_NOT_FEDORA": "This machine runs {{product}}."
+}
+
 
 @rule(RedhatRelease)
 def report(rel):
     """Fires if the machine is running Fedora."""
 
     if "Fedora" in rel.product:
-        return make_response("IS_FEDORA")
+        return make_response("IS_FEDORA", product=rel.product)
     else:
-        return make_response("IS_NOT_FEDORA")
+        return make_response("IS_NOT_FEDORA", product=rel.product)
 
 
 if __name__ == "__main__":

--- a/stand_alone.py
+++ b/stand_alone.py
@@ -10,7 +10,7 @@ from insights.parsers.redhat_release import RedhatRelease
 ERROR_KEY = "TOO_MANY_HOSTS"
 
 CONTENT = {
-    ERROR_KEY: """Too many hosts! {{hosts}}"""
+    ERROR_KEY: """Too many hosts in /etc/hosts: {{num}}"""
 }
 
 
@@ -44,7 +44,7 @@ class HostParser(Parser):
 @rule(HostParser, RedhatRelease)
 def report(hp, rhr):
     if len(hp.hosts) > 1:
-        return make_response("TOO_MANY_HOSTS", hosts=len(hp.hosts))
+        return make_response("TOO_MANY_HOSTS", num=len(hp.hosts))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Support analysis of clusters.

First extract "cluster facts" from individual hosts using our standard data model.

Then cluster rules use those facts from all the environments for further analysis.

```python
#!/usr/bin/env python
from insights import run
from insights.parsers.installed_rpms import InstalledRpms
from insights.core.plugins import cluster_fact, cluster_rule

@cluster_fact(InstalledRpms)
def get_bash(rpms):
    rpm = rpms.get_max("bash")
    return {"name": rpm.name, version=rpm.nvr}

@cluster_rule(get_bash)
def report(bash):
    print(bash)

if __name__ == "__main__":
    from insights import run
    run(report, print_summary=True)
```
Run the script against a directory of archives or an uber archive:

`./bash_version.py archives/` for the rule to receive a list of dictionaries.
`./bash_version.py --pandas archives/` for the rule to receive a pandas DataFrame.

Either version will have been enhanced with the machine_id, hostname, or automatically generated unique identifier so that joins are possible across multiple arguments.

Integration support is in `insights/core/cluster.py` with the following functions:

*  `process_archives` runs an archive at a time and yields a broker for each
*  `extract_cluster_facts` extracts the facts from a generator of brokers
*  `process_cluster_facts` accepts the facts generated above and continues processing of cluster components.
*  `process_cluster` runs everything from a list of archives on disk to the final results. It just ties the above functions together in the same process.

The main integration points are `extract_cluster_facts` and `process_cluster_facts`. Facts are simple python types and so are easy to store, enhance, and reload at different times.

Still have work to do in the integration test framework, making external cluster metadata available, unit tests, docs.