### PR TITLE
Do not install docs tools on Python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,13 +48,13 @@ develop = set([
     'pytest==3.0.6',
     'pytest-cov==2.4.0',
     'mock==2.0.0',
-    'Sphinx',
-    'nbsphinx==0.3.1',
-    'sphinx_rtd_theme',
+    'Sphinx;python_version>="2.7"',
+    'nbsphinx==0.3.1;python_version>="2.7"',
+    'sphinx_rtd_theme;python_version>="2.7"',
     'futures==3.0.5',
     'requests==2.13.0',
     'wheel',
-    'ipython<6',
+    'ipython<6;python_version>="2.7"',
     'colorama',
 ])
 


### PR DESCRIPTION
The [docs tools](
https://github.com/RedHatInsights/insights-core/pull/1369/files#diff-2eeaed663bd0d25b7e608891384b7298R51) cannot be installed on Python 2.6. The [nbsphinx](
https://pypi.org/project/nbsphinx/) package is not compatible with this legacy version of Python. Building docs is not necessary even for development. Added a [condition](https://github.com/Glutexo/insights-core/blob/no_docs_on_python26/setup.py#L51) to not install those on an unsupported system. That finally prevents `pip install -e .[develop]` from failing. Rejoice!

No warning is issued. Even though it is possible to do so. PIP [discourages](https://stackoverflow.com/a/44617404/1307676) it, it might not work when the wheel is already built in the cache, wouldn’t be printed if ran without `-v` (verbose) etc. It would be good to add some note to the documentation: to the guide to building docs and to the proclaimed Python 2.6 support.

To test this, you have to [limit](https://github.com/Glutexo/insights-core/blob/4272741dff67ebe23cbbdcfd8126b6e25d5ad631/setup.py#L42) pyOpenSSL version to [17.5.0](
https://pypi.org/project/pyOpenSSL/17.5.0/) or simply apply #1386.

Together with #1386 this will help #1342 to run `pip install -e .[develop]` in a clean environment even before #1369 is merged.

Fixes #1387.