### PR TITLE
[ovirt_engine_log] Use datetime object for timestamp

### DIFF
--- a/insights/parsers/ovirt_engine_log.py
+++ b/insights/parsers/ovirt_engine_log.py
@@ -116,8 +116,8 @@ class EngineLog(LogFileOutput):
 
 
 @parser(Specs.ovirt_engine_server_log)
-class ServerLog(LogFileOutput):
-    '''Provide access to ``/var/log/ovirt-engine/server.log`` using the LogFileoutput parser class.
+class ServerLog(EngineLog):
+    '''Provide access to ``/var/log/ovirt-engine/server.log`` using the EngineLog parser class.
 
     Sample input::
 
@@ -136,13 +136,18 @@ class ServerLog(LogFileOutput):
         >>> matched_line = '2018-01-17 01:46:17,739+05 WARN  [org.jboss.as.dependency.unsupported] (MSC service thread 1-7) WFLYSRV0019: Deployment "deployment.engine.ear" is using an unsupported module ("org.dom4j") which may be changed or removed in future versions without notice.'
         >>> server_log.get('WARN')[-1].get('raw_message') == matched_line
         True
+        >>> sec_lines = server_log.get('org.wildfly.security')
+        >>> len(sec_lines)
+        1
+        >>> sec_lines[0]['level']
+        'INFO'
     '''
     pass
 
 
 @parser(Specs.ovirt_engine_ui_log)
-class UILog(LogFileOutput):
-    '''Provide access to ``/var/log/ovirt-engine/ui.log`` using the LogFileoutput parser class.
+class UILog(EngineLog):
+    '''Provide access to ``/var/log/ovirt-engine/ui.log`` using the EngineLog parser class.
 
     Sample input::
 
@@ -156,5 +161,12 @@ class UILog(LogFileOutput):
         >>> from datetime import datetime
         >>> len(list(ui_log.get_after(datetime(2018, 1, 24, 5, 31, 26, 0))))
         2
+        >>> exception_lines = ui_log.get('Uncaught exception')
+        >>> len(exception_lines)
+        1
+        >>> exception_lines[0].get('procname')
+        'org.ovirt.engine.ui.frontend.server.gwt.OvirtRemoteLoggingService'
+        >>> exception_lines[0].get('level')
+        'ERROR'
     '''
     pass

