### PR TITLE
encode lastupload results before writing

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -396,7 +396,10 @@ def upload(config, pconn, tar_file, collection_duration=None):
 
             # Write to last upload file
             with open(constants.last_upload_results_file, 'w') as handler:
-                handler.write(upload.text)
+                if six.PY3:
+                    handler.write(upload.text)
+                else:
+                    handler.write(upload.text.encode('utf-8'))
             write_to_disk(constants.lastupload_file)
 
             account_number = config.account_number


### PR DESCRIPTION
this is a bandaid for now just to fix the bug being seen. going to spend sometime next week examining py2/3 file writes and string behavior so we have a unified solution