### PR TITLE
[wip] Refactor connection_rules.InsightsUploadConf.get_conf

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -201,8 +201,12 @@ def get_machine_id():
 
 
 def update_rules(config, pconn):
+    if not pconn:
+        raise ValueError('ERROR: Cannot update rules in --offline mode. '
+                         'Disable auto_update in config file.')
+
     pc = InsightsUploadConf(config, conn=pconn)
-    return pc.get_conf(True, {})
+    return pc.get_conf_update()
 
 
 def get_branch_info(config, pconn):
@@ -293,7 +297,11 @@ def collect(config, pconn):
                      ('--from-file' if config.from_file else '--from-stdin'))
         return False
 
-    collection_rules, rm_conf = pc.get_conf(False, stdin_config)
+    if stdin_config:
+        collection_rules = pc.get_conf_stdin(stdin_config)
+    else:
+        collection_rules = pc.get_conf_file()
+    rm_conf = pc.get_rm_conf()
     if rm_conf:
         logger.warn("WARNING: Excluding data from files")
 

--- a/insights/client/collection_rules.py
+++ b/insights/client/collection_rules.py
@@ -167,57 +167,78 @@ class InsightsUploadConf(object):
         with os.fdopen(fd, 'w') as dyn_conf_file:
             dyn_conf_file.write(data)
 
-    def get_conf(self, update, stdin_config=None):
+    def get_conf_file(self):
         """
-        Get the config
+        Get config from local config file, first try cache, then fallback.
         """
-        rm_conf = None
-        # Convert config object into dict
-        if os.path.isfile(self.remove_file):
-            parsedconfig = ConfigParser.RawConfigParser()
-            parsedconfig.read(self.remove_file)
-            rm_conf = {}
-            for item, value in parsedconfig.items('remove'):
-                rm_conf[item] = value.strip().split(',')
-        if stdin_config:
-            rules_fp = NamedTemporaryFile(delete=False)
-            rules_fp.write(stdin_config["uploader.json"].encode('utf-8'))
-            rules_fp.flush()
-            sig_fp = NamedTemporaryFile(delete=False)
-            sig_fp.write(stdin_config["sig"].encode('utf-8'))
-            sig_fp.flush()
-            if not self.gpg or self.validate_gpg_sig(rules_fp.name, sig_fp.name):
-                return json.loads(stdin_config["uploader.json"]), rm_conf
-            else:
-                logger.error("Unable to validate GPG signature in from_stdin mode.")
-                raise Exception("from_stdin mode failed to validate GPG sig")
-        elif update:
-            if not self.conn:
-                raise ValueError('ERROR: Cannot update rules in --offline mode. '
-                                 'Disable auto_update in config file.')
-            dyn_conf = self.get_collection_rules()
-            if dyn_conf:
-                version = dyn_conf.get('version', None)
-                if version is None:
-                    raise ValueError("ERROR: Could not find version in json")
-                dyn_conf['file'] = self.collection_rules_file
-                logger.debug("Success reading config")
-                config_hash = hashlib.sha1(json.dumps(dyn_conf).encode('utf-8')).hexdigest()
-                logger.debug('sha1 of config: %s', config_hash)
-                return dyn_conf, rm_conf
         for conf_file in [self.collection_rules_file, self.fallback_file]:
             logger.debug("trying to read conf from: " + conf_file)
             conf = self.try_disk(conf_file, self.gpg)
-            if conf:
-                version = conf.get('version', None)
-                if version is None:
-                    raise ValueError("ERROR: Could not find version in json")
 
-                conf['file'] = conf_file
-                logger.debug("Success reading config")
-                logger.debug(json.dumps(conf))
-                return conf, rm_conf
+            if not conf:
+                continue
+
+            version = conf.get('version', None)
+            if version is None:
+                raise ValueError("ERROR: Could not find version in json")
+
+            conf['file'] = conf_file
+            logger.debug("Success reading config")
+            logger.debug(json.dumps(conf))
+            return conf
+
         raise ValueError("ERROR: Unable to download conf or read it from disk!")
+
+    def get_conf_update(self):
+        """
+        Get updated config from URL, fallback to local file if download fails.
+        """
+        dyn_conf = self.get_collection_rules()
+
+        if not dyn_conf:
+            return self.get_conf_file()
+
+        version = dyn_conf.get('version', None)
+        if version is None:
+            raise ValueError("ERROR: Could not find version in json")
+
+        dyn_conf['file'] = self.collection_rules_file
+        logger.debug("Success reading config")
+        config_hash = hashlib.sha1(json.dumps(dyn_conf).encode('utf-8')).hexdigest()
+        logger.debug('sha1 of config: %s', config_hash)
+        return dyn_conf
+
+    def get_conf_stdin(self, stdin_config):
+        """
+        Get config from STDIN.
+        """
+        rules_fp = NamedTemporaryFile(delete=False)
+        rules_fp.write(stdin_config["uploader.json"].encode('utf-8'))
+        rules_fp.flush()
+        sig_fp = NamedTemporaryFile(delete=False)
+        sig_fp.write(stdin_config["sig"].encode('utf-8'))
+        sig_fp.flush()
+        if not self.gpg or self.validate_gpg_sig(rules_fp.name, sig_fp.name):
+            return json.loads(stdin_config["uploader.json"])
+        else:
+            logger.error("Unable to validate GPG signature in from_stdin mode.")
+            raise Exception("from_stdin mode failed to validate GPG sig")
+
+    def get_rm_conf(self):
+        """
+        Get excluded files config from remove_file.
+        """
+        if not os.path.isfile(self.remove_file):
+            return None
+
+        # Convert config object into dict
+        parsedconfig = ConfigParser.RawConfigParser()
+        parsedconfig.read(self.remove_file)
+        rm_conf = {}
+        for item, value in parsedconfig.items('remove'):
+            rm_conf[item] = value.strip().split(',')
+
+        return rm_conf
 
 
 if __name__ == '__main__':

--- a/insights/tests/client/collection_rules/helpers.py
+++ b/insights/tests/client/collection_rules/helpers.py
@@ -1,0 +1,12 @@
+# -*- coding: UTF-8 -*-
+
+from insights.client.collection_rules import InsightsUploadConf
+from insights.client.config import InsightsConfig
+
+
+def insights_upload_conf(*args, **kwargs):
+    """
+    Instantiates InsightsUploadConf with a config created with given arguments.
+    """
+    config = InsightsConfig(*args, **kwargs)
+    return InsightsUploadConf(config)

