### PR TITLE
Do not retry if server returns 412 on upload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,8 @@ pipeline {
             }
           }
           steps {
+            echo "Installing Insights..."
+            sh 'pip install --user -e .[develop]'
             echo "Testing with Pytest..."
             sh 'pytest'
           }
@@ -22,7 +24,7 @@ pipeline {
           }
           steps {
             echo "Installing Insights..."
-            sh 'pip install --user -e .'
+            sh 'pip install --user -e .[develop]'
             echo "Testing with Pytest..."
             sh 'pytest'
             echo "Testing with flake8..."   
@@ -37,7 +39,7 @@ pipeline {
           }
           steps {
             echo "Installing Insights..."
-            sh '/bin/python36 -m pip install --user -e .'
+            sh '/bin/python36 -m pip install --user -e .[develop]'
             echo "Testing with Pytest..."
             sh '/bin/python36 -m pytest'
             echo "Testing with flake8..."   

--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -448,6 +448,7 @@ def upload(config, tar_file, collection_duration=None):
 
         elif upload.status_code == 412:
             pconn.handle_fail_rcs(upload)
+            break
         else:
             logger.error("Upload attempt %d of %d failed! Status Code: %s",
                          tries + 1, config.retries, upload.status_code)

--- a/insights/tests/client/test_client.py
+++ b/insights/tests/client/test_client.py
@@ -3,7 +3,11 @@ import sys
 from insights.client import InsightsClient
 from insights.client.config import InsightsConfig
 from insights import package_info
+from mock.mock import patch
+from mock.mock import Mock
 
+
+# @TODO DRY the args hack.
 
 def test_version():
 
@@ -16,5 +20,67 @@ def test_version():
         client = InsightsClient(config)
         result = client.version()
         assert result == "%s-%s" % (package_info["VERSION"], package_info["RELEASE"])
+    finally:
+        sys.argv = tmp
+
+
+@patch('insights.client.client.constants.sleep_time', 0)
+@patch('insights.client.client.InsightsConnection.upload_archive',
+       return_value=Mock(status_code=500))
+def test_upload_500_retry(upload_archive):
+
+    # Hack to prevent client from parsing args to py.test
+    tmp = sys.argv
+    sys.argv = []
+
+    try:
+        retries = 3
+
+        config = InsightsConfig(logging_file='/tmp/insights.log', retries=retries)
+        client = InsightsClient(config)
+        client.upload('/tmp/insights.tar.gz')
+
+        upload_archive.assert_called()
+        assert upload_archive.call_count == retries
+    finally:
+        sys.argv = tmp
+
+
+@patch('insights.client.client.InsightsConnection.handle_fail_rcs')
+@patch('insights.client.client.InsightsConnection.upload_archive',
+       return_value=Mock(status_code=412))
+def test_upload_412_no_retry(upload_archive, handle_fail_rcs):
+
+    # Hack to prevent client from parsing args to py.test
+    tmp = sys.argv
+    sys.argv = []
+
+    try:
+        config = InsightsConfig(logging_file='/tmp/insights.log', retries=3)
+        client = InsightsClient(config)
+        client.upload('/tmp/insights.tar.gz')
+
+        upload_archive.assert_called_once()
+    finally:
+        sys.argv = tmp
+
+
+@patch('insights.client.connection.write_unregistered_file')
+@patch('insights.client.client.InsightsConnection.upload_archive',
+       return_value=Mock(**{"status_code": 412,
+                            "json.return_value": {"unregistered_at": "now", "message": "msg"}}))
+def test_upload_412_write_unregistered_file(upload_archive, write_unregistered_file):
+
+    # Hack to prevent client from parsing args to py.test
+    tmp = sys.argv
+    sys.argv = []
+
+    try:
+        config = InsightsConfig(logging_file='/tmp/insights.log', retries=3)
+        client = InsightsClient(config)
+        client.upload('/tmp/insights.tar.gz')
+
+        unregistered_at = upload_archive.return_value.json()["unregistered_at"]
+        write_unregistered_file.assert_called_once_with(unregistered_at)
     finally:
         sys.argv = tmp

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ develop = set([
     'coverage==4.3.4',
     'pytest==3.0.6',
     'pytest-cov==2.4.0',
+    'mock==2.0.0',
     'Sphinx',
     'nbsphinx==0.3.1',
     'sphinx_rtd_theme',


### PR DESCRIPTION
Status code 412 means that the machine is unregistered. Thus there is almost no point in retrying as this is not a temporary condition.

This is rather a “hotfix”, since the `--retry` parameter is ignored regardless of whether the `.unregistered` file is actually written. This is because the `InsightsConnection.handle_fail_rcs` actually does not treat a 412 without a valid API response body as a reason to unregister. I’d address this separately.

If the assumption that 412 should result in not retrying at all is correct, then this solves https://bugzilla.redhat.com/show_bug.cgi?id=1554794 and https://projects.engineering.redhat.com/browse/MAASPLAT-205. @kylape and @YakovLittle can confirm this.

Added some tests and along with that [mock](https://pypi.org/project/mock/) as a development requirement.