### PR TITLE
Add OpenSCAP ARF report to default spec

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -109,9 +109,8 @@ class DefaultSpecs(Specs):
     # are these locations for different rhel versions?
     cobbler_settings = first_file(["/etc/cobbler/settings", "/conf/cobbler/settings"])
     cobbler_modules_conf = first_file(["/etc/cobbler/modules.conf", "/conf/cobbler/modules.conf"])
-
+    compliance = simple_file("/var/lib/insights/latest-report.xml")
     corosync = simple_file("/etc/sysconfig/corosync")
-
     cpu_cores = glob_file("sys/devices/system/cpu/cpu[0-9]*/online")
     cpu_siblings = glob_file("sys/devices/system/cpu/cpu[0-9]*/topology/thread_siblings_list")
     cpu_smt_active = simple_file("sys/devices/system/cpu/smt/active")


### PR DESCRIPTION
cc @kylape I think this is what you wanted, notice the XML can easily go up to 15MB (before compression), for relatively common policies like HIPAA, PCI..

Thanks for reviewing!