### PR TITLE
improve parsing for number config vars

### DIFF
--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -462,10 +462,7 @@ class InsightsConfig(object):
             if k in insights_env_opts:
                 v = insights_env_opts[k]
                 try:
-                    if k == 'http_timeout':
-                        insights_env_opts[k] = float(v)
-                    else:
-                        insights_env_opts[k] = int(v)
+                    insights_env_opts[k] = float(v) if k == 'http_timeout' else int(v)
                 except ValueError:
                     raise ValueError(
                         'ERROR: Invalid value specified for {0}: {1}.'.format(k, v))

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -152,7 +152,7 @@ DEFAULT_OPTS = {
     },
     'http_timeout': {
         # non-CLI
-        'default': 10
+        'default': 10.0
     },
     'insecure_connection': {
         # non-CLI
@@ -539,7 +539,7 @@ class InsightsConfig(object):
             return
         for key in d:
             try:
-                if key == 'retries' or key =='cmd_timeout':
+                if key == 'retries' or key == 'cmd_timeout':
                     d[key] = parsedconfig.getint(constants.app_name, key)
                 if key == 'http_timeout':
                     d[key] = parsedconfig.getfloat(constants.app_name, key)

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -457,6 +457,18 @@ class InsightsConfig(object):
                                  for k, v in os.environ.items()
                                  if k.upper().startswith("INSIGHTS_") and
                                  k.upper() not in ignore)
+
+        for k in ['retries', 'cmd_timeout', 'http_timeout']:
+            if k in insights_env_opts:
+                v = insights_env_opts[k]
+                try:
+                    if k == 'http_timeout':
+                        insights_env_opts[k] = float(v)
+                    else:
+                        insights_env_opts[k] = int(v)
+                except ValueError:
+                    raise ValueError(
+                        'ERROR: Invalid value specified for {0}: {1}.'.format(k, v))
         self._update_dict(insights_env_opts)
 
     def load_command_line(self, conf_only=False):
@@ -530,7 +542,7 @@ class InsightsConfig(object):
             return
         for key in d:
             try:
-                if key == 'retries':
+                if key == 'retries' or key =='cmd_timeout':
                     d[key] = parsedconfig.getint(constants.app_name, key)
                 if key == 'http_timeout':
                     d[key] = parsedconfig.getfloat(constants.app_name, key)

--- a/insights/tests/client/test_config.py
+++ b/insights/tests/client/test_config.py
@@ -61,9 +61,9 @@ def test_defaults():
 
 @patch('insights.client.config.os.environ', {
         'INSIGHTS_HTTP_TIMEOUT': '1234',
-        'INSIGHTS_RETRIES':      '1234',
-        'INSIGHTS_CMD_TIMEOUT':  '1234'
-    })
+        'INSIGHTS_RETRIES': '1234',
+        'INSIGHTS_CMD_TIMEOUT': '1234'
+       })
 def test_env_number_parsing():
     c = InsightsConfig()
     c.load_env()
@@ -74,9 +74,9 @@ def test_env_number_parsing():
 
 @patch('insights.client.config.os.environ', {
         'INSIGHTS_HTTP_TIMEOUT': 'STAY AWAY',
-        'INSIGHTS_RETRIES':      'FROM ME',
-        'INSIGHTS_CMD_TIMEOUT':  'BICK HAZARD'
-    })
+        'INSIGHTS_RETRIES': 'FROM ME',
+        'INSIGHTS_CMD_TIMEOUT': 'BICK HAZARD'
+     })
 def test_env_number_bad_values():
     c = InsightsConfig()
     with pytest.raises(ValueError):

--- a/insights/tests/client/test_config.py
+++ b/insights/tests/client/test_config.py
@@ -1,3 +1,4 @@
+import pytest
 from io import TextIOWrapper, BytesIO
 from insights.client.config import InsightsConfig, DEFAULT_OPTS
 from mock.mock import patch
@@ -49,3 +50,34 @@ def test_config_load_value_error(open_):
     c = InsightsConfig()
     c.load_config_file()
     assert c.http_timeout == DEFAULT_OPTS['http_timeout']['default']
+
+
+def test_defaults():
+    c = InsightsConfig()
+    assert isinstance(c.cmd_timeout, int)
+    assert isinstance(c.retries, int)
+    assert isinstance(c.http_timeout, float)
+
+
+@patch('insights.client.config.os.environ', {
+        'INSIGHTS_HTTP_TIMEOUT': '1234',
+        'INSIGHTS_RETRIES':      '1234',
+        'INSIGHTS_CMD_TIMEOUT':  '1234'
+    })
+def test_env_number_parsing():
+    c = InsightsConfig()
+    c.load_env()
+    assert isinstance(c.cmd_timeout, int)
+    assert isinstance(c.retries, int)
+    assert isinstance(c.http_timeout, float)
+
+
+@patch('insights.client.config.os.environ', {
+        'INSIGHTS_HTTP_TIMEOUT': 'STAY AWAY',
+        'INSIGHTS_RETRIES':      'FROM ME',
+        'INSIGHTS_CMD_TIMEOUT':  'BICK HAZARD'
+    })
+def test_env_number_bad_values():
+    c = InsightsConfig()
+    with pytest.raises(ValueError):
+        c.load_env()


### PR DESCRIPTION
Discovered an issue where ENV-specified http_timeout wasn't parsed as a float and caused exceptions where it was being used during requests. Made the parsing a little more robust.