### PR TITLE
Update specs to rules script to work with version 3 of core

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -633,8 +633,8 @@ def first_of(deps):
                 return broker[c]
 
     docs = [escape(d.__doc__) for d in deps if d.__doc__]
-    docs = ["Returns the first of the following:"] + docs
-    inner.__doc__ = "\n".join(docs)
+    docs = [b"Returns the first of the following:"] + docs
+    inner.__doc__ = b"\n".join(docs)
     return inner
 
 

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -22,9 +22,13 @@ log = logging.getLogger(__name__)
 COMMANDS = {}
 
 
-def escape(s):
+def enc(s):
     escape_encoding = "string_escape" if six.PY2 else "unicode_escape"
     return s.encode(escape_encoding)
+
+
+def escape(s):
+    return re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", s)
 
 
 def mangle_command(command, name_max=255):
@@ -339,7 +343,7 @@ def simple_file(path, context=None, kind=TextFileProvider):
     def inner(broker):
         ctx = _get_context(context, FSRoots, broker)
         return kind(ctx.locate_path(path), root=ctx.root, ds=inner)
-    inner.__doc__ = 'Path: ' + re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", path)
+    inner.__doc__ = 'Path: ' + escape(path)
     return inner
 
 
@@ -383,7 +387,7 @@ def glob_file(patterns, ignore=None, context=None, kind=TextFileProvider, max_fi
                                        "the specs file pattern to narrow down results".format(len(results), max_files))
             return results
         raise ContentException("[%s] didn't match." % ', '.join(patterns))
