### PR TITLE
Fix #324 by removing parse_systemd_ini's dependency on py2.7 ConfigParser

### DIFF
--- a/insights/configtree/__init__.py
+++ b/insights/configtree/__init__.py
@@ -455,7 +455,7 @@ class LineGetter(PushBack):
         while l.endswith("\\"):
             self.pos += 1
             l = l.rstrip("\\")
-            l += next(self.stream)
+            l += next(self.stream).lstrip()
 
         return l.strip() if self.strip else l.rstrip()
 


### PR DESCRIPTION
`parse_systemd_ini` required some `ConfigParser` behavior that changed between python 2.6 and python 2.7. This PR entirely removes the function's dependency on `ConfigParser`.