### PR TITLE
Allow filtering by node type

### DIFF
--- a/docs/notebooks/Config Tree Tutorial.ipynb
+++ b/docs/notebooks/Config Tree Tutorial.ipynb
@@ -386,7 +386,9 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -484,7 +486,220 @@
     "editable": true
    },
    "source": [
-    "Several predicates are provided: startswith, endswith, contains, lt, le, gt, ge, and eq. They can all be negated with ~ (not) and combined with & (boolean and) and | (boolean or)."
+    "Several predicates are provided: startswith, endswith, contains, lt, le, gt, ge, and eq. They can all be negated with ~ (not) and combined with & (boolean and) and | (boolean or).\n",
+    "\n",
+    "It's also possible to filter results based on whether they're a `Section` or a `Directive`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "[Directory /]\n",
+       "    AllowOverride: none\n",
+       "    Require: all denied\n",
+       "\n",
+       "\n",
+       "[Directory /var/www]\n",
+       "    AllowOverride: None\n",
+       "    Require: all granted\n",
+       "\n",
+       "\n",
+       "[Directory /var/www/html]\n",
+       "    Options: Indexes FollowSymLinks\n",
+       "    AllowOverride: None\n",
+       "    Require: all granted\n",
+       "\n",
+       "DirectoryIndex: index.html\n",
+       "\n",
+       "[Directory /var/www/cgi-bin]\n",
+       "    AllowOverride: None\n",
+       "    Options: None\n",
+       "    Require: all granted\n",
+       "\n",
+       "\n",
+       "[Directory /usr/share/httpd/icons]\n",
+       "    Options: Indexes MultiViews FollowSymlinks\n",
+       "    AllowOverride: None\n",
+       "    Require: all granted\n",
+       "\n",
+       "\n",
+       "[Directory /home/*/public_html]\n",
+       "    AllowOverride: FileInfo AuthConfig Limit Indexes\n",
+       "    Options: MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec\n",
+       "    Require: method GET POST OPTIONS\n",
+       "\n",
+       "\n",
+       "[Directory /usr/share/httpd/noindex]\n",
+       "    AllowOverride: None\n",
+       "    Require: all granted"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conf.find_all(startswith(\"Directory\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Directives:\n",
+      "DirectoryIndex: index.html\n",
+      "\n",
+      "Sections:\n",
+      "\n",
+      "[Directory /]\n",
+      "    AllowOverride: none\n",
+      "    Require: all denied\n",
+      "\n",
+      "\n",
+      "[Directory /var/www]\n",
+      "    AllowOverride: None\n",
+      "    Require: all granted\n",
+      "\n",
+      "\n",
+      "[Directory /var/www/html]\n",
+      "    Options: Indexes FollowSymLinks\n",
+      "    AllowOverride: None\n",
+      "    Require: all granted\n",
+      "\n",
+      "\n",
+      "[Directory /var/www/cgi-bin]\n",
+      "    AllowOverride: None\n",
+      "    Options: None\n",
+      "    Require: all granted\n",
+      "\n",
+      "\n",
+      "[Directory /usr/share/httpd/icons]\n",
+      "    Options: Indexes MultiViews FollowSymlinks\n",
+      "    AllowOverride: None\n",
+      "    Require: all granted\n",
+      "\n",
+      "\n",
+      "[Directory /home/*/public_html]\n",
+      "    AllowOverride: FileInfo AuthConfig Limit Indexes\n",
+      "    Options: MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec\n",
+      "    Require: method GET POST OPTIONS\n",
+      "\n",
+      "\n",
+      "[Directory /usr/share/httpd/noindex]\n",
+      "    AllowOverride: None\n",
+      "    Require: all granted\n",
+      "\n",
+      "\n",
+      "Chained filtering:\n",
+      "Options: Indexes FollowSymLinks\n",
+      "Options: None\n",
+      "Options: Indexes MultiViews FollowSymlinks\n",
+      "Options: MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = startswith(\"Directory\")\n",
+    "print \"Directives:\"\n",
+    "print conf.find_all(query).directives\n",
+    "print\n",
+    "print \"Sections:\"\n",
+    "print conf.find_all(query).sections\n",
+    "print\n",
+    "print \"Chained filtering:\"\n",
+    "print conf.find_all(query).sections[\"Options\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that `conf[startswith(\"Dir\")].sections` is not the same as `conf.sections.[startswith(\"Dir\")]`. The first finds all the top level nodes that start with \"Dir\" and then filters those to just the sections. The second gets all of the top level sections and then searches their children for nodes starting with \"Dir.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top level Sections starting with 'Dir':\n",
+      "\n",
+      "[Directory /]\n",
+      "    AllowOverride: none\n",
+      "    Require: all denied\n",
+      "\n",
+      "\n",
+      "[Directory /var/www]\n",
+      "    AllowOverride: None\n",
+      "    Require: all granted\n",
+      "\n",
+      "\n",
+      "[Directory /var/www/html]\n",
+      "    Options: Indexes FollowSymLinks\n",
+      "    AllowOverride: None\n",
+      "    Require: all granted\n",
+      "\n",
+      "\n",
+      "[Directory /var/www/cgi-bin]\n",
+      "    AllowOverride: None\n",
+      "    Options: None\n",
+      "    Require: all granted\n",
+      "\n",
+      "\n",
+      "[Directory /usr/share/httpd/icons]\n",
+      "    Options: Indexes MultiViews FollowSymlinks\n",
+      "    AllowOverride: None\n",
+      "    Require: all granted\n",
+      "\n",
+      "\n",
+      "[Directory /home/*/public_html]\n",
+      "    AllowOverride: FileInfo AuthConfig Limit Indexes\n",
+      "    Options: MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec\n",
+      "    Require: method GET POST OPTIONS\n",
+      "\n",
+      "\n",
+      "[Directory /usr/share/httpd/noindex]\n",
+      "    AllowOverride: None\n",
+      "    Require: all granted\n",
+      "\n",
+      "\n",
+      "Children starting with 'Dir' of any top level Section:\n",
+      "DirectoryIndex: index.html\n"
+     ]
+    }
+   ],
+   "source": [
+    "print \"Top level Sections starting with 'Dir':\"\n",
+    "print conf[startswith(\"Dir\")].sections\n",
+    "print\n",
+    "print \"Children starting with 'Dir' of any top level Section:\"\n",
+    "print conf.sections[startswith(\"Dir\")]"
    ]
   },
   {
@@ -500,7 +715,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -559,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -596,7 +811,7 @@
        " 'User']"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -618,7 +833,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -666,7 +881,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -712,7 +927,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -725,7 +940,7 @@
        "ServerRoot: /etc/httpd"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -736,7 +951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -749,7 +964,7 @@
        "Alias: /icons/ /usr/share/httpd/icons/"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -770,7 +985,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -783,7 +998,7 @@
        "Alias: /.noindex.html /usr/share/httpd/noindex/index.html"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -794,7 +1009,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -827,7 +1042,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -873,7 +1088,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -909,12 +1124,12 @@
     "editable": true
    },
    "source": [
-    "The `find` asks for the first named Directory that also contains a child named Options. It returns the first root of a matching sub tree. The brackets first ask for all Directory nodes and then ask for all the Option nodes within them. It returns the leaves of all matching subtrees that start at the root of the configuration."
+    "The `find` asks for the first node named Directory that also contains a child named Options. It returns the first root of a matching sub tree. The brackets first ask for all Directory nodes and then ask for all the Option nodes within them. It returns the leaves of all matching subtrees that start at the root of the configuration."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 26,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -996,7 +1211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -1021,7 +1236,7 @@
        "    LogFormat: '%h %l %u %t \\\"%r\\\" %>s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\" %I %O' combinedio"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1044,7 +1259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -1059,7 +1274,7 @@
        "    LogFormat: '%h %l %u %t \\\"%r\\\" %>s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\" %I %O' combinedio"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1087,7 +1302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 29,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -1145,7 +1360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 30,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -1162,7 +1377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "metadata": {
     "collapsed": false,
     "deletable": true,

--- a/insights/configtree/__init__.py
+++ b/insights/configtree/__init__.py
@@ -180,6 +180,17 @@ class Node(object):
         """
         return self.select(*queries, deep=True, roots=False)
 
+    def _children_of_type(self, t):
+        return [c for c in self.children if isinstance(c, t)]
+
+    @property
+    def sections(self):
+        return SearchResult(children=self._children_of_type(Section))
+
+    @property
+    def directives(self):
+        return SearchResult(children=self._children_of_type(Directive))
+
     def __getitem__(self, query):
         """
         Similar to select, except tuples are constructed without parentheses:

--- a/insights/configtree/tests/test_dsl.py
+++ b/insights/configtree/tests/test_dsl.py
@@ -371,3 +371,14 @@ def test_complex_queries():
 
     res = result.select(("VirtualHost", ~is_private & in_network("128.39.0.0/16")))
     assert len(res) == 3
+
+
+def test_directives_and_sections():
+    httpd1 = _HttpdConf(context_wrap(HTTPD_CONF_NEST_1, path='/etc/httpd/conf/httpd.conf'))
+    httpd2 = _HttpdConf(context_wrap(HTTPD_CONF_NEST_3, path='/etc/httpd/conf.d/00-a.conf'))
+    httpd3 = _HttpdConf(context_wrap(HTTPD_CONF_NEST_4, path='/etc/httpd/conf.d/01-b.conf'))
+    result = HttpdConfTree([httpd1, httpd2, httpd3])
+    assert len(result.directives) == 3
+    assert len(result.sections) == 7
+    assert len(result.find_all(startswith("Dir")).directives) == 1
+    assert len(result.find_all(startswith("Dir")).sections) == 1

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -11,6 +11,7 @@ import six
 from fnmatch import fnmatch
 
 from insights.configtree import from_dict, iniconfig, Root, select, first
+from insights.configtree import Directive, SearchResult, Section
 from insights.contrib.ConfigParser import RawConfigParser
 
 from insights.parsers import ParseException
@@ -250,6 +251,17 @@ class ConfigComponent(object):
         Returns an empty `SearchResult` if no results are found.
         """
         return self.select(*queries, deep=True, roots=False)
+
+    def _children_of_type(self, t):
+        return [c for c in self.doc.children if isinstance(c, t)]
+
+    @property
+    def sections(self):
+        return SearchResult(children=self._children_of_type(Section))
+
+    @property
+    def directives(self):
+        return SearchResult(children=self._children_of_type(Directive))
 
     def __getitem__(self, query):
         """


### PR DESCRIPTION
Allow configuration filtering by sections (might have child nodes) or directives (no child nodes). For example, if you want all the sections that have names starting with "Dir" anywhere in the config:

```python
conf.find_all(startswith("Dir")).sections
```