### PR TITLE
Fix exception count for cmd line runs

### DIFF
--- a/insights/formats/text.py
+++ b/insights/formats/text.py
@@ -69,10 +69,7 @@ class HumanReadableFormat(Formatter):
             else:
                 print(".", end="")
         elif c in broker.exceptions:
-            if len(broker.exceptions[c]) > 1:
-                self.counts['exception'] += len(broker.exceptions[c])
-            else:
-                self.counts['exception'] += 1
+            self.counts['exception'] += len(broker.exceptions[c])
             print(Fore.RED + "E" + Style.RESET_ALL, end="")
         return self
 

--- a/insights/formats/text.py
+++ b/insights/formats/text.py
@@ -69,7 +69,7 @@ class HumanReadableFormat(Formatter):
             else:
                 print(".", end="")
         elif c in broker.exceptions:
-            if broker.exceptions[c] > 1:
+            if len(broker.exceptions[c]) > 1:
                 self.counts['exception'] += len(broker.exceptions[c])
             else:
                 self.counts['exception'] += 1


### PR DESCRIPTION
* Exceptions are stored in broker as a defaultdict(list)
* This exception was showing up when testing with Python 3.5

```
Traceback (most recent call last):
  File "/home/bfahr/work/support/venv35/lib/python3.5/site-packages/insights/core/dr.py", line 548, in fire_observers
    o(component, self)
  File "/home/bfahr/work/support/venv35/lib/python3.5/site-packages/insights/formats/text.py", line 72, in progress_bar
    if broker.exceptions[c] > 1:
TypeError: unorderable types: list() > int()
```