### PR TITLE
[yum] Added new property to retrive RHEL repo names

### DIFF
--- a/insights/parsers/tests/test_yum_repolist.py
+++ b/insights/parsers/tests/test_yum_repolist.py
@@ -49,6 +49,21 @@ def test_eus():
     assert repo_list.eus == ["6.2.aus"]
 
 
+def test_rhel_repos():
+    repo_list = YumRepoList(context_wrap(YUM_REPOLIST_CONTENT))
+    assert len(repo_list.rhel_repos) == 4
+    assert repo_list.rhel_repos == ['rhel-7-server-satellite-capsule-6.1-rpms',
+                                    'rhel-server-rhscl-7-rpms',
+                                    'rhel-7-server-rpms',
+                                    'rhel-7-server-satellite-6.1-rpms']
+
+    repo_list = YumRepoList(context_wrap(YUM_REPOLIST_CONTENT_MISSING_STATUS))
+    assert len(repo_list.rhel_repos) == 0
+
+    repo_list = YumRepoList(context_wrap(''))
+    assert len(repo_list.rhel_repos) == 0
+
+
 def test_valueerror_in_parse():
     repo_list = YumRepoList(context_wrap(YUM_REPOLIST_CONTENT_MISSING_STATUS))
     assert repo_list[0]['name'] == ''

--- a/insights/parsers/tests/test_yum_repolist.py
+++ b/insights/parsers/tests/test_yum_repolist.py
@@ -52,10 +52,10 @@ def test_eus():
 def test_rhel_repos():
     repo_list = YumRepoList(context_wrap(YUM_REPOLIST_CONTENT))
     assert len(repo_list.rhel_repos) == 4
-    assert repo_list.rhel_repos == ['rhel-7-server-satellite-capsule-6.1-rpms',
-                                    'rhel-server-rhscl-7-rpms',
-                                    'rhel-7-server-rpms',
-                                    'rhel-7-server-satellite-6.1-rpms']
+    assert set(repo_list.rhel_repos) == set(['rhel-7-server-rpms',
+                                             'rhel-7-server-satellite-6.1-rpms',
+                                             'rhel-7-server-satellite-capsule-6.1-rpms',
+                                             'rhel-server-rhscl-7-rpms'])
 
     repo_list = YumRepoList(context_wrap(YUM_REPOLIST_CONTENT_MISSING_STATUS))
     assert len(repo_list.rhel_repos) == 0

--- a/insights/parsers/yum.py
+++ b/insights/parsers/yum.py
@@ -73,3 +73,8 @@ class YumRepoList(Parser):
                 if eus_version in eus:
                     euses.append(eus_version)
         return euses
+
+    @property
+    def rhel_repos(self):
+        '''Get list of RHEL repos'''
+        return [i.split('/')[0] for i in self.repos.keys() if i.startswith('rhel')]

--- a/insights/parsers/yum.py
+++ b/insights/parsers/yum.py
@@ -76,5 +76,5 @@ class YumRepoList(Parser):
 
     @property
     def rhel_repos(self):
-        '''Get list of RHEL repos'''
+        '''Get list of RHEL repos/Repo IDs'''
         return [i.split('/')[0] for i in self.repos.keys() if i.startswith('rhel')]


### PR DESCRIPTION
Often we need a list of repo-ids and not entire repo dictionary to
check if a repo is available in customer's environment. This patch
provides that property.

Signed-off-by: Sachin Patil <psachin@redhat.com>