### PR TITLE
Enhance the deprecated description in documentation.

### DIFF
--- a/insights/combiners/httpd_V.py
+++ b/insights/combiners/httpd_V.py
@@ -4,10 +4,6 @@ Combiner for `httpd -V` command
 
 Combiner to get the valid parsed result of command `httpd -V`.
 
-.. warning::
-    Deprecated combiner in the 3.0 framework, please use the
-    :class:`insights.parsers.httpd_V.HttpdV` parser instead.
-
 Examples:
 
     >>> HTTPDV2 = '''
@@ -57,6 +53,10 @@ from insights.util import deprecated
 @combiner(requires=[redhat_release, PsAuxcww, [HV, HEV, HWV]])
 class HttpdV(LegacyItemAccess):
     """
+    .. warning::
+        Deprecated combiner in the 3.0 framework, please use the
+        :class:`insights.parsers.httpd_V.HttpdV` parser instead.
+
     A combiner to get the valid :class:`insights.parsers.httpd_V.HttpdV` on a
     rhel host.
 

--- a/insights/combiners/httpd_conf.py
+++ b/insights/combiners/httpd_conf.py
@@ -29,8 +29,9 @@ from insights.util import deprecated
 @combiner(HttpdConf)
 class HttpdConfAll(object):
     """
-    .. note::
-        This combiner class is deprecated, please use :py:class:`HttpdConfTree` instead.
+    .. warning::
+        This combiner class is deprecated, please use
+        :py:class:`insights.combiners.httpd_conf.HttpdConfTree` instead.
 
     A combiner for parsing all httpd configurations. It parses all sources and makes a composition
     to store actual loaded values of the settings as well as information about parsed configuration
@@ -60,7 +61,7 @@ class HttpdConfAll(object):
     ConfigData = namedtuple('ConfigData', ['file_name', 'file_path', 'full_data_dict'])
 
     def __init__(self, httpd_conf):
-        deprecated(HttpdConfAll, "Import HttpdConfTree instead.")
+        deprecated(HttpdConfAll, "Import HttpdConfTree from 'insights.combiners.httpd_conf' instead.")
 
         self.data = {}
         self.config_data = []

--- a/insights/parsers/engine_log.py
+++ b/insights/parsers/engine_log.py
@@ -32,6 +32,10 @@ from insights.specs import Specs
 @parser(Specs.engine_log)
 class EngineLog(LogFileOutput):
     """
+    .. warning::
+        This parser is deprecated, please use
+        :py:class:`insights.parsers.ovirt_engine_log.EngineLog` instead.
+
     Provide access to ovirt engine logs using the LogFileOutput parser class.
     """
     def __init__(self, *args, **kwargs):

--- a/insights/parsers/ipcs_sem.py
+++ b/insights/parsers/ipcs_sem.py
@@ -21,6 +21,10 @@ from insights.specs import Specs
 @parser(Specs.ipcs_s)
 class IpcsS(CommandParser):
     """
+    .. warning::
+        This parser is deprecated, please use
+        :py:class:`insights.parsers.ipcs.IpcsS` instead.
+
     Class for parsing the output of `ipcs -s` command.
 
     Typical output of the command is::
@@ -92,6 +96,10 @@ class IpcsS(CommandParser):
 @parser(Specs.ipcs_s_i)
 class IpcsSI(CommandParser):
     """
+    .. warning::
+        This parser is deprecated, please use
+        :py:class:`insights.parsers.ipcs.IpcsSI` instead.
+
     Class for parsing the output of `ipcs -s -i ##` command. ``##`` will be
     replaced with specific semid
 

--- a/insights/parsers/nfs_exports.py
+++ b/insights/parsers/nfs_exports.py
@@ -141,13 +141,14 @@ class NFSExportsBase(Parser):
     @staticmethod
     def reconstitute(path, d):
         """
+        .. warning::
+            This function is deprecated.  Please use the `raw_lines` dictionary
+            property of the parser instance instead, as this contains the actual
+            lines from the exports file.
+
         'Reconstitute' a line from its parsed value.  The original lines are
         not used for this.  The hosts in d are listed in alphabetical order,
         and the options are listed in the order originally given.
-
-        This function is deprecated.  Please use the `raw_lines` dictionary
-        property of the parser instance instead, as this contains the actual
-        lines from the exports file.
 
         Arguments:
             path (str): The exported path

--- a/insights/parsers/nginx_conf.py
+++ b/insights/parsers/nginx_conf.py
@@ -118,6 +118,10 @@ from insights.util import deprecated
 @parser(Specs.nginx_conf)
 class NginxConf(Parser, LegacyItemAccess):
     """
+    .. warning::
+        This parser is deprecated, please import
+        :py:class:`insights.combiners.nginx_conf.NginxConfTree` instead.
+
     Class for ``nginx.conf`` and ``conf.d`` configuration files.
 
     Gerenally nginx.conf is writed as key-value format. It has a mail section and several sections,

--- a/insights/parsers/systemd/config.py
+++ b/insights/parsers/systemd/config.py
@@ -151,7 +151,13 @@ class SystemdLogindConf(SystemdConf):
 
 
 class MultiOrderedDict(dict):
-    """Class for condition that duplicate keys exist"""
+    """
+    .. warning::
+        This class is deprecated.
+
+    Class for condition that duplicate keys exist
+    """
+
     def __init__(self, *args, **kwargs):
         deprecated(MultiOrderedDict, "This class is deprecated")
         super(MultiOrderedDict, self).__init__(*args, **kwargs)
@@ -165,10 +171,10 @@ class MultiOrderedDict(dict):
 
 def parse_systemd_ini(content):
     """
-    Function to parse config format file, the result format is dictionary.
-
-    .. note::
+    .. warning::
         This function is deprecated, please use :py:class:`SystemdConf` instead.
+
+    Function to parse config format file, the result format is dictionary.
     """
 
     deprecated(parse_systemd_ini, "Use the `SystemdConf` class instead.")


### PR DESCRIPTION
- use `warning` instead of `note`
- move/add `warning` into class's docstring
- correct the reference link in the warning