### PR TITLE
few tweaks for py3

### DIFF
--- a/insights/client/collection_rules.py
+++ b/insights/client/collection_rules.py
@@ -108,7 +108,7 @@ class InsightsUploadConf(object):
                 logger.debug("Successfully downloaded collection rules")
 
                 json_response = NamedTemporaryFile()
-                json_response.write(req.text)
+                json_response.write(req.text.encode())
                 json_response.file.flush()
             else:
                 logger.error("ERROR: Could not download dynamic configuration")
@@ -153,7 +153,7 @@ class InsightsUploadConf(object):
         """
         sig_text = self.fetch_gpg()
         sig_response = NamedTemporaryFile(suffix=".asc")
-        sig_response.write(sig_text)
+        sig_response.write(sig_text.encode())
         sig_response.file.flush()
         self.validate_gpg_sig(collection_rules.name, sig_response.name)
         self.write_collection_data(self.collection_rules_file + ".asc", sig_text)
@@ -203,7 +203,7 @@ class InsightsUploadConf(object):
                     raise ValueError("ERROR: Could not find version in json")
                 dyn_conf['file'] = self.collection_rules_file
                 logger.debug("Success reading config")
-                config_hash = hashlib.sha1(json.dumps(dyn_conf)).hexdigest()
+                config_hash = hashlib.sha1(json.dumps(dyn_conf).encode()).hexdigest()
                 logger.debug('sha1 of config: %s', config_hash)
                 return dyn_conf, rm_conf
         for conf_file in [self.collection_rules_file, self.fallback_file]:

--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -9,6 +9,7 @@ from . import archive
 import logging
 import copy
 import glob
+import six
 from subprocess import Popen, PIPE, STDOUT
 from tempfile import NamedTemporaryFile
 
@@ -63,6 +64,8 @@ class DataCollector(object):
         logger.debug("Return Code: %s", the_return_code)
         if the_return_code != 0:
             return []
+        if six.PY3:
+            stdout = stdout.decode('utf-8')
         return stdout.splitlines()
 
     def _parse_file_spec(self, spec):

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -99,8 +99,8 @@ def write_to_disk(filename, delete=False, content=get_time()):
         if os.path.lexists(filename):
             os.remove(filename)
     else:
-        with open(filename, 'w') as f:
-            f.write(content)
+        with open(filename, 'wb') as f:
+            f.write(content.encode('utf-8'))
 
 
 def generate_machine_id(new=False,
@@ -191,7 +191,7 @@ def write_data_to_file(data, filepath):
     except OSError:
         pass
 
-    write_to_disk(filepath, content=data.encode('utf8'))
+    write_to_disk(filepath, content=data)
 
 
 def magic_plan_b(filename):


### PR DESCRIPTION
- `shlex.split()` in python 3 barfs if you give it unicode
- `hashlib.sha1()` in python 3 expects bytes
- Need to explicitly write bytes to file instead of str