### PR TITLE
Limit maximum pyOpenSSL version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,8 +21,6 @@ pipeline {
             sh """
                 virtualenv .testenv
                 source .testenv/bin/activate
-                pip install "pycparser<=2.18"
-                pip install "pyOpenSSL<=17.5.0"
                 pip install -e .[testing]
                 pytest
             """
@@ -30,8 +28,6 @@ pipeline {
             sh """
                 virtualenv .lintenv
                 source .lintenv/bin/activate
-                pip install "pycparser<=2.18"
-                pip install "pyOpenSSL<=17.5.0"
                 pip install -e .[linting]
                 flake8
             """

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ maybe_require("argparse")
 
 client = set([
     'requests',
-    'pyOpenSSL',
+    'pycparser<=2.18',
+    'pyOpenSSL<=17.5.0',
 ])
 
 develop = set([


### PR DESCRIPTION
The [most recent version](
https://pypi.org/project/pyOpenSSL/18.0.0/) of [pyOpenSSL](https://pypi.org/project/pyOpenSSL/) fails to install on Python 2.6. Its cryptography dependency cannot be satisfied. Forced installation of [the last version](https://pypi.org/project/pyOpenSSL/17.5.0/) that still supports 2.6.

To use the downgraded [pyOpenSSL](
https://pypi.org/project/pyOpenSSL/) in Jenkins pipeline I updated [Jenkinsfile](https://github.com/RedHatInsights/insights-core/pull/1386/files#diff-58231b16fdee45a03a4ee3cf94a9f2c3) to use a virtual environment just like other pipeline branches do. This is necessary to do at once with the downgrade, because the global environment in the image prevents proper installation of [pyOpenSSL](https://pypi.org/project/pyOpenSSL/).

~~This PR should help #1369.~~ (Merged.) Fixes #1373.

No _pytest_ tests fail after the downgrade neither on Python 2.6, 2.7 nor 3.