### PR TITLE
Fix setting display name

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -411,7 +411,9 @@ class InsightsClient(object):
     @_net
     def set_display_name(self, display_name):
         '''
-            returns True on success, False on failure
+            returns True on success,
+                    False on failure,
+                    None on unchanged
         '''
         return self.connection.set_display_name(display_name)
 

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -411,9 +411,7 @@ class InsightsClient(object):
     @_net
     def set_display_name(self, display_name):
         '''
-            returns True on success,
-                    False on failure,
-                    None on unchanged
+            returns True on success, False on failure
         '''
         return self.connection.set_display_name(display_name)
 

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -724,7 +724,7 @@ class InsightsConnection(object):
             old_display_name = json.loads(res.content).get('display_name', None)
             if display_name == old_display_name:
                 logger.debug('Display name unchanged: %s', old_display_name)
-                return None
+                return True
 
             net_logger.info("PUT %s", url)
             res = self.session.put(url,

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -718,6 +718,14 @@ class InsightsConnection(object):
         machine_id = generate_machine_id()
         try:
             url = self.api_url + '/v1/systems/' + machine_id
+
+            net_logger.info("GET %s", url)
+            res = self.session.get(url, timeout=self.config.http_timeout)
+            old_display_name = json.loads(res.content).get('display_name', None)
+            if display_name == old_display_name:
+                logger.debug('Display name unchanged: %s', old_display_name)
+                return None
+
             net_logger.info("PUT %s", url)
             res = self.session.put(url,
                                    timeout=self.config.http_timeout,
@@ -725,7 +733,9 @@ class InsightsConnection(object):
                                    data=json.dumps(
                                         {'display_name': display_name}))
             if res.status_code == 200:
-                logger.info('System display name changed to %s', display_name)
+                logger.info('System display name changed from %s to %s',
+                            old_display_name,
+                            display_name)
                 return True
             elif res.status_code == 404:
                 logger.error('System not found. '

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -139,7 +139,9 @@ def post_update(client, config):
     if config.display_name and not config.register:
         # setting display name independent of registration
         if client.set_display_name(config.display_name):
-            sys.exit(constants.sig_kill_ok)
+            if 'display_name' in config._cli_opts:
+                # only exit on success if it was invoked from command line
+                sys.exit(constants.sig_kill_ok)
         else:
             sys.exit(constants.sig_kill_bad)
 

--- a/insights/tests/client/test_displayname.py
+++ b/insights/tests/client/test_displayname.py
@@ -7,15 +7,20 @@ class MockSession(object):
     def __init__(self):
         self.status_code = None
         self.text = None
+        self.content = '{"display_name": "test"}'
+
+    def get(self, url=None, timeout=None, headers=None, data=None):
+        return MockResponse(self.status_code, self.text, self.content)
 
     def put(self, url=None, timeout=None, headers=None, data=None):
-        return MockResponse(self.status_code, self.text)
+        return MockResponse(self.status_code, self.text, None)
 
 
 class MockResponse(object):
-    def __init__(self, expected_status, expected_text):
+    def __init__(self, expected_status, expected_text, expected_content):
         self.status_code = expected_status
         self.text = expected_text
+        self.content = expected_content
 
 
 def mock_init_session(obj):


### PR DESCRIPTION
Previously, by design, setting display name would immediately exit the client.

An unfortunate side effect of this is that, because the client treats all config (env, conf file, cmd line) identically, having display_name permanently set in the config file will always cause the client to exit.

This patch will check against the command line args to see whether display_name came from there or not. Then, it will only exit when setting display-name as a command line switch. Otherwise it will continue with collection and upload as normal.

In addition, the PUT to update display name is no longer made if the name is unchanged, and some messaging is improved.