### PR TITLE
New Parser For /etc/ansible/hosts

### DIFF
--- a/docs/shared_parsers_catalog/ansible_hosts.rst
+++ b/docs/shared_parsers_catalog/ansible_hosts.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.ansible_hosts
+   :members:
+   :show-inheritance:

--- a/insights/parsers/ansible_hosts.py
+++ b/insights/parsers/ansible_hosts.py
@@ -1,0 +1,179 @@
+"""
+Ansible Hosts file ``/etc/ansible/hosts``
+=========================================
+
+A /etc/ansible/hosts file consists of host groups and hosts within those
+groups. This file is Ansible's inventory file for the playbook used to
+install OpenShift Container Platform. The inventory file describes the
+configuration for your OpenShift Container Platform cluster.
+
+"""
+
+from .. import parser, Parser, LegacyItemAccess
+from insights.specs import Specs
+from insights.core.filters import add_filter
+
+add_filter(Specs.ansible_hosts, "[")
+
+
+@parser(Specs.ansible_hosts)
+class AnsibleHosts(Parser, LegacyItemAccess):
+    """
+    It parse the content of the file ``/etc/ansible/hosts`` file.
+    Sample of the content of this file::
+
+        mail.example.com
+
+        [webservers]
+        foo.example.com
+        bar.example.com
+
+        [raleigh]
+        host2
+        host3
+
+        mail.example.com
+
+        [southeast:children]
+        atlanta
+        raleigh
+
+        ansible_become=true
+
+        [targets]
+        localhost              ansible_connection=local
+        other1.example.com     ansible_connection=ssh        ansible_user=mpdehaan
+        other2.example.com     ansible_connection=ssh        ansible_user=mdehaan
+
+        [atlanta]
+        host1
+        host2
+
+        [atlanta:vars]
+        ntp_server=ntp.atlanta.example.com
+        proxy=proxy.atlanta.example.com
+
+    Examples:
+        >>> type(hosts_info)
+        <class 'insights.parsers.ansible_hosts.AnsibleHosts'>
+        >>> 'host1' in hosts_info["raleigh"]
+        False
+        >>> 'bar.example.com' in hosts_info["webservers"]
+        True
+        >>> hosts_info["southeast:children"]
+        ['atlanta', 'raleigh']
+        >>> hosts_info["targets"]["localhost"]["ansible_connection"]
+        'local'
+        >>> hosts_info.has_var("ansible_become")
+        True
+        >>> hosts_info.has_host("any.node.com")
+        False
+        >>> hosts_info.has_host("mail.example.com")
+        True
+
+    """
+
+    def parse_content(self, content):
+        dict_all = {}
+        dict_all["global-vars"] = {}
+        dict_all["ungrouped-hosts"] = {}
+        section = ""
+
+        for line in content:
+            line = line.strip()
+            if line.startswith("#"):
+                continue
+
+            if line.startswith("[") and line.endswith("]"):
+                section = line[1:-1].strip()
+
+                if section.endswith(":vars"):
+                    dict_all[section] = {}
+                elif section.endswith(":children"):
+                    dict_all[section] = []
+                else:
+                    dict_all[section] = {}
+                continue
+
+            # Get global variables and ungrouped hosts
+            elif (not section) and (line):
+                space_separated_line = line.split(" ", 1)
+                if len(space_separated_line) == 1:
+                    if space_separated_line[0].find("=") == -1:
+                        dict_all["ungrouped-hosts"][space_separated_line[0]] = {}
+                    else:
+                        key, value = line.split("=")
+                        dict_all["global-vars"][key.strip()] = value.strip()
+                else:
+                    host, host_vars = line.split(" ", 1)
+                    dict_all["ungrouped-hosts"][host.strip()] = {}
+                    splitwithequal = host_vars.split("=")
+                    keys = [splitwithequal[0].strip()]
+                    values = []
+                    for item in splitwithequal[1:-1]:
+                        value, key = item.rsplit(" ", 1)
+                        keys.append(key.strip())
+                        values.append(value.strip())
+                    values.append(splitwithequal[-1].strip())
+
+                    for i in range(len(keys)):
+                        dict_all["ungrouped-hosts"][host][keys[i]] = values[i]
+
+            elif section:
+                if not line:
+                    section = ""
+                    continue
+
+                if section.endswith(":children"):
+                    dict_all[section].append(line)
+
+                elif section.endswith(":vars"):
+                    key, value = line.split("=")
+                    dict_all[section][key.strip()] = value.strip()
+                else:
+                    if len(line.split(" ")) == 1:
+                        dict_all[section][line] = {}
+                    else:
+                        host, host_vars = line.split(" ", 1)
+                        dict_all[section][host.strip()] = {}
+                        splitwithequal = host_vars.split("=")
+                        keys = [splitwithequal[0].strip()]
+                        values = []
+                        for item in splitwithequal[1:-1]:
+                            value, key = item.rsplit(" ", 1)
+                            keys.append(key.strip())
+                            values.append(value.strip())
+                        values.append(splitwithequal[-1].strip())
+
+                        for i in range(len(keys)):
+                            dict_all[section][host][keys[i]] = values[i]
+
+        self.data = dict_all
+
+    def has_var(self, var):
+        """
+        Indicate whether the named var is present in configuration.
+
+        :param var: Global variable
+        :return: True if the given var is present and False if not present
+        """
+        return ("global-vars" in self.data) and (var in self.data["global-vars"])
+
+    def has_host(self, host):
+        """
+        Indicate whether the host is present in the configuration.
+
+        :param host: Grouped or ungrouped host
+        :return: True if the given host is present, anf False if not present.
+        """
+        present_in_ungrouped = "ungrouped-hosts" in self.data and \
+            host in self.data["ungrouped-hosts"].keys()
+
+        present_in_hosts_group = False
+        for group in self.data:
+            if group.endswith(":vars") or group.endswith(":children"):
+                continue
+            elif host in self.data[group].keys():
+                present_in_hosts_group = True
+
+        return present_in_ungrouped or present_in_hosts_group

