### PR TITLE
All cluster rules use pandas. Ansible inventory files define cluster topology.

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -56,21 +56,21 @@ def add_status(name, nvr, commit):
     RULES_STATUS[name] = {"version": nvr, "commit": commit}
 
 
-def process_dir(broker, root, graph, context, use_pandas=False):
+def process_dir(broker, root, graph, context, inventory=None):
     ctx = create_context(root, context)
     log.debug("Processing %s with %s" % (root, ctx))
 
     if isinstance(ctx, ClusterArchiveContext):
         from .core.cluster import process_cluster
         archives = [f for f in ctx.all_files if f.endswith(COMPRESSION_TYPES)]
-        return process_cluster(archives, broker=broker, use_pandas=use_pandas)
+        return process_cluster(archives, broker=broker, inventory=inventory)
 
     broker[ctx.__class__] = ctx
     broker = dr.run(graph, broker=broker)
     return broker
 
 
-def _run(broker, graph=None, root=None, context=None, use_pandas=False):
+def _run(broker, graph=None, root=None, context=None, inventory=None):
     """
     run is a general interface that is meant for stand alone scripts to use
     when executing insights components.
@@ -95,10 +95,10 @@ def _run(broker, graph=None, root=None, context=None, use_pandas=False):
         return dr.run(graph, broker=broker)
 
     if os.path.isdir(root):
-        return process_dir(broker, root, graph, context, use_pandas)
+        return process_dir(broker, root, graph, context, inventory=inventory)
     else:
         with extract(root) as ex:
-            return process_dir(broker, ex.tmp_dir, graph, context, use_pandas)
+            return process_dir(broker, ex.tmp_dir, graph, context, inventory=inventory)
 
 
 def apply_configs(configs):
@@ -154,8 +154,7 @@ def _load_context(path):
 
 
 def run(component=None, root=None, print_summary=False,
-        context=None, use_pandas=False,
-        print_component=None):
+        context=None, inventory=None, print_component=None):
 
     from .core import dr
     dr.load_components("insights.specs.default")
@@ -172,11 +171,11 @@ def run(component=None, root=None, print_summary=False,
         p.add_argument("archive", nargs="?", help="Archive or directory to analyze.")
         p.add_argument("-p", "--plugins", default="", help="Comma-separated list without spaces of package(s) or module(s) containing plugins.")
         p.add_argument("-c", "--config", help="Configure components.")
+        p.add_argument("-i", "--inventory", help="Ansible inventory file for cluster analysis.")
         p.add_argument("-v", "--verbose", help="Verbose output.", action="store_true")
         p.add_argument("-f", "--format", help="Output format.", default="insights.formats.text")
         p.add_argument("-D", "--debug", help="Verbose debug output.", action="store_true")
         p.add_argument("--context", help="Execution Context. Defaults to HostContext if an archive isn't passed.")
-        p.add_argument("--pandas", action="store_true", help="Use pandas dataframes with cluster rules.")
 
         class Args(object):
             pass
@@ -197,7 +196,7 @@ def run(component=None, root=None, print_summary=False,
 
         logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO if args.verbose else logging.ERROR)
         context = _load_context(args.context) or context
-        use_pandas = args.pandas or use_pandas
+        inventory = args.inventory
 
         root = args.archive or root
         if root:
@@ -239,13 +238,13 @@ def run(component=None, root=None, print_summary=False,
 
     if formatter:
         formatter.preprocess(broker)
-        broker = _run(broker, graph, root, context=context, use_pandas=use_pandas)
+        broker = _run(broker, graph, root, context=context, inventory=inventory)
         formatter.postprocess(broker)
     elif print_component:
-        broker = _run(broker, graph, root, context=context, use_pandas=use_pandas)
+        broker = _run(broker, graph, root, context=context, inventory=inventory)
         broker.print_component(print_component)
     else:
-        broker = _run(broker, graph, root, context=context, use_pandas=use_pandas)
+        broker = _run(broker, graph, root, context=context, inventory=inventory)
 
     return broker
 

--- a/insights/core/cluster.py
+++ b/insights/core/cluster.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 import itertools
+import pandas as pd
 from collections import defaultdict
+
+from ansible.parsing.dataloader import DataLoader
+from ansible.inventory.manager import InventoryManager
 
 from insights.core import dr, plugins
 from insights.core.archives import extract
@@ -11,10 +15,10 @@ from insights.specs import Specs
 ID_GENERATOR = itertools.count()
 
 
-class ClusterMeta(object):
-    def __init__(self, num_members, **kwargs):
+class ClusterMeta(dict):
+    def __init__(self, num_members, kwargs):
         self.num_members = num_members
-        self.kwargs = kwargs
+        self.update(**kwargs)
 
 
 @plugins.combiner(optional=[Specs.machine_id, Specs.hostname])
@@ -23,6 +27,11 @@ def machine_id(mid, hn):
     if ds:
         return ds.content[0].strip()
     return str(next(ID_GENERATOR))
+
+
+def parse_inventory(path):
+    inventory = InventoryManager(loader=DataLoader(), sources=path)
+    return inventory.get_groups_dict()
 
 
 def attach_machine_id(result, mid):
@@ -57,18 +66,18 @@ def extract_facts(brokers):
     return results
 
 
-def process_facts(facts, meta, broker, use_pandas=False):
-    if use_pandas:
-        import pandas as pd
-
+def process_facts(facts, meta, broker):
     broker[ClusterMeta] = meta
     for k, v in facts.items():
-        broker[k] = pd.DataFrame(v) if use_pandas else v
+        broker[k] = pd.DataFrame(v)
     return dr.run(dr.COMPONENTS[dr.GROUPS.cluster], broker=broker)
 
 
-def process_cluster(archives, broker, use_pandas=False):
+def process_cluster(archives, broker, inventory=None):
+    inventory = parse_inventory(inventory) if inventory else {}
+
     brokers = process_archives(archives)
     facts = extract_facts(brokers)
-    meta = ClusterMeta(len(archives))
-    return process_facts(facts, meta, broker, use_pandas=use_pandas)
+    meta = ClusterMeta(len(archives), inventory)
+
+    return process_facts(facts, meta, broker)

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ docs = set([
     'sphinx_rtd_theme',
     'ipython<6',
     'colorama',
+    'jinja2',
 ])
 
 testing = set([
@@ -68,12 +69,18 @@ testing = set([
     'mock==2.0.0',
 ])
 
+cluster = set([
+    'ansible',
+    'pandas',
+    'jinja2',
+    'colorama',
+])
+
 linting = set([
     'flake8==2.6.2',
 ])
 
 optional = set([
-    'jinja2',
     'python-cjson',
     'python-logstash',
     'python-statsd',
@@ -97,8 +104,9 @@ if __name__ == "__main__":
         package_data={'': ['LICENSE']},
         license='Apache 2.0',
         extras_require={
-            'develop': list(runtime | develop | client | docs | linting | testing),
+            'develop': list(runtime | develop | client | docs | linting | testing | cluster),
             'client': list(runtime | client),
+            'cluster': list(runtime | cluster),
             'optional': list(optional),
             'docs': list(docs),
             'linting': list(linting | client),


### PR DESCRIPTION
* Remove the `--pandas` command line option and arguments to related functions.
* Add a new `cluster` section to `setup.py` to require `pandas` and `ansible`.
* Add a `-i` option for inventory when analyzing clusters. The value is a path to an ansible inventory file like `/etc/ansible/hosts`