### PR TITLE
Added filter '[' to enable filtering of metadata_agent.ini

### DIFF
--- a/insights/parsers/neutron_metadata_agent_conf.py
+++ b/insights/parsers/neutron_metadata_agent_conf.py
@@ -6,8 +6,10 @@ The ``NeutronMetadataAgentIni`` class parses the metadata-agent configuration fi
 See the ``IniConfigFile`` class for more usage information.
 '''
 
-from .. import parser, IniConfigFile
+from .. import add_filter, parser, IniConfigFile
 from insights.specs import Specs
+
+add_filter(Specs.neutron_metadata_agent_ini, ["["])
 
 
 @parser(Specs.neutron_metadata_agent_ini)


### PR DESCRIPTION
Updated existing parser for OSP Neutron metadata_agent.ini to add the "[" filter in the parser.