### PR TITLE
Fix remove file usage in collection tests

### DIFF
--- a/insights/tests/client/collection_rules/test_get_rm_conf.py
+++ b/insights/tests/client/collection_rules/test_get_rm_conf.py
@@ -4,8 +4,8 @@ from .helpers import insights_upload_conf
 from mock.mock import patch
 
 
-remove_file = '/etc/insights-client/remove.conf'
-remove_files = ["/etc/remove.conf", "/tmp/remove.conf"]
+conf_remove_file = '/tmp/remove.conf'
+removed_files = ["/etc/some_file", "/tmp/another_file"]
 
 
 def patch_isfile(isfile):
@@ -29,28 +29,28 @@ def patch_raw_config_parser(items):
     return decorator
 
 
-@patch_isfile(False)
 @patch_raw_config_parser([])
-def test_no_file(raw_config_parser, isfile):
-    upload_conf = insights_upload_conf(remove_file=remove_file)
+@patch_isfile(False)
+def test_no_file(isfile, raw_config_parser):
+    upload_conf = insights_upload_conf(remove_file=conf_remove_file)
     result = upload_conf.get_rm_conf()
 
-    isfile.assert_called_once_with(remove_file)
+    isfile.assert_called_once_with(conf_remove_file)
     raw_config_parser.assert_not_called()
 
     assert result is None
 
 
-@patch_raw_config_parser([("files", ",".join(remove_files))])
+@patch_raw_config_parser([("files", ",".join(removed_files))])
 @patch_isfile(True)
 def test_return(isfile, raw_config_parser):
-    upload_conf = insights_upload_conf(remove_file=remove_file)
+    upload_conf = insights_upload_conf(remove_file=conf_remove_file)
     result = upload_conf.get_rm_conf()
 
-    isfile.assert_called_once_with(remove_file)
+    isfile.assert_called_once_with(conf_remove_file)
 
     raw_config_parser.assert_called_once_with()
-    raw_config_parser.return_value.read.assert_called_with(remove_file)
+    raw_config_parser.return_value.read.assert_called_with(conf_remove_file)
     raw_config_parser.return_value.items.assert_called_with('remove')
 
-    assert result == {"files": remove_files}
+    assert result == {"files": removed_files}

--- a/insights/tests/client/test_collect.py
+++ b/insights/tests/client/test_collect.py
@@ -12,15 +12,15 @@ from tempfile import NamedTemporaryFile, TemporaryFile
 stdin_uploader_json = {"some key": "some value"}
 stdin_sig = "some signature"
 stdin_payload = {"uploader.json": json_dumps(stdin_uploader_json), "sig": stdin_sig}
-remove_file = "/tmp/remove.conf"
-remove_files = ["/etc/insights-client/remove.conf", "/tmp/remove.conf"]
+conf_remove_file = "/tmp/remove.conf"
+removed_files = ["/etc/some_file", "/tmp/another_file"]
 
 
 def collect_args(*insights_config_args, **insights_config_custom_kwargs):
     """
     Instantiates InsightsConfig with a default logging_file argument.
     """
-    all_insights_config_kwargs = {"logging_file": "/tmp/insights.log", "remove_file": remove_file}
+    all_insights_config_kwargs = {"logging_file": "/tmp/insights.log", "remove_file": conf_remove_file}
     all_insights_config_kwargs.update(insights_config_custom_kwargs)
     return InsightsConfig(*insights_config_args, **all_insights_config_kwargs), Mock()
 
@@ -119,14 +119,17 @@ def patch_isfile(remove_file_exists):
     """
     def decorator(old_function):
         def decider(*args, **kwargs):
-            if args[0] == remove_file:
+            """
+            Returns given value for remove_file and True for any other file.
+            """
+            if args[0] == conf_remove_file:
                 return remove_file_exists
             else:
                 return True
 
         patcher = patch("insights.client.collection_rules.os.path.isfile", decider)
-        isfile_patched = patcher(old_function)
-        return isfile_patched
+        return patcher(old_function)
+
     return decorator
 
 
@@ -135,7 +138,7 @@ def patch_raw_config_parser():
     Mocks RawConfigParser, so it returns a fixed configuration of removed files.
     """
     def decorator(old_function):
-        files = ",".join(remove_files)
+        files = ",".join(removed_files)
         patcher = patch("insights.client.collection_rules.ConfigParser.RawConfigParser",
                         **{"return_value.items.return_value": [("files", files)]})
         return patcher(old_function)
@@ -324,7 +327,7 @@ def test_stdin_result(get_branch_info, stdin, raw_config_parser, validate_gpg_si
     collect(config, pconn)
 
     collection_rules = stdin_uploader_json
-    rm_conf = {"files": remove_files}
+    rm_conf = {"files": removed_files}
     branch_info = get_branch_info.return_value
     data_collector.return_value.run_collection.assert_called_once_with(collection_rules, rm_conf, branch_info)
     data_collector.return_value.done.assert_called_once_with(collection_rules, rm_conf)
@@ -399,7 +402,7 @@ def test_file_result(get_branch_info, try_disk, raw_config_parser, data_collecto
     collection_rules = try_disk.return_value.copy()
     collection_rules.update({"file": args[0]})
 
-    rm_conf = {"files": remove_files}
+    rm_conf = {"files": removed_files}
     branch_info = get_branch_info.return_value
 
     data_collector.return_value.run_collection.assert_called_once_with(collection_rules, rm_conf, branch_info)


### PR DESCRIPTION
[_test_get_rm_conf.test_no_file_](https://github.com/RedHatInsights/insights-core/blob/ce519eca9785a56495a2cd50e84917ab3f4aa058/insights/tests/client/collection_rules/test_get_rm_conf.py#L44) did not work properly: it tested the default value of the remote_file constant instead of the [patched](https://github.com/RedHatInsights/insights-core/blob/ce519eca9785a56495a2cd50e84917ab3f4aa058/insights/tests/client/collection_rules/test_get_rm_conf.py#L7) one. Fixed this to be consistend with other tests.

[_test_collect.patch_isfile_](https://github.com/RedHatInsights/insights-core/blob/ce519eca9785a56495a2cd50e84917ab3f4aa058/insights/tests/client/test_collect.py#L114) was patching the _isfile_ method and the [_collection_remove_file_](https://github.com/RedHatInsights/insights-core/blob/ce519eca9785a56495a2cd50e84917ab3f4aa058/insights/client/constants.py#L24) constant at once, which was not very transparent and violated SRP. [Split](https://github.com/RedHatInsights/insights-core/compare/master...Glutexo:fix_collection_tests?expand=1#diff-bc977d9fd95882baacf1c6411537a40bR115) into two methods.

[Changed](https://github.com/RedHatInsights/insights-core/compare/master...Glutexo:fix_collection_tests?expand=1#diff-bc977d9fd95882baacf1c6411537a40bR16) mocked [removed files](https://github.com/RedHatInsights/insights-core/blob/ce519eca9785a56495a2cd50e84917ab3f4aa058/insights/tests/client/test_collect.py#L15) in [_test_collect_](https://github.com/RedHatInsights/insights-core/blob/ce519eca9785a56495a2cd50e84917ab3f4aa058/insights/tests/client/test_collect.py) so their names are not so confusing. It looked like configuration file names, but they are files to be removed. Also [renamed](https://github.com/RedHatInsights/insights-core/compare/master...Glutexo:fix_collection_tests?expand=1#diff-bc977d9fd95882baacf1c6411537a40bR16) the variables to make their purpose clearer.

This is related to @gravitypriest’s PR #1436. I found those issues when reviewing. If it gets merged before this one, I’ll resolve the conflicts.