### PR TITLE
Fix Satellite 5 auto configuration

### DIFF
--- a/insights/client/auto_config.py
+++ b/insights/client/auto_config.py
@@ -193,7 +193,7 @@ def _try_satellite5_configuration(config):
                 else:
                     proxy = proxy + proxy_host_port
                     logger.debug("RHN Proxy: %s", proxy)
-            set_auto_configuration(hostname, rhn_ca, proxy)
+            set_auto_configuration(config, hostname, rhn_ca, proxy)
         else:
             logger.debug("Could not find hostname")
             return False

--- a/insights/tests/client/auto_config/test_try_satellite5_configuration.py
+++ b/insights/tests/client/auto_config/test_try_satellite5_configuration.py
@@ -1,0 +1,20 @@
+from insights.client.auto_config import _try_satellite5_configuration
+from mock.mock import Mock, patch
+
+
+@patch("insights.client.auto_config.set_auto_configuration")
+@patch("insights.client.auto_config.open", return_value=["serverURL=https://some-hostname/",
+                                                                 "sslCACert=some-certificate",
+                                                                 "enableProxy=0"])
+@patch("insights.client.auto_config._read_systemid_file")
+@patch("insights.client.auto_config.os.path.isfile", return_value=True)
+def test_set_auto_configuration(isfile_mock, read_systemid_file_mock, open_mock, set_auto_configuration_mock):
+    """
+    set_auto_configuration_mock is called with correct arguments.
+    """
+    config_mock = Mock()
+    _try_satellite5_configuration(config_mock)
+    set_auto_configuration_mock.assert_called_once_with(config_mock,
+                                                        "some-hostname/redhat_access",
+                                                        "some-certificate",
+                                                        None)


### PR DESCRIPTION
A [_set_auto_configuration_](https://github.com/RedHatInsights/insights-core/blob/5979ee1438cb75b46614c57c165c36daf269b753/insights/client/auto_config.py#L53) function call was [missing](https://github.com/RedHatInsights/insights-core/compare/master...Glutexo:fix_satellite5_autoconfig?expand=1#diff-2ff859dc8d708efc4e54514c0a483be0L196) a _config_ argument. That caused a runtime error if auto configuration [falls back](https://github.com/RedHatInsights/insights-core/blob/5979ee1438cb75b46614c57c165c36daf269b753/insights/client/auto_config.py#L212) to Satellite 5.

The test is not very nice – uses a lot of patching and virtually tests many things that are out of its scope. That‘s because the method is very non-atomic, does a lot of stuff that is not well mockable and thus is only difficultly testable. Please 🐻 with that for now. It’s a nice candidate for refactoring.