### PR TITLE
Added amended_generic column to virt_what combiner

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -286,7 +286,7 @@ class InsightsConnection(object):
         sock = socket.socket()
         sock.setblocking(1)
         if self.proxies:
-            connect_str = 'CONNECT {0} HTTP/1.0\r\n'.format(hostname[0])
+            connect_str = 'CONNECT {0}:443 HTTP/1.0\r\n'.format(hostname[0])
             if self.proxy_auth:
                 connect_str += 'Proxy-Authorization: {0}\r\n'.format(self.proxy_auth)
             connect_str += '\r\n'
@@ -299,7 +299,7 @@ class InsightsConnection(object):
                 return False
             sock.send(connect_str.encode('utf-8'))
             res = sock.recv(4096)
-            if '200 Connection established' not in res:
+            if '200 connection established' not in res.lower():
                 logger.error('Failed to connect to %s. Invalid hostname.', self.base_url)
                 return False
         else:

--- a/insights/combiners/tests/test_virt_what.py
+++ b/insights/combiners/tests/test_virt_what.py
@@ -22,6 +22,12 @@ T4 = """
 virt-what: virt-what-cpuid-helper program not found in $PATH
 """.strip()
 
+# test for ovirt
+T5 = """
+ovirt
+kvm
+""".strip()
+
 DMIDECODE = '''
 # dmidecode 2.11
 SMBIOS 2.7 present.
@@ -273,6 +279,70 @@ Chassis Information
 \tContained Elements: 0
 '''
 
+DMIDECODE_OVIRT = """
+# dmidecode 3.1
+Getting SMBIOS data from sysfs.
+SMBIOS 2.8 present.
+10 structures occupying 511 bytes.
+Table at 0x000F6050.
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+\tVendor: SeaBIOS
+\tVersion: 1.11.0-2.el7
+\tRelease Date: 04/01/2014
+\tAddress: 0xE8000
+\tRuntime Size: 96 kB
+\tROM Size: 64 kB
+\tCharacteristics:
+\t\tBIOS characteristics not supported
+\t\tTargeted content distribution is supported
+BIOS Revision: 0.0
+
+Handle 0x0100, DMI type 1, 27 bytes
+System Information
+\tManufacturer: oVirt
+\tProduct Name: oVirt Node
+\tVersion: 7-5.1804.4.el7.centos
+\tSerial Number: 30393137-3436-584D-5136-323830304E46
+\tUUID: a35ae32b-ed0a-49a4-9dbb-eecf21f88aab
+\tWake-up Type: Power Switch
+\tSKU Number: Not Specified
+\tFamily: Red Hat Enterprise Linux
+"""
+
+DMIDECODE_BOGUS_OVIRT = """
+# dmidecode 3.1
+Getting SMBIOS data from sysfs.
+SMBIOS 2.8 present.
+10 structures occupying 511 bytes.
+Table at 0x000F6050.
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+\tVendor: SeaBIOS
+\tVersion: 1.11.0-2.el7
+\tRelease Date: 04/01/2014
+\tAddress: 0xE8000
+\tRuntime Size: 96 kB
+\tROM Size: 64 kB
+\tCharacteristics:
+\t\tBIOS characteristics not supported
+\t\tTargeted content distribution is supported
+\tBIOS Revision: 0.0
+
+Handle 0x0100, DMI type 1, 27 bytes
+System Information
+\tManufacturer: oVirt
+\tProduct Name: RHEV Hypervisor
+\tVersion: 7-5.1804.4.el7.centos
+\tSerial Number: 30393137-3436-584D-5136-323830304E46
+\tUUID: a35ae32b-ed0a-49a4-9dbb-eecf21f88aab
+\tWake-up Type: Power Switch
+\tSKU Number: Not Specified
+\tFamily: Red Hat Enterprise Linux
+"""
+
 DMIDECODE_FAIL = "# dmidecode 2.11\n# No SMBIOS nor DMI entry point found, sorry.\n"
 
 
@@ -331,6 +401,7 @@ def test_vw_dmidecode_3():
     assert ret.is_virtual is True
     assert ret.is_physical is False
     assert ret.generic == "vmware"
+    assert ret.amended_generic == "vmware"
 
 
 def test_vw_dmidecode_4():
@@ -340,6 +411,7 @@ def test_vw_dmidecode_4():
     assert ret.is_virtual is True
     assert ret.is_physical is False
     assert ret.generic == "kvm"
+    assert ret.amended_generic == "rhev"
 
 
 def test_vw_dmidecode_5():
@@ -348,3 +420,42 @@ def test_vw_dmidecode_5():
     assert ret.is_virtual is True
     assert ret.is_physical is False
     assert ret.generic == "kvm"