--- a/insights/tests/client/collection_rules/test_get_conf_file.py
+++ b/insights/tests/client/collection_rules/test_get_conf_file.py
@@ -1,0 +1,124 @@
+# -*- coding: UTF-8 -*-
+
+from .helpers import insights_upload_conf
+from mock.mock import call, patch
+from pytest import raises
+
+
+collection_rules_file = "/tmp/collection_rules"
+collection_fallback_file = "/tmp/collection_fallback"
+
+
+def patch_collection_rules_file():
+    """
+    Makes collection_rules_file contain a fixed path.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.constants.collection_rules_file", collection_rules_file)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_collection_fallback_file():
+    """
+    Makes collection_fallback_file contain a fixed path.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.constants.collection_fallback_file", collection_fallback_file)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_try_disk(return_values):
+    """
+    Makes try_disk sequentially return the passed contents.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.InsightsUploadConf.try_disk", side_effect=return_values)
+        return patcher(old_function)
+    return decorator
+
+
+@patch_try_disk([{"version": "1.2.3"}])
+@patch_collection_rules_file()
+def test_collection_rules_file_try_disk(try_disk):
+    """
+    Collection rules are loaded from the default file while performing signature validation.
+    """
+    gpg = "perhaps"
+    upload_conf = insights_upload_conf(gpg=gpg)
+    upload_conf.get_conf_file()
+
+    try_disk.assert_called_once_with(collection_rules_file, gpg)
+
+
+@patch_try_disk([{"version": None}])
+def test_collection_rules_file_no_version_error(try_disk):
+    """
+    Collection rules from the default file are rejected if they don't specify version.
+    """
+    upload_conf = insights_upload_conf()
+
+    with raises(ValueError):
+        upload_conf.get_conf_file()
+
+
+@patch_try_disk([{"version": "1.2.3"}])
+@patch_collection_rules_file()
+def test_return_collection_rules(try_disk):
+    """
+    Collection rules from the default file are returned with the filename appended to the data.
+    """
+    upload_conf = insights_upload_conf()
+
+    assert upload_conf.get_conf_file() == {"version": "1.2.3", "file": collection_rules_file}
+
+
+@patch_try_disk([None, {"version": "1.2.3"}])
+@patch_collection_fallback_file()
+@patch_collection_rules_file()
+def test_fallback_file_try_disk(try_disk):
+    """
+    If there are no collection rules in the default file, they are loaded from the fallback file while performing
+    signature validation.
+    """
+    gpg = "perhaps"
+    upload_conf = insights_upload_conf(gpg=gpg)
+
+    upload_conf.get_conf_file()
+
+    calls = [call(collection_rules_file, gpg), call(collection_fallback_file, gpg)]
+    try_disk.assert_has_calls(calls)
+
+
+@patch_try_disk([None, {"version": None}])
+def test_fallback_file_no_version_error(try_disk):
+    """
+    Collection rules from the fallback file are rejected if they don't specify version.
+    """
+    upload_conf = insights_upload_conf()
+
+    with raises(ValueError):
+        upload_conf.get_conf_file()
+
+
+@patch_try_disk([None, {"version": "1.2.3"}])
+@patch_collection_fallback_file()
+def test_return_collection_fallback(try_disk):
+    """
+    Collection rules from the fallback file are returned with the filename appended to the data.
+    """
+    upload_conf = insights_upload_conf()
+
+    assert upload_conf.get_conf_file() == {"version": "1.2.3", "file": collection_fallback_file}
+
+
+@patch_try_disk([None, None])
+def test_no_file_error(try_disk):
+    """
+    An error is raised if there are no collection rules neither in the default nor the fallback file.
+    """
+    upload_conf = insights_upload_conf()
+
+    with raises(ValueError):
+        upload_conf.get_conf_file()

--- a/insights/tests/client/collection_rules/test_get_conf_stdin.py
+++ b/insights/tests/client/collection_rules/test_get_conf_stdin.py
@@ -1,0 +1,80 @@
+# -*- coding: UTF-8 -*-
+
+from .helpers import insights_upload_conf
+from json import dumps as json_dumps
+from mock.mock import call, Mock, patch
+from pytest import raises
+
+
+stdin_uploader_json = {"key": "value"}
+stdin_sig = "signature"
+stdin = {"uploader.json": json_dumps(stdin_uploader_json), "sig": stdin_sig}
+
+
+def patch_named_temporary_file():
+    """
+    Mocks NamedTemporaryFile so it sequentially builds rules objects. Adds these objects to the Mock.
+    """
+    def decorator(old_function):
+        rules_fp = Mock()
+        rules_fp.name = "rules name"
+        sig_fp = Mock()
+        sig_fp.name = "sig name"
+
+        patcher = patch("insights.client.collection_rules.NamedTemporaryFile",
+                        side_effect=[rules_fp, sig_fp],
+                        rules_fp=rules_fp,
+                        sig_fp=sig_fp)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_validate_gpg_sig(valid):
+    """
+    Makes validate_gpg_sig return the passed result.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.InsightsUploadConf.validate_gpg_sig", return_value=valid)
+        return patcher(old_function)
+    return decorator
+
+
+@patch_named_temporary_file()
+def test_file_writes(named_temporary_file):
+    """
+    Correct data is written into the temporary files, that are to be passed to signature validation.
+    """
+    upload_conf = insights_upload_conf(gpg=False)
+    upload_conf.get_conf_stdin(stdin)
+
+    calls = [call(delete=False),
+             call.rules_fp.write(stdin["uploader.json"].encode("utf-8")),
+             call.rules_fp.flush(),
+             call(delete=False),
+             call.sig_fp.write(stdin_sig.encode("utf-8")),
+             call.sig_fp.flush()]
+    named_temporary_file.assert_has_calls(calls)
+
+
+@patch_validate_gpg_sig(False)
+@patch_named_temporary_file()
+def test_invalid_gpg(named_temporary_file, validate_gpg_sig):
+    """
+    GPG signature is validated, invalid signature raises an exception.
+    """
+    upload_conf = insights_upload_conf(gpg=True)
+
+    with raises(Exception):
+        upload_conf.get_conf_stdin(stdin)
+
+    validate_gpg_sig.assert_called_once_with(named_temporary_file.rules_fp.name, named_temporary_file.sig_fp.name)
+
+
+def test_return():
+    """
+    The collection rules present under the "uploader.json" key of the stdin data is returned.
+    """
+    upload_conf = insights_upload_conf(gpg=False)
+    result = upload_conf.get_conf_stdin(stdin)
+
+    assert result == stdin_uploader_json

--- a/insights/tests/client/collection_rules/test_get_conf_update.py
+++ b/insights/tests/client/collection_rules/test_get_conf_update.py
@@ -1,0 +1,56 @@
+# -*- coding: UTF-8 -*-
+
+from .helpers import insights_upload_conf
+from mock.mock import patch
+from pytest import raises
+
+
+collection_rules = {"version": "1.2.3"}
+collection_rules_file = "/tmp/collection-rules"
+
+
+@patch("insights.client.collection_rules.InsightsUploadConf.get_conf_file")
+@patch("insights.client.collection_rules.InsightsUploadConf.get_collection_rules", return_value=None)
+def test_load_from_file(get_collection_rules, get_conf_file):
+    """
+    Falls back to file if collection rules are not downloaded.
+    """
+    upload_conf = insights_upload_conf()
+    result = upload_conf.get_conf_update()
+
+    get_collection_rules.assert_called_once_with()
+    get_conf_file.assert_called_once_with()
+    assert result is get_conf_file.return_value
+
+
+@patch("insights.client.collection_rules.InsightsUploadConf.get_conf_file")
+@patch("insights.client.collection_rules.InsightsUploadConf.get_collection_rules", return_value={"some": "value"})
+def test_no_version_error(get_collection_rules, get_conf_file):
+    """
+    Error is raised if there is no version in the collection rules loaded from URL.
+    """
+    upload_conf = insights_upload_conf()
+    with raises(ValueError):
+        upload_conf.get_conf_update()
+
+    get_collection_rules.assert_called_once_with()
+    get_conf_file.assert_not_called()
+
+
+@patch("insights.client.collection_rules.constants.collection_rules_file", collection_rules_file)
+@patch("insights.client.collection_rules.InsightsUploadConf.get_conf_file")
+@patch("insights.client.collection_rules.InsightsUploadConf.get_collection_rules", return_value=collection_rules)
+def test_load_from_url(get_collection_rules, get_conf_file):
+    """
+    Return collection rules loaded from URL with added file path.
+    """
+    upload_conf = insights_upload_conf()
+    actual_result = upload_conf.get_conf_update()
+
+    get_collection_rules.assert_called_once_with()
+    get_conf_file.assert_not_called()
+
+    expected_result = collection_rules.copy()
+    expected_result["file"] = collection_rules_file
+
+    assert actual_result == expected_result

--- a/insights/tests/client/collection_rules/test_get_rm_conf.py
+++ b/insights/tests/client/collection_rules/test_get_rm_conf.py
@@ -1,0 +1,67 @@
+# -*- coding: UTF-8 -*-
+
+from .helpers import insights_upload_conf
+from mock.mock import patch
+
+
+remove_file = '/etc/insights-client/remove.conf'
+remove_files = ["/etc/remove.conf", "/tmp/remove.conf"]
+
+
+def patch_isfile(isfile):
+    """
+    Makes isfile return the passed result.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.os.path.isfile", return_value=isfile)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_raw_config_parser(items):
+    """
+    Mocks RawConfigParser so it returns the passed items.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.ConfigParser.RawConfigParser",
+                          **{"return_value.items.return_value": items})
+        return patcher(old_function)
+    return decorator
+
+
+def patch_collection_remove_file():
+    """
+    Mocks InsightsConstants collection_remove_file so it contains a fixed value.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.constants.collection_remove_file", remove_file)
+        return patcher(old_function)
+    return decorator
+
+
+@patch_isfile(False)
+@patch_raw_config_parser([])
+def test_no_file(raw_config_parser, isfile):
+    upload_conf = insights_upload_conf()
+    result = upload_conf.get_rm_conf()
+
+    isfile.assert_called_once_with(remove_file)
+    raw_config_parser.assert_not_called()
+
+    assert result is None
+
+
+@patch_collection_remove_file()
+@patch_raw_config_parser([("files", ",".join(remove_files))])
+@patch_isfile(True)
+def test_return(isfile, raw_config_parser):
+    upload_conf = insights_upload_conf()
+    result = upload_conf.get_rm_conf()
+
+    isfile.assert_called_once_with(remove_file)
+
+    raw_config_parser.assert_called_once_with()
+    raw_config_parser.return_value.read.assert_called_with(remove_file)
+    raw_config_parser.return_value.items.assert_called_with('remove')
+
+    assert result == {"files": remove_files}

--- a/insights/tests/client/test_collect.py
+++ b/insights/tests/client/test_collect.py
@@ -2,18 +2,12 @@
 
 from insights.client.client import collect
 from insights.client.config import InsightsConfig
-from json import dump as json_dump, dumps as json_dumps
-from mock.mock import call, Mock, patch, PropertyMock
-from pytest import raises
+from json import dump as json_dump
+from mock.mock import Mock, patch, PropertyMock
 from tempfile import TemporaryFile
 
 
-branch_info = Mock()
-stdin_payload_uploader_json = json_dumps({"key": "value"})
-stdin_payload = {"uploader.json": stdin_payload_uploader_json, "sig": "signature"}
-remove_file = "/tmp/remove.conf"
-collection_rules_file = "/tmp/collection_rules"
-collection_fallback_file = "/tmp/collection_rules"
+stdin_payload = {"uploader.json": "some JSON", "sig": "some signature"}
 
 
 def collect_args(*insights_config_args, **insights_config_custom_kwargs):
@@ -25,279 +19,150 @@ def collect_args(*insights_config_args, **insights_config_custom_kwargs):
     return InsightsConfig(*insights_config_args, **insights_config_all_kwargs), Mock()
 
 
-def patch_get_branch_info():
+def patch_get_branch_info(old_function):
     """
     Sets a static response to get_branch_info method.
     """
-    def decorator(old_function):
-        patcher = patch("insights.client.client.get_branch_info", return_value=branch_info)
-        return patcher(old_function)
-    return decorator
+    patcher = patch("insights.client.client.get_branch_info")
+    return patcher(old_function)
 
 
-def patch_stdin():
+def patch_stdin(old_function):
     """
     Sets a static JSON data to stdin.
     """
-    def decorator(old_function):
-        stdin = TemporaryFile("w+t")
-        json_dump(stdin_payload, stdin)
-        stdin.seek(0)
+    stdin = TemporaryFile("w+t")
+    json_dump(stdin_payload, stdin)
+    stdin.seek(0)
 
-        patcher = patch("insights.client.client.sys.stdin", new_callable=PropertyMock(return_value=stdin))
-        return patcher(old_function)
-    return decorator
+    patcher = patch("insights.client.client.sys.stdin", new_callable=PropertyMock(return_value=stdin))
+    return patcher(old_function)
 
 
-def patch_isfile(isfile):
+def patch_get_conf_stdin(old_function):
     """
