### PR TITLE
Rule component should override process instead of invoke. #1376

### DIFF
--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -46,11 +46,7 @@ class parser(dr.ComponentType):
         super(parser, self).__init__(dep, group=group)
 
     def invoke(self, broker):
-        dependency = self.requires[0]
-        if dependency not in broker:
-            raise dr.MissingRequirements(([dependency], []))
-
-        dep_value = broker[dependency]
+        dep_value = broker[self.requires[0]]
         if not isinstance(dep_value, list):
             return self.component(dep_value)
 
@@ -89,15 +85,20 @@ class rule(dr.ComponentType):
     ComponentType for a component that can see all parsers and combiners for a
     single host.
     """
-    def invoke(self, broker):
-        try:
-            r = super(rule, self).invoke(broker)
-            if r is None:
-                raise dr.SkipComponent()
-        except dr.MissingRequirements as mr:
-            details = dr.stringify_requirements(mr.requirements)
-            r = _make_skip(dr.get_name(self.component),
+    def process(self, broker):
+        """
+        Ensures dependencies have been met before delegating to `self.invoke`.
+        """
+        if any(i in broker for i in dr.IGNORE.get(self.component, [])):
+            raise dr.SkipComponent()
+        missing = self.get_missing_dependencies(broker)
+        if missing:
+            details = dr.stringify_requirements(missing)
+            return _make_skip(dr.get_name(self.component),
                     reason="MISSING_REQUIREMENTS", details=details)
+        r = self.invoke(broker)
+        if r is None:
+            raise dr.SkipComponent()
         if not isinstance(r, Response):
             raise Exception("rules must return Response objects.")
         return r


### PR DESCRIPTION
The `rule ComponentType` overrode `invoke` instead of `process`. Invoke is too late to catch exceptions raise by missing requirements, so skips wouldn't be generated. This fixes that.