### PR TITLE
Add epoch to installed rpms and use json format

### DIFF
--- a/insights/parsers/installed_rpms.py
+++ b/insights/parsers/installed_rpms.py
@@ -339,7 +339,7 @@ class InstalledRpm(object):
 
         for k, v in data.items():
             setattr(self, k, v)
-        if 'epoch' not in data:
+        if 'epoch' not in data or data['epoch'] == '(none)':
             self.epoch = '0'
 
         """Below is only for version comparison"""

--- a/insights/parsers/tests/test_installed_rpms.py
+++ b/insights/parsers/tests/test_installed_rpms.py
@@ -131,6 +131,7 @@ def test_from_json():
     assert isinstance(rpms.get_max("log4j").source, InstalledRpm)
     assert len(rpms.packages) == len(RPMS_JSON.splitlines())
     assert rpms.get_max("log4j").source.name == "log4j"
+    assert rpms.get_max("util-linux").epoch == '0'
 
 
 def test_garbage():

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -29,20 +29,23 @@ from insights.specs import Specs
 def _make_rpm_formatter(fmt=None):
     if fmt is None:
         fmt = [
-            "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}",
-            "%{INSTALLTIME:date}",
-            "%{BUILDTIME}",
-            "%{VENDOR}",
-            "%{BUILDHOST}",
-            "DUMMY",
-            "%{SIGPGP:pgpsig}"
+            '"name":"%{NAME}"',
+            '"epoch":"%{EPOCH}"',
+            '"version":"%{VERSION}"',
+            '"release":"%{RELEASE}"',
+            '"arch":"%{ARCH}"',
+            '"installtime":"%{INSTALLTIME:date}"',
+            '"buildtime":"%{BUILDTIME}"',
+            '"vendor":"%{VENDOR}"',
+            '"buildhost":"%{BUILDHOST}"',
+            '"sigpgp":"%{SIGPGP:pgpsig}"'
         ]
 
     def inner(idx=None):
         if idx:
-            return "\t".join(fmt[:idx]) + "\n"
+            return "\{" + ",".join(fmt[:idx]) + "\}\n"
         else:
-            return "\t".join(fmt) + "\n"
+            return "\{" + ",".join(fmt) + "\}\n"
     return inner
 
 


### PR DESCRIPTION
* Fixes issue #1431 
* Switch input for installed RPMs to be collected in JSON format which is already supported by the parser.
* Missing epoch is '(none)' so check for that
* Add test for epoch