### PR TITLE
[wip] Add flake8 test to RHEL6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,8 @@ pipeline {
             sh 'pip install --user -e .[develop]'
             echo "Testing with Pytest..."
             sh 'pytest'
+            echo "Testing with flake8..."
+            sh 'flake8'
           }
         }
         stage('Build RHEL7 Python 2.7') {


### PR DESCRIPTION
Both RHEL7 stages run flake8 test, the RHEL6 one doesn’t. Flake8 documentation says that it is important to run it on the exact version of Python used. Added this test from Python 2.6 used by RHEL6.

Fixes #1262.