--- a/insights/parsers/tests/test_ansible_hosts.py
+++ b/insights/parsers/tests/test_ansible_hosts.py
@@ -1,0 +1,66 @@
+import doctest
+from insights.parsers import ansible_hosts
+from insights.parsers.ansible_hosts import AnsibleHosts
+from insights.tests import context_wrap
+
+
+ANSIBLE_HOSTS = """
+mail.example.com
+jumper ansible_port=5555  ansible_host=192.0.2.50
+
+[webservers]
+foo.example.com    http_port=80
+bar.example.com
+
+# If ansible_ssh_user is not root, ansible_become must be set to true
+ansible_become=true
+
+[raleigh]
+host2
+host3
+
+openshift_examples_modify_imagestreams=true
+
+[southeast:children]
+atlanta
+raleigh
+
+[Blanktest]
+
+[targets]
+localhost              ansible_connection=local
+other1.example.com     ansible_connection=ssh        ansible_user=mpdehaan
+other2.example.com     ansible_connection=ssh        ansible_user=mdehaan
+
+[atlanta]
+host1
+host2
+
+[atlanta:vars]
+ntp_server=ntp.atlanta.example.com
+proxy=proxy.atlanta.example.com
+""".strip()
+
+
+def test_ansible_hosts():
+    hosts_info = ansible_hosts.AnsibleHosts(context_wrap(ANSIBLE_HOSTS))
+
+    assert "foo.example.com" in hosts_info["webservers"]
+    assert hosts_info["southeast:children"] == ["atlanta", "raleigh"]
+    assert hosts_info["targets"]["localhost"]["ansible_connection"] == "local"
+    assert hosts_info["atlanta:vars"]["ntp_server"] == "ntp.atlanta.example.com"
+    assert hosts_info["global-vars"]["ansible_become"] == "true"
+    assert "mail.example.com" in hosts_info["ungrouped-hosts"]
+    assert hosts_info["Blanktest"] == {}
+
+    assert hosts_info.has_var("openshift_examples_modify_imagestreams")
+    assert hosts_info.has_host("host2")
+    assert not hosts_info.has_host("any.example.com")
+
+
+def test_doc_examples():
+    env = {
+            'hosts_info': AnsibleHosts(context_wrap(ANSIBLE_HOSTS))
+          }
+    failed, total = doctest.testmod(ansible_hosts, globs=env)
+    assert failed == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -3,6 +3,7 @@ from insights.core.spec_factory import SpecSet, RegistryPoint
 
 class Specs(SpecSet):
     amq_broker = RegistryPoint(multi_output=True)
+    ansible_hosts = RegistryPoint(filterable=True)
     auditd_conf = RegistryPoint()
     audit_log = RegistryPoint(filterable=True)
     autofs_conf = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -50,6 +50,7 @@ format_rpm = _make_rpm_formatter()
 
 class DefaultSpecs(Specs):
     amq_broker = glob_file("/var/opt/amq-broker/*/etc/broker.xml")
+    ansible_hosts = simple_file("/etc/ansible/hosts")
     auditd_conf = simple_file("/etc/audit/auditd.conf")
     audit_log = simple_file("/var/log/audit/audit.log")
     autofs_conf = simple_file("/etc/autofs.conf")


### PR DESCRIPTION
Parser for file /etc/ansible/hosts parses hosts, hosts groups and variables
from the inventory file. This file is used for OpenShift container platform
configuration.

Checklist
- [x] Parser
- [x] Tests
- [x] Specs changes
- [x] Docs