### PR TITLE
set up basic logging so config.py can log (BZ1554484)

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -4,6 +4,7 @@ import logging
 import tempfile
 import shlex
 import shutil
+import sys
 from subprocess import Popen, PIPE
 
 from .. import package_info
@@ -21,14 +22,22 @@ class InsightsClient(object):
         """
         The Insights client interface
         """
-        #  small hack to maintain compatability with RPM wrapper
+        # initial logging for config file
+        logging.basicConfig()
+
+        # small hack to maintain compatability with RPM wrapper
         if isinstance(config, InsightsConfig):
             self.config = config
         else:
-            self.config = InsightsConfig().load_all()
+            try:
+                self.config = InsightsConfig().load_all()
+            except ValueError as e:
+                sys.stderr.write('ERROR: ' + str(e) + '\n')
+                sys.exit(constants.sig_kill_bad)
         # end hack. in the future, just set self.config=config
 
         # set up logging
+        logging.root.handlers = []
         if setup_logging:
             self.set_up_logging()
 

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -455,8 +455,10 @@ class InsightsConfig(object):
         try:
             parsedconfig.read(fname or self.conf)
         except ConfigParser.Error:
-            logger.error(
-                'ERROR: Could not read configuration file, using defaults')
+            if len(logging.root.handlers) > 0:
+                # suppress this if there's no logging available
+                logger.error(
+                    'ERROR: Could not read configuration file, using defaults')
         try:
             # Try to add the insights-client section
             parsedconfig.add_section(constants.app_name)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1554484

Sets up basic logging so config.py has a handler, then removes it so normal logging can initialize. Also suppresses multiple outputs of the same message from config.py, as described in the bug.