--- a/insights/parsers/ovirt_engine_log.py
+++ b/insights/parsers/ovirt_engine_log.py
@@ -16,7 +16,7 @@ ConsoleLog - file ``/var/log/ovirt-engine/console.log``
 -------------------------------------------------------
 """
 from time import strptime
-
+from datetime import datetime
 from insights import LogFileOutput, Syslog, parser
 from insights.specs import Specs
 
@@ -50,7 +50,7 @@ class BootLog(Syslog):
         line_splits = line.split()
         try:
             if strptime(line_splits[0], self.time_format):
-                msg_info['timestamp'] = line_splits[0]
+                msg_info['timestamp'] = strptime(line_splits[0], self.time_format)
                 msg_info['level'] = line_splits[1]
                 msg_info['procname'] = line_splits[2].strip('[]')
                 msg_info['message'] = ' '.join(line_splits[3:])
@@ -74,6 +74,18 @@ class EngineLog(LogFileOutput):
 
         2018-08-06 04:06:33,229+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'engine' is using 0 threads out of 500, 8 threads waiting for tasks and 0 tasks in queue.
         2018-08-06 04:06:33,229+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'engineScheduled' is using 0 threads out of 100, 100 threads waiting for tasks.
+        2018-08-06 04:06:33,229+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'engineThreadMonitoring' is using 1 threads out of 1, 0 threads waiting for tasks.
+        2018-08-06 04:06:33,229+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'hostUpdatesChecker' is using 0 threads out of 5, 5 threads waiting for tasks.
+        2018-08-06 04:16:33,231+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'commandCoordinator' is using 0 threads out of 10, 2 threads waiting for tasks.
+        2018-08-06 04:16:33,231+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'default' is using 0 threads out of 1, 5 threads waiting for tasks.
+        2018-08-06 04:16:33,231+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'engine' is using 0 threads out of 500, 8 threads waiting for tasks and 0 tasks in queue.
+        2018-08-06 04:16:33,231+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'engineScheduled' is using 0 threads out of 100, 100 threads waiting for tasks.
+        2018-08-06 04:16:33,231+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'engineThreadMonitoring' is using 1 threads out of 1, 0 threads waiting for tasks.
+        2018-08-06 04:16:33,231+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'hostUpdatesChecker' is using 0 threads out of 5, 5 threads waiting for tasks.
+        2018-08-06 04:26:33,233+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'commandCoordinator' is using 0 threads out of 10, 2 threads waiting for tasks.
+        2018-08-06 04:26:33,233+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'default' is using 0 threads out of 1, 5 threads waiting for tasks.
+        2018-08-06 04:26:33,233+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'engine' is using 0 threads out of 500, 8 threads waiting for tasks and 0 tasks in queue.
+        2018-08-22 00:16:14,357+05 INFO  [org.ovirt.engine.core.vdsbroker.vdsbroker.HotUnplugLeaseVDSCommand] (default task-133) [e3bc976c-bc3e-4b41-807f-3a518169ad18] START, HotUnplugLeaseVDSCommand(HostName = example.com, LeaseVDSParameters:{hostId='bfa308ab-5add-4ad7-8f1c-389cb8dcf703', vmId='789489a3-be62-40e4-b13e-beb34ba5ff93'}), log id: 7a634963
 
     Examples:
 
@@ -81,12 +93,26 @@ class EngineLog(LogFileOutput):
         >>> "Thread pool 'engine'" in engine_log
         True
         >>> len(list(engine_log.get_after(datetime(2018, 8, 6, 4, 16, 33, 0))))
-        9
+        10
         >>> matched_line = "2018-08-06 04:16:33,231+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'hostUpdatesChecker' is using 0 threads out of 5, 5 threads waiting for tasks."
         >>> engine_log.get('hostUpdatesChecker')[-1].get('raw_message') == matched_line
         True
+        >>> engine_log.get('vdsbroker')[-1].get('procname') == 'org.ovirt.engine.core.vdsbroker.vdsbroker.HotUnplugLeaseVDSCommand'
+        True
     '''
-    pass
+    def _parse_line(self, line):
+        msg_info = {'raw_message': line}
+        line_splits = line.split()
+        dt = ' '.join(line_splits[0:2]).split(',')[0]
+        try:
+            if datetime.strptime(dt, self.time_format):
+                msg_info['timestamp'] = datetime.strptime(dt, self.time_format)
+                msg_info['level'] = line_splits[2]
+                msg_info['procname'] = line_splits[3].strip('[]')
+                msg_info['message'] = ' '.join(line_splits[4:])
+        except ValueError:
+            pass
+        return msg_info
 
 
 @parser(Specs.ovirt_engine_server_log)

--- a/insights/parsers/tests/test_ovirt_engine_log.py
+++ b/insights/parsers/tests/test_ovirt_engine_log.py
@@ -119,6 +119,7 @@ ENGINE_LOG = """
 2018-08-06 04:26:33,233+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'commandCoordinator' is using 0 threads out of 10, 2 threads waiting for tasks.
 2018-08-06 04:26:33,233+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'default' is using 0 threads out of 1, 5 threads waiting for tasks.
 2018-08-06 04:26:33,233+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'engine' is using 0 threads out of 500, 8 threads waiting for tasks and 0 tasks in queue.
