### PR TITLE
check directory before writing a file (BZ1610497)

### DIFF
--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -95,6 +95,8 @@ def write_to_disk(filename, delete=False, content=get_time()):
     """
     Write filename out to disk
     """
+    if not os.path.exists(os.path.dirname(filename)):
+        return
     if delete:
         if os.path.lexists(filename):
             os.remove(filename)


### PR DESCRIPTION
I previously made a fix to maintain the .registered and .unregistered files in both needed locations. Well, turns out it doesn't work so well if you delete the old directory: https://bugzilla.redhat.com/show_bug.cgi?id=1610497

This change makes it so that existence of the containing directory is checked before writing any files.