### PR TITLE
Limit time of requests issued before failure

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -127,10 +127,10 @@ class InsightsClient(object):
         if current_etag and not force:
             logger.debug('Requesting new file with etag %s', current_etag)
             etag_headers = {'If-None-Match': current_etag}
-            response = self.session.get(url, headers=etag_headers)
+            response = self.session.get(url, headers=etag_headers, timeout=self.config.http_timeout)
         else:
             logger.debug('Found no etag or forcing fetch')
-            response = self.session.get(url)
+            response = self.session.get(url, timeout=self.config.http_timeout)
 
         # Debug information
         logger.debug('Status code: %d', response.status_code)

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -126,7 +126,7 @@ class InsightsConnection(object):
                 # Need to make a request that will fail to get proxies set up
                 net_logger.info("GET https://cert-api.access.redhat.com/r/insights")
                 session.request(
-                    "GET", "https://cert-api.access.redhat.com/r/insights")
+                    "GET", "https://cert-api.access.redhat.com/r/insights", timeout=self.config.http_timeout)
             except requests.ConnectionError:
                 pass
             # Major hack, requests/urllib3 does not make access to
@@ -470,7 +470,7 @@ class InsightsConnection(object):
         logger.debug("Obtaining branch information from %s",
                      self.branch_info_url)
         net_logger.info("GET %s", self.branch_info_url)
-        response = self.session.get(self.branch_info_url)
+        response = self.session.get(self.branch_info_url, timeout=self.config.http_timeout)
         logger.debug("GET branch_info status: %s", response.status_code)
         if response.status_code != 200:
             logger.error("Bad status from server: %s", response.status_code)

--- a/insights/tests/client/connection/test_branch_info.py
+++ b/insights/tests/client/connection/test_branch_info.py
@@ -1,0 +1,16 @@
+from insights.client.connection import InsightsConnection
+from mock.mock import Mock, patch
+
+
+@patch("insights.client.connection.InsightsConnection._init_session")
+@patch("insights.client.connection.InsightsConnection.get_proxies")
+def test_request(get_proxies, init_session):
+    """
+    The request to get branch info is issued with correct timeout set.
+    """
+    config = Mock(base_url="www.example.com", branch_info_url="https://www.example.com/branch_info")
+
+    connection = InsightsConnection(config)
+    connection.branch_info()
+
+    init_session.return_value.get.assert_called_once_with(config.branch_info_url, timeout=config.http_timeout)

--- a/insights/tests/client/connection/test_init_session.py
+++ b/insights/tests/client/connection/test_init_session.py
@@ -1,0 +1,31 @@
+from insights.client.connection import InsightsConnection
+from mock.mock import Mock, patch
+
+
+@patch("insights.client.connection.requests.Session")
+@patch("insights.client.connection.InsightsConnection.__init__", return_value=None)
+def test_proxy_request(init, session):
+    """
+    If proxy authentication is enabled, the failing hacky request is issued with correct timeout set.
+    """
+    config = Mock()
+
+    # The constructor is bypassed, because it itself runs the _init_session method.
+    connection = InsightsConnection(None)
+    connection.config = config
+    connection.user_agent = None
+    connection.systemid = None
+    connection.authmethod = "BASIC"
+    connection.username = "some username"
+    connection.password = "some password"
+    connection.cert_verify = None
+    connection.proxies = {"https": "some proxy"}
+    connection.proxy_auth = True
+
+    connection._init_session()
+
+    session.return_value.request.assert_called_once_with(
+        "GET",
+        "https://cert-api.access.redhat.com/r/insights",
+        timeout=config.http_timeout
+    )

--- a/insights/tests/client/init/test_fetch.py
+++ b/insights/tests/client/init/test_fetch.py
@@ -1,0 +1,44 @@
+from insights.client import InsightsClient
+from insights.client.config import InsightsConfig
+from mock.mock import Mock
+from pytest import fixture
+from tempfile import NamedTemporaryFile
+
+
+@fixture
+def insights_client():
+    config = InsightsConfig(http_timeout=123)
+    client = InsightsClient(config)
+    client.session = Mock(**{"get.return_value.headers.items.return_value": []})
+    client.connection = Mock(base_url="http://www.example.com/")
+    return client
+
+
+def test_request_with_etag(insights_client):
+    """
+    An egg fetch request with Etag is issued with correct timeout set.
+    """
+    etag_file = NamedTemporaryFile('w+t')
+    etag_value = 'some_etag'
+    etag_file.write(etag_value)
+    etag_file.seek(0)
+
+    source_path = 'some-source-path'
+    insights_client._fetch(source_path, etag_file.name, "", force=False)
+
+    url = "{0}{1}".format(insights_client.connection.base_url, source_path)
+    headers = {'If-None-Match': etag_value}
+    timeout = insights_client.config.http_timeout
+    insights_client.session.get.assert_called_once_with(url, headers=headers, timeout=timeout)
+
+
+def test_request_forced(insights_client):
+    """
+    A forced egg fetch request is issued with correct timeout set.
+    """
+    source_path = 'some-source-path'
+    insights_client._fetch(source_path, "", "", force=False)
+
+    url = "{0}{1}".format(insights_client.connection.base_url, source_path)
+    timeout = insights_client.config.http_timeout
+    insights_client.session.get.assert_called_once_with(url, timeout=timeout)

