### PR TITLE
Split MD5CheckSum parser into prelink version and normal version

### DIFF
--- a/insights/parsers/md5check.py
+++ b/insights/parsers/md5check.py
@@ -7,19 +7,20 @@ Module for processing output of the ``prelink -y --md5`` or ``md5sum`` command.
 The name and md5 checksums of specified files are stored as lists. Each
 entry will be processed by the shared parser.
 
-This MD5CheckSum class provide the following properties:
+This MD5CheckSum class provide the following attributes:
 
-* ``filename``: the file name which derived from the output.
-* ``md5sum``: the checksums for the file.
+* ``files``: the files which derived from the output.
+* ``checksums``: the checksums for the files.
 """
+
 from .. import parser, CommandParser
 from insights.specs import Specs
+from insights.parsers import ParseException
 
 
-@parser(Specs.prelink_orig_md5)
 class MD5CheckSum(CommandParser):
     """
-    Class to parse ``prelink -y --md5`` or ``md5sum`` command information.
+    Common class to parse ``prelink -y --md5`` or ``md5sum`` command information.
 
     The output of these two commands contains two fields, the first is the
     md5 checksum and the second is the file name.
@@ -27,41 +28,63 @@ class MD5CheckSum(CommandParser):
     Especially, we add /dev/null as one of the specified file to be checked,
     as ``md5sum`` command can read from stdin without feeding a file.
 
-    Attributes::
-
-        filename (str): File name.
-        md5sum (str): MD5 checksums of that file.
-
     Sample input for ``prelink -y --md5`` or ``md5sum`` command::
 
         d1e6613cfb62d3f111db7bdda39ac821  /usr/lib64/libsoftokn3.so
 
-    Examples::
-
-        >>> collection = shared[MD5CheckSum]
-        >>> len(collection) # All MD5 checksums in a list
+    Examples:
+        >>> md5info = shared[MD5CheckSum]
+        >>> len(md5info.files) # Total MD5 checksums collected
         1
-        >>> record = collection[0]
-        >>> record.filename
-        /usr/lib64/libsoftokn3.so
-        >>> record.md5sum
+        >>> "/usr/lib64/libsoftokn3.so" in md5info.files
+        True
+        >>> "d1e6613cfb62d3f111db7bdda39ac821" in md5info.checksums
+        True
+        >>> md5info['/usr/lib64/libsoftokn3.so']
         d1e6613cfb62d3f111db7bdda39ac821
 
+    Attributes:
+        data (dict): All MD5 checksums are stored in this dictionary with the
+                     filename as the key and the checksum as the value.
+        files (list): Return the all file names in the checksum results.
+        checksums (list): Return the checksums in the checksum results.
     """
-    @property
-    def filename(self):
-        """ str: Return the file name for the current file."""
-        return self.data.get('filename')
-
-    @property
-    def md5sum(self):
-        """ str: Return the checksum for the current file."""
-        return self.data.get('md5sum')
 
     def parse_content(self, content):
+        if not content:
+            raise ParseException("Input content is empty.")
         self.data = {}
-        fields = content[0].strip().split() if content else None
-        # skip the '/dev/null'
-        if fields and len(fields) == 2 and fields[1] != "/dev/null":
-            self.data["md5sum"] = fields[0]
-            self.data["filename"] = fields[1]
+        self.files = []
+        self.checksums = []
+        for line in content:
+            md5sum, filename = line.strip().split(' ', 1)
+            md5sum, filename = md5sum.strip(), filename.strip()
+            # skip the '/dev/null'
+            if len(md5sum) == 32 and filename != "/dev/null":
+                self.data[filename] = md5sum
+
+        if self.data:
+            self.files = self.data.keys()
+            self.checksums = self.data.values()
+
+    def __getitem__(self, filename):
+        """
+        Retrieves an item from the underlying data dictionary.
+        """
+        return self.data.get(filename)
+
+
+@parser(Specs.prelink_orig_md5)
+class PrelinkMD5(MD5CheckSum):
+    """
+    A parser for parsing the output of the ``prelink -y --md5``
+    """
+    pass
+
+
+@parser(Specs.md5chk_files)
+class NormalMD5(MD5CheckSum):
+    """
+    A parser for parsing the output of the ``md5sum``
+    """
+    pass

--- a/insights/parsers/md5check.py
+++ b/insights/parsers/md5check.py
@@ -6,19 +6,14 @@ Module for processing output of the ``prelink -y --md5`` or ``md5sum`` command.
 
 The name and md5 checksums of specified files are stored as lists. Each
 entry will be processed by the shared parser.
-
-This MD5CheckSum class provide the following attributes:
-
-* ``files``: the files which derived from the output.
-* ``checksums``: the checksums for the files.
 """
 
