### PR TITLE
Add output_encoding keyword to subproc.call defaulting to 'utf-8'

### DIFF
--- a/insights/tests/test_specs.py
+++ b/insights/tests/test_specs.py
@@ -62,7 +62,7 @@ def test_spec_factory():
     assert dostuff in broker, broker.tracebacks
     assert broker[Stuff.smpl_file].content == file_content
     assert not any(l.endswith("\n") for l in broker[Stuff.smpl_file].content)
-    assert b"hello" in broker[Stuff.smpl_cmd_list_of_lists].content[0]
+    assert "hello" in broker[Stuff.smpl_cmd_list_of_lists].content[0]
     assert len(broker[Stuff.smpl_cmd_list_of_lists].content) == 1
 
 
@@ -74,8 +74,8 @@ def test_line_terminators():
     broker = dr.run(dr.get_dependency_graph(dostuff), broker)
 
     content = broker[Stuff.smpl_file].content
-    assert all(b"def test" in l for l in content), content
-    assert not any(l.endswith(b"\n") for l in content)
+    assert all("def test" in l for l in content), content
+    assert not any(l.endswith("\n") for l in content)
 
 
 def test_glob_max(max_globs):

--- a/insights/tests/test_subproc.py
+++ b/insights/tests/test_subproc.py
@@ -7,14 +7,14 @@ from insights.util import subproc
 
 def test_call():
     result = subproc.call('echo -n hello')
-    assert result == b'hello'
+    assert result == 'hello'
 
 
 def test_call_list_of_lists():
     cmd = "echo -n ' hello '"
     cmd = shlex.split(cmd)
     result = subproc.call([cmd, ["grep", "-F", "hello"]])
-    assert b"hello" in result
+    assert "hello" in result
 
 
 def test_call_timeout():

--- a/insights/util/subproc.py
+++ b/insights/util/subproc.py
@@ -46,7 +46,7 @@ class CalledProcessError(Exception):
 
 
 def call(cmd, timeout=None, signum=signal.SIGKILL, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-         keep_rc=False, **kwargs):
+         keep_rc=False, output_encoding="utf-8", **kwargs):
     """Call cmd with an optional timeout in seconds.
 
     If `timeout` is supplied and expires, the process is killed with
@@ -114,7 +114,7 @@ def call(cmd, timeout=None, signum=signal.SIGKILL, shell=False, stdout=subproces
     except Exception as e:
         six.reraise(CalledProcessError, CalledProcessError(rc, cmd, str(e)), sys.exc_info()[2])
     if keep_rc:
-        return rc, output
+        return rc, output.decode(output_encoding) if output_encoding else output
     if rc:
         raise CalledProcessError(rc, cmd, output)
-    return output
+    return output.decode(output_encoding) if output_encoding else output


### PR DESCRIPTION
Fix for #1181 

Command datasources were returning bytes by default instead of unicode, which causes string comparison failures in parsers in python 3. I added a "output_encoding" keyword to `insights.util.subproc.call` that defaults to UTF-8. Pass it `None` to get raw bytes.