### PR TITLE
Fix woopsie spec to exit on 1st found matching file

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -683,7 +683,7 @@ class DefaultSpecs(Specs):
     vmcore_dmesg = glob_file("/var/crash/*/vmcore-dmesg.txt")
     vsftpd = simple_file("/etc/pam.d/vsftpd")
     vsftpd_conf = simple_file("/etc/vsftpd/vsftpd.conf")
-    woopsie = simple_command(r"/usr/bin/find /var/crash /var/tmp -path '*.reports-*/whoopsie-report'")
+    woopsie = simple_command(r"/usr/bin/find /var/crash /var/tmp -path '*.reports-*/whoopsie-report' -print -quit")
     x86_pti_enabled = simple_file("sys/kernel/debug/x86/pti_enabled")
     x86_ibpb_enabled = simple_file("sys/kernel/debug/x86/ibpb_enabled")
     x86_ibrs_enabled = simple_file("sys/kernel/debug/x86/ibrs_enabled")


### PR DESCRIPTION
The original output size is undefined. Could be one, two, tens, etc. The improvement ensures it returns just one line with file path. The optimization is to stop 'find' command and return just the first found matching file.

https://bugzilla.redhat.com/show_bug.cgi?id=1628498