-from .. import parser, CommandParser
-from insights.specs import Specs
-from insights.parsers import ParseException
+from .. import parser, CommandParser, LegacyItemAccess
+from ..parsers import ParseException
+from ..specs import Specs
 
 
-class MD5CheckSum(CommandParser):
+class MD5CheckSum(LegacyItemAccess, CommandParser):
     """
     Common class to parse ``prelink -y --md5`` or ``md5sum`` command information.
 
@@ -33,21 +28,20 @@ class MD5CheckSum(CommandParser):
         d1e6613cfb62d3f111db7bdda39ac821  /usr/lib64/libsoftokn3.so
 
     Examples:
-        >>> md5info = shared[MD5CheckSum]
-        >>> len(md5info.files) # Total MD5 checksums collected
+
+        >>> type(md5info)
+        <class 'insights.parsers.md5check.MD5CheckSum'>
+        >>> len(md5info.files)
         1
         >>> "/usr/lib64/libsoftokn3.so" in md5info.files
         True
-        >>> "d1e6613cfb62d3f111db7bdda39ac821" in md5info.checksums
-        True
         >>> md5info['/usr/lib64/libsoftokn3.so']
-        d1e6613cfb62d3f111db7bdda39ac821
+        'd1e6613cfb62d3f111db7bdda39ac821'
 
     Attributes:
         data (dict): All MD5 checksums are stored in this dictionary with the
                      filename as the key and the checksum as the value.
         files (list): Return the all file names in the checksum results.
-        checksums (list): Return the checksums in the checksum results.
     """
 
     def parse_content(self, content):
@@ -55,23 +49,14 @@ class MD5CheckSum(CommandParser):
             raise ParseException("Input content is empty.")
         self.data = {}
         self.files = []
-        self.checksums = []
         for line in content:
             md5sum, filename = line.strip().split(' ', 1)
             md5sum, filename = md5sum.strip(), filename.strip()
             # skip the '/dev/null'
             if len(md5sum) == 32 and filename != "/dev/null":
                 self.data[filename] = md5sum
-
         if self.data:
             self.files = self.data.keys()
-            self.checksums = self.data.values()
-
-    def __getitem__(self, filename):
-        """
-        Retrieves an item from the underlying data dictionary.
-        """
-        return self.data.get(filename)
 
 
 @parser(Specs.prelink_orig_md5)

--- a/insights/parsers/tests/test_md5check.py
+++ b/insights/parsers/tests/test_md5check.py
@@ -1,47 +1,65 @@
 from insights.tests import context_wrap
 from insights.parsers import md5check
+from insights.parsers import ParseException
+import pytest
 
