### PR TITLE
Remove size validation on make_metadata_key response

### DIFF
--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -288,6 +288,9 @@ class make_metadata_key(Response):
     def __init__(self, key, value):
         super(make_metadata_key, self).__init__(key, value=value)
 
+    def adjust_for_length(self, key, r, kwargs):
+        return kwargs
+
 
 class make_metadata(Response):
     """


### PR DESCRIPTION
Bandaid for a telemetry plugin that returns all rpms as metadata.