### PR TITLE
complete patching of dotfiles

### DIFF
--- a/insights/tests/client/test_utilities.py
+++ b/insights/tests/client/test_utilities.py
@@ -100,6 +100,9 @@ def test_write_registered_file():
 @patch('insights.client.utilities.constants.registered_files',
        ['/tmp/insights-client.registered',
         '/tmp/redhat-access-insights.registered'])
+@patch('insights.client.utilities.constants.unregistered_files',
+       ['/tmp/insights-client.unregistered',
+        '/tmp/redhat-access-insights.unregistered'])
 def test_delete_registered_file():
     util.write_registered_file()
     util.delete_registered_file()
@@ -121,6 +124,9 @@ def test_write_unregistered_file():
         assert os.path.isfile(u) is True
 
 
+@patch('insights.client.utilities.constants.registered_files',
+       ['/tmp/insights-client.registered',
+        '/tmp/redhat-access-insights.registered'])
 @patch('insights.client.utilities.constants.unregistered_files',
        ['/tmp/insights-client.unregistered',
         '/tmp/redhat-access-insights.unregistered'])


### PR DESCRIPTION
`write_(un)registered_file()` will delete the opposite dotfile but these weren't mocked out in testing. mock em out