-PRELINK_SAMPLE = """
-039a62d3e9786f5a63e84def09cb3b27  /usr/lib64/libfreeblpriv3.so
-""".strip()
-
-MD5_SAMPLE = """
-4777325b4a49cfae41a3991887920b68  /usr/lib64/libfreebl3.so
+NORMAL_MD5_SAMPLE = """
+d41d8cd98f00b204e9800998ecf8427e  /dev/null
+7d4855248419b8a3ce6616bbc0e58301  /etc/localtime
+910c11e6b93ae222b44143cb14f2b670  /usr/share/zoneinfo/America/Sao_Paulo
+96db70199bdca045254f321a5e06d7b9  /usr/share/zoneinfo/America/Campo_Grande
+ddc716ed2eac2ebfab07db289dd4270d  /usr/share/zoneinfo/America/Cuiaba
 """.strip()
 
 BAD_INPUT_SAMPLE = """
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  /dev/null
 """.strip()
 
-FILES_NOT_FOUND_SAMPLE = """
+BLANK_INPUT_SAMPLE = """
+""".strip()
+
+ONLY_NULL_SAMPLE = """
 d41d8cd98f00b204e9800998ecf8427e  /dev/null
 """.strip()
 
-
-def test_md5check_prelink():
-    md5info = md5check.MD5CheckSum(context_wrap(PRELINK_SAMPLE))
-    assert md5info.data['md5sum'] == '039a62d3e9786f5a63e84def09cb3b27'
-    assert md5info.data['filename'] == '/usr/lib64/libfreeblpriv3.so'
-    assert md5info.md5sum == '039a62d3e9786f5a63e84def09cb3b27'
-    assert md5info.filename == '/usr/lib64/libfreeblpriv3.so'
+PRELINK_SAMPLE = """
+b4949565c561187ebc69d21cf20b0207  /etc/pki/product/69.pem
+""".strip()
 
 
-def test_md5check_md5():
-    md5info = md5check.MD5CheckSum(context_wrap(MD5_SAMPLE))
-    assert md5info.data['md5sum'] == '4777325b4a49cfae41a3991887920b68'
-    assert md5info.data['filename'] == '/usr/lib64/libfreebl3.so'
-    assert md5info.md5sum == '4777325b4a49cfae41a3991887920b68'
-    assert md5info.filename == '/usr/lib64/libfreebl3.so'
+def test_normal_md5():
+    md5info = md5check.NormalMD5(context_wrap(NORMAL_MD5_SAMPLE))
+    assert "/dev/null" not in md5info.files
+    assert "/etc/localtime" in md5info.files
+    assert "/usr/share/zoneinfo/America/Sao_Paulo" in md5info.files
+    assert md5info['/etc/localtime'] == "7d4855248419b8a3ce6616bbc0e58301"
+    assert "ddc716ed2eac2ebfab07db289dd4270d" in md5info.checksums
+    assert md5info['/etc/hostname'] is None
+    assert "/etc/hostname" not in md5info.files
 
 
-def test_md5check_bad_input():
-    md5info = md5check.MD5CheckSum(context_wrap(BAD_INPUT_SAMPLE))
+def test_normal_md5_blank_input():
+    ctx = context_wrap(BLANK_INPUT_SAMPLE)
+    with pytest.raises(ParseException) as sc:
+        md5check.NormalMD5(ctx)
+    assert "Input content is empty." in str(sc)
+
+
+def test_normal_md5_bad_input():
+    md5info = md5check.NormalMD5(context_wrap(BAD_INPUT_SAMPLE))
     assert md5info.data == {}
-    assert md5info.md5sum is None
-    assert md5info.filename is None
+    assert md5info.files == []
+    assert md5info.checksums == []
 
 
-def test_md5check_files_not_found():
-    md5info = md5check.MD5CheckSum(context_wrap(FILES_NOT_FOUND_SAMPLE))
+def test_normal_md5_only_null():
+    md5info = md5check.NormalMD5(context_wrap(ONLY_NULL_SAMPLE))
     assert md5info.data == {}
-    assert md5info.md5sum is None
-    assert md5info.filename is None
+    assert md5info.files == []
+    assert md5info.checksums == []
+
+
+def test_prelink_md5():
+    md5info = md5check.PrelinkMD5(context_wrap(PRELINK_SAMPLE))
+    assert "/etc/pki/product/69.pem" in md5info.files
+    assert md5info['/etc/pki/product/69.pem'] == "b4949565c561187ebc69d21cf20b0207"