+    assert ret.amended_generic == "rhev"
+
+
+def test_vw_dmidecode_is_ovirt():
+    vw = VWP(context_wrap(T5))
+    dmi = DMIDecode(context_wrap(DMIDECODE_OVIRT))
+    ret = VirtWhat(dmi, vw)
+    assert ret.is_virtual is True
+    assert ret.is_physical is False
+    assert ret.generic == "ovirt"
+    assert ret.amended_generic == "ovirt"
+
+
+def test_vw_dmidecode_is_rhev():
+    vw = VWP(context_wrap(T5))
+    dmi = DMIDecode(context_wrap(DMIDECODE_BOGUS_OVIRT))
+    ret = VirtWhat(dmi, vw)
+    assert ret.is_virtual is True
+    assert ret.is_physical is False
+    assert ret.generic == "ovirt"
+    assert ret.amended_generic == "rhev"
+
+
+def test_dmidecode_is_ovirt():
+    dmi = DMIDecode(context_wrap(DMIDECODE_OVIRT))
+    ret = VirtWhat(dmi, None)
+    assert ret.is_virtual is True
+    assert ret.is_physical is False
+    assert ret.generic == "kvm"
+    assert ret.amended_generic == "ovirt"
+
+
+def test_dmidecode_is_rhev():
+    dmi = DMIDecode(context_wrap(DMIDECODE_BOGUS_OVIRT))
+    ret = VirtWhat(dmi, None)
+    assert ret.is_virtual is True
+    assert ret.is_physical is False
+    assert ret.generic == "kvm"
+    assert ret.amended_generic == "rhev"

--- a/insights/combiners/tests/test_virt_what.py
+++ b/insights/combiners/tests/test_virt_what.py
@@ -28,6 +28,7 @@ ovirt
 kvm
 """.strip()
 
+
 DMIDECODE = '''
 # dmidecode 2.11
 SMBIOS 2.7 present.
@@ -459,3 +460,12 @@ def test_dmidecode_is_rhev():
     assert ret.is_physical is False
     assert ret.generic == "kvm"
     assert ret.amended_generic == "rhev"
+
+
+def test_virtwhat_only():
+    vw = VWP(context_wrap(T5))
+    ret = VirtWhat(None, vw)
+    assert ret.is_virtual is True
+    assert ret.is_physical is False
+    assert ret.generic == "ovirt"
+    assert ret.amended_generic == "ovirt"

--- a/insights/combiners/virt_what.py
+++ b/insights/combiners/virt_what.py
@@ -93,7 +93,7 @@ class VirtWhat(object):
                     self.is_virtual = False
                     self.is_physical = True
 
-        sys_info = dmi.get("system_information", [{}])[0] if "system_information" in dmi.data else None
+        sys_info = dmi.get("system_information", [{}])[0] if dmi else None
 
         self.amended_generic = (RHEV if sys_info['product_name'].lower() == 'rhev hypervisor' else
                                 OVIRT if sys_info['product_name'].lower() == 'ovirt node' else

--- a/insights/combiners/virt_what.py
+++ b/insights/combiners/virt_what.py
@@ -14,6 +14,8 @@ Examples:
     False
     >>> vw.generic
     'kvm'
+    >>> vw.amended_generic
+    'rhev'
     >>> 'aws' in vw
     False
 """
@@ -39,6 +41,10 @@ SPECIFIC_MAP = {
 }
 
 
+OVIRT = 'ovirt'
+RHEV = 'rhev'
+
+
 @combiner([DMIDecode, VW])
 class VirtWhat(object):
     """
@@ -52,6 +58,9 @@ class VirtWhat(object):
         is_physical (bool): It's running in a physical machine?
         generic (str): The type of the virtual machine. 'baremetal' if physical machine.
         specifics (list): List of the specific information.
+        amended_generic (str):The type of the virtual machine. 'baremetal' if physical machine.
+            Added to address an issue with virt_what/dmidecode when identifying 'ovirt' vs 'rhev'.
+            Will match the generic attribute in all other cases.
     """
 
     def __init__(self, dmi, vw):
@@ -83,6 +92,12 @@ class VirtWhat(object):
                     self.generic = BAREMETAL
                     self.is_virtual = False
                     self.is_physical = True
+
+        sys_info = dmi.get("system_information", [{}])[0] if "system_information" in dmi.data else None
+
+        self.amended_generic = (RHEV if sys_info['product_name'].lower() == 'rhev hypervisor' else
+                                OVIRT if sys_info['product_name'].lower() == 'ovirt node' else
+                                 self.generic) if sys_info else self.generic
 
     def __contains__(self, name):
         """bool: Is this ``name`` found in the specific list?"""


### PR DESCRIPTION
This PR address an issue where virt_what sometimes returns `ovirt` instead of `rhev` for it's virtualization
property.
The issue has been address in BZ 1631361 - https://bugzilla.redhat.com/show_bug.cgi?id=1631361 
Even though this issue has been corrected in a bug fix it seems as though it has not been consumed by
all users so we have implemented a remedy by adding a new column that will contain the correct virtualization value. 