### PR TITLE
Add tags to components and update pydoc.

### DIFF
--- a/docs/api_index.rst
+++ b/docs/api_index.rst
@@ -41,6 +41,18 @@ insights.core.context
     :show-inheritance:
     :undoc-members:
 
+insights.core.dr
+----------------
+
+.. automodule:: insights.core.dr
+    :members:
+    :show-inheritance:
+    :undoc-members:
+
+.. autoclass:: insights.core.dr.ComponentType
+    :members:
+    :exclude-members: requires, optional, metadata, group, tags
+
 insights.core.filters
 ---------------------
 
@@ -87,13 +99,16 @@ insights.specs
 --------------
 .. automodule:: insights.specs
     :members:
+    :exclude-members: context_handlers, registry
     :show-inheritance:
     :undoc-members:
+
 
 insights.specs.default
 ----------------------
 .. automodule:: insights.specs.default
     :members:
+    :exclude-members: context_handlers, registry
     :show-inheritance:
     :undoc-members:
 
@@ -101,6 +116,7 @@ insights.specs.insights_archive
 -------------------------------
 .. automodule:: insights.specs.insights_archive
     :members:
+    :exclude-members: context_handlers, registry
     :show-inheritance:
     :undoc-members:
 
@@ -108,6 +124,7 @@ insights.specs.sos_archive
 --------------------------
 .. automodule:: insights.specs.sos_archive
     :members:
+    :exclude-members: context_handlers, registry
     :show-inheritance:
     :undoc-members:
 
@@ -115,6 +132,7 @@ insights.specs.jdr_archive
 --------------------------
 .. automodule:: insights.specs.jdr_archive
     :members:
+    :exclude-members: context_handlers, registry
     :show-inheritance:
     :undoc-members:
 

--- a/docs/api_index.rst
+++ b/docs/api_index.rst
@@ -48,6 +48,7 @@ insights.core.dr
     :members:
     :show-inheritance:
     :undoc-members:
+    :exclude-members: ComponentType
 
 .. autoclass:: insights.core.dr.ComponentType
     :members:

--- a/docs/embedded_content.rst
+++ b/docs/embedded_content.rst
@@ -27,10 +27,11 @@ to embed content into the rule code.
 
 To embedded content with a rule, create a ``CONTENT`` attribute.  This
 attribute can be a string or a dictionary.  When it is a string, it is
-interpreted as a `jinja2 <http://jinja.pocoo.org/docs/2.10/>`_ string.
-The kwargs of the ``make_*`` functions are interpolated into the string.
+interpreted as a `jinja2 <http://jinja.pocoo.org/docs/2.10/>`_ template,
+and the kwargs of the ``make_*`` functions are interpolated into it.
 This would take place for all rules and all their responses in the
-module.
+module. If you want to scope content to a particular rule, set
+``content=CONTENT`` in the ``@rule`` declaraction.
 
 When the ``CONTENT`` attribute is a dictionary, the keys are interpreted
 as "ERROR_KEYS" with strings as values.   The string values are treated

--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -1,3 +1,21 @@
+"""
+Insights Core is a data collection and analysis framework that is built for
+extensibility and rapid development. It includes a set of reusable components
+for gathering data in myriad ways and providing a reliable object model for it.
+
+.. code-block: python
+
+    >>> from insights import run
+    >>> from insights.parsers import installed_rpms as rpm
+    >>> lower = rpm.Rpm("bash-4.4.11-1.fc26")
+    >>> upper = rpm.Rpm("bash-4.4.22-1.fc26")
+    >>> results = run(rpm.Installed)
+    >>> rpms = results[rpm.Installed]
+    >>> rpms.newest("bash")
+    0:bash-4.4.12-7.fc26
+    >>> lower <= rpms.newest("bash") < upper
+    True
+"""
 from __future__ import print_function
 import logging
 import pkgutil
@@ -135,6 +153,7 @@ def apply_configs(configs):
             if cname.startswith(name):
                 dr.ENABLED[c] = comp_cfg.get("enabled", True)
                 delegate.metadata.update(comp_cfg.get("metadata", {}))
+                delegate.tags = set(comp_cfg.get("tags", delegate.tags))
                 for k, v in delegate.metadata.items():
                     if hasattr(c, k):
                         setattr(c, k, v)

--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -12,7 +12,7 @@ for gathering data in myriad ways and providing a reliable object model for it.
     >>> results = run(rpm.Installed)
     >>> rpms = results[rpm.Installed]
     >>> rpms.newest("bash")
-    0:bash-4.4.12-7.fc26
+    "0:bash-4.4.12-7.fc26"
     >>> lower <= rpms.newest("bash") < upper
     True
 """

--- a/insights/configtree/__init__.py
+++ b/insights/configtree/__init__.py
@@ -1,6 +1,4 @@
 """
-configtree
-==========
 configtree models configurations that are similar to dictionaries except that
 each option may have a list of un-named attributes, and duplicate options are
 allowed. Compound options containing children in addition to attributes also

--- a/insights/core/context.py
+++ b/insights/core/context.py
@@ -129,14 +129,15 @@ class ExecutionContext(object):
         self.timeout = timeout
         self.all_files = all_files or []
 