--- a/insights/parsers/tests/test_md5check.py
+++ b/insights/parsers/tests/test_md5check.py
@@ -33,8 +33,7 @@ def test_normal_md5():
     assert "/etc/localtime" in md5info.files
     assert "/usr/share/zoneinfo/America/Sao_Paulo" in md5info.files
     assert md5info['/etc/localtime'] == "7d4855248419b8a3ce6616bbc0e58301"
-    assert "ddc716ed2eac2ebfab07db289dd4270d" in md5info.checksums
-    assert md5info['/etc/hostname'] is None
+    assert md5info.get('/etc/hostname') is None
     assert "/etc/hostname" not in md5info.files
 
 
@@ -49,14 +48,12 @@ def test_normal_md5_bad_input():
     md5info = md5check.NormalMD5(context_wrap(BAD_INPUT_SAMPLE))
     assert md5info.data == {}
     assert md5info.files == []
-    assert md5info.checksums == []
 
 
 def test_normal_md5_only_null():
     md5info = md5check.NormalMD5(context_wrap(ONLY_NULL_SAMPLE))
     assert md5info.data == {}
     assert md5info.files == []
-    assert md5info.checksums == []
 
 
 def test_prelink_md5():

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -506,7 +506,7 @@ class DefaultSpecs(Specs):
                               glob_file("/database/postgresql-*.log")
                               ])
     puppetserver_config = simple_file("/etc/sysconfig/puppetserver")
-    md5chk_files = simple_command("/bin/ls -H /usr/lib*/{libfreeblpriv3.so,libsoftokn3.so} /etc/pki/product*/69.pem /etc/fonts/fonts.conf /dev/null 2>/dev/null")
+    md5chk_files = simple_command("/usr/bin/md5sum /dev/null /etc/localtime /usr/share/zoneinfo/America/{Sao_Paulo,Campo_Grande,Cuiaba} /etc/pki/{product,product-default}/69.pem 2>/dev/null")
     prelink_orig_md5 = None
     prev_uploader_log = simple_file("var/log/redhat-access-insights/redhat-access-insights.log.1")
     proc_snmp_ipv4 = simple_file("proc/net/snmp")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -118,7 +118,7 @@ class InsightsArchiveSpecs(Specs):
     lvdisplay = simple_file("insights_commands/lvdisplay")
     lvs_noheadings = simple_file("insights_commands/lvs_--nameprefixes_--noheadings_--separator_-a_-o_lv_name_lv_size_lv_attr_mirror_log_vg_name_devices_region_size_data_percent_metadata_percent_segtype_--config_global_locking_type_0")
     lvs_noheadings_all = simple_file("insights_commands/lvs_--nameprefixes_--noheadings_--separator_-a_-o_lv_name_lv_size_lv_attr_mirror_log_vg_name_devices_region_size_data_percent_metadata_percent_segtype_--config_global_locking_type_0_devices_filter_a")
-    md5chk_files = simple_file("insights_commands/ls_-H_.usr.lib_._libfreeblpriv3.so_libsoftokn3.so_.etc.pki.product_.69.pem_.etc.fonts.fonts.conf_.dev.null_2_.dev.null")
+    md5chk_files = simple_file("insights_commands/md5sum_.dev.null_.etc.localtime_.usr.share.zoneinfo.America._Sao_Paulo_Campo_Grande_Cuiaba_.etc.pki._product_product-default_.69.pem_2_.dev.null")
     mlx4_port = simple_file("insights_commands/find_.sys.bus.pci.devices._.mlx4_port_0-9_-print_-exec_cat")
     mount = simple_file("insights_commands/mount")
     multicast_querier = simple_file("insights_commands/find_.sys.devices.virtual.net._-name_multicast_querier_-print_-exec_cat")


### PR DESCRIPTION
 - Fix md5chk_files spec. Don't check libfreeblpriv3.so, libsoftokn3.so and pem file as prelink has been deprecated on RHEL7
 - Check extra timezone files
 - Keep prelink_orig_md5 spec disabled as it needs extra work under current framework