-    pat = [re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", p) for p in patterns]
+    pat = [escape(p) for p in patterns]
     inner.__doc__ = 'Path: ' + ", ".join(pat)
     return inner
 
@@ -399,7 +403,7 @@ def head(dep):
             return c[0]
         raise dr.SkipComponent()
 
-    inner.__doc__ = re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", dep.func_doc)
+    inner.__doc__ = escape(dep.func_doc)
     return inner
 
 
@@ -429,7 +433,7 @@ def first_file(files, context=None, kind=TextFileProvider):
             except:
                 pass
         raise ContentException("None of [%s] found." % ', '.join(files))
-    fls = [re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", f) for f in files]
+    fls = [escape(f) for f in files]
     inner.__doc__ = 'Path: ' + ", ".join(fls)
     return inner
 
@@ -461,7 +465,7 @@ def listdir(path, context=None):
         if result:
             return [os.path.basename(r) for r in result]
         raise ContentException("Can't list %s or nothing there." % p)
-    inner.__doc__ = 'Path: ' + re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", path)
+    inner.__doc__ = 'Path: ' + escape(path)
     return inner
 
 
@@ -509,7 +513,7 @@ def simple_command(cmd, context=HostContext, split=True, keep_rc=False, timeout=
             result = raw
         return CommandOutputProvider(cmd, ctx, split=split, content=result, rc=rc, keep_rc=keep_rc)
     COMMANDS[inner] = cmd
-    inner.__doc__ = 'Command: ' + re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", cmd)
+    inner.__doc__ = 'Command: ' + escape(cmd)
     return inner
 
 
@@ -576,7 +580,7 @@ def foreach_execute(provider, cmd, context=HostContext, split=True, keep_rc=Fals
         if result:
             return result
         raise ContentException("No results found for [%s]" % cmd)
-    inner.__doc__ = 'Command: ' + re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", cmd)
+    inner.__doc__ = 'Command: ' + escape(cmd)
     return inner
 
 
@@ -619,7 +623,7 @@ def foreach_collect(provider, path, ignore=None, context=HostContext, kind=TextF
         if result:
             return result
         raise ContentException("No results found for [%s]" % path)
-    inner.__doc__ = 'Path: ' + re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", path)
+    inner.__doc__ = 'Path: ' + escape(path)
     return inner
 
 
@@ -636,11 +640,9 @@ def first_of(deps):
             if c in broker:
                 return broker[c]
 
-    docs = [re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", d.__doc__) if isinstance(d, list) and
-            d.func_name != 'inner' else d.__doc__ for d in deps if d.__doc__]
-    docs = [escape(d) for d in docs]
-    docs = [b"Returns the first of the following:"] + docs
-    inner.__doc__ = b",".join(docs)
+    docs = [escape(d) if isinstance(d, list) and d.func_name != 'inner' else d.__doc__ for d in deps if d.__doc__]
+    docs = [enc(d) for d in docs]
+    inner.__doc__ = b",".join([b"Returns the first of the following:"] + docs)
     return inner
 
 

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -384,8 +384,8 @@ def glob_file(patterns, ignore=None, context=None, kind=TextFileProvider, max_fi
                                        "the specs file pattern to narrow down results".format(len(results), max_files))
             return results
         raise ContentException("[%s] didn't match." % ', '.join(patterns))
-    patterns = [re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", p) for p in patterns]
-    inner.__doc__ = 'Path: ' + ", ".join(patterns)
+    pat = [re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", p) for p in patterns]
+    inner.__doc__ = 'Path: ' + ", ".join(pat)
     return inner
 
 
@@ -430,8 +430,8 @@ def first_file(files, context=None, kind=TextFileProvider):
             except:
                 pass
         raise ContentException("None of [%s] found." % ', '.join(files))
-    files = [re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", f) for f in files]
-    inner.__doc__ = 'Path: ' + ", ".join(files)
+    fls = [re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", f) for f in files]
+    inner.__doc__ = 'Path: ' + ", ".join(fls)
     return inner
 
 

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -4,7 +4,6 @@ import os
 import re
 import six
 import traceback
-import re
 
 from collections import defaultdict
 from glob import glob
@@ -637,8 +636,8 @@ def first_of(deps):
             if c in broker:
                 return broker[c]
 
-    docs = [re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", d.__doc__) if d.func_name != 'inner' else d.__doc__
-            for d in deps if d.__doc__]
+    docs = [re.sub(r"([=\(\)|\-_!@*~\"&/\\\^\$\=])", r"\\\1", d.__doc__) if isinstance(d, list) and
+            d.func_name != 'inner' else d.__doc__ for d in deps if d.__doc__]
     docs = [escape(d) for d in docs]
     docs = [b"Returns the first of the following:"] + docs
     inner.__doc__ = b",".join(docs)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -271,7 +271,7 @@ class DefaultSpecs(Specs):
 
     @datasource(ipcs_s)
     def semid(broker):
-        """Command - semids"""
+        """Command: semids"""
         source = broker[DefaultSpecs.ipcs_s].content
         results = set()
         for s in source:

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -66,6 +66,7 @@ class DefaultSpecs(Specs):
 
     @datasource(ps_auxww)
     def tomcat_base(broker):
+        """Path: Tomcat base path"""
         ps = broker[DefaultSpecs.ps_auxww].content
         results = []
         findall = re.compile(r"\-Dcatalina\.base=(\S+)").findall
@@ -140,6 +141,7 @@ class DefaultSpecs(Specs):
 
     @datasource(docker_list_images)
     def docker_image_ids(broker):
+        """Command: docker_image_ids"""
         images = broker[DefaultSpecs.docker_list_images]
         try:
             result = set()
@@ -154,6 +156,7 @@ class DefaultSpecs(Specs):
     # TODO: This parsing is broken.
     @datasource(docker_list_containers)
     def docker_container_ids(broker):
+        """Command: docker_container_ids"""
         containers = broker[DefaultSpecs.docker_list_containers]
         try:
             result = set()
@@ -234,6 +237,7 @@ class DefaultSpecs(Specs):
 
     @datasource(ps_auxww)
     def httpd_cmd(broker):
+        """Command: httpd_command"""
         ps = broker[DefaultSpecs.ps_auxww].content
         ps_httpds = set()
         for p in ps:
@@ -267,6 +271,7 @@ class DefaultSpecs(Specs):
 
     @datasource(ipcs_s)
     def semid(broker):
+        """Command - semids"""
         source = broker[DefaultSpecs.ipcs_s].content
         results = set()
         for s in source:
@@ -434,6 +439,7 @@ class DefaultSpecs(Specs):
 
     @datasource(ps_auxww, context=HostContext)
     def package_and_java(broker):
+        """Command: package_and_java"""
         ps = broker[DefaultSpecs.ps_auxww].content
         ctx = broker[HostContext]
         results = set()
@@ -517,6 +523,7 @@ class DefaultSpecs(Specs):
 
     @datasource(HostContext)
     def block(broker):
+        """Path: /sys/block directories starting with . or ram or dm- or loop"""
         remove = (".", "ram", "dm-", "loop")
         tmp = "/dev/%s"
         return[(tmp % f) for f in os.listdir("/sys/block") if not f.startswith(remove)]
@@ -575,6 +582,7 @@ class DefaultSpecs(Specs):
 
     @datasource(ps_auxww)
     def tomcat_home_base(broker):
+        """Command: tomcat_home_base_paths"""
         ps = broker[DefaultSpecs.ps_auxww].content
         results = []
         findall = re.compile(r"\-Dcatalina\.(home|base)=(\S+)").findall
@@ -629,6 +637,7 @@ class DefaultSpecs(Specs):
 
     @datasource(DockerImageContext)
     def docker_installed_rpms(broker):
+        """ Command: /usr/bin/rpm -qa --root `%s` --qf `%s`"""
         ctx = broker[DockerImageContext]
         root = ctx.root
         fmt = DefaultSpecs.rpm_format
@@ -641,6 +650,7 @@ class DefaultSpecs(Specs):
 
     @datasource(ps_auxww, context=HostContext)
     def jboss_home(broker):
+        """Command: JBoss home progress command content paths"""
         ps = broker[DefaultSpecs.ps_auxww].content
         results = []
         findall = re.compile(r"\-Djboss\.home\.dir=(\S+)").findall
@@ -658,6 +668,7 @@ class DefaultSpecs(Specs):
 
     @datasource(ps_auxww, context=HostContext, multi_output=True)
     def jboss_domain_server_log_dir(broker):
+        """Command: JBoss domain server log directory"""
         ps = broker[DefaultSpecs.ps_auxww].content
         results = []
         findall = re.compile(r"\-Djboss\.server\.log\.dir=(\S+)").findall
@@ -674,6 +685,7 @@ class DefaultSpecs(Specs):
 
     @datasource(ps_auxww, context=HostContext, multi_output=True)
     def jboss_standalone_main_config_files(broker):
+        """Command: JBoss standalone main config files"""
         ps = broker[DefaultSpecs.ps_auxww].content
         results = []
         search = re.compile(r"\-Djboss\.server\.base\.dir=(\S+)").search

--- a/insights/tools/specs_to_rules.py
+++ b/insights/tools/specs_to_rules.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""
+Create a mapping of specs, rules and filters for each parser
+
+To run this script execute the following commands:
+$ cd insights-core
+$ source bin/activate
+$ cd ../insights-plugins
+$ export PYTHONPATH=./
+$ ../insights-core/insights/tools/specs_to_rules.py > report.html
+
+"""
+from collections import defaultdict
+# import json
+import datetime
+from insights.core import plugins
+from insights.config.factory import get_config
+from jinja2 import Environment
+
+REPORT = """
+<html><head><title>Parser Rule Mapping Report ({{ report_date }})</title>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+</head>
+<body>
+<h2>Parser Rule Mapping Report {{ report_date }}</h2>
+<p>This is the mapping of Red Hat Insights Parsers to Insights Rules that utilize those parsers.</p>
+
+<table class="table table-striped table-bordered">
+<thead>
+<tr><th>Spec Name</th><th>Spec</th><th>Rules</th><th>Filters</th></tr>
+</thead>
+<tbody>
+{% for name in specs.keys()|sort %}
+    {% for spec in specs[name].keys() %}
+        {% if "_filters" not in spec %}
+            <tr>
+                <td>{{ name }}</td>
+                <td><code>{{ spec.strip('<>') }}</code></td>
+                <td>{{ specs[name][spec] }}</td>
+                <td>
+                    {% for f in specs[name][name + "_filters"] %}
+                       <li>{{ f|e }}</li>
+                    {% endfor %}
+                </td>
+            </tr>
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+</tbody>
+</table>
+</body></html>
+""".strip()
+
+
+def get_filters_for(name):
+    return list(plugins.NAME_TO_FILTER_MAP.get(name, ()))
+
+
+def main():
+    config = get_config()
+
+    plugins.load("insights.parsers")
+    plugins.load("insights.combiners")
+    plugins.load("telemetry.rules")
+
+    parsers = [p for p in plugins.COMPONENTS_BY_TYPE[plugins.parser] if p.consumers]
+    deps = defaultdict(dict)
+
+    for p in parsers:
+        for name in p.symbolic_names:
+            spec = config.get_specs(name)
+            rules = sorted(plugins.get_name(c) for c in p.consumers)
+
+            for s in spec:
+                deps[name][str(s)] = ", ".join(rules)
+                deps[name][name + "_filters"] = sorted(get_filters_for(name))
+
+    # print json.dumps(dict(deps))
+
+    report = Environment().from_string(REPORT).render(
+        report_date=datetime.date.today().strftime("%B %d, %Y"), specs=deps)
+
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/insights/tools/specs_to_rules.py
+++ b/insights/tools/specs_to_rules.py
@@ -14,7 +14,8 @@ from collections import defaultdict
 import datetime
 from insights.core import dr, filters
 from jinja2 import Environment
-from insights.core.plugins import is_datasource
+from insights.core.plugins import is_datasource, datasource
+
 
 REPORT = """
 <html><head><title>Parser Rule Mapping Report ({{ report_date }})</title>
@@ -30,12 +31,11 @@ REPORT = """
 </thead>
 <tbody>
 {% for name in specs.keys()|sort %}
-    {% for spec in specs[name].keys() %}
         {% if "_filters" not in spec %}
             <tr>
                 <td>{{ name }}</td>
-                <td><code>{{ spec.strip('<>') }}</code></td>
-                <td>{{ specs[name][spec] }}</td>
+                <td><code>{{ specs[name][name + "_spec-def"] }}</code></td>
+                <td>{{ specs[name][name + "_rules"] }}</td>
                 <td>
                     {% for f in specs[name][name + "_filters"] %}
                        <li>{{ f|e }}</li>
@@ -43,7 +43,6 @@ REPORT = """
                 </td>
             </tr>
         {% endif %}
-    {% endfor %}
 {% endfor %}
 </tbody>
 </table>
@@ -55,29 +54,69 @@ def main():
     # config = get_config()
 
     dr.load_components("insights.specs.default")
-    dr.load_components("insights.specs.insights_archive")
-    dr.load_components("insights.specs.sos_archive")
     dr.load_components("insights.parsers")
     dr.load_components("insights.combiners")
     dr.load_components("telemetry.rules.plugins")
     dr.load_components("prodsec")
+    ds = dr.COMPONENTS_BY_TYPE[datasource]
 
-    # parsers = sorted([c for c in dr.DELEGATES if is_parser(c)], key=dr.get_simple_name)
-    # combiners = sorted([c for c in dr.DELEGATES if is_combiner(c)], key=dr.get_name)
-    specs = sorted([c for c in dr.DELEGATES
-                    if is_datasource(c) and dr.get_module_name(c) == 'insights.specs'],
-                   key=dr.get_simple_name)
+    specs = []
+    for c in ds:
+        if not is_datasource(c):
+            continue
+        if not any(is_datasource(d) for d in dr.get_dependents(c)):
+            specs.append(c)
 
     deps = defaultdict(dict)
 
-    for spec in specs:
+    pspec = ''
+    for spec in sorted(specs, key=dr.get_name):
+
         info = dict(name=dr.get_simple_name(spec))
+
         f = filters.get_filters(spec)
         info['dependents'] = []
+
+        spds = None
+        d = [d for d in dr.get_dependencies(spec) if is_datasource(d)]
+        for dp in d:
+            c = dr.get_dependencies(dp)
+            for cdeps in c:
+                if is_datasource(cdeps) and '__qualname__' in cdeps.func_dict and 'DefaultSpecs' in cdeps.func_dict['__qualname__']:
+                    spds = cdeps
+
+        for d in dr.get_dependencies(spec):
+            cp = ''
+            if d.__doc__:
+                lines = d.__doc__.splitlines()
+            if len(lines) > 1 and "Returns the first" in lines[0]:
+                head = [lines[0]]
+                top = ["<ul>"]
+                bottom = ["</ul>"]
+                if spds:
+                    lines = [l.replace('Command:', '') for l in lines]
+                    lines = [l.replace('Path:', '') for l in lines]
+                    lines = ["<li>" + l + "</li>" for l in lines[1:]]
+                    # lines = ["<li>" + spds.func_doc + ',' + l + "</li>" for l in lines[1:]]
+                else:
+                    lines = ["<li>" + l + "</li>" for l in lines[1:]]
+                cp = "\n".join(head + top + lines + bottom)
+            else:
+                if spds:
+                    d.__doc__ = d.__doc__.replace('Command:', '')
+                    d.__doc__ = d.__doc__.replace('Path:', '')
+                    d.__doc__ = spds.func_doc + ', ' + d.__doc__
+                cp = d.__doc__
+
         for d in dr.get_dependents(spec):
+            if dr.get_simple_name(pspec) == dr.get_simple_name(d):
+                continue
+            pspec = d
+
             p = [dr.get_name(sd) for sd in dr.get_dependents(d)]
             rules = sorted([x.rsplit('.', 2)[1] for x in p])
-            deps[info['name']][info['name']] = ", ".join(rules)
+            deps[info['name']][info['name'] + "_spec-def"] = cp
+            deps[info['name']][info['name'] + "_rules"] = ", ".join(rules)
             deps[info['name']][info['name'] + "_filters"] = f
 
     report = Environment().from_string(REPORT).render(

--- a/insights/tools/specs_to_rules.py
+++ b/insights/tools/specs_to_rules.py
@@ -89,9 +89,6 @@ def main():
             cp = ''
             lines = []
 
-            if spec.func_name == 'installed_rpms':
-                o=0
-
             if d.__doc__ and "Returns the first" in d.__doc__:
                 lines = d.__doc__.replace(',', '\n')
                 lines = lines.splitlines()

--- a/insights/tools/specs_to_rules.py
+++ b/insights/tools/specs_to_rules.py
@@ -87,9 +87,14 @@ def main():
 
         for d in dr.get_dependencies(spec):
             cp = ''
-            if d.__doc__:
-                lines = d.__doc__.splitlines()
-            if len(lines) > 1 and "Returns the first" in lines[0]:
+            lines = []
+
+            if spec.func_name == 'installed_rpms':
+                o=0
+
+            if d.__doc__ and "Returns the first" in d.__doc__:
+                lines = d.__doc__.replace(',', '\n')
+                lines = lines.splitlines()
                 head = [lines[0]]
                 top = ["<ul>"]
                 bottom = ["</ul>"]


### PR DESCRIPTION
Took the Insights Core 1.x version of specs_to_rules (insights-core/insights/tools/specs_to_rules.py) and refactored to work with Insights Core 3.x