### PR TITLE
remove dupe method, fix func call, fix timeout parse

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -328,17 +328,6 @@ class InsightsClient(object):
         return client.handle_unregistration(self.config, self.connection)
 
     @_net
-    def get_registration_information(self):
-        """
-            returns (json):
-                {'messages': [dotfile message, api message],
-                 'status': (bool) registered = true; unregistered = false
-                 'unreg_date': Date the machine was unregistered | None,
-                 'unreachable': API could not be reached}
-        """
-        return client.get_registration_status(self.config, self.connection)
-
-    @_net
     def upload(self, path, rotate_eggs=True):
         """
             returns (int): upload status code
@@ -428,6 +417,13 @@ class InsightsClient(object):
 
     @_net
     def get_registration_status(self):
+        """
+            returns (json):
+                {'messages': [dotfile message, api message],
+                 'status': (bool) registered = true; unregistered = false
+                 'unreg_date': Date the machine was unregistered | None,
+                 'unreachable': API could not be reached}
+        """
         return client.get_registration_status(self.config, self.connection)
 
 

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -487,10 +487,20 @@ class InsightsConfig(object):
             pass
         d = dict(parsedconfig.items(constants.app_name))
         for key in d:
-            if key == 'retries':
-                d[key] = parsedconfig.getint(constants.app_name, key)
-            if key in DEFAULT_BOOLS and isinstance(d[key], six.string_types):
-                d[key] = parsedconfig.getboolean(constants.app_name, key)
+            try:
+                if key == 'retries':
+                    d[key] = parsedconfig.getint(constants.app_name, key)
+                if key == 'http_timeout':
+                    d[key] = parsedconfig.getfloat(constants.app_name, key)
+                if key in DEFAULT_BOOLS and isinstance(
+                        d[key], six.string_types):
+                    d[key] = parsedconfig.getboolean(constants.app_name, key)
+            except ValueError as e:
+                if self._print_errors:
+                    sys.stdout.write(
+                        'ERROR: {0}.\nCould not read configuration file, '
+                        'using defaults\n'.format(e))
+                return
         self._update_dict(d)
 
     def load_all(self):

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -10,7 +10,7 @@ from insights.client import InsightsClient
 from insights.client.config import InsightsConfig
 from insights.client.constants import InsightsConstants as constants
 from insights.client.auto_config import try_auto_configuration
-from insights.client.support import registration_check, InsightsSupport
+from insights.client.support import InsightsSupport
 from insights.client.utilities import validate_remove_file
 from insights.client.schedule import get_scheduler
 
@@ -115,7 +115,7 @@ def update(client, config):
 def post_update(client, config):
     logger.debug("CONFIG: %s", config)
     if config.status:
-        reg_check = registration_check(client.get_connection())
+        reg_check = client.get_registration_status()
         for msg in reg_check['messages']:
             logger.info(msg)
         sys.exit(constants.sig_kill_ok)

--- a/insights/tests/client/test_client.py
+++ b/insights/tests/client/test_client.py
@@ -170,7 +170,7 @@ def test_reg_check_registered():
     client.session = True
 
     # test function and integration in .register()
-    assert client.get_registration_information()['status'] is True
+    assert client.get_registation_status()['status'] is True
     assert client.register() is True
     for r in constants.registered_files:
         assert os.path.isfile(r) is True
@@ -195,7 +195,7 @@ def test_reg_check_unregistered():
     client.session = True
 
     # test function and integration in .register()
-    assert client.get_registration_information()['status'] is False
+    assert client.get_registation_status()['status'] is False
     assert client.register() is False
     for r in constants.registered_files:
         assert os.path.isfile(r) is False
@@ -223,7 +223,7 @@ def test_reg_check_registered_unreachable():
     # reset config and try to check registration
     config.register = False
     client.connection = FakeConnection(registered=False)
-    assert client.get_registration_information()['unreachable'] is True
+    assert client.get_registation_status()['unreachable'] is True
     assert client.register() is None
     for r in constants.registered_files:
         assert os.path.isfile(r) is True
@@ -251,7 +251,7 @@ def test_reg_check_unregistered_unreachable():
     # reset config and try to check registration
     config.unregister = False
     client.connection = FakeConnection(registered=False)
-    assert client.get_registration_information()['unreachable'] is True
+    assert client.get_registation_status()['unreachable'] is True
     assert client.register() is None
     for r in constants.registered_files:
         assert os.path.isfile(r) is False


### PR DESCRIPTION
The registration refactoring brought about some bugs we didn't catch til today, namely:

- still using `InsightsClient.get_connection()`
- `http_timeout` not being parsed to a float correctly

This commit fixes those, as well as removing the duplicate function `get_registration_information` in favor of `get_registration_status`, to keep name parity with the matching function in `client.py`.