### PR TITLE
Remove docs from develop bundle

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
         package_data={'': ['LICENSE']},
         license='Apache 2.0',
         extras_require={
-            'develop': list(runtime | develop | client | docs | linting | testing),
+            'develop': list(runtime | develop | client | linting | testing),
             'client': list(runtime | client),
             'optional': list(optional),
             'docs': list(docs),


### PR DESCRIPTION
Some docs packages, namely [Sphinx](https://pypi.org/project/Sphinx/), don’t install on Python 2.6. Removed the docs bundle from develop, since it’s not essential and it makes installation on RHEL 6 straightforward. Moreover not having [Sphinx](https://github.com/RedHatInsights/insights-core/blob/7f1a9304ad649a15f9380699b00df1a19e311ead/setup.py#L52), [IPython](https://github.com/RedHatInsights/insights-core/blob/7f1a9304ad649a15f9380699b00df1a19e311ead/setup.py#L55) and other packages in a basic development bundle can be helpful.

Steps to reproduce:

* Spin up a fresh virtual environment on a system with Python 2.6 (e.g. RHEL 6).
* Run `pip install -e .[develop]` in that environment.
* ~~See that it installs everything just fine.~~ Which is actually not true, because #1373 is not merged yet. 🙁 But it’s possible to incorporate those changes to the [_setup.py_](https://github.com/RedHatInsights/insights-core/blob/7f1a9304ad649a15f9380699b00df1a19e311ead/setup.py) file, then it would work.