-    Makes isfile return the passed result.
+    Mocks InsightsUploadConf.get_conf_stdin.
     """
-    def decorator(old_function):
-        patcher = patch("insights.client.client.os.path.isfile", return_value=isfile)
-        return patcher(old_function)
-    return decorator
+    patcher = patch("insights.client.client.InsightsUploadConf.get_conf_stdin")
+    return patcher(old_function)
 
 
-def patch_collection_remove_file():
+def patch_get_conf_file(old_function):
     """
-    Makes collection_remove_file contain a fixed path.
+    Mocks InsightsUploadConf.get_conf_file so it returns a fixed configuration.
     """
-    def decorator(old_function):
-        patcher = patch("insights.client.client.constants.collection_remove_file", remove_file)
-        return patcher(old_function)
-    return decorator
+    patcher = patch("insights.client.client.InsightsUploadConf.get_conf_file")
+    return patcher(old_function)
 
 
-def patch_raw_config_parser(items=[]):
+def patch_get_rm_conf(old_function):
     """
-    Mocks RawConfigParser so it returns the passed items.
+    Mocks InsightsUploadConf.get_rm_conf so it returns a fixed configuration.
     """
-    def decorator(old_function):
-        patcher = patch("insights.client.collection_rules.ConfigParser.RawConfigParser",
-                          **{"return_value.items.return_value": items})
-        return patcher(old_function)
-    return decorator
+    patcher = patch("insights.client.client.InsightsUploadConf.get_rm_conf")
+    return patcher(old_function)
 
 
-def patch_validate_gpg_sig(valid):
-    """
-    Makes validate_gpg_sig return the passed result.
-    """
-    def decorator(old_function):
-        patcher = patch("insights.client.collection_rules.InsightsUploadConf.validate_gpg_sig", return_value=valid)
-        return patcher(old_function)
-    return decorator
-
-
-def patch_collection_rules_file():
-    """
-    Makes collection_rules_file contain a fixed path.
-    """
-    def decorator(old_function):
-        patcher = patch("insights.client.collection_rules.constants.collection_rules_file", "/tmp/collection_rules")
-        return patcher(old_function)
-    return decorator
-
-
-def patch_collection_fallback_file():
-    """
-    Makes collection_fallback_file contain a fixed path.
-    """
-    def decorator(old_function):
-        patcher = patch("insights.client.collection_rules.constants.collection_fallback_file", collection_fallback_file)
-        return patcher(old_function)
-    return decorator
-
-
-def patch_try_disk(return_values):
-    """
-    Makes try_disk sequentially return the passed contents.
-    """
-    def decorator(old_function):
-        patcher = patch("insights.client.collection_rules.InsightsUploadConf.try_disk", side_effect=return_values)
-        return patcher(old_function)
-    return decorator
-
-
-def patch_data_collector():
+def patch_data_collector(old_function):
     """
     Replaces DataCollector with a dummy mock.
     """
-    def decorator(old_function):
-        patcher = patch("insights.client.client.DataCollector")
-        return patcher(old_function)
-    return decorator
+    patcher = patch("insights.client.client.DataCollector")
+    return patcher(old_function)
 
 
-def patch_named_temporary_file():
+@patch_data_collector
+@patch_get_conf_file
+@patch_get_conf_stdin
+@patch_get_branch_info
+def test_get_conf_file(get_branch_info, get_conf_stdin, get_conf_file, data_collector):
     """
