### PR TITLE
Fixes an error when script executes insights run

### DIFF
--- a/insights/formats/text.py
+++ b/insights/formats/text.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import six
 import sys
+import inspect
 from collections import namedtuple
 
 from pprint import pprint
@@ -26,7 +27,7 @@ except ImportError:
 
 def _find_context(broker):
     for k, v in broker.instances.items():
-        if issubclass(k, ExecutionContext):
+        if inspect.isclass(k) and issubclass(k, ExecutionContext):
             return v
 
 


### PR DESCRIPTION
* When a script executes insights.run directly and the -d option is used
then a exception will occur in _find_context when trying to determine
the context of a report function, when it assumes a class context.
* Adding a check for a class object fixes the error in
insights.formats.text._find_context
* duplicate by running `./sample_script.py -d`