### PR TITLE
About the parser 'pcs_status' updated with correct path

### DIFF
--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -62,7 +62,7 @@ class SosSpecs(Specs):
     netstat_s = simple_file("sos_commands/networking/netstat_-s")
     nmcli_dev_show = simple_file("sos_commands/networking/nmcli_dev_show")
     ntptime = simple_file("sos_commands/ntp/ntptime")
-    pcs_status = simple_file("sos_commands/cluster/pcs_status")
+    pcs_status = simple_file("sos_commands/pacemaker/pcs_status")
     ps_auxww = first_file(["sos_commands/process/ps_auxwww", "sos_commands/process/ps_aux", "sos_commands/process/ps_auxcww"])
     puppet_ssl_cert_ca_pem = simple_file("sos_commands/foreman/foreman-debug/var/lib/puppet/ssl/certs/ca.pem")
     pvs = simple_file("sos_commands/lvm2/pvs_-a_-v_-o_pv_mda_free_pv_mda_size_pv_mda_count_pv_mda_used_count_pe_start_--config_global_locking_type_0")


### PR DESCRIPTION
For most recent sosreport, the file path would be 'sos_commands/pacemaker/pcs_status'(for example sosreport-overcloud-controller-0-20180703073332/sos_commands/pacemaker/pcs_status), so this need to be fixed first with adding the path to the sos_archive in the insights-core repo.

The raised issue for this enhancement https://github.com/RedHatInsights/insights-core/issues/1315

Signed-off-by: Akshay Ghodake <aghodake@redhat.com>