-    Mocks NamedTemporaryFile so it sequentially builds rules objects. Adds these object to test function arguments.
+    If there is no config passed via stdin, it is loaded from a file instead.
     """
-    def decorator(old_function):
-        rules_fp = Mock()
-        rules_fp.name = "rules name"
-        sig_fp = Mock()
-        sig_fp.name = "sig name"
-
-        patcher = patch("insights.client.collection_rules.NamedTemporaryFile",
-                        side_effect=[rules_fp, sig_fp],
-                        rules_fp=rules_fp,
-                        sig_fp=sig_fp)
-        return patcher(old_function)
-    return decorator
-
-
-@patch_data_collector()
-@patch_raw_config_parser()
-@patch_collection_remove_file()
-@patch_isfile(False)
-@patch_stdin()
-@patch_get_branch_info()
-def test_remove_file_not_exists(get_branch_info, stdin, isfile, raw_config_parser, data_collector):
-    config, pconn = collect_args(from_stdin=True, gpg=False)
-    collect(config, pconn)
-
-    isfile.assert_called_once_with(remove_file)
-    raw_config_parser.assert_not_called()
-
-
-@patch_data_collector()
-@patch_raw_config_parser([])
-@patch_collection_remove_file()
-@patch_isfile(True)
-@patch_stdin()
-@patch_get_branch_info()
-def test_remove_file_exists(get_branch_info, stdin, isfile, raw_config_parser, data_collector):
-    config, pconn = collect_args(from_stdin=True, gpg=False)
-    collect(config, pconn)
-
-    isfile.assert_called_once_with(remove_file)
-    raw_config_parser.assert_called_once_with()
-    raw_config_parser.return_value.read.assert_called_once_with(remove_file)
-    raw_config_parser.return_value.items.assert_called_once_with("remove")
-
-
-@patch_data_collector()
-@patch_stdin()
-@patch_named_temporary_file()
-@patch_get_branch_info()
-def test_stdin_write_rules(get_branch_info, named_temporary_file, stdin, data_collector):
-    config, pconn = collect_args(from_stdin=True, gpg=False)
-    collect(config, pconn)
-
-    calls = [call(delete=False),
-             call.rules_fp.write(stdin_payload_uploader_json.encode("utf-8")),
-             call.rules_fp.flush(),
-             call(delete=False),
-             call.sig_fp.write("signature".encode("utf-8")),
-             call.sig_fp.flush()]
-    named_temporary_file.assert_has_calls(calls)
-
-
-@patch_data_collector()
-@patch_validate_gpg_sig(True)
-@patch_stdin()
-@patch_named_temporary_file()
-@patch_get_branch_info()
-def test_validate_gpg_sig(get_branch_info, named_temporary_file, stdin, validate_gpg_sig, data_collector):
-    config, pconn = collect_args(from_stdin=True, gpg=True)
-    collect(config, pconn)
-
-    validate_gpg_sig.assert_called_with(named_temporary_file.rules_fp.name, named_temporary_file.sig_fp.name)
-
-
-@patch_try_disk([{}])
-@patch_validate_gpg_sig(False)
-@patch_stdin()
-@patch_named_temporary_file()
-@patch_get_branch_info()
-def test_invalid_gpg(get_branch_info, named_temporary_file, stdin, validate_gpg_sig, try_disk):
-    config, pconn = collect_args(from_stdin=True, gpg=True)
-
-    with raises(Exception):
-        collect(config, pconn)
-    try_disk.assert_not_called()  # Ensure it’s not ValueError
-
-
-@patch_data_collector()
-@patch_try_disk([{"version": "1.2.3"}])
-@patch_collection_rules_file()
-@patch_stdin()
-@patch_get_branch_info()
-def test_collection_rules_file_conf_try_disk(get_branch_info, stdin, try_disk, data_collector):
-    config, pconn = collect_args(gpg="perhaps")
-    collect(config, pconn)
-    try_disk.assert_called_once_with(collection_rules_file, "perhaps")
-
-
-@patch_try_disk([{"version": None}])
-@patch_stdin()
-@patch_get_branch_info()
-def test_collection_rules_file_conf_no_version_error(get_branch_info, stdin, try_disk):
-    config, pconn = collect_args()
-    with raises(ValueError):
-        collect(config, pconn)
-
-
-@patch_data_collector()
-@patch_try_disk([None, {"version": "1.2.3"}])
-@patch_collection_fallback_file()
-@patch_collection_rules_file()
-@patch_stdin()
-@patch_get_branch_info()
-def test_fallback_file_conf_try_disk(get_branch_info, stdin, try_disk, data_collector):
-    config, pconn = collect_args(gpg="perhaps")
-    collect(config, pconn)
-    calls = [call(collection_rules_file, "perhaps"), call(collection_fallback_file, "perhaps")]
-    try_disk.assert_has_calls(calls)
-    assert try_disk.call_count == len(calls)
-
-
-@patch_try_disk([None, {"version": None}])
-@patch_stdin()
-@patch_get_branch_info()
-def test_fallback_file_conf_no_version_error(get_branch_info, stdin, try_disk):
-    config, pconn = collect_args()
-    with raises(ValueError):
-        collect(config, pconn)
-
-
-@patch_try_disk([None, None])
-@patch_stdin()
-@patch_get_branch_info()
-def test_no_file_conf_error(get_branch_info, stdin, try_disk):
-    config, pconn = collect_args()
-    with raises(ValueError):
-        collect(config, pconn)
-
-
-@patch_data_collector()
-@patch_try_disk([{"version": "1.2.3"}])
-@patch_collection_rules_file()
-@patch_isfile(False)
-@patch_stdin()
-@patch_get_branch_info()
-def test_return_without_rm_conf(get_branch_info, stdin, isfile, try_disk, data_collector):
     config, pconn = collect_args()
     collect(config, pconn)
 
-    collection_rules = {"version": "1.2.3", "file": collection_rules_file}
-    rm_conf = None
+    get_conf_stdin.assert_not_called()
+    get_conf_file.assert_called_once_with()
+
+
+@patch_data_collector
+@patch_get_conf_file
+@patch_get_conf_stdin
+@patch_stdin
+@patch_get_branch_info
+def test_get_conf_stdin(get_branch_info, stdin, get_conf_stdin, get_conf_file, data_collector):
+    """
+    If there is config passed via stdin, use it and do not look for it in files.
+    """
+    config, pconn = collect_args(from_stdin=True)
+    collect(config, pconn)
+
+    get_conf_stdin.assert_called_once_with(stdin_payload)
+    get_conf_file.assert_not_called()
+
+
+@patch_data_collector
+@patch_get_rm_conf
+@patch_get_conf_stdin
+@patch_stdin
+@patch_get_branch_info
+def test_get_rm_conf_stdin(get_branch_info, stdin, get_conf_stdin, get_rm_conf, data_collector):
+    """
+    Load configuration of files removed from collection when collection rules are loaded from stdin.
+    """
+    config, pconn = collect_args(from_stdin=True)
+    collect(config, pconn)
+
+    get_rm_conf.assert_called_once_with()
+
+
+@patch_data_collector
+@patch_get_rm_conf
+@patch_get_conf_file
+@patch_get_branch_info
+def test_get_rm_conf_file(get_branch_info, get_conf_file, get_rm_conf, data_collector):
+    """
+    Load configuration of files removed from collection when collection rules are loaded from a file.
+    """
+    config, pconn = collect_args(from_stdin=False)
+    collect(config, pconn)
+
+    get_rm_conf.assert_called_once_with()
+
+
+@patch_data_collector
+@patch_get_rm_conf
+@patch_get_conf_stdin
+@patch_stdin
+@patch_get_branch_info
+def test_data_collector_stdin(get_branch_info, stdin, get_conf_stdin, get_rm_conf, data_collector):
+    """
+    Configuration from stdin is passed to the DataCollector along with removed files configuration.
+    """
+    config, pconn = collect_args(from_stdin=True)
+    collect(config, pconn)
+
+    collection_rules = get_conf_stdin.return_value
+    rm_conf = get_rm_conf.return_value
+    branch_info = get_branch_info.return_value
     data_collector.return_value.run_collection.assert_called_once_with(collection_rules, rm_conf, branch_info)
+    data_collector.return_value.done.assert_called_once_with(collection_rules, rm_conf)
 
 
-@patch_data_collector()
-@patch_try_disk([{"version": "1.2.3"}])
-@patch_collection_rules_file()
-@patch_raw_config_parser([("files", "/etc/remove.conf,/tmp/remove.conf")])
-@patch_isfile(True)
-@patch_stdin()
-@patch_get_branch_info()
-def test_return_with_rm_conf(get_branch_info, stdin, isfile, raw_config_parser, try_disk, data_collector):
-    config, pconn = collect_args()
+@patch_data_collector
+@patch_get_rm_conf
+@patch_get_conf_file
+@patch_get_branch_info
+def test_data_collector_file(get_branch_info, get_conf_file, get_rm_conf, data_collector):
+    """
+    Configuration from a file is passed to the DataCollector along with removed files configuration.
+    """
+    config, pconn = collect_args(from_stdin=False)
     collect(config, pconn)
 
-    collection_rules = {"version": "1.2.3", "file": collection_rules_file}
-    rm_conf = {"files": ["/etc/remove.conf", "/tmp/remove.conf"]}
+    collection_rules = get_conf_file.return_value
+    rm_conf = get_rm_conf.return_value
+    branch_info = get_branch_info.return_value
     data_collector.return_value.run_collection.assert_called_once_with(collection_rules, rm_conf, branch_info)
+    data_collector.return_value.done.assert_called_once_with(collection_rules, rm_conf)

--- a/insights/tests/client/test_collect.py
+++ b/insights/tests/client/test_collect.py
@@ -1,80 +1,176 @@
 # -*- coding: UTF-8 -*-
 
+from contextlib import contextmanager
 from insights.client.client import collect
 from insights.client.config import InsightsConfig
-from json import dump as json_dump
+from json import dump as json_dump, dumps as json_dumps
 from mock.mock import Mock, patch, PropertyMock
-from tempfile import TemporaryFile
+from pytest import mark, raises
+from tempfile import NamedTemporaryFile, TemporaryFile
 
 
-stdin_payload = {"uploader.json": "some JSON", "sig": "some signature"}
+stdin_uploader_json = {"some key": "some value"}
+stdin_sig = "some signature"
+stdin_payload = {"uploader.json": json_dumps(stdin_uploader_json), "sig": stdin_sig}
+remove_files = ["/etc/insights-client/remove.conf", "/tmp/remove.conf"]
 
 
 def collect_args(*insights_config_args, **insights_config_custom_kwargs):
     """
     Instantiates InsightsConfig with a default logging_file argument.
     """
-    insights_config_all_kwargs = {"logging_file": "/tmp/insights.log"}
-    insights_config_all_kwargs.update(insights_config_custom_kwargs)
-    return InsightsConfig(*insights_config_args, **insights_config_all_kwargs), Mock()
+    all_insights_config_kwargs = {"logging_file": "/tmp/insights.log"}
+    all_insights_config_kwargs.update(insights_config_custom_kwargs)
+    return InsightsConfig(*insights_config_args, **all_insights_config_kwargs), Mock()
 
 
-def patch_get_branch_info(old_function):
+@contextmanager
+def patch_temp_conf_file():
+    """
+    Creates a valid temporary config file.
+    """
+    collection_rules_file = NamedTemporaryFile("w+t")
+    json_dump({"version": "1.2.3"}, collection_rules_file)
+    collection_rules_file.seek(0)
+    with patch("insights.client.collection_rules.constants.collection_rules_file", collection_rules_file.name):
+        yield collection_rules_file
+    collection_rules_file.close()
+
+
+def temp_conf_file():
+    """
+    Creates a valid temporary config file.
+    """
+    collection_rules_file = NamedTemporaryFile()
+    json_dump({"version": "1.2.3"}, collection_rules_file)
+    collection_rules_file.seek(0)
+    return collection_rules_file
+
+
+def patch_get_branch_info():
     """
     Sets a static response to get_branch_info method.
     """
-    patcher = patch("insights.client.client.get_branch_info")
-    return patcher(old_function)
+    def decorator(old_function):
+        patcher = patch("insights.client.client.get_branch_info")
+        return patcher(old_function)
+    return decorator
 
 
-def patch_stdin(old_function):
+def patch_stdin():
     """
     Sets a static JSON data to stdin.
     """
-    stdin = TemporaryFile("w+t")
-    json_dump(stdin_payload, stdin)
-    stdin.seek(0)
+    def decorator(old_function):
+        stdin = TemporaryFile("w+t")
+        json_dump(stdin_payload, stdin)
+        stdin.seek(0)
 
-    patcher = patch("insights.client.client.sys.stdin", new_callable=PropertyMock(return_value=stdin))
-    return patcher(old_function)
+        patcher = patch("insights.client.client.sys.stdin", new_callable=PropertyMock(return_value=stdin))
+        return patcher(old_function)
+    return decorator
 
 
-def patch_get_conf_stdin(old_function):
+def patch_get_conf_stdin():
     """
     Mocks InsightsUploadConf.get_conf_stdin.
     """
-    patcher = patch("insights.client.client.InsightsUploadConf.get_conf_stdin")
-    return patcher(old_function)
+    def decorator(old_function):
+        patcher = patch("insights.client.client.InsightsUploadConf.get_conf_stdin")
+        return patcher(old_function)
+    return decorator
 
 
-def patch_get_conf_file(old_function):
+def patch_get_conf_file():
     """
     Mocks InsightsUploadConf.get_conf_file so it returns a fixed configuration.
     """
-    patcher = patch("insights.client.client.InsightsUploadConf.get_conf_file")
-    return patcher(old_function)
+    def decorator(old_function):
+        patcher = patch("insights.client.client.InsightsUploadConf.get_conf_file")
+        return patcher(old_function)
+    return decorator
 
 
-def patch_get_rm_conf(old_function):
+def patch_get_rm_conf():
     """
     Mocks InsightsUploadConf.get_rm_conf so it returns a fixed configuration.
     """
-    patcher = patch("insights.client.client.InsightsUploadConf.get_rm_conf")
-    return patcher(old_function)
+    def decorator(old_function):
+        patcher = patch("insights.client.client.InsightsUploadConf.get_rm_conf")
+        return patcher(old_function)
+    return decorator
 
 
-def patch_data_collector(old_function):
+def patch_data_collector():
     """
     Replaces DataCollector with a dummy mock.
     """
-    patcher = patch("insights.client.client.DataCollector")
-    return patcher(old_function)
+    def decorator(old_function):
+        patcher = patch("insights.client.client.DataCollector")
+        return patcher(old_function)
+    return decorator
 
 
-@patch_data_collector
-@patch_get_conf_file
-@patch_get_conf_stdin
-@patch_get_branch_info
+def patch_isfile(remove_file_exists):
+    """
+    Mocks os.path.isfile so it always claims that a file exists. If it‘s a remove conf file, the result depends on the
+    given value.
+    """
+    def decorator(old_function):
+        remove_file = "/tmp/remove.conf"
+
+        def decider(*args, **kwargs):
+            if args[0] == remove_file:
+                return remove_file_exists
+            else:
+                return True
+
+        isfile_patcher = patch("insights.client.collection_rules.os.path.isfile", decider)
+        isfile_patched = isfile_patcher(old_function)
+
+        collection_remove_file_patcher = patch("insights.client.collection_rules.constants.collection_remove_file",
+                                               remove_file)
+        return collection_remove_file_patcher(isfile_patched)
+    return decorator
+
+
+def patch_raw_config_parser():
+    """
+    Mocks RawConfigParser, so it returns a fixed configuration of removed files.
+    """
+    def decorator(old_function):
+        files = ",".join(remove_files)
+        patcher = patch("insights.client.collection_rules.ConfigParser.RawConfigParser",
+                        **{"return_value.items.return_value": [("files", files)]})
+        return patcher(old_function)
+    return decorator
+
+
+def patch_validate_gpg_sig(return_value):
+    """
+    Mocks the InsightsUploadConf.validate_gpg_sig method so it returns the given validation result.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.InsightsUploadConf.validate_gpg_sig",
+                        return_value=return_value)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_try_disk(return_value):
+    """
+    Mocks the InsightsUploadConf.try_disk method so it returns the given parsed file contents.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.InsightsUploadConf.try_disk", return_value=return_value)
+        return patcher(old_function)
+    return decorator
+
+
+@patch_data_collector()
+@patch_get_conf_file()
+@patch_get_conf_stdin()
+@patch_get_branch_info()
 def test_get_conf_file(get_branch_info, get_conf_stdin, get_conf_file, data_collector):
     """
     If there is no config passed via stdin, it is loaded from a file instead.
