### PR TITLE
Add method to get count of processes with given string

### DIFF
--- a/insights/parsers/ps.py
+++ b/insights/parsers/ps.py
@@ -130,6 +130,18 @@ class Ps(CommandParser):
         """
         return any(proc in row[self.command_name] for row in self.data)
 
+    def number_occurences(self, proc):
+        """
+        Returns the number of occurencies of commands that contain given text
+
+        Returns:
+            int: The number of occurencies of commands with given text
+
+        .. note:: 'proc' can match anywhere in the command path, name or
+           arguments.
+        """
+        return len([True for row in self.data if proc in row[self.command_name]])
+
     def search(self, **kwargs):
         """
         Search the process list for matching rows based on key-value pairs.

--- a/insights/parsers/tests/test_ps.py
+++ b/insights/parsers/tests/test_ps.py
@@ -80,6 +80,8 @@ def test_ps_auxww_from_auxww():
     assert '[kthreadd]' in p
     assert 'sshd' not in p
     assert not p.fuzzy_match("sshd")
+    assert p.number_occurences("systemd") == 2
+    assert p.number_occurences("openshift") != 2
     assert p.cpu_usage('/usr/lib64/firefox/firefox') == '2.4'
     assert p.cpu_usage('firefox') is None
     assert p.cpu_usage('dhclient') is None
@@ -126,6 +128,8 @@ def test_ps_ef_from_ef():
         'PPID': '1', 'COMMAND_NAME': 'rhel-push-plugin'
     }
     assert p.fuzzy_match('kthreadd')
+    assert p.number_occurences("systemd") != 2
+    assert p.number_occurences("openshift") == 2
     assert p.parent_pid("111435") == ["111434", "nginx: master process /usr/sbin/nginx -c /etc/nginx/nginx.conf"]
     assert '[kthreadd]' in p
     assert 'sshd' not in p
@@ -176,6 +180,8 @@ def test_ps_auxww_from_auxcww():
     assert d[2]["COMMAND"] == 'irqbalance'
     assert d[-2]["COMMAND"] == 'qemu-kvm'
     assert p.fuzzy_match('irqbal')
+    assert p.number_occurences("bash") == 3
+    assert p.number_occurences("qemu-kvm") != 2
     assert 'dhclient' in p
     assert 'sshd' not in p
     assert not p.fuzzy_match("sshd")
@@ -220,6 +226,8 @@ def test_ps_auxww_from_auxwww():
     assert 'sshd' not in p
     assert 'kthread' not in p
     assert not p.fuzzy_match("sshd")
+    assert p.number_occurences("python") == 1
+    assert p.number_occurences("sshd") != 2
     assert p.fuzzy_match('python')
 
     assert p.search() == []
@@ -261,6 +269,8 @@ def test_ps_auxww_from_aux():
     assert 'sshd' not in p
     assert 'kondemand' not in p
     assert not p.fuzzy_match("sshd")
+    assert p.number_occurences("systemd") != 2
+    assert p.number_occurences("bash") == 1
     assert p.fuzzy_match('kondemand')
 
     assert p.search() == []


### PR DESCRIPTION
This commit adds a method to the Ps Parser that returns the number
of occurencies of commands with a given string. This is very much needed
and useful when writing rules for OpenStack because we have some performance
considerations wehn using a large number of worker processes for services.
For example, the recommendation is to cap the woker count at
ming(processorcount/2, 12) to avoid issues with database conenctions etc, so
we need the parser to provide this data in order to write rules.