### PR TITLE
Init created_tmp_dir variable at instantiation

### DIFF
--- a/insights/core/archives.py
+++ b/insights/core/archives.py
@@ -46,6 +46,7 @@ class TarExtractor(object):
     def __init__(self, timeout=None):
         self.timeout = timeout
         self.tmp_dir = None
+        self.created_tmp_dir = False
 
     TAR_FLAGS = {
         "application/x-xz": "-J",


### PR DESCRIPTION
Hit this error during testing:
```
Traceback (most recent call last):
  File "/opt/app-root/src/insights_core_frontends/amqp/worker.py", line 257, in kafkaWorker
    with archives.extract(tmp_file.name) as ex:
  File "/opt/rh/python27/root/usr/lib64/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "insights/core/archives.py", line 116, in extract
    if extractor.created_tmp_dir:
AttributeError: 'TarExtractor' object has no attribute 'created_tmp_dir'
```

`created_tmp_dir` should be defined at `TarExtractor` instantiation.