+2018-08-22 00:16:14,357+05 INFO  [org.ovirt.engine.core.vdsbroker.vdsbroker.HotUnplugLeaseVDSCommand] (default task-133) [e3bc976c-bc3e-4b41-807f-3a518169ad18] START, HotUnplugLeaseVDSCommand(HostName = example.com, LeaseVDSParameters:{hostId='bfa308ab-5add-4ad7-8f1c-389cb8dcf703', vmId='789489a3-be62-40e4-b13e-beb34ba5ff93'}), log id: 7a634963
 """.strip()
 
 BOOT_LOG = """
@@ -156,10 +157,11 @@ def test_ui_log():
 def test_engine_log():
     engine_log = ovirt_engine_log.EngineLog(context_wrap(ENGINE_LOG))
     assert "Thread pool 'engine'" in engine_log
-    assert len(list(engine_log.get_after(datetime(2018, 8, 6, 4, 16, 33, 0)))) == 9
+    assert len(list(engine_log.get_after(datetime(2018, 8, 6, 4, 16, 33, 0)))) == 10
 
     matched_line = "2018-08-06 04:16:33,231+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'hostUpdatesChecker' is using 0 threads out of 5, 5 threads waiting for tasks."
     assert engine_log.get('hostUpdatesChecker')[-1].get('raw_message') == matched_line
+    engine_log.get('vdsbroker')[-1].get('procname') == 'org.ovirt.engine.core.vdsbroker.vdsbroker.HotUnplugLeaseVDSCommand'
 
 
 def test_boot_log():

--- a/insights/parsers/tests/test_ovirt_engine_log.py
+++ b/insights/parsers/tests/test_ovirt_engine_log.py
@@ -147,11 +147,20 @@ def test_server_log():
     matched_line = '2018-01-17 01:46:17,739+05 WARN  [org.jboss.as.dependency.unsupported] (MSC service thread 1-7) WFLYSRV0019: Deployment "deployment.engine.ear" is using an unsupported module ("org.dom4j") which may be changed or removed in future versions without notice.'
     assert server_log.get('WARN')[-1].get('raw_message') == matched_line
 
+    sec_lines = server_log.get('org.wildfly.security')
+    assert len(sec_lines) == 1
+    assert sec_lines[0]['level'] == 'INFO'
+
 
 def test_ui_log():
     ui_log = ovirt_engine_log.UILog(context_wrap(UI_LOG))
     assert 'Permutation name' in ui_log
     assert len(list(ui_log.get_after(datetime(2018, 1, 24, 5, 31, 26, 0)))) == 2
+
+    exception_lines = ui_log.get('Uncaught exception')
+    assert len(exception_lines) == 1
+    assert exception_lines[0].get('procname') == 'org.ovirt.engine.ui.frontend.server.gwt.OvirtRemoteLoggingService'
+    assert exception_lines[0].get('level') == 'ERROR'
 
 
 def test_engine_log():

--- a/insights/parsers/tests/test_ovirt_engine_log.py
+++ b/insights/parsers/tests/test_ovirt_engine_log.py
@@ -170,7 +170,7 @@ def test_engine_log():
 
     matched_line = "2018-08-06 04:16:33,231+05 INFO  [org.ovirt.engine.core.bll.utils.ThreadPoolMonitoringService] (EE-ManagedThreadFactory-engineThreadMonitoring-Thread-1) [] Thread pool 'hostUpdatesChecker' is using 0 threads out of 5, 5 threads waiting for tasks."
     assert engine_log.get('hostUpdatesChecker')[-1].get('raw_message') == matched_line
-    engine_log.get('vdsbroker')[-1].get('procname') == 'org.ovirt.engine.core.vdsbroker.vdsbroker.HotUnplugLeaseVDSCommand'
+    assert engine_log.get('vdsbroker')[-1].get('procname') == 'org.ovirt.engine.core.vdsbroker.vdsbroker.HotUnplugLeaseVDSCommand'
 
 
 def test_boot_log():


### PR DESCRIPTION
Using datetime will make it simple to use the timestamp in the rule when using `.get_after()`

Signed-off-by: Sachin Patil <psachin@redhat.com>