### PR TITLE
Fix tar content type check

### DIFF
--- a/insights/core/archives.py
+++ b/insights/core/archives.py
@@ -102,7 +102,7 @@ def extract(path, timeout=None, extract_dir=None, content_type=None):
     If the extraction takes longer than `timeout` seconds, the temporary path
     is removed, and an exception is raised.
     """
-    content_type = content_type or from_file(path)
+    content_type = content_type or content_type_from_file(path)
     if content_type == "application/zip":
         extractor = ZipExtractor(timeout=timeout)
     else:

--- a/insights/core/archives.py
+++ b/insights/core/archives.py
@@ -4,9 +4,9 @@ import logging
 import os
 import tempfile
 from contextlib import contextmanager
-from insights.util import content_type, fs, subproc
+from insights.util import fs, subproc
+from insights.util.content_type import from_file as content_type_from_file
 
-from insights.util.content_type import from_file
 logger = logging.getLogger(__name__)
 
 
@@ -55,18 +55,18 @@ class TarExtractor(object):
         "application/x-tar": ""
     }
 
-    def _archive_type(self, _input):
-        _type = content_type.from_file(_input)
-        if _type not in self.TAR_FLAGS:
-            raise InvalidContentType(_type)
-        return _type
+    def _tar_flag_for_content_type(self, content_type):
+        flag = self.TAR_FLAGS.get(content_type)
+        if not flag:
+            raise InvalidContentType(content_type)
+        return flag
 
     def from_path(self, path, extract_dir=None, content_type=None):
         if os.path.isdir(path):
             self.tmp_dir = path
         else:
-            self.content_type = content_type or self._archive_type(path)
-            tar_flag = self.TAR_FLAGS.get(self.content_type)
+            self.content_type = content_type or content_type_from_file(path)
+            tar_flag = self._tar_flag_for_content_type(self.content_type)
             self.tmp_dir = tempfile.mkdtemp(prefix="insights-", dir=extract_dir)
             self.created_tmp_dir = True
             command = "tar %s -x --exclude=*/dev/null -f %s -C %s" % (tar_flag, path, self.tmp_dir)


### PR DESCRIPTION
Running into this intermittent error during testing:
```
Traceback (most recent call last):
  File "/opt/app-root/src/insights_core_frontends/amqp/worker.py", line 257, in kafkaWorker
    with archives.extract(tmp_file.name) as ex:
  File "/opt/rh/python27/root/usr/lib64/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "insights/core/archives.py", line 112, in extract
    ctx = extractor.from_path(path, extract_dir=extract_dir, content_type=content_type)
  File "insights/core/archives.py", line 74, in from_path
    subproc.call(command, timeout=self.timeout)
  File "insights/util/subproc.py", line 119, in call
    raise CalledProcessError(rc, cmd, output)
CalledProcessError: (64, [['tar', 'None', '-x', '--exclude=*/dev/null', '-f', '/tmp/tmp634Gz8', '-C', '/tmp/insights-GsWPxx']], "tar: invalid option -- 'e'\nTry `tar --help' or `tar --usage' for more information.\n")
```
Note arg #2 for the tar command is "None"

That means this returned 'None': https://github.com/RedHatInsights/insights-core/blob/master/insights/core/archives.py#L69

Because `from_file` didn't eval content type properly: https://github.com/RedHatInsights/insights-core/blob/master/insights/core/archives.py#L105

Though if we hadn't passed the content_type as a kwarg into `TarExtractor.from_path`, we'd have hit an an `InvalidContentType` exception because `self._archive_type` would check it: https://github.com/RedHatInsights/insights-core/blob/master/insights/core/archives.py#L68

Tweaking things here to *always* check the content type and raise if we can't find a tar flag for it