-    def check_output(self, cmd, timeout=None, keep_rc=False, env=os.environ):
+    def check_output(self, cmd, timeout=None, keep_rc=False, env=None):
         """ Subclasses can override to provide special
             environment setup, command prefixes, etc.
         """
         return subproc.call(cmd, timeout=timeout or self.timeout,
                 keep_rc=keep_rc, env=env)
 
-    def shell_out(self, cmd, split=True, timeout=None, keep_rc=False, env=os.environ):
+    def shell_out(self, cmd, split=True, timeout=None, keep_rc=False, env=None):
+        env = env or os.environ
         rc = None
         raw = self.check_output(cmd, timeout=timeout, keep_rc=keep_rc, env=env)
         if keep_rc:

--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -845,7 +845,7 @@ def add_observer(o, component_type=ComponentType):
     Args:
         o (func): the callback function
 
-    Keyword Arg:
+    Keyword Args:
         component_type (ComponentType): the :class:`ComponentType` to observe.
             The callback will fire any time an instance of the class or its
             subclasses is invoked.

--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -111,7 +111,7 @@ def is_enabled(component):
 
     Args:
         component (callable): The component to check. The component must
-        already be loaded.
+            already be loaded.
 
     Returns:
         True if the component is enabled. False otherwise.
@@ -162,7 +162,11 @@ def _get_component(name):
 
 
 COMPONENT_NAME_CACHE = KeyPassingDefaultDict(_get_component)
-get_component = COMPONENT_NAME_CACHE.__getitem__
+
+
+def get_component(name):
+    """ Returns the class or function specified, importing it if necessary. """
+    return COMPONENT_NAME_CACHE[name]
 
 
 @defaults(None)
@@ -875,12 +879,12 @@ def observer(component_type=ComponentType):
     return inner
 
 
-def run_order(components):
+def run_order(graph):
     """
     Returns components in an order that satisfies their dependency
     relationships.
     """
-    return toposort_flatten(components, sort=False)
+    return toposort_flatten(graph, sort=False)
 
 
 def _determine_components(components):

--- a/insights/core/filters.py
+++ b/insights/core/filters.py
@@ -6,7 +6,7 @@ If a datasource has filters defined, it will return only lines matching at
 least one of them. If a datasource has no filters, it will return all lines.
 
 Filters aren't applicable to "raw" datasources, which are created with
-``kind=RawFileProvider`` and have ``RegistryPoint``s with ``raw=True``.
+``kind=RawFileProvider`` and have ``RegistryPoint`` instances with ``raw=True``.
 
 The addition of a single filter can cause a datasource to change from returning
 all lines to returning just those that match. Therefore, any filtered

--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -198,7 +198,7 @@ class rule(dr.ComponentType):
         cluster (bool): if ``True`` will put the component into the
             ``GROUPS.cluster`` group. Defaults to ``False``. Overrides ``group``
             if ``True``.
-        content (str or dict): a jinja2 template or dictionary of jinja2
+        content (string or dict): a jinja2 template or dictionary of jinja2
             templates. The :class:`Response` subclasses rules can return are
             dictionaries. :class:`make_pass`, :class:`make_fail`, and
             :class:`make_response` all accept first a key and then a list of

--- a/insights/formats/__init__.py
+++ b/insights/formats/__init__.py
@@ -95,8 +95,11 @@ try:
     from jinja2 import Template
 
     def get_content(obj, key):
-        mod = sys.modules[obj.__module__]
-        c = getattr(mod, "CONTENT", None)
+        c = dr.get_delegate(obj).content
+        if c is None:
+            mod = sys.modules[obj.__module__]
+            c = getattr(mod, "CONTENT", None)
+
         if c:
             if isinstance(c, dict):
                 if key:

--- a/insights/plugins/always_fires.py
+++ b/insights/plugins/always_fires.py
@@ -1,7 +1,7 @@
 from insights.core.plugins import make_response, rule
 
 
-@rule()
+@rule(tags=["test"])
 def report():
     if True:
         return make_response("ALWAYS_FIRES", kernel="this is junk")

--- a/insights/util/__init__.py
+++ b/insights/util/__init__.py
@@ -29,7 +29,8 @@ def parse_bool(s, default=False):
     return TRUTH.get(s.lower(), default)
 
 
-def which(cmd, env=os.environ):
+def which(cmd, env=None):
+    env = env or os.environ
     if cmd.startswith("/"):
         if os.access(cmd, os.X_OK) and os.path.isfile(cmd):
             return cmd

--- a/sample_script.py
+++ b/sample_script.py
@@ -8,7 +8,7 @@ CONTENT = {
 }
 
 
-@rule(RedhatRelease)
+@rule(RedhatRelease, content=CONTENT)
 def report(rel):
     """Fires if the machine is running Fedora."""
 

--- a/stand_alone.py
+++ b/stand_alone.py
@@ -41,7 +41,7 @@ class HostParser(Parser):
         return msg % me
 
 
-@rule(HostParser, RedhatRelease)
+@rule(HostParser, RedhatRelease, content=CONTENT)
 def report(hp, rhr):
     if len(hp.hosts) > 1:
         return make_response("TOO_MANY_HOSTS", num=len(hp.hosts))


### PR DESCRIPTION
`tags` is an additional keyword argument you can add to any decorator like `@rule(InstalledRpms, tags=["security", "apache"])`. This is to help with various use cases that might require grouping or filtering of rule results.

Documentation updates include significant pydoc enhancements in insights.core.dr and insights.core.plugins.