### PR TITLE
Convert evaluators to formatters. Allow them to run all at once or incrementally.

### DIFF
--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -523,9 +523,12 @@ class Broker(object):
         self.exec_times = {}
 
         self.observers = defaultdict(set)
-        self.observers[ComponentType] = set()
-        for k, v in TYPE_OBSERVERS.items():
-            self.observers[k] = set(v)
+        if seed_broker is not None:
+            self.observers.update(seed_broker.observers)
+        else:
+            self.observers[ComponentType] = set()
+            for k, v in TYPE_OBSERVERS.items():
+                self.observers[k] |= set(v)
 
     def observer(self, component_type=ComponentType):
         def inner(func):
@@ -730,4 +733,4 @@ def run_incremental(components=COMPONENTS[GROUPS.single], broker=None):
     seed_broker = broker or Broker()
     for graph in get_subgraphs(components):
         broker = Broker(seed_broker)
-        yield run(graph, broker)
+        yield run(graph, broker=broker)

--- a/insights/core/evaluators.py
+++ b/insights/core/evaluators.py
@@ -1,5 +1,7 @@
 import logging
+import sys
 
+from ..formats import Formatter
 from ..specs import Specs
 from ..combiners.hostname import hostname as combiner_hostname
 from ..parsers.branch_info import BranchInfo
@@ -12,31 +14,33 @@ def get_simple_module_name(obj):
     return dr.BASE_MODULE_NAMES.get(obj, None)
 
 
-class Evaluator(object):
-
-    def __init__(self, broker=None):
-        self.broker = broker
+class Evaluator(Formatter):
+    def __init__(self, broker=None, stream=sys.stdout, incremental=False):
+        super(Evaluator, self).__init__(broker or dr.Broker(), stream)
         self.rule_skips = []
         self.rule_results = []
         self.fingerprint_results = []
         self.hostname = None
         self.metadata = {}
         self.metadata_keys = {}
-        self.release = None
+        self.incremental = incremental
 
-    def pre_process(self):
-        pass
+    def observer(self, comp, broker):
+        if comp is combiner_hostname and comp in broker:
+            self.hostname = broker[comp].fqdn
 
-    def post_process(self):
-        if combiner_hostname in self.broker:
-            self.hostname = self.broker[combiner_hostname].fqdn
+        if plugins.is_rule(comp) and comp in broker:
+            self.handle_result(comp, broker[comp])
 
-        for p, r in self.broker.items():
-            if plugins.is_rule(p):
-                self.handle_result(p, r)
+    def preprocess(self):
+        self.broker.add_observer(self.observer)
 
-    def run_components(self, graph=None):
+    def run_serial(self, graph=None):
         dr.run(graph or dr.COMPONENTS[dr.GROUPS.single], broker=self.broker)
