### PR TITLE
tweak constants

### DIFF
--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -161,9 +161,7 @@ DEFAULT_OPTS = {
         'group': 'debug'
     },
     'logging_file': {
-        'default': os.path.join(
-            constants.log_dir,
-            constants.app_name) + '.log',
+        'default': constants.default_log_file,
         'opt': ['--logging-file'],
         'help': 'Path to log file location',
         'action': 'store'

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -9,10 +9,11 @@ class InsightsConstants(object):
     package_path = os.path.dirname(
         os.path.dirname(os.path.abspath(__file__)))
     sleep_time = 300
+    default_conf_dir = '/etc/insights-client'
     default_conf_file = '/etc/insights-client/insights-client.conf'
     user_agent = os.path.join(app_name, package_info["VERSION"])
     log_dir = os.path.join(os.sep, 'var', 'log', app_name)
-    default_conf_dir = '/etc/insights-client'
+    default_log_file = os.path.join(log_dir, app_name + '.log')
     default_sed_file = os.path.join(default_conf_dir, '.exp.sed')
     base_url = ''
     collection_rules_file = os.path.join(default_conf_dir, '.cache.json')


### PR DESCRIPTION
We were referencing `constants.default_log_file` in `auto_config.py` but it didn't actually exist. So, create it.