### PR TITLE
Add flake8 linting to RHEL6 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,15 @@ pipeline {
                 pip install -e .[testing]
                 pytest
             """
+            echo "Testing with Linter..."
+            sh """
+                virtualenv .lintenv
+                source .lintenv/bin/activate
+                pip install "pycparser<=2.18"
+                pip install "pyOpenSSL<=17.5.0"
+                pip install -e .[linting]
+                flake8
+            """
           }
         }
         stage('Build RHEL7 Python 2.7') {

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ testing = set([
 ])
 
 linting = set([
-    'flake8==3.3.0',
+    'flake8==2.6.2',
 ])
 
 optional = set([


### PR DESCRIPTION
Both RHEL 7 stages run _flake8_ linting, but the RHEL 6 one doesn’t. Flake8 documentation [says](http://flake8.pycqa.org/en/latest/) that it is important to run it on the exact version of Python used. Added this test from Python 2.6 used by RHEL 6.

This PR intends to replace @eduardocerqueira’s #1342 and my former #1335.

~~The reason why `flake8` command failed was because a version from RPM was used even though we wanted the one [described](https://github.com/RedHatInsights/insights-core/pull/1452/files#diff-2eeaed663bd0d25b7e608891384b7298R67) in [_setup.py_](https://github.com/RedHatInsights/insights-core/pull/1452/files#diff-2eeaed663bd0d25b7e608891384b7298). Fixed by [calling](https://github.com/RedHatInsights/insights-core/pull/1452/files#diff-58231b16fdee45a03a4ee3cf94a9f2c3R25) the one installed by PIP in the user home directory directly using its path.~~

~~I didn’t introduce a virtual environment to RHEL 6 in this PR. There is already another [PR](
https://github.com/RedHatInsights/insights-core/pull/1451) for that. (#1451) I [downgraded](https://github.com/RedHatInsights/insights-core/pull/1452/files#diff-2eeaed663bd0d25b7e608891384b7298R67) Flake8 to the last version that supports Python 2.6. This version works on newer RHELs fine.~~

Thanks to #1451 we’re already [using](https://github.com/RedHatInsights/insights-core/blob/05c224f1292727f40234054cdb2b40caf93801d8/Jenkinsfile#L22) virtualenv on [RHEL 6](
https://github.com/RedHatInsights/insights-core/blob/05c224f1292727f40234054cdb2b40caf93801d8/Jenkinsfile#L13). That means that adding [another one](https://github.com/RedHatInsights/insights-core/pull/1452/files#diff-58231b16fdee45a03a4ee3cf94a9f2c3R31) to run [Flake8](https://github.com/RedHatInsights/insights-core/pull/1452/files#diff-58231b16fdee45a03a4ee3cf94a9f2c3R34) has become simple. It just must use the same [hack](https://github.com/RedHatInsights/insights-core/pull/1452/files#diff-58231b16fdee45a03a4ee3cf94a9f2c3R33) as the [testing](https://github.com/RedHatInsights/insights-core/blob/05c224f1292727f40234054cdb2b40caf93801d8/Jenkinsfile#L22) one.

@eduardocerqueira or @bfahr may want to review this.

Fixes #1262.