+
+    def run_incremental(self, graph=None):
+        for _ in dr.run_incremental(graph or dr.COMPONENTS[dr.GROUPS.single], broker=self.broker):
+            pass
 
     def format_response(self, response):
         """
@@ -52,14 +56,15 @@ class Evaluator(object):
         return result
 
     def process(self, graph=None):
-        self.pre_process()
-        self.run_components(graph)
-        self.post_process()
+        with self:
+            if self.incremental:
+                self.run_incremental(graph)
+            else:
+                self.run_serial(graph)
         return self.get_response()
 
 
 class SingleEvaluator(Evaluator):
-
     def append_metadata(self, r):
         for k, v in r.items():
             if k != "type":
@@ -102,33 +107,29 @@ class SingleEvaluator(Evaluator):
 
 
 class InsightsEvaluator(SingleEvaluator):
-
-    def __init__(self, broker=None, system_id=None):
-        super(InsightsEvaluator, self).__init__(broker)
+    def __init__(self, broker=None, system_id=None, stream=sys.stdout, incremental=False):
+        super(InsightsEvaluator, self).__init__(broker, stream=sys.stdout, incremental=incremental)
         self.system_id = system_id
-        self.branch_info = None
+        self.branch_info = {}
         self.product = "rhel"
         self.type = "host"
+        self.release = None
 
-    def post_process(self):
-        if Specs.machine_id in self.broker:
-            self.system_id = self.broker[Specs.machine_id].content[0].strip()
-        else:
-            self.system_id = None
+    def observer(self, comp, broker):
+        super(InsightsEvaluator, self).observer(comp, broker)
+        if comp is Specs.machine_id and comp in broker:
+            self.system_id = broker[Specs.machine_id].content[0].strip()
 
-        release = self.broker.get(Specs.redhat_release)
-        if release:
-            self.release = release.content[0].strip()
+        if comp is Specs.redhat_release and comp in broker:
+            self.release = broker[comp].content[0].strip()
 
-        branch_info = self.broker.get(BranchInfo)
-        self.branch_info = branch_info.data if branch_info else {}
+        if comp is BranchInfo and BranchInfo in broker:
+            self.branch_info = broker[comp].data
 
-        md = self.broker.get("metadata.json")
-        if md:
+        if comp is Specs.metadata_json and comp in broker:
+            md = broker[comp]
             self.product = md.get("product_code")
             self.type = md.get("role")
-
-        super(InsightsEvaluator, self).post_process()
 
     def format_result(self, result):
         result["system_id"] = self.system_id

--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -18,6 +18,9 @@ class ContentException(dr.SkipComponent):
     pass
 
 
+component = dr.ComponentType
+
+
 class datasource(dr.ComponentType):
     """ Decorates a component that one or more Parsers will consume. """
     multi_output = False

--- a/insights/formats/__init__.py
+++ b/insights/formats/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import six
 import sys
 from insights import dr, rule
@@ -68,19 +67,6 @@ class Formatter(object):
 
     def postprocess(self):
         pass
-
-
-class EvaluatorFormatter(Formatter):
-    def preprocess(self):
-        from insights.core.evaluators import SingleEvaluator
-        self.evaluator = SingleEvaluator(broker=self.broker)
-
-    def postprocess(self):
-        self.evaluator.post_process()
-        print(self.dump(self.evaluator.get_response()), file=self.stream)
-
-    def dump(self, data):
-        raise NotImplemented("Subclasses must implement the dump method.")
 
 
 class EvaluatorFormatterAdapter(FormatterAdapter):

--- a/insights/formats/_json.py
+++ b/insights/formats/_json.py
@@ -1,11 +1,12 @@
 import json
 
-from insights.formats import EvaluatorFormatterAdapter, EvaluatorFormatter
+from insights.core.evaluators import SingleEvaluator
+from insights.formats import EvaluatorFormatterAdapter
 
 
-class JsonFormat(EvaluatorFormatter):
-    def dump(self, data):
-        return json.dumps(data)
+class JsonFormat(SingleEvaluator):
+    def postprocess(self):
+        json.dump(self.get_response(), self.stream)
 
 
 class JsonFormatterAdapter(EvaluatorFormatterAdapter):

--- a/insights/formats/_yaml.py
+++ b/insights/formats/_yaml.py
@@ -1,11 +1,12 @@
 import yaml
 
-from insights.formats import EvaluatorFormatterAdapter, EvaluatorFormatter
+from insights.core.evaluators import SingleEvaluator
+from insights.formats import EvaluatorFormatterAdapter
 
 
-class YamlFormat(EvaluatorFormatter):
-    def dump(self, data):
-        return yaml.dump(data)
+class YamlFormat(SingleEvaluator):
+    def postprocess(self):
+        yaml.dump(self.get_response(), self.stream)
 
 
 class YamlFormatterAdapter(EvaluatorFormatterAdapter):

--- a/insights/tests/test_evaluators.py
+++ b/insights/tests/test_evaluators.py
@@ -1,0 +1,133 @@
+from insights import dr, rule, make_fail, make_pass
+from insights.core.plugins import component
+from insights.core.evaluators import InsightsEvaluator, SingleEvaluator
+from insights.combiners.hostname import hostname
+from insights.specs import Specs
+from insights.tests import context_wrap
+
+
+@component()
+def one():
+    return 1
+
+
+@component()
+def two():
+    return 2
+
+
+@component()
+def boom():
+    raise Exception()
+
+
+@rule()
+def report_pass():
+    return make_pass("PASS")
+
+
+@rule()
+def report_fail():
+    return make_fail("FAIL")
+
+
+@rule(boom)
+def report_boom():
+    pass
+
+
+@rule(one, two)
+def report(a, b):
+    return make_fail("FAIL2", a=a, b=b, c=a + b)
+
+
+components = [
+    hostname,
+    Specs.redhat_release,
+    Specs.machine_id,
+    one,
+    two,
+    boom,
+    report_pass,
+    report_fail,
+    report_boom,
+    report
+]
+
+
+def test_single_evaluator():
+    broker = dr.Broker()
+    e = SingleEvaluator(broker)
+    graph = dr.get_dependency_graph(report)
+    result1 = e.process(graph)
+
+    broker = dr.Broker()
+    with SingleEvaluator(broker) as e:
+        dr.run(report, broker=broker)
+        result2 = e.get_response()
+        assert result1 == result2
+
+
+def test_insights_evaluator():
+    broker = dr.Broker()
+    e = InsightsEvaluator(broker)
+    graph = dr.get_dependency_graph(report)
+    result1 = e.process(graph)
+
+    broker = dr.Broker()
+    with InsightsEvaluator(broker) as e:
+        dr.run(report, broker=broker)
+        result2 = e.get_response()
+        assert result1 == result2
+
+
+def test_insights_evaluator_attrs_serial():
+    broker = dr.Broker()
+    broker[Specs.hostname] = context_wrap("www.example.com")
+    broker[Specs.machine_id] = context_wrap("12345")
+    broker[Specs.redhat_release] = context_wrap("Red Hat Enterprise Linux Server release 7.4 (Maipo)")
+    with InsightsEvaluator(broker) as e:
+        dr.run(components, broker=broker)
+        result = e.get_response()
+        assert result["system"]["hostname"] == "www.example.com"
+        assert result["system"]["system_id"] == "12345"
+        assert result["system"]["metadata"]["release"] == "Red Hat Enterprise Linux Server release 7.4 (Maipo)"
+
+
+def test_insights_evaluator_attrs_serial_process():
+    broker = dr.Broker()
+    broker[Specs.hostname] = context_wrap("www.example.com")
+    broker[Specs.machine_id] = context_wrap("12345")
+    broker[Specs.redhat_release] = context_wrap("Red Hat Enterprise Linux Server release 7.4 (Maipo)")
+    e = InsightsEvaluator(broker)
+    e.process(components)
+    result = e.get_response()
+    assert result["system"]["hostname"] == "www.example.com"
+    assert result["system"]["system_id"] == "12345"
+    assert result["system"]["metadata"]["release"] == "Red Hat Enterprise Linux Server release 7.4 (Maipo)"
+
+
+def test_insights_evaluator_attrs_incremental():
+    broker = dr.Broker()
+    broker[Specs.hostname] = context_wrap("www.example.com")
+    broker[Specs.machine_id] = context_wrap("12345")
+    broker[Specs.redhat_release] = context_wrap("Red Hat Enterprise Linux Server release 7.4 (Maipo)")
+    with InsightsEvaluator(broker) as e:
+        list(dr.run_incremental(components, broker=broker))
+        result = e.get_response()
+        assert result["system"]["hostname"] == "www.example.com"
+        assert result["system"]["system_id"] == "12345"
+        assert result["system"]["metadata"]["release"] == "Red Hat Enterprise Linux Server release 7.4 (Maipo)"
+
+
+def test_insights_evaluator_attrs_incremental_process():
+    broker = dr.Broker()
+    broker[Specs.hostname] = context_wrap("www.example.com")
+    broker[Specs.machine_id] = context_wrap("12345")
+    broker[Specs.redhat_release] = context_wrap("Red Hat Enterprise Linux Server release 7.4 (Maipo)")
+    e = InsightsEvaluator(broker)
+    e.process(components)
+    result = e.get_response()
+    assert result["system"]["hostname"] == "www.example.com"
+    assert result["system"]["system_id"] == "12345"
+    assert result["system"]["metadata"]["release"] == "Red Hat Enterprise Linux Server release 7.4 (Maipo)"


### PR DESCRIPTION
`SingleEvaluator` and `InsightsEvaluator` now implement `Formatter`. They can be constructed with an `incremental` boolean, which will determine whether the evaluator's process function will run everything in one broker or in one broker per sub-graph.

Evaluators can now be used in two ways:
```python
broker = dr.Broker()
e = InsightsEvaluator(broker) as e:
    dr.run(broker=broker)
results = e.get_response()
```
or
```python
broker = dr.Broker()
e = InsightsEvaluator(broker=broker, incremental=True/False)
results = e.process(<some optional graph>)
```

* This preserves the previous constructor and `process` function while extending the constructor with a new option that affects how `process` works.
* It also allows the Json and Yaml formatters to extend an evaluator directly with minimal new code.
* It solves a problem caused by importing `SingleEvaluator` in the formats package and removing parsers and combiners from the project when building the client. We no longer need to import the evaluator in the package. The client build makes the json and yaml formatters unloadable, but they're not used in the client anyway.