### PR TITLE
get hostname archive path from uploader.json

### DIFF
--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -189,7 +189,7 @@ class DataCollector(object):
 
         for c in conf['commands']:
             # remember hostname archive path
-            if c['command'].startswith('/bin/hostname'):
+            if 'symbolic_name' in c and c['symbolic_name'] == 'hostname':
                 self.hostname_path = os.path.join(
                     'insights_commands', mangle.mangle_command(c['command']))
 

--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -40,6 +40,7 @@ class DataCollector(object):
         self.mountpoint = '/'
         if mountpoint:
             self.mountpoint = mountpoint
+        self.hostname_path = None
 
     def _write_branch_info(self, branch_info):
         logger.debug("Writing branch information to archive...")
@@ -189,7 +190,7 @@ class DataCollector(object):
 
         for c in conf['commands']:
             # remember hostname archive path
-            if 'symbolic_name' in c and c['symbolic_name'] == 'hostname':
+            if c.get('symbolic_name') == 'hostname':
                 self.hostname_path = os.path.join(
                     'insights_commands', mangle.mangle_command(c['command']))
 
@@ -264,6 +265,7 @@ class CleanOptions(object):
                 pass
 
         if config.obfuscate_hostname:
-            self.hostname_path = hostname_path
+            # default to its original location
+            self.hostname_path = hostname_path or 'insights_commands/hostname'
         else:
             self.hostname_path = None

--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -13,6 +13,7 @@ import six
 from subprocess import Popen, PIPE, STDOUT
 from tempfile import NamedTemporaryFile
 
+from insights.util import mangle
 from ..contrib.soscleaner import SOSCleaner
 from .utilities import _expand_paths
 from .constants import InsightsConstants as constants
@@ -187,6 +188,11 @@ class DataCollector(object):
             return
 
         for c in conf['commands']:
+            # remember hostname archive path
+            if c['command'].startswith('/bin/hostname'):
+                self.hostname_path = os.path.join(
+                    'insights_commands', mangle.mangle_command(c['command']))
+
             if c['command'] in rm_conf.get('commands', []):
                 logger.warn("WARNING: Skipping command %s", c['command'])
             elif self.mountpoint == "/" or c.get("image"):
@@ -224,7 +230,8 @@ class DataCollector(object):
         """
         if self.config.obfuscate:
             cleaner = SOSCleaner(quiet=True)
-            clean_opts = CleanOptions(self.config, self.archive.tmp_dir, rm_conf)
+            clean_opts = CleanOptions(
+                self.config, self.archive.tmp_dir, rm_conf, self.hostname_path)
             fresh = cleaner.clean_report(clean_opts, self.archive.archive_dir)
             if clean_opts.keyword_file is not None:
                 os.remove(clean_opts.keyword_file.name)
@@ -236,7 +243,7 @@ class CleanOptions(object):
     """
     Options for soscleaner
     """
-    def __init__(self, config, tmp_dir, rm_conf):
+    def __init__(self, config, tmp_dir, rm_conf, hostname_path):
         self.report_dir = tmp_dir
         self.domains = []
         self.files = []
@@ -257,6 +264,6 @@ class CleanOptions(object):
                 pass
 
         if config.obfuscate_hostname:
-            self.hostname_path = "insights_commands/hostname"
+            self.hostname_path = hostname_path
         else:
             self.hostname_path = None


### PR DESCRIPTION
Changing `/bin/hostname` to `/bin/hostname -f` broke the soscleaner obfuscation... so from now on to avoid the code being out of step let's auto-determine what the hostname path is from what's in uploader.json.