### PR TITLE
Allow adding arbitrary components to InputData to mock dependencies.

### DIFF
--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -99,16 +99,6 @@ def context_wrap(lines,
 input_data_cache = {}
 
 
-# UUID is kinda slow
-GLOBAL_NUMBER = 0
-
-
-def next_gn():
-    global GLOBAL_NUMBER
-    GLOBAL_NUMBER += 1
-    return GLOBAL_NUMBER
-
-
 def create_metadata(system_id, product):
     ctx_metadata = {
         "system_id": system_id,
@@ -146,12 +136,16 @@ class InputData(object):
         input_data_cache[name] = cnt + 1
         if hostname:
             self.add(Specs.hostname, hostname)
+        self.num_source = itertools.count()
 
     def __setitem__(self, key, value):
         self.add(key, value)
 
     def __getitem__(self, key):
         return self.data[key]
+
+    def _make_path(self):
+        return str(next(self.num_source)) + "BOGUS"
 
     def get(self, key, default):
         return self.data.get(key, default)
@@ -164,9 +158,17 @@ class InputData(object):
         the_clone.name = name
         return the_clone
 
+    def add_component(self, comp, obj):
+        """
+        Allow adding arbitrary objects as components. This allows tests to mock
+        components that have external dependencies so their dependents can be
+        integration tested.
+        """
+        self.data[comp] = obj
+
     def add(self, spec, content, path=None, do_filter=True):
         if not path:  # path must change to allow parsers to fire
-            path = str(next_gn()) + "BOGUS"
+            path = self._make_path()
         if not path.startswith("/"):
             path = "/" + path
 

--- a/insights/tests/test_add_component.py
+++ b/insights/tests/test_add_component.py
@@ -1,0 +1,24 @@
+from insights import combiner
+from insights.tests import archive_provider, InputData
+
+
+@combiner()
+def one():
+    return 1
+
+
+@combiner()
+def two():
+    return 2
+
+
+@combiner(one, two)
+def three(x, y):
+    return x + y
+
+
+@archive_provider(three)
+def integration_tests():
+    data = InputData()
+    data.add_component(two, 5)
+    yield data, 6


### PR DESCRIPTION
Some people are writing components that call out to services. This will let them mock those services to test their components without external dependencies.