### PR TITLE
Fix insights-run to run insights cmd line

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -210,5 +210,9 @@ def run(component=None, root=None, print_summary=False,
     return broker
 
 
-if __name__ == "__main__":
+def main():
     run(print_summary=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ for name in package_info:
 
 entry_points = {
     'console_scripts': [
-        'insights-run = insights.core:main',
+        'insights-run = insights:main',
         'gen_api = insights.tools.generate_api_config:main',
         'insights-perf = insights.tools.perf:main',
         'client = insights.client:run',


### PR DESCRIPTION
The `insights-run` command was broken and whatever it used to run in core is no longer present.  This change re-enables the insights-run command to do the same as `python -m insights`.