### PR TITLE
fixed typo for pcs_config first file in sos_archive.py

### DIFF
--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -64,7 +64,7 @@ class SosSpecs(Specs):
     netstat_s = simple_file("sos_commands/networking/netstat_-s")
     nmcli_dev_show = simple_file("sos_commands/networking/nmcli_dev_show")
     ntptime = simple_file("sos_commands/ntp/ntptime")
-    pcs_config = first_file(["sos_commands/pacemaker/pcs_config", "sos_commands/cluster/pcs_confi "])
+    pcs_config = first_file(["sos_commands/pacemaker/pcs_config", "sos_commands/cluster/pcs_config"])
     pcs_status = first_file(["sos_commands/pacemaker/pcs_status", "sos_commands/cluster/pcs_status"])
     ps_auxww = first_file(["sos_commands/process/ps_auxwww", "sos_commands/process/ps_aux", "sos_commands/process/ps_auxcww"])
     puppet_ssl_cert_ca_pem = simple_file("sos_commands/foreman/foreman-debug/var/lib/puppet/ssl/certs/ca.pem")


### PR DESCRIPTION
This was a typo in recently merged parser, pcs_config.