@@ -86,11 +182,11 @@ def test_get_conf_file(get_branch_info, get_conf_stdin, get_conf_file, data_coll
     get_conf_file.assert_called_once_with()
 
 
-@patch_data_collector
-@patch_get_conf_file
-@patch_get_conf_stdin
-@patch_stdin
-@patch_get_branch_info
+@patch_data_collector()
+@patch_get_conf_file()
+@patch_get_conf_stdin()
+@patch_stdin()
+@patch_get_branch_info()
 def test_get_conf_stdin(get_branch_info, stdin, get_conf_stdin, get_conf_file, data_collector):
     """
     If there is config passed via stdin, use it and do not look for it in files.
@@ -102,11 +198,11 @@ def test_get_conf_stdin(get_branch_info, stdin, get_conf_stdin, get_conf_file, d
     get_conf_file.assert_not_called()
 
 
-@patch_data_collector
-@patch_get_rm_conf
-@patch_get_conf_stdin
-@patch_stdin
-@patch_get_branch_info
+@patch_data_collector()
+@patch_get_rm_conf()
+@patch_get_conf_stdin()
+@patch_stdin()
+@patch_get_branch_info()
 def test_get_rm_conf_stdin(get_branch_info, stdin, get_conf_stdin, get_rm_conf, data_collector):
     """
     Load configuration of files removed from collection when collection rules are loaded from stdin.
@@ -117,10 +213,10 @@ def test_get_rm_conf_stdin(get_branch_info, stdin, get_conf_stdin, get_rm_conf, 
     get_rm_conf.assert_called_once_with()
 
 
-@patch_data_collector
-@patch_get_rm_conf
-@patch_get_conf_file
-@patch_get_branch_info
+@patch_data_collector()
+@patch_get_rm_conf()
+@patch_get_conf_file()
+@patch_get_branch_info()
 def test_get_rm_conf_file(get_branch_info, get_conf_file, get_rm_conf, data_collector):
     """
     Load configuration of files removed from collection when collection rules are loaded from a file.
@@ -131,11 +227,11 @@ def test_get_rm_conf_file(get_branch_info, get_conf_file, get_rm_conf, data_coll
     get_rm_conf.assert_called_once_with()
 
 
-@patch_data_collector
-@patch_get_rm_conf
-@patch_get_conf_stdin
-@patch_stdin
-@patch_get_branch_info
+@patch_data_collector()
+@patch_get_rm_conf()
+@patch_get_conf_stdin()
+@patch_stdin()
+@patch_get_branch_info()
 def test_data_collector_stdin(get_branch_info, stdin, get_conf_stdin, get_rm_conf, data_collector):
     """
     Configuration from stdin is passed to the DataCollector along with removed files configuration.
@@ -150,10 +246,10 @@ def test_data_collector_stdin(get_branch_info, stdin, get_conf_stdin, get_rm_con
     data_collector.return_value.done.assert_called_once_with(collection_rules, rm_conf)
 
 
-@patch_data_collector
-@patch_get_rm_conf
-@patch_get_conf_file
-@patch_get_branch_info
+@patch_data_collector()
+@patch_get_rm_conf()
+@patch_get_conf_file()
+@patch_get_branch_info()
 def test_data_collector_file(get_branch_info, get_conf_file, get_rm_conf, data_collector):
     """
     Configuration from a file is passed to the DataCollector along with removed files configuration.
@@ -166,3 +262,181 @@ def test_data_collector_file(get_branch_info, get_conf_file, get_rm_conf, data_c
     branch_info = get_branch_info.return_value
     data_collector.return_value.run_collection.assert_called_once_with(collection_rules, rm_conf, branch_info)
     data_collector.return_value.done.assert_called_once_with(collection_rules, rm_conf)
+
+
+@mark.regression
+@patch_data_collector()
+@patch_validate_gpg_sig(False)
+@patch_isfile(False)
+@patch_stdin()
+@patch_get_branch_info()
+def test_stdin_signature_ignored(get_branch_info, stdin, validate_gpg_sig, data_collector):
+    """
+    Signature of configuration from stdin is not validated if validation is disabled.
+    """
+    config, pconn = collect_args(from_stdin=True, gpg=False)
+    collect(config, pconn)
+
+    validate_gpg_sig.assert_not_called()
+
+
+@mark.regression
+@patch_data_collector()
+@patch_validate_gpg_sig(True)
+@patch_isfile(False)
+@patch_stdin()
+@patch_get_branch_info()
+def test_stdin_signature_valid(get_branch_info, stdin, validate_gpg_sig, data_collector):
+    """
+    Correct signature of configuration from stdin is recognized.
+    """
+    config, pconn = collect_args(from_stdin=True)
+    collect(config, pconn)
+
+    validate_gpg_sig.assert_called_once()
+
+
+@mark.regression
+@patch_data_collector()
+@patch_validate_gpg_sig(False)
+@patch_isfile(False)
+@patch_stdin()
+@patch_get_branch_info()
+def test_stdin_signature_invalid(get_branch_info, stdin, validate_gpg_sig, data_collector):
+    """
+    Incorrect signature of configuration from stdin causes failure.
+    """
+    config, pconn = collect_args(from_stdin=True)
+    with raises(Exception):
+        collect(config, pconn)
+
+    validate_gpg_sig.assert_called_once()
+
+
+@mark.regression
+@patch_data_collector()
+@patch_validate_gpg_sig(True)
+@patch_raw_config_parser()
+@patch_isfile(True)
+@patch_stdin()
+@patch_get_branch_info()
+def test_stdin_result(get_branch_info, stdin, raw_config_parser, validate_gpg_sig, data_collector):
+    """
+    Configuration from stdin is loaded from the "uploader.json" key.
+    """
+    config, pconn = collect_args(from_stdin=True)
+    collect(config, pconn)
+
+    collection_rules = stdin_uploader_json
+    rm_conf = {"files": remove_files}
+    branch_info = get_branch_info.return_value
+    data_collector.return_value.run_collection.assert_called_once_with(collection_rules, rm_conf, branch_info)
+    data_collector.return_value.done.assert_called_once_with(collection_rules, rm_conf)
+
+
+@mark.regression
+@patch_data_collector()
+@patch_validate_gpg_sig(False)
+@patch_isfile(False)
+@patch_get_branch_info()
+def test_file_signature_ignored(get_branch_info, validate_gpg_sig, data_collector):
+    """
+    Signature of configuration from a file is not validated if validation is disabled.
+    """
+
+    config, pconn = collect_args(from_stdin=False, gpg=False)
+    with patch_temp_conf_file():
+        collect(config, pconn)
+
+    validate_gpg_sig.assert_not_called()
+
+
+@mark.regression
+@patch_data_collector()
+@patch_validate_gpg_sig(True)
+@patch_isfile(False)
+@patch_stdin()
+@patch_get_branch_info()
+def test_file_signature_valid(get_branch_info, stdin, validate_gpg_sig, data_collector):
+    """
+    Correct signature of configuration from a file is recognized.
+    """
+    config, pconn = collect_args(from_stdin=False)
+    with patch_temp_conf_file():
+        collect(config, pconn)
+
+    validate_gpg_sig.assert_called_once()
+
+
+@mark.regression
+@patch_data_collector()
+@patch_validate_gpg_sig(False)
+@patch_isfile(False)
+@patch_stdin()
+@patch_get_branch_info()
+def test_file_signature_invalid(get_branch_info, stdin, validate_gpg_sig, data_collector):
+    """
+    Incorrect signature of configuration from a file skips that file.
+    """
+    config, pconn = collect_args(from_stdin=False)
+    with patch_temp_conf_file():
+        with raises(ValueError):
+            collect(config, pconn)
+
+    validate_gpg_sig.assert_called()
+
+
+@mark.regression
+@patch_data_collector()
+@patch_raw_config_parser()
+@patch_isfile(True)
+@patch_try_disk({"version": "1.2.3"})
+@patch_get_branch_info()
+def test_file_result(get_branch_info, try_disk, raw_config_parser, data_collector):
+    """
+    Configuration from file is loaded from the "uploader.json" key.
+    """
+    config, pconn = collect_args(from_stdin=False)
+    collect(config, pconn)
+
+    name, args, kwargs = try_disk.mock_calls[0]
+    collection_rules = try_disk.return_value.copy()
+    collection_rules.update({"file": args[0]})
+
+    rm_conf = {"files": remove_files}
+    branch_info = get_branch_info.return_value
+
+    data_collector.return_value.run_collection.assert_called_once_with(collection_rules, rm_conf, branch_info)
+    data_collector.return_value.done.assert_called_once_with(collection_rules, rm_conf)
+
+
+@mark.regression
+@patch_data_collector()
+@patch_try_disk({"value": "abc"})
+@patch_get_branch_info()
+def test_file_no_version(get_branch_info, try_disk, data_collector):
+    """
+    Configuration from file is loaded from the "uploader.json" key.
+    """
+    config, pconn = collect_args(from_stdin=False)
+    with raises(ValueError):
+        collect(config, pconn)
+
+    data_collector.return_value.run_collection.assert_not_called()
+    data_collector.return_value.done.assert_not_called()
+
+
+@mark.regression
+@patch_data_collector()
+@patch_try_disk(None)
+@patch_get_branch_info()
+def test_file_no_data(get_branch_info, try_disk, data_collector):
+    """
+    Configuration from file is loaded from the "uploader.json" key.
+    """
+    config, pconn = collect_args(from_stdin=False)
+    with raises(ValueError):
+        collect(config, pconn)
+
+    data_collector.return_value.run_collection.assert_not_called()
+    data_collector.return_value.done.assert_not_called()

--- a/insights/tests/client/test_collect.py
+++ b/insights/tests/client/test_collect.py
@@ -1,0 +1,303 @@
+# -*- coding: UTF-8 -*-
+
+from insights.client.client import collect
+from insights.client.config import InsightsConfig
+from json import dump as json_dump, dumps as json_dumps
+from mock.mock import call, Mock, patch, PropertyMock
+from pytest import raises
+from tempfile import TemporaryFile
+
+
+branch_info = Mock()
+stdin_payload_uploader_json = json_dumps({"key": "value"})
+stdin_payload = {"uploader.json": stdin_payload_uploader_json, "sig": "signature"}
+remove_file = "/tmp/remove.conf"
+collection_rules_file = "/tmp/collection_rules"
+collection_fallback_file = "/tmp/collection_rules"
+
+
+def collect_args(*insights_config_args, **insights_config_custom_kwargs):
+    """
+    Instantiates InsightsConfig with a default logging_file argument.
+    """
+    insights_config_all_kwargs = {"logging_file": "/tmp/insights.log"}
+    insights_config_all_kwargs.update(insights_config_custom_kwargs)
+    return InsightsConfig(*insights_config_args, **insights_config_all_kwargs), Mock()
+
+
+def patch_get_branch_info():
+    """
+    Sets a static response to get_branch_info method.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.client.get_branch_info", return_value=branch_info)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_stdin():
+    """
+    Sets a static JSON data to stdin.
+    """
+    def decorator(old_function):
+        stdin = TemporaryFile("w+t")
+        json_dump(stdin_payload, stdin)
+        stdin.seek(0)
+
+        patcher = patch("insights.client.client.sys.stdin", new_callable=PropertyMock(return_value=stdin))
+        return patcher(old_function)
+    return decorator
+
+
+def patch_isfile(isfile):
+    """
+    Makes isfile return the passed result.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.client.os.path.isfile", return_value=isfile)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_collection_remove_file():
+    """
+    Makes collection_remove_file contain a fixed path.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.client.constants.collection_remove_file", remove_file)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_raw_config_parser(items=[]):
+    """
+    Mocks RawConfigParser so it returns the passed items.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.ConfigParser.RawConfigParser",
+                          **{"return_value.items.return_value": items})
+        return patcher(old_function)
+    return decorator
+
+
+def patch_validate_gpg_sig(valid):
+    """
+    Makes validate_gpg_sig return the passed result.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.InsightsUploadConf.validate_gpg_sig", return_value=valid)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_collection_rules_file():
+    """
+    Makes collection_rules_file contain a fixed path.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.constants.collection_rules_file", "/tmp/collection_rules")
+        return patcher(old_function)
+    return decorator
+
+
+def patch_collection_fallback_file():
+    """
+    Makes collection_fallback_file contain a fixed path.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.constants.collection_fallback_file", collection_fallback_file)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_try_disk(return_values):
+    """
+    Makes try_disk sequentially return the passed contents.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.InsightsUploadConf.try_disk", side_effect=return_values)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_data_collector():
+    """
+    Replaces DataCollector with a dummy mock.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.client.DataCollector")
+        return patcher(old_function)
+    return decorator
+
+
+def patch_named_temporary_file():
+    """
+    Mocks NamedTemporaryFile so it sequentially builds rules objects. Adds these object to test function arguments.
+    """
+    def decorator(old_function):
+        rules_fp = Mock()
+        rules_fp.name = "rules name"
+        sig_fp = Mock()
+        sig_fp.name = "sig name"
+
+        patcher = patch("insights.client.collection_rules.NamedTemporaryFile",
+                        side_effect=[rules_fp, sig_fp],
+                        rules_fp=rules_fp,
+                        sig_fp=sig_fp)
+        return patcher(old_function)
+    return decorator
+
+
+@patch_data_collector()
+@patch_raw_config_parser()
+@patch_collection_remove_file()
+@patch_isfile(False)
+@patch_stdin()
+@patch_get_branch_info()
+def test_remove_file_not_exists(get_branch_info, stdin, isfile, raw_config_parser, data_collector):
+    config, pconn = collect_args(from_stdin=True, gpg=False)
+    collect(config, pconn)
+
+    isfile.assert_called_once_with(remove_file)
+    raw_config_parser.assert_not_called()
+
+
+@patch_data_collector()
+@patch_raw_config_parser([])
+@patch_collection_remove_file()
+@patch_isfile(True)
+@patch_stdin()
+@patch_get_branch_info()
+def test_remove_file_exists(get_branch_info, stdin, isfile, raw_config_parser, data_collector):
+    config, pconn = collect_args(from_stdin=True, gpg=False)
+    collect(config, pconn)
+
+    isfile.assert_called_once_with(remove_file)
+    raw_config_parser.assert_called_once_with()
+    raw_config_parser.return_value.read.assert_called_once_with(remove_file)
+    raw_config_parser.return_value.items.assert_called_once_with("remove")
+
+
+@patch_data_collector()
+@patch_stdin()
+@patch_named_temporary_file()
+@patch_get_branch_info()
+def test_stdin_write_rules(get_branch_info, named_temporary_file, stdin, data_collector):
+    config, pconn = collect_args(from_stdin=True, gpg=False)
+    collect(config, pconn)
+
+    calls = [call(delete=False),
+             call.rules_fp.write(stdin_payload_uploader_json.encode("utf-8")),
+             call.rules_fp.flush(),
+             call(delete=False),
+             call.sig_fp.write("signature".encode("utf-8")),
+             call.sig_fp.flush()]
+    named_temporary_file.assert_has_calls(calls)
+
+
+@patch_data_collector()
+@patch_validate_gpg_sig(True)
+@patch_stdin()
+@patch_named_temporary_file()
+@patch_get_branch_info()
+def test_validate_gpg_sig(get_branch_info, named_temporary_file, stdin, validate_gpg_sig, data_collector):
+    config, pconn = collect_args(from_stdin=True, gpg=True)
+    collect(config, pconn)
+
+    validate_gpg_sig.assert_called_with(named_temporary_file.rules_fp.name, named_temporary_file.sig_fp.name)
+
+
+@patch_try_disk([{}])
+@patch_validate_gpg_sig(False)
+@patch_stdin()
+@patch_named_temporary_file()
+@patch_get_branch_info()
+def test_invalid_gpg(get_branch_info, named_temporary_file, stdin, validate_gpg_sig, try_disk):
+    config, pconn = collect_args(from_stdin=True, gpg=True)
+
+    with raises(Exception):
+        collect(config, pconn)
+    try_disk.assert_not_called()  # Ensure it’s not ValueError
+
+
+@patch_data_collector()
+@patch_try_disk([{"version": "1.2.3"}])
+@patch_collection_rules_file()
+@patch_stdin()
+@patch_get_branch_info()
+def test_collection_rules_file_conf_try_disk(get_branch_info, stdin, try_disk, data_collector):
+    config, pconn = collect_args(gpg="perhaps")
+    collect(config, pconn)
+    try_disk.assert_called_once_with(collection_rules_file, "perhaps")
+
+
+@patch_try_disk([{"version": None}])
+@patch_stdin()
+@patch_get_branch_info()
+def test_collection_rules_file_conf_no_version_error(get_branch_info, stdin, try_disk):
+    config, pconn = collect_args()
+    with raises(ValueError):
+        collect(config, pconn)
+
+
+@patch_data_collector()
+@patch_try_disk([None, {"version": "1.2.3"}])
+@patch_collection_fallback_file()
+@patch_collection_rules_file()
+@patch_stdin()
+@patch_get_branch_info()
+def test_fallback_file_conf_try_disk(get_branch_info, stdin, try_disk, data_collector):
+    config, pconn = collect_args(gpg="perhaps")
+    collect(config, pconn)
+    calls = [call(collection_rules_file, "perhaps"), call(collection_fallback_file, "perhaps")]
+    try_disk.assert_has_calls(calls)
+    assert try_disk.call_count == len(calls)
+
+
+@patch_try_disk([None, {"version": None}])
+@patch_stdin()
+@patch_get_branch_info()
+def test_fallback_file_conf_no_version_error(get_branch_info, stdin, try_disk):
+    config, pconn = collect_args()
+    with raises(ValueError):
+        collect(config, pconn)
+
+
+@patch_try_disk([None, None])
+@patch_stdin()
+@patch_get_branch_info()
+def test_no_file_conf_error(get_branch_info, stdin, try_disk):
+    config, pconn = collect_args()
+    with raises(ValueError):
+        collect(config, pconn)
+
+
+@patch_data_collector()
+@patch_try_disk([{"version": "1.2.3"}])
+@patch_collection_rules_file()
+@patch_isfile(False)
+@patch_stdin()
+@patch_get_branch_info()
+def test_return_without_rm_conf(get_branch_info, stdin, isfile, try_disk, data_collector):
+    config, pconn = collect_args()
+    collect(config, pconn)
+
+    collection_rules = {"version": "1.2.3", "file": collection_rules_file}
+    rm_conf = None
+    data_collector.return_value.run_collection.assert_called_once_with(collection_rules, rm_conf, branch_info)
+
+
+@patch_data_collector()
+@patch_try_disk([{"version": "1.2.3"}])
+@patch_collection_rules_file()
+@patch_raw_config_parser([("files", "/etc/remove.conf,/tmp/remove.conf")])
+@patch_isfile(True)
+@patch_stdin()
+@patch_get_branch_info()
+def test_return_with_rm_conf(get_branch_info, stdin, isfile, raw_config_parser, try_disk, data_collector):
+    config, pconn = collect_args()
+    collect(config, pconn)
+
+    collection_rules = {"version": "1.2.3", "file": collection_rules_file}
+    rm_conf = {"files": ["/etc/remove.conf", "/tmp/remove.conf"]}
+    data_collector.return_value.run_collection.assert_called_once_with(collection_rules, rm_conf, branch_info)

--- a/insights/tests/client/test_update_rules.py
+++ b/insights/tests/client/test_update_rules.py
@@ -1,124 +1,53 @@
 # -*- coding: UTF-8 -*-
 
-from insights.client.config import InsightsConfig
 from insights.client.client import update_rules
-from mock.mock import call, Mock, patch
+from mock.mock import Mock, patch
 from pytest import raises
 
 
-collection_rules_file = "/tmp/collection_rules"
-collection_fallback_file = "/tmp/fallback"
-
-
-def update_rules_args(*insights_config_args, **insights_config_custom_kwargs):
+def patch_insights_upload_conf():
     """
-    Instantiates InsightsConfig with a default logging_file argument.
+    Mocks InsightsUploadConf.
     """
-    insights_config_all_kwargs = {"logging_file": "/tmp/insights.log"}
-    insights_config_all_kwargs.update(insights_config_custom_kwargs)
-    return InsightsConfig(*insights_config_args, **insights_config_all_kwargs), Mock()
-
-
-def patch_get_collection_rules(collection_rules):
     def decorator(old_function):
-        patcher = patch("insights.client.collection_rules.InsightsUploadConf.get_collection_rules",
-                        return_value=collection_rules)
+        patcher = patch("insights.client.client.InsightsUploadConf")
         return patcher(old_function)
     return decorator
 
 
-def patch_get_connection():
-    def decorator(old_function):
-        patcher = patch("insights.client.client.get_connection", return_value=None)
-        return patcher(old_function)
-    return decorator
-
-
-def patch_collection_rules_file():
-    def decorator(old_function):
-        patcher = patch("insights.client.collection_rules.constants.collection_rules_file", collection_rules_file)
-        return patcher(old_function)
-    return decorator
-
-
-def patch_collection_fallback_file():
-    def decorator(old_function):
-        patcher = patch("insights.client.collection_rules.constants.collection_fallback_file", collection_fallback_file)
-        return patcher(old_function)
-    return decorator
-
-
-def patch_try_disk(disk_confs):
-    def decorator(old_function):
-        patcher = patch("insights.client.collection_rules.InsightsUploadConf.try_disk", side_effect=disk_confs)
-        return patcher(old_function)
-    return decorator
-
-
-@patch_get_collection_rules({"version": "1.2.3"})
-@patch_get_connection()
-def test_no_connection_error(get_connection, get_collection_rules):
-    config, pconn = update_rules_args()
+@patch_insights_upload_conf()
+def test_no_connection_error(insights_upload_conf):
+    """
+    Error is raised when connection couldn't be established.
+    """
+    config = Mock()
     with raises(ValueError):
         update_rules(config, None)
 
+    insights_upload_conf.return_value.get_conf_update.assert_not_called()
 
-@patch_get_collection_rules({"version": "1.2.3"})
-def test_get_collection_rules(get_collection_rules):
-    config, pconn = update_rules_args()
+
+@patch_insights_upload_conf()
+def test_configuration(insights_upload_conf):
+    """
+    Configuration is created with given options and retrieved connection.
+    """
+    config = Mock()
+    pconn = Mock()
     update_rules(config, pconn)
-    get_collection_rules.assert_called_once_with()
+
+    insights_upload_conf.assert_called_once_with(config, conn=pconn)
 
 
-@patch_get_collection_rules({"version": None})
-def test_dyn_conf_no_version_error(get_collection_rules):
-    config, pconn = update_rules_args()
-    with raises(ValueError):
-        update_rules(config, pconn)
+@patch_insights_upload_conf()
+def test_return_get_conf_update(insights_upload_conf):
+    """
+    Updated configuration is loaded and returned.
+    """
+    config = Mock()
+    pconn = Mock()
+    result = update_rules(config, pconn)
 
-
-@patch_try_disk([{"version": "1.2.3"}])
-@patch_collection_rules_file()
-@patch_get_collection_rules(None)
-def test_collection_rules_file_conf_try_disk(get_collection_rules, try_disk):
-    gpg = "perhaps"
-    config, pconn = update_rules_args(gpg=gpg)
-    update_rules(config, pconn)
-    try_disk.assert_called_once_with(collection_rules_file, gpg)
-
-
-@patch_try_disk([{"version": None}])
-@patch_get_collection_rules({"version": None})
-def test_collection_rules_file_conf_no_version_error(get_collection_rules, try_disk):
-    config, pconn = update_rules_args()
-    with raises(ValueError):
-        update_rules(config, pconn)
-
-
-@patch_try_disk([None, {"version": "1.2.3"}])
-@patch_collection_fallback_file()
-@patch_collection_rules_file()
-@patch_get_collection_rules(None)
-def test_fallback_file_conf_try_disk(get_collection_rules, try_disk):
-    gpg = "perhaps"
-    config, pconn = update_rules_args(gpg=gpg)
-    update_rules(config, pconn)
-    calls = [call(collection_rules_file, gpg), call(collection_fallback_file, gpg)]
-    try_disk.assert_has_calls(calls)
-    assert try_disk.call_count == len(calls)
-
-
-@patch_try_disk([None, {"version": None}])
-@patch_get_collection_rules(None)
-def test_fallback_file_conf_no_version_error(get_collection_rules, try_disk):
-    config, pconn = update_rules_args()
-    with raises(ValueError):
-        update_rules(config, pconn)
-
-
-@patch_try_disk([None, None])
-@patch_get_collection_rules(None)
-def test_no_file_conf_error(get_collection_rules, try_disk):
-    config, pconn = update_rules_args()
-    with raises(ValueError):
-        update_rules(config, pconn)
+    get_conf_update = insights_upload_conf.return_value.get_conf_update
+    get_conf_update.assert_called_once_with()
+    assert result == get_conf_update.return_value

--- a/insights/tests/client/test_update_rules.py
+++ b/insights/tests/client/test_update_rules.py
@@ -2,12 +2,39 @@
 
 from insights.client.client import update_rules
 from mock.mock import Mock, patch
-from pytest import raises
+from pytest import mark, raises
+
+collection_rules_file = "/tmp/collection_rules"
+
+
+def update_rules_args():
+    """
+    Mocks InsightsConfig with some values that allow instantiating InsightsUploadConf without errors.
+    """
+    return Mock(base_url=""), Mock
+
+
+def coerce_result(result):
+    """
+    Coerces return value to a tuple if it returned only a single value.
+    """
+    if isinstance(result, tuple):
+        return result
+    else:
+        return (result,)
+
+
+def try_disk_call_file(mock):
+    """
+    Finds a filename what the try_disk method was called with.
+    """
+    name, args, kwargs = mock.mock_calls[0]
+    return args[0]
 
 
 def patch_insights_upload_conf():
     """
-    Mocks InsightsUploadConf.
+    Mocks InsightsUploadConf class.
     """
     def decorator(old_function):
         patcher = patch("insights.client.client.InsightsUploadConf")
@@ -15,16 +42,58 @@ def patch_insights_upload_conf():
     return decorator
 
 
-@patch_insights_upload_conf()
-def test_no_connection_error(insights_upload_conf):
+def patch_get_collection_rules(return_value):
+    """
+    Mocks InsightsUploadConf.get_collection_rules method so it returns a given value.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.client.InsightsUploadConf.get_collection_rules", return_value=return_value)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_try_disk(return_value):
+    """
+    Mocks InsightsUploadConf.try_disk method so it returns a given value.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.client.InsightsUploadConf.try_disk", return_value=return_value)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_collection_rules_file():
+    """
+    Mocks the collection_rules_file contant so it contains a fixed value.
+    """
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.constants.collection_rules_file", collection_rules_file)
+        return patcher(old_function)
+    return decorator
+
+
+@mark.regression
+def test_no_connection_error():
     """
     Error is raised when connection couldn't be established.
     """
-    config = Mock()
+    config, pconn = update_rules_args()
     with raises(ValueError):
         update_rules(config, None)
 
-    insights_upload_conf.return_value.get_conf_update.assert_not_called()
+
+@patch_insights_upload_conf()
+def test_no_connection_no_configuration(insights_upload_conf):
+    """
+    Configuration is not loaded when connection couldn't be established.
+    """
+    config, pconn = update_rules_args()
+    try:
+        update_rules(config, None)
+    except ValueError:
+        pass
+
+    insights_upload_conf.assert_not_called()
 
 
 @patch_insights_upload_conf()
@@ -32,8 +101,7 @@ def test_configuration(insights_upload_conf):
     """
     Configuration is created with given options and retrieved connection.
     """
-    config = Mock()
-    pconn = Mock()
+    config, pconn = update_rules_args()
     update_rules(config, pconn)
 
     insights_upload_conf.assert_called_once_with(config, conn=pconn)
@@ -44,10 +112,93 @@ def test_return_get_conf_update(insights_upload_conf):
     """
     Updated configuration is loaded and returned.
     """
-    config = Mock()
-    pconn = Mock()
+    config, pconn = update_rules_args()
     result = update_rules(config, pconn)
 
     get_conf_update = insights_upload_conf.return_value.get_conf_update
     get_conf_update.assert_called_once_with()
     assert result == get_conf_update.return_value
+
+
+@mark.regression
+@patch_try_disk(None)
+@patch_get_collection_rules({"version": "1.2.3"})
+def test_get_collection_rules_calls(get_collection_rules, try_disk):
+    """
+    Collection rules are retrieved from online source, skipping loading from file.
+    """
+    config, pconn = update_rules_args()
+    update_rules(config, pconn)
+
+    get_collection_rules.assert_called_once_with()
+    try_disk.assert_not_called()
+
+
+@mark.regression
+@patch_get_collection_rules({"value": "abc"})
+def test_get_collection_rules_no_version_error(get_collection_rules):
+    """
+    An error is raised if collection rules retrieved from online source don’t contain a version.
+    """
+    config, pconn = update_rules_args()
+    with raises(ValueError):
+        update_rules(config, pconn)
+
+
+@mark.regression
+@patch_collection_rules_file()
+@patch_get_collection_rules({"version": "1.2.3"})
+def test_get_collection_rules_result(get_collection_rules):
+    """
+    Collection rules file name is added to the retrieved result.
+    """
+    config, pconn = update_rules_args()
+    raw_result = update_rules(config, pconn)
+    coerced_result = coerce_result(raw_result)
+
+    expected = get_collection_rules.return_value.copy()
+    expected.update({"file": collection_rules_file})
+    assert coerced_result[0] == expected
+
+
+@mark.regression
+@patch_try_disk({"version": "1.2.3"})
+@patch_get_collection_rules(None)
+def test_try_disk_calls(get_collection_rules, try_disk):
+    """
+    Collection rules are not retrieved from online source, loading from file.
+    """
+    config, pconn = update_rules_args()
+    update_rules(config, pconn)
+
+    get_collection_rules.assert_called_once_with()
+    try_disk.assert_called()
+
+
+@mark.regression
+@patch_try_disk({"value": "abc"})
+@patch_get_collection_rules(None)
+def test_try_disk_no_version_error(get_collection_rules, try_disk):
+    """
+    An error is raised if collection rules retrieved from file don’t contain a version.
+    """
+    config, pconn = update_rules_args()
+    with raises(ValueError):
+        update_rules(config, pconn)
+
+
+@mark.regression
+@patch_try_disk({"version": "1.2.3"})
+@patch_get_collection_rules(None)
+def test_try_disk_result(get_collection_rules, try_disk):
+    """
+    Local file name is added to the stored result.
+    """
+    config, pconn = update_rules_args()
+    raw_result = update_rules(config, pconn)
+    coerced_result = coerce_result(raw_result)
+
+    name, args, kwargs = try_disk.mock_calls[0]
+    expected = try_disk.return_value
+    expected.update({"file": args[0]})
+    assert coerced_result[0] == expected

--- a/insights/tests/client/test_update_rules.py
+++ b/insights/tests/client/test_update_rules.py
@@ -1,0 +1,124 @@
+# -*- coding: UTF-8 -*-
+
+from insights.client.config import InsightsConfig
+from insights.client.client import update_rules
+from mock.mock import call, Mock, patch
+from pytest import raises
+
+
+collection_rules_file = "/tmp/collection_rules"
+collection_fallback_file = "/tmp/fallback"
+
+
+def update_rules_args(*insights_config_args, **insights_config_custom_kwargs):
+    """
+    Instantiates InsightsConfig with a default logging_file argument.
+    """
+    insights_config_all_kwargs = {"logging_file": "/tmp/insights.log"}
+    insights_config_all_kwargs.update(insights_config_custom_kwargs)
+    return InsightsConfig(*insights_config_args, **insights_config_all_kwargs), Mock()
+
+
+def patch_get_collection_rules(collection_rules):
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.InsightsUploadConf.get_collection_rules",
+                        return_value=collection_rules)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_get_connection():
+    def decorator(old_function):
+        patcher = patch("insights.client.client.get_connection", return_value=None)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_collection_rules_file():
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.constants.collection_rules_file", collection_rules_file)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_collection_fallback_file():
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.constants.collection_fallback_file", collection_fallback_file)
+        return patcher(old_function)
+    return decorator
+
+
+def patch_try_disk(disk_confs):
+    def decorator(old_function):
+        patcher = patch("insights.client.collection_rules.InsightsUploadConf.try_disk", side_effect=disk_confs)
+        return patcher(old_function)
+    return decorator
+
+
+@patch_get_collection_rules({"version": "1.2.3"})
+@patch_get_connection()
+def test_no_connection_error(get_connection, get_collection_rules):
+    config, pconn = update_rules_args()
+    with raises(ValueError):
+        update_rules(config, None)
+
+
+@patch_get_collection_rules({"version": "1.2.3"})
+def test_get_collection_rules(get_collection_rules):
+    config, pconn = update_rules_args()
+    update_rules(config, pconn)
+    get_collection_rules.assert_called_once_with()
+
+
+@patch_get_collection_rules({"version": None})
+def test_dyn_conf_no_version_error(get_collection_rules):
+    config, pconn = update_rules_args()
+    with raises(ValueError):
+        update_rules(config, pconn)
+
+
+@patch_try_disk([{"version": "1.2.3"}])
+@patch_collection_rules_file()
+@patch_get_collection_rules(None)
+def test_collection_rules_file_conf_try_disk(get_collection_rules, try_disk):
+    gpg = "perhaps"
+    config, pconn = update_rules_args(gpg=gpg)
+    update_rules(config, pconn)
+    try_disk.assert_called_once_with(collection_rules_file, gpg)
+
+
+@patch_try_disk([{"version": None}])
+@patch_get_collection_rules({"version": None})
+def test_collection_rules_file_conf_no_version_error(get_collection_rules, try_disk):
+    config, pconn = update_rules_args()
+    with raises(ValueError):
+        update_rules(config, pconn)
+
+
+@patch_try_disk([None, {"version": "1.2.3"}])
+@patch_collection_fallback_file()
+@patch_collection_rules_file()
+@patch_get_collection_rules(None)
+def test_fallback_file_conf_try_disk(get_collection_rules, try_disk):
+    gpg = "perhaps"
+    config, pconn = update_rules_args(gpg=gpg)
+    update_rules(config, pconn)
+    calls = [call(collection_rules_file, gpg), call(collection_fallback_file, gpg)]
+    try_disk.assert_has_calls(calls)
+    assert try_disk.call_count == len(calls)
+
+
+@patch_try_disk([None, {"version": None}])
+@patch_get_collection_rules(None)
+def test_fallback_file_conf_no_version_error(get_collection_rules, try_disk):
+    config, pconn = update_rules_args()
+    with raises(ValueError):
+        update_rules(config, pconn)
+
+
+@patch_try_disk([None, None])
+@patch_get_collection_rules(None)
+def test_no_file_conf_error(get_collection_rules, try_disk):
+    config, pconn = update_rules_args()
+    with raises(ValueError):
+        update_rules(config, pconn)


### PR DESCRIPTION
When fixing #1226, I found the `get_conf` method very bulky with too many conditionals.

Reduced its cognitive complexity by splitting the method into smaller ones. Used separate methods for different configuration sources: file, url (with fallback to file) and stdin for regular configuration, and one for the remove_file configuration.

`InsightsUploadConf` class interface changed, existing behavior should remain the same. It’s just syntax shuffling that should not have any impact on an actual execution. I don’t have much confidence in the test coverage though: even when I intentionally break the code, no additional test fails. Thus I’d like to ask for a thorough review of the execution paths of former `get_conf` method calls.

My goal was not to make the code polished and beautiful, only to split that one big method into more readable pieces. I didn’t touch anything extra.

WIP: Python 2/3 compatibility issues. Reported by @gravitypriest.