### PR TITLE
Implement console output formats as loadable modules.

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import os
 import pkgutil
-from pprint import pprint
 from .core import Scannable, LogFileOutput, Parser, IniConfigFile  # noqa: F401
 from .core import FileListing, LegacyItemAccess, SysconfigOptions  # noqa: F401
 from .core import YAMLParser, JSONParser, XMLParser, CommandParser  # noqa: F401
@@ -17,6 +16,7 @@ from .core.plugins import combiner, fact, metadata, parser, rule  # noqa: F401
 from .core.plugins import datasource, condition, incident  # noqa: F401
 from .core.plugins import make_response, make_metadata, make_fingerprint  # noqa: F401
 from .core.filters import add_filter, apply_filters, get_filters  # noqa: F401
+from .formats import get_formatter
 from .parsers import get_active_lines  # noqa: F401
 from .util import defaults  # noqa: F401
 
@@ -51,31 +51,19 @@ def add_status(name, nvr, commit):
     RULES_STATUS[name] = {"version": nvr, "commit": commit}
 
 
-def process_dir(root, graph, context, show_dropped=False, use_pandas=False):
-    broker = dr.Broker()
+def process_dir(broker, root, graph, context, use_pandas=False):
     ctx = create_context(root, context)
 
     if isinstance(ctx, ClusterArchiveContext):
         archives = [f for f in ctx.all_files if f.endswith(COMPRESSION_TYPES)]
-        return process_cluster(archives, use_pandas=use_pandas)
+        return process_cluster(archives, use_pandas=use_pandas, broker=broker)
 
     broker[ctx.__class__] = ctx
     broker = dr.run(graph, broker=broker)
-    if show_dropped:
-        ds = broker.get_by_type(datasource)
-        vals = []
-        for v in ds.values():
-            if isinstance(v, list):
-                vals.extend(d.path for d in v)
-            else:
-                vals.append(v.path)
-        dropped = set(ctx.all_files) - set(vals)
-        pprint("Dropped Files:")
-        pprint(dropped, indent=4)
     return broker
 
 
