### PR TITLE
Update pyyaml to 3.13 to fix 'pip3 install pyyaml' error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ entry_points = {
 }
 
 runtime = set([
-    'pyyaml>=3.10,<=3.12',
+    'pyyaml>=3.10,<=3.13',
     'six',
 ])
 


### PR DESCRIPTION
- See https://github.com/yaml/pyyaml/issues/152
      https://github.com/yaml/pyyaml/issues/152#issuecomment-402791014