--- a/insights/tests/client/test_net_comm.py
+++ b/insights/tests/client/test_net_comm.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from insights.client.phase import v1
+from insights.tests.helpers import dummy_requests_session, getenv_bool, Timeout
+from mock.mock import patch
+from pytest import mark
+
+
+RUN_TESTS = getenv_bool("TEST_NET_COMM", False)
+MAX_TIME = 30  # The tests mustn't run longer even if all requests wait for timeout.
+
+
+def load_all(self):
+    return self
+
+
+@mark.skipif(not RUN_TESTS, reason="Net communication tests take a long time to finish.")
+@patch("insights.client.connection.requests.Session", dummy_requests_session)
+@patch("insights.client.config.InsightsConfig.load_all", load_all)
+def test_failure_does_not_take_too_long():
+    """
+    Client execution does not take too long if connection is blocked by a firewall. First thing that fails is the new
+    egg fetch in the update phase. Every net request up to this point must timeout in reasonable time.
+    """
+    def worker():
+        """
+        Runs first two phases. Expected to be run in a subprocess. The update phase is expected to fail.
+        """
+        try:
+            v1.pre_update()
+        except SystemExit as exception:
+            if exception.code:
+                exit(1)  # This phase must not fail.
+        else:
+            exit(1)  # Phase did not exit.
+
+        try:
+            v1.update()
+        except SystemExit as exception:
+            if exception.code != 1:
+                exit(1)  # Egg update is expected to fail.
+        else:
+            exit(1)  # Phase did not exit.
+
+    timeout = Timeout()
+    timeout.start(worker, MAX_TIME)
+
+    assert timeout.state != timeout.FAIL
+    assert timeout.state != timeout.TIMEOUT
+    assert timeout.state == timeout.SUCCESS

--- a/insights/tests/helpers.py
+++ b/insights/tests/helpers.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+from threading import Timer
+from multiprocessing import Process
+from os import getenv
+from requests import Session
+from requests.adapters import BaseAdapter
+from requests.exceptions import ConnectionError, ConnectTimeout
+from time import sleep, time
+
+
+class Timeout:
+    """
+    Runs a function for a limited amount of time. Reports whether it finished in time.
+    """
+    PRISTINE = 0
+    RUNNING = 1
+    SUCCESS = 2
+    FAIL = 3
+    TIMEOUT = 4
+
+    def __init__(self):
+        """
+        New timeout service. self.state becomes PRISTINE.
+        """
+        self.reset()
+
+    def reset(self):
+        """
+        Prepares the service for the next run, setting the state to PRISTINE.
+        """
+        self.state = self.PRISTINE
+
+    def start(self, worker, timeout):
+        """
+        Spawns given function in a subprocess. Regularly checks whether it has finished or whether the set time-out has
+        been reached. Sets self.state accordingly. Terminates the process on time-out.
+        """
+        def tick():
+            """
+            Relaunches itself every second until the process finishes or time runs out.
+            """
+            if not process.is_alive():
+                self.state = self.FAIL if process.exitcode else self.SUCCESS
+                return
+
+            now = time()
+            lapsed = now - started
+            if lapsed > timeout:
+                process.terminate()
+                self.state = self.TIMEOUT
+                return
+
+            timer = Timer(1, tick)
+            timer.start()
+            timer.join()
+
+        self.reset()
+
+        process = Process(target=worker)
+        process.start()
+        started = time()
+        self.state = self.RUNNING
+
+        tick()
+
+
+class DummyRequestsAdapter(BaseAdapter):
+    """
+    Emulates timeout behavior without making actual requests. Supports only simple numeric timeout values.
+    """
+    def send(self, request, **kwargs):
+        if kwargs["timeout"] is not None:
+            sleep(kwargs["timeout"])
+            raise ConnectTimeout
+        else:
+            sleep(60)  # One minute, don’t hang for eternity.
+            raise ConnectionError
+
+    def close(self):
+        pass
+
+
+def dummy_requests_session():
+    """
+    Mount our dummy adapter to every requests.Session instance created.
+    """
+    instance = Session()
+    adapter = DummyRequestsAdapter()
+    instance.mount("https://", adapter)  # All our requests are HTTPS.
+    return instance
+
+
+def getenv_bool(name, default=None):
+    """
+    Get a boolean value from an environment variable. Accepts only True or False.
+    """
+    env_string = getenv(name)
+    if env_string == "True":
+        bool_value = True
+    elif env_string == "False":
+        bool_value = False
+    elif env_string is None:
+        if default is None:
+            raise ValueError("{0} must be set. Provide True/False.".format(name))
+        bool_value = default
+    else:
+        raise ValueError("{0}={1} is not a valid value. Provide True/False.".format(name, env_string))
+    return bool_value


### PR DESCRIPTION
If the API servers are not reachable, the first thing that fails is the egg update. To reach there, several requests are made to set up the right configuration. Most of those have no timeout set though. That results to a long waits when connection blocked by a firewall.

This is the first step to solve the reported bug that client hangs too long when connection is blocked by a firewall. In the long run it would be better to transparently use the timeout from config for every request. Solution to the failure on update will come in a separate PR. @kylape suggested not crashing on this, more specifically not crashing at all if it doesn’t prevent the app flow.

The functional tests are currently testing only one possible configuration. Improvements to this will come in a separate PR.