-def _run(graph=None, root=None, context=None, show_dropped=False, use_pandas=False):
+def _run(broker, graph=None, root=None, context=None, use_pandas=False):
     """
     run is a general interface that is meant for stand alone scripts to use
     when executing insights components.
@@ -96,15 +84,14 @@ def _run(graph=None, root=None, context=None, show_dropped=False, use_pandas=Fal
 
     if not root:
         context = context or HostContext
-        broker = dr.Broker()
         broker[context] = context()
         return dr.run(graph, broker=broker)
 
     if os.path.isdir(root):
-        return process_dir(root, graph, context, show_dropped, use_pandas)
+        return process_dir(broker, root, graph, context, use_pandas)
     else:
         with extract(root) as ex:
-            return process_dir(ex.tmp_dir, graph, context, show_dropped, use_pandas)
+            return process_dir(broker, ex.tmp_dir, graph, context, use_pandas)
 
 
 def _load_context(path):
@@ -114,34 +101,6 @@ def _load_context(path):
     if "." not in path:
         path = ".".join(["insights.core.context", path])
     return dr.get_component(path)
-
-
-def describe(broker, show_missing=False, show_tracebacks=False):
-    if show_missing and broker.missing_requirements:
-        print()
-        print("Missing Requirements:")
-        if broker.missing_requirements:
-            print(broker.missing_requirements)
-
-    if show_tracebacks and broker.tracebacks:
-        print()
-        print("Tracebacks:")
-        for t in broker.tracebacks.values():
-            print(t)
-
-    def printit(c, v):
-        name = dr.get_name(c)
-        print(name)
-        print('-' * len(name))
-        print(dr.to_str(c, v))
-        print()
-        print()
-
-    print()
-    for c in sorted(broker.get_by_type(rule), key=dr.get_name):
-        v = broker[c]
-        if v["type"] != "skip":
-            printit(c, v)
 
 
 def run(component=None, root=None, print_summary=False,
@@ -155,20 +114,35 @@ def run(component=None, root=None, print_summary=False,
     dr.load_components("insights.specs.jdr_archive")
 
     args = None
+    formatter = None
     if print_summary:
         import argparse
         import logging
-        p = argparse.ArgumentParser()
+        p = argparse.ArgumentParser(add_help=False)
         p.add_argument("archive", nargs="?", help="Archive or directory to analyze.")
         p.add_argument("-p", "--plugins", default="", help="Comma-separated list without spaces of package(s) or module(s) containing plugins.")
         p.add_argument("-v", "--verbose", help="Verbose output.", action="store_true")
+        p.add_argument("-f", "--format", help="Output format.", default="insights.formats.text")
         p.add_argument("-D", "--debug", help="Verbose debug output.", action="store_true")
-        p.add_argument("-m", "--missing", help="Show missing requirements.", action="store_true")
-        p.add_argument("-t", "--tracebacks", help="Show stack traces.", action="store_true")
-        p.add_argument("-d", "--dropped", help="Show collected files that weren't processed.", action="store_true", default=False)
         p.add_argument("--context", help="Execution Context. Defaults to HostContext if an archive isn't passed.")
         p.add_argument("--pandas", action="store_true", help="Use pandas dataframes with cluster rules.")
-        args = p.parse_args()
+
+        class Args(object):
+            pass
+
+        args = Args()
+        p.parse_known_args(namespace=args)
+        p = argparse.ArgumentParser(parents=[p])
+        args.format = "insights.formats._json" if args.format == "json" else args.format
+        args.format = "insights.formats._yaml" if args.format == "yaml" else args.format
+        fmt = args.format if "." in args.format else "insights.formats." + args.format
+        Formatter = dr.get_component(fmt)
+        if not Formatter:
+            dr.load_components(fmt, continue_on_error=False)
+            Formatter = get_formatter(fmt)
+        Formatter.configure(p)
+        p.parse_args(namespace=args)
+        formatter = Formatter(args)
 
         logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO if args.verbose else logging.ERROR)
         context = _load_context(args.context) or context
@@ -197,7 +171,6 @@ def run(component=None, root=None, print_summary=False,
                 if c.__module__.startswith(plugins):
                     component.append(c)
 
-    show_dropped = args.dropped if args else False
     if component:
         if not isinstance(component, (list, set)):
             component = [component]
@@ -207,12 +180,18 @@ def run(component=None, root=None, print_summary=False,
     else:
         graph = dr.COMPONENTS[dr.GROUPS.single]
 
-    broker = _run(graph, root, context=context, show_dropped=show_dropped, use_pandas=use_pandas)
+    broker = dr.Broker()
 
-    if print_summary:
-        describe(broker, show_missing=args.missing, show_tracebacks=args.tracebacks)
+    if formatter:
+        formatter.preprocess(broker)
+        broker = _run(broker, graph, root, context=context, use_pandas=use_pandas)
+        formatter.postprocess(broker)
     elif print_component:
+        broker = _run(broker, graph, root, context=context, use_pandas=use_pandas)
         broker.print_component(print_component)
+    else:
+        broker = _run(broker, graph, root, context=context, use_pandas=use_pandas)
+
     return broker
 
 

--- a/insights/formats/__init__.py
+++ b/insights/formats/__init__.py
@@ -1,0 +1,71 @@
+import six
+from insights import dr
+from insights.core.evaluators import SingleEvaluator
+
+
+_FORMATTERS = {}
+
+
+def get_formatter(name):
+    """
+    Looks up a formatter class given a prefix to it.
+    The names are sorted, and the first matching class is returned.
+    """
+    for k in sorted(_FORMATTERS):
+        if k.startswith(name):
+            return _FORMATTERS[k]
+
+
+class FormatterMeta(type):
+    """ Automatically registers subclasses for later lookup. """
+
+    def __init__(cls, name, bases, dct):
+        if name not in ("Formatter", "EvaluatorFormatter"):
+            _FORMATTERS[dr.get_name(cls)] = cls
+        super(FormatterMeta, cls).__init__(name, bases, dct)
+
+
+class Formatter(six.with_metaclass(FormatterMeta)):
+
+    @staticmethod
+    def configure(p):
+        """ Override to add arguments to the ArgumentParser. """
+        pass
+
+    def __init__(self, args=None):
+        """ Subclasses get passed the parsed args. """
+        pass
+
+    def preprocess(self, broker):
+        """
+        Called before any components have been run. Useful for registering
+        observers.
+        """
+        pass
+
+    def postprocess(self, broker):
+        """
+        Called after all components have been run. Useful for interrogating
+        the broker for final state.
+        """
+
+
+class EvaluatorFormatter(Formatter):
+    """
+    Base class for formatters that want to serialize a SingleEvaluator after
+    execution.
+    """
+    def __init__(self, args=None):
+        if args:
+            hn = "insights.combiners.hostname"
+            args.plugins = ",".join([args.plugins, hn]) if args.plugins else hn
+
+    def preprocess(self, broker):
+        self.evaluator = SingleEvaluator(broker=broker)
+
+    def postprocess(self, broker):
+        self.evaluator.post_process()
+        print(self.dump(self.evaluator.get_response()))
+
+    def dump(self, data):
+        raise NotImplemented("Subclasses must implement the dump method.")

--- a/insights/formats/_json.py
+++ b/insights/formats/_json.py
@@ -1,0 +1,8 @@
+import json
+
+from insights.formats import EvaluatorFormatter
+
+
+class JsonFormatter(EvaluatorFormatter):
+    def dump(self, data):
+        return json.dumps(data)

--- a/insights/formats/_yaml.py
+++ b/insights/formats/_yaml.py
@@ -1,0 +1,8 @@
+import yaml
+
+from insights.formats import EvaluatorFormatter
+
+
+class YamlFormatter(EvaluatorFormatter):
+    def dump(self, data):
+        return yaml.dump(data)

--- a/insights/formats/text.py
+++ b/insights/formats/text.py
@@ -1,0 +1,79 @@
+from __future__ import print_function
+from pprint import pprint
+from insights import dr, datasource, rule
+from insights.core.context import ExecutionContext
+from insights.formats import Formatter
+
+
+def _find_context(broker):
+    for k, v in broker.instances.items():
+        if issubclass(k, ExecutionContext):
+            return v
+
+
+class HumanReadableFormat(Formatter):
+    """ Displays results in a human readable format. """
+
+    @staticmethod
+    def configure(p):
+        p.add_argument("-m", "--missing", help="Show missing requirements.", action="store_true")
+        p.add_argument("-t", "--tracebacks", help="Show stack traces.", action="store_true")
+        p.add_argument("-d", "--dropped", help="Show collected files that weren't processed.", action="store_true")
+
+    def __init__(self, args):
+        self.missing = args.missing
+        self.tracebacks = args.tracebacks
+        self.dropped = args.dropped
+
+    def postprocess(self, broker):
+        if self.missing:
+            self.show_missing(broker)
+        if self.tracebacks:
+            self.show_tracebacks(broker)
+        if self.dropped:
+            self.show_dropped(broker)
+
+        self.show_description(broker)
+
+    def show_missing(self, broker):
+        if broker.missing_requirements:
+            print()
+            print("Missing Requirements:")
+            if broker.missing_requirements:
+                print(broker.missing_requirements)
+
+    def show_tracebacks(self, broker):
+        if broker.tracebacks:
+            print()
+            print("Tracebacks:")
+            for t in broker.tracebacks.values():
+                print(t)
+
+    def show_dropped(self, broker):
+        ctx = _find_context(broker)
+        if ctx and ctx.all_files:
+            ds = broker.get_by_type(datasource)
+            vals = []
+            for v in ds.values():
+                if isinstance(v, list):
+                    vals.extend(d.path for d in v)
+                else:
+                    vals.append(v.path)
+            dropped = set(ctx.all_files) - set(vals)
+            pprint("Dropped Files:")
+            pprint(dropped, indent=4)
+
+    def show_description(self, broker):
+        def printit(c, v):
+            name = dr.get_name(c)
+            print(name)
+            print('-' * len(name))
+            print(dr.to_str(c, v))
+            print()
+            print()
+
+        print()
+        for c in sorted(broker.get_by_type(rule), key=dr.get_name):
+            v = broker[c]
+            if v["type"] != "skip":
+                printit(c, v)


### PR DESCRIPTION
Implement output formats as loadable modules. Cleans up the run function and allows us to extend with more formats if needed. The next formatter probably would be one that prints rule results or errors as they execute.

Examples:
*  `python -m insights -f json`
*  `python -m insights -f yaml`
*  `python -m insights -f text` (the default)