### PR TITLE
BUGREPORT: configtree breaks on quotes

### DIFF
--- a/insights/combiners/tests/test_httpd_conf_tree.py
+++ b/insights/combiners/tests/test_httpd_conf_tree.py
@@ -91,6 +91,21 @@ Bar 3C
 </IfModule>
 '''.strip()
 
+HTTPD_CONF_WITH_NONSTANDARD_INCLUDE_PATH = '''
+JustFotTest_NoSec "/var/www/cgi"
+Include blaaaa.blaaa.blabla.d/*.conf
+Include conf.modules.d/*.conf
+# prefork MPM
+<IfModule prefork.c>
+ServerLimit      256
+ThreadsPerChild  16
+JustForTest      "AB"
+MaxClients       256
+</IfModule>
+
+IncludeOptional conf.d/*.conf
+'''.strip()
+
 HTTPD_CONF_MAIN_1 = '''
 ServerRoot "/etc/httpd"
 Listen 80
@@ -256,10 +271,395 @@ HTTPD_CONF_NEST_4 = """
 """.strip()
 
 
+# TODO
+# These are real-world config files - you can delete them after reviewing the MR, I provide them in case the minimum crashing example seems inscrutable to you.
+# There are at least 983 customer machines with such a config file.
+
+BZ1591241C7_CRASHING_FULL_ETC_HTTPD_CONF_HTTPD_CONF = "/etc/httpd/conf/httpd.conf"
+BZ1591241C7_CRASHING_FULL_ETC_HTTPD_CONF_HTTPD_CONF_CONTENT = r"""
+ServerTokens OS
+ServerRoot "/etc/httpd"
+PidFile run/httpd.pid
+Timeout 60
+KeepAlive Off
+MaxKeepAliveRequests 100
+KeepAliveTimeout 15
+<IfModule prefork.c>
+StartServers       8
+MinSpareServers    5
+MaxSpareServers   20
+ServerLimit      256
+MaxClients       256
+MaxRequestsPerChild  4000
+</IfModule>
+<IfModule worker.c>
+StartServers         4
+MaxClients         300
+MinSpareThreads     25
+MaxSpareThreads     75
+ThreadsPerChild     25
+MaxRequestsPerChild  0
+</IfModule>
+Listen 80
+LoadModule auth_basic_module modules/mod_auth_basic.so
+LoadModule auth_digest_module modules/mod_auth_digest.so
+LoadModule authn_file_module modules/mod_authn_file.so
+LoadModule authn_alias_module modules/mod_authn_alias.so
+LoadModule authn_anon_module modules/mod_authn_anon.so
+LoadModule authn_dbm_module modules/mod_authn_dbm.so
+LoadModule authn_default_module modules/mod_authn_default.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_user_module modules/mod_authz_user.so
+LoadModule authz_owner_module modules/mod_authz_owner.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_dbm_module modules/mod_authz_dbm.so
+LoadModule authz_default_module modules/mod_authz_default.so
+LoadModule ldap_module modules/mod_ldap.so
+LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
+LoadModule include_module modules/mod_include.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule logio_module modules/mod_logio.so
+LoadModule env_module modules/mod_env.so
+LoadModule ext_filter_module modules/mod_ext_filter.so
+LoadModule mime_magic_module modules/mod_mime_magic.so
+LoadModule expires_module modules/mod_expires.so
+LoadModule deflate_module modules/mod_deflate.so
+LoadModule headers_module modules/mod_headers.so
+LoadModule usertrack_module modules/mod_usertrack.so
+LoadModule setenvif_module modules/mod_setenvif.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule dav_module modules/mod_dav.so
+LoadModule status_module modules/mod_status.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule info_module modules/mod_info.so
+LoadModule dav_fs_module modules/mod_dav_fs.so
+LoadModule vhost_alias_module modules/mod_vhost_alias.so
+LoadModule negotiation_module modules/mod_negotiation.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule actions_module modules/mod_actions.so
+LoadModule speling_module modules/mod_speling.so
+LoadModule userdir_module modules/mod_userdir.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule substitute_module modules/mod_substitute.so
+LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
+LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
+LoadModule proxy_connect_module modules/mod_proxy_connect.so
+LoadModule cache_module modules/mod_cache.so
+LoadModule suexec_module modules/mod_suexec.so
+LoadModule disk_cache_module modules/mod_disk_cache.so
+LoadModule cgi_module modules/mod_cgi.so
+LoadModule version_module modules/mod_version.so
+Include conf.d/*.conf
+User apache
+Group apache
+ServerAdmin root@localhost
+UseCanonicalName Off
+DocumentRoot "/var/www/html"
+<Directory />
+Options FollowSymLinks
+AllowOverride None
+</Directory>
+<Directory "/var/www/html">
+Options Indexes FollowSymLinks
+AllowOverride None
+Order allow,deny
+Allow from all
+</Directory>
+<IfModule mod_userdir.c>
+UserDir disabled
+</IfModule>
+DirectoryIndex index.html index.html.var
+AccessFileName .htaccess
+<Files ~ "^.ht">
+Order allow,deny
+Deny from all
+Satisfy All
+</Files>
+TypesConfig /etc/mime.types
+DefaultType text/plain
+<IfModule mod_mime_magic.c>
+MIMEMagicFile conf/magic
+</IfModule>
+HostnameLookups Off
+ErrorLog logs/error_log
+LogLevel warn
+LogFormat "%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i"" combined
+LogFormat "%h %l %u %t "%r" %>s %b" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+CustomLog logs/access_log combined
+ServerSignature On
+Alias /icons/ "/var/www/icons/"
+<Directory "/var/www/icons">
+Options Indexes MultiViews FollowSymLinks
+AllowOverride None
+Order allow,deny
+Allow from all
+</Directory>
+<IfModule mod_dav_fs.c>
+DAVLockDB /var/lib/dav/lockdb
+</IfModule>
+ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
+<Directory "/var/www/cgi-bin">
+AllowOverride None
+Options None
+Order allow,deny
+Allow from all
+</Directory>
+IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
+AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
+AddIconByType (TXT,/icons/text.gif) text/*
+AddIconByType (IMG,/icons/image2.gif) image/*
+AddIconByType (SND,/icons/sound2.gif) audio/*
+AddIconByType (VID,/icons/movie.gif) video/*
+AddIcon /icons/binary.gif .bin .exe
+AddIcon /icons/binhex.gif .hqx
+AddIcon /icons/tar.gif .tar
+AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
+AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
+AddIcon /icons/a.gif .ps .ai .eps
+AddIcon /icons/layout.gif .html .shtml .htm .pdf
+AddIcon /icons/text.gif .txt
+AddIcon /icons/c.gif .c
+AddIcon /icons/p.gif .pl .py
+AddIcon /icons/f.gif .for
+AddIcon /icons/dvi.gif .dvi
+AddIcon /icons/uuencoded.gif .uu
+AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
+AddIcon /icons/tex.gif .tex
+AddIcon /icons/bomb.gif /core
+AddIcon /icons/back.gif ..
+AddIcon /icons/hand.right.gif README
+AddIcon /icons/folder.gif ^^DIRECTORY^^
+AddIcon /icons/blank.gif ^^BLANKICON^^
+DefaultIcon /icons/unknown.gif
+ReadmeName README.html
+HeaderName HEADER.html
+IndexIgnore .??* *~ *
+AddLanguage ca .ca
+AddLanguage cs .cz .cs
+AddLanguage da .dk
+AddLanguage de .de
+AddLanguage el .el
+AddLanguage en .en
+AddLanguage eo .eo
+AddLanguage es .es
+AddLanguage et .et
+AddLanguage fr .fr
+AddLanguage he .he
+AddLanguage hr .hr
+AddLanguage it .it
+AddLanguage ja .ja
+AddLanguage ko .ko
+AddLanguage ltz .ltz
+AddLanguage nl .nl
+AddLanguage nn .nn
+AddLanguage no .no
+AddLanguage pl .po
+AddLanguage pt .pt
+AddLanguage pt-BR .pt-br
+AddLanguage ru .ru
+AddLanguage sv .sv
+AddLanguage zh-CN .zh-cn
+AddLanguage zh-TW .zh-tw
+LanguagePriority en ca cs da de el eo es et fr he hr it ja ko ltz nl nn no pl pt pt-BR ru sv zh-CN zh-TW
+ForceLanguagePriority Prefer Fallback
+AddDefaultCharset UTF-8
+AddType application/x-compress .Z
+AddType application/x-gzip .gz .tgz
+AddType application/x-x509-ca-cert .crt
+AddType application/x-pkcs7-crl    .crl
+AddHandler type-map var
+AddType text/html .shtml
+AddOutputFilter INCLUDES .shtml
+Alias /error/ "/var/www/error/"
+<IfModule mod_negotiation.c>
+<IfModule mod_include.c>
+<Directory "/var/www/error">
+AllowOverride None
+Options IncludesNoExec
+AddOutputFilter Includes html
+AddHandler type-map var
+Order allow,deny
+Allow from all
+LanguagePriority en es de fr
+ForceLanguagePriority Prefer Fallback
+</Directory>
+</IfModule>
+</IfModule>
+BrowserMatch "Mozilla/2" nokeepalive
+BrowserMatch "MSIE 4.0b2;" nokeepalive downgrade-1.0 force-response-1.0
+BrowserMatch "RealPlayer 4.0" force-response-1.0
+BrowserMatch "Java/1.0" force-response-1.0
+BrowserMatch "JDK/1.0" force-response-1.0
+BrowserMatch "Microsoft Data Access Internet Publishing Provider" redirect-carefully
+BrowserMatch "MS FrontPage" redirect-carefully
+BrowserMatch "^WebDrive" redirect-carefully
+BrowserMatch "^WebDAVFS/1.[0123]" redirect-carefully
+BrowserMatch "^gnome-vfs/1.0" redirect-carefully
+BrowserMatch "^XML Spy" redirect-carefully
+BrowserMatch "^Dreamweaver-WebDAV-SCM1" redirect-carefully
+""".strip()
+
+BZ1591241C7_CRASHING_FULL_ETC_HTTPD_CONF_D_SSL_CONF = "/etc/httpd/conf.d/ssl.conf"
+BZ1591241C7_CRASHING_FULL_ETC_HTTPD_CONF_D_SSL_CONF_CONTENT = r"""
+LoadModule ssl_module modules/mod_ssl.so
+Listen 443
+SSLPassPhraseDialog  builtin
+SSLSessionCache         shmcb:/var/cache/mod_ssl/scache(512000)
+SSLSessionCacheTimeout  300
+SSLMutex default
+SSLRandomSeed startup file:/dev/urandom  256
+SSLRandomSeed connect builtin
+SSLCryptoDevice builtin
+<VirtualHost _default_:443>
+ErrorLog logs/ssl_error_log
+TransferLog logs/ssl_access_log
+LogLevel warn
+SSLEngine on
+SSLProtocol all -SSLv2
+SSLCipherSuite DEFAULT:!EXP:!SSLv2:!DES:!IDEA:!SEED:+3DES
+SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+<Files ~ ".(cgi|shtml|phtml|php3?)$">
+SSLOptions +StdEnvVars
+</Files>
+<Directory "/var/www/cgi-bin">
+SSLOptions +StdEnvVars
+</Directory>
+SetEnvIf User-Agent ".*MSIE.*" 
+nokeepalive ssl-unclean-shutdown 
+downgrade-1.0 force-response-1.0
+CustomLog logs/ssl_request_log 
+"%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x "%r" %b"
+</VirtualHost>
+""".strip()
+
+BZ1591241C7_CRASHING_FULL_ETC_HTTPD_CONF_D_WELCOME_CONF = "/etc/httpd/conf.d/welcome.conf"
+BZ1591241C7_CRASHING_FULL_ETC_HTTPD_CONF_D_WELCOME_CONF_CONTENT = r"""
+<LocationMatch "^/+$">
+Options -Indexes
+ErrorDocument 403 /error/noindex.html
+</LocationMatch>
+""".strip()
+
+# And their minimized variant
+
+BZ1591241C7_CRASHING_MINIMAL_ETC_HTTPD_CONF_HTTPD_CONF = "/etc/httpd/conf/httpd.conf"
+BZ1591241C7_CRASHING_MINIMAL_ETC_HTTPD_CONF_HTTPD_CONF_CONTENT = r"""
+<IfModule prefork.c>
+</IfModule>
+<IfModule worker.c>
+</IfModule>
+LoadModule include_module modules/mod_include.so
+Include conf.d/*.conf
+<Directory />
+</Directory>
+<Directory "/var/www/html">
+</Directory>
+<IfModule mod_userdir.c>
+</IfModule>
+<Files ~ "^.ht">
+</Files>
+<IfModule mod_mime_magic.c>
+</IfModule>
+<Directory "/var/www/icons">
+</Directory>
+<IfModule mod_dav_fs.c>
+</IfModule>
+<Directory "/var/www/cgi-bin">
+</Directory>
+AddOutputFilter INCLUDES .shtml
+<IfModule mod_negotiation.c>
+<IfModule mod_include.c>
+<Directory "/var/www/error">
+Options IncludesNoExec
+AddOutputFilter Includes html
+</Directory>
+</IfModule>
+</IfModule>
+""".strip()
+
+# this line makes it crash - "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x "%r" %b"
+BZ1591241C7_CRASHING_MINIMAL_ETC_HTTPD_CONF_D_SSL_CONF = "/etc/httpd/conf.d/ssl.conf"
+BZ1591241C7_CRASHING_MINIMAL_ETC_HTTPD_CONF_D_SSL_CONF_CONTENT = r"""
+<VirtualHost _default_:443>
+SSLProtocol all -SSLv2
+<Files ~ ".(cgi|shtml|phtml|php3?)$">
+</Files>
+<Directory "/var/www/cgi-bin">
+</Directory>
+CustomLog logs/ssl_request_log 
+"%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x "%r" %b"
+</VirtualHost>
+""".strip()
+
+BZ1591241C7_CRASHING_MINIMAL_ETC_HTTPD_CONF_D_WELCOME_CONF = "/etc/httpd/conf.d/welcome.conf"
+BZ1591241C7_CRASHING_MINIMAL_ETC_HTTPD_CONF_D_WELCOME_CONF_CONTENT = r"""
+<LocationMatch "^/+$">
+</LocationMatch>
+""".strip()
+
+
+# TODO
+# Just a crashing line without any context - ' and " characters make it crash
+# This test doesn't really make sense, but I think it should not crash at least
+BZ1591241C7_CRASHING_ULTRAMINIMAL_ETC_HTTPD_CONF_HTTPD_CONF = "/etc/httpd/conf/httpd.conf"
+BZ1591241C7_CRASHING_ULTRAMINIMAL_ETC_HTTPD_CONF_HTTPD_CONF_CONTENT = r"""
+<VirtualHost>
+' ' ' '
+SSLProtocol all -SSLv2
+</VirtualHost>
+""".strip()
+
+
+# NOTE: You can use this test to be merged into master with the fix, probably.
+HTTPD_CONF_QUOTES = r"""
+<VirtualHost>
+CustomLog logs/blabla_request_log 
+' ' ' '
+CustomLog logs/ssl_request_log 
+"%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x "%r" %b"
+SSLProtocol all -SSLv2
+</VirtualHost>
+""".strip()
+
+
+def test_bz1591241c7_crashing_full():
+    httpd1 = _HttpdConf(context_wrap(BZ1591241C7_CRASHING_FULL_ETC_HTTPD_CONF_HTTPD_CONF_CONTENT, path=BZ1591241C7_CRASHING_FULL_ETC_HTTPD_CONF_HTTPD_CONF))
+    httpd2 = _HttpdConf(context_wrap(BZ1591241C7_CRASHING_FULL_ETC_HTTPD_CONF_D_SSL_CONF_CONTENT, path=BZ1591241C7_CRASHING_FULL_ETC_HTTPD_CONF_D_SSL_CONF))
+    httpd3 = _HttpdConf(context_wrap(BZ1591241C7_CRASHING_FULL_ETC_HTTPD_CONF_D_WELCOME_CONF_CONTENT, path=BZ1591241C7_CRASHING_FULL_ETC_HTTPD_CONF_D_WELCOME_CONF))
+    result = HttpdConfTree([httpd1, httpd2, httpd3])
+    assert result['VirtualHost']['SSLProtocol'][first].value == 'all -SSLv2'
+
+
+def test_bz1591241c7_crashing_minimal():
+    httpd1 = _HttpdConf(context_wrap(BZ1591241C7_CRASHING_MINIMAL_ETC_HTTPD_CONF_HTTPD_CONF_CONTENT, path=BZ1591241C7_CRASHING_MINIMAL_ETC_HTTPD_CONF_HTTPD_CONF))
+    httpd2 = _HttpdConf(context_wrap(BZ1591241C7_CRASHING_MINIMAL_ETC_HTTPD_CONF_D_SSL_CONF_CONTENT, path=BZ1591241C7_CRASHING_MINIMAL_ETC_HTTPD_CONF_D_SSL_CONF))
+    httpd3 = _HttpdConf(context_wrap(BZ1591241C7_CRASHING_MINIMAL_ETC_HTTPD_CONF_D_WELCOME_CONF_CONTENT, path=BZ1591241C7_CRASHING_MINIMAL_ETC_HTTPD_CONF_D_WELCOME_CONF))
+    result = HttpdConfTree([httpd1, httpd2, httpd3])
+    assert result['VirtualHost']['SSLProtocol'][first].value == 'all -SSLv2'
+
+
+def test_bz1591241c7_crashing_ultraminimal():
+    httpd1 = _HttpdConf(context_wrap(BZ1591241C7_CRASHING_ULTRAMINIMAL_ETC_HTTPD_CONF_HTTPD_CONF_CONTENT, path=BZ1591241C7_CRASHING_ULTRAMINIMAL_ETC_HTTPD_CONF_HTTPD_CONF))
+    result = HttpdConfTree([httpd1])
+    assert result['VirtualHost']['SSLProtocol'][first].value == 'all -SSLv2'
+
+
+def test_superfluous_quotes():
+    httpd1 = _HttpdConf(context_wrap(HTTPD_CONF_QUOTES, path="/etc/httpd/conf/httpd.conf"))
+    result = HttpdConfTree([httpd1])
+    assert result['VirtualHost']['SSLProtocol'][first].value == 'all -SSLv2'
+
+
 def test_mixed_case_tags():
     httpd = _HttpdConf(context_wrap(HTTPD_CONF_MIXED, path='/etc/httpd/conf/httpd.conf'))
     httpd.find("ServerLimit").value == 256
-
 
 def test_nopath():
     # no path
@@ -331,6 +731,35 @@ def test_nopath():
     assert result['IfModule', 'prefork.c']['MaxClients'][2].value == 512   # httpd3
     assert result['IfModule', 'prefork.c']['MaxClients'][-1].value == 512  # httpd3
 
+
+def test_nonstandard_include_path():
+
+    # with an include
+    httpd1 = _HttpdConf(context_wrap(HTTPD_CONF_WITH_NONSTANDARD_INCLUDE_PATH, path='/etc/httpd/conf/httpd.conf'))
+    httpd2 = _HttpdConf(context_wrap(HTTPD_CONF_2, path='/etc/httpd/conf.d/00-z.conf'))
+    result = HttpdConfTree([httpd1, httpd2])
+    assert len(result['IfModule', 'prefork.c']['ServerLimit']) == 2
+    assert result['IfModule', 'prefork.c']['ServerLimit'][first].value == 256
+    assert result['IfModule', 'prefork.c']['ServerLimit'][last].value == 1024
+
+    # colliding filenames
+    httpd1 = _HttpdConf(context_wrap(HTTPD_CONF_WITH_NONSTANDARD_INCLUDE_PATH, path='/etc/httpd/conf/httpd.conf'))
+    httpd2 = _HttpdConf(context_wrap(HTTPD_CONF_2, path='/etc/httpd/conf.d/00-z.conf'))
+    httpd3 = _HttpdConf(context_wrap(HTTPD_CONF_3, path='/etc/httpd/conf.d/00-z.conf'))
+    result = HttpdConfTree([httpd1, httpd2, httpd3])
+    assert len(result['IfModule', 'prefork.c']['ServerLimit']) == 3
+    assert result['IfModule', 'prefork.c']['ServerLimit'][first].value == 256  # httpd1
+    assert result['IfModule', 'prefork.c']['ServerLimit'][1].value == 1024     # httpd2
+    assert result['IfModule', 'prefork.c']['ServerLimit'][last].value == 256   # httpd3
+    assert len(result['IfModule', 'prefork.c']['MaxClients']) == 3
+    assert result['IfModule', 'prefork.c']['MaxClients'][first].value == 256  # httpd1
+    assert result['IfModule', 'prefork.c']['MaxClients'][1].value == 1024     # httpd2
+    assert result['IfModule', 'prefork.c']['MaxClients'][last].value == 512   # httpd3
+
+    # testing other ways to access the same indices
+    assert result['IfModule', 'prefork.c']['MaxClients'][0].value == 256   # httpd1
+    assert result['IfModule', 'prefork.c']['MaxClients'][2].value == 512   # httpd3
+    assert result['IfModule', 'prefork.c']['MaxClients'][-1].value == 512  # httpd3
 
 def test_active_httpd():
     httpd1 = _HttpdConf(context_wrap(HTTPD_CONF_1, path='/etc/httpd/conf/httpd.conf'))


### PR DESCRIPTION
The diff says it all - I figured it is more efficient to write exact failing tests than to explain otherwise.

The majority of hits for one rule are machines with such failing config files (thousands of machines), so a particular rule has wildly different results on the old httpd_conf combiner vs. the new configtree one.

@csams Can you fix it, please?