### PR TITLE
Lock sphinx version to 1.7.9 to avoid python bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ develop = set([
 ])
 
 docs = set([
-    'Sphinx',
+    'Sphinx==1.7.9',
     'nbsphinx==0.3.1',
     'sphinx_rtd_theme',
     'ipython<6',


### PR DESCRIPTION
* A bug in earlier version of python < 2.7.9 have a bug that is exposed
in version 1.8.0 of sphinx
* Locking the version to 1.7.9 avoids the issue