### PR TITLE
Core 3 collection with whitelisted components and serde types. No client integration.

### DIFF
--- a/examples/collection/manifest.yaml
+++ b/examples/collection/manifest.yaml
@@ -19,6 +19,8 @@ blacklist:
     keywords: []
 
 # packages and modules to load
+# loading the parsers ensures the default filters get added.
+# loading combiners ensures hostname is available for persistence below.
 packages:
     - insights.specs.default
     - insights.parsers
@@ -34,15 +36,6 @@ persist:
 
     - name: insights.combiners.hostname
       enabled: true
-
-# If a file datasource hasn't already been pulled into memory, its contents are
-# serialized with other info about the datasource if they're smaller than this
-# value. Otherwise, they're copied into a raw_data directory, and a pointer to
-# the file is put into the datasource's record. Set to 0 to put everything into
-# json regardless of file size. Set to a negative number to put everything into
-# a raw data directory. Defaults to 0 if not specified. Below is 2**19.
-# max_serializable_file_size: 524288
-max_serializable_file_size: -1
 
 # configuration of loaded components. names are prefixes, so any component with
 # a fully qualified name that starts with a key will get the associated

--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -22,6 +22,7 @@ import pkgutil
 import os
 import sys
 import yaml
+
 from .core import Scannable, LogFileOutput, Parser, IniConfigFile  # noqa: F401
 from .core import FileListing, LegacyItemAccess, SysconfigOptions  # noqa: F401
 from .core import YAMLParser, JSONParser, XMLParser, CommandParser  # noqa: F401
@@ -29,7 +30,7 @@ from .core import AttributeDict  # noqa: F401
 from .core import Syslog  # noqa: F401
 from .core.archives import COMPRESSION_TYPES, extract  # noqa: F401
 from .core import dr  # noqa: F401
-from .core.context import ClusterArchiveContext, HostContext, HostArchiveContext  # noqa: F401
+from .core.context import ClusterArchiveContext, HostContext, HostArchiveContext, SerializedArchiveContext  # noqa: F401
 from .core.dr import SkipComponent  # noqa: F401
 from .core.hydration import create_context
 from .core.plugins import combiner, fact, metadata, parser, rule  # noqa: F401
@@ -37,6 +38,7 @@ from .core.plugins import datasource, condition, incident  # noqa: F401
 from .core.plugins import make_response, make_metadata, make_fingerprint  # noqa: F401
 from .core.plugins import make_pass, make_fail  # noqa: F401
 from .core.filters import add_filter, apply_filters, get_filters  # noqa: F401
+from .core.serde import Hydration
 from .formats import get_formatter
 from .parsers import get_active_lines  # noqa: F401
 from .util import defaults  # noqa: F401
@@ -84,6 +86,9 @@ def process_dir(broker, root, graph, context, inventory=None):
         return process_cluster(archives, broker=broker, inventory=inventory)
 
     broker[ctx.__class__] = ctx
+    if isinstance(ctx, SerializedArchiveContext):
+        h = Hydration(ctx.root)
+        broker = h.hydrate(broker=broker)
     broker = dr.run(graph, broker=broker)
     return broker
 

--- a/insights/collect.py
+++ b/insights/collect.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python
+"""
+This module runs insights and serializes the results into a directory. It is
+configurable with a yaml manifest that specifies what to load, what to run,
+and what to serialize. If a manifest isn't provided, a default one is used that
+runs all datasources in ``insights.specs.Specs`` and
+``insights.specs.default.DefaultSpecs`` and saves all datasources in
+``insights.specs.Specs``.
+"""
+from __future__ import print_function
+import argparse
+import logging
+import os
+import tempfile
+import yaml
+
+from collections import defaultdict
+from datetime import datetime
+
+from insights import apply_configs, dr
+from insights.core import blacklist
+from insights.core.serde import Hydration
+from insights.util import fs
+from insights.util.subproc import call
+
+SAFE_ENV = {
+    "PATH": os.path.pathsep.join(["/bin", "/usr/bin", "/sbin", "/usr/sbin"])
+}
+
+log = logging.getLogger(__name__)
+
+default_manifest = """
+---
+# version is for the format of this file, not its contents.
+version: 0
+
+context:
+    class: insights.core.context.HostContext
+    args:
+        timeout: 10 # timeout in seconds for commands. Doesn't apply to files.
+
+# disable everything by default
+# defaults to false if not specified.
+default_component_enabled: false
+
+# commands and files to ignore
+blacklist:
+    files: []
+    commands: []
+    patterns: []
+    keywords: []
+
+# packages and modules to load
+packages:
+    - insights.specs.default
+
+# Can be a list of dictionaries with name/enabled fields or a list of strings
+# where the string is the name and enabled is assumed to be true. Matching is
+# by prefix, and later entries override previous ones. Persistence for a
+# component is disabled by default.
+persist:
+    - name: insights.specs.Specs
+      enabled: true
+
+# configuration of loaded components. names are prefixes, so any component with
+# a fully qualified name that starts with a key will get the associated
+# configuration applied. Can specify timeout, which will apply to command
+# datasources. Can specify metadata, which must be a dictionary and will be
+# merged with the components' default metadata.
+configs:
+    - name: insights.specs.Specs
+      enabled: true
+
+    - name: insights.specs.default.DefaultSpecs
+      enabled: true
+
+    - name: insights.parsers.hostname
+      enabled: true
+
+    - name: insights.parsers.facter
+      enabled: true
+
+    - name: insights.parsers.systemid
+      enabled: true
+
+    - name: insights.combiners.hostname
+      enabled: true
+
+# needed because some specs aren't given names before they're used in DefaultSpecs
+    - name: insights.core.spec_factory
+      enabled: true
+""".strip()
+
+
+def load_manifest(data):
+    """ Helper for loading a manifest yaml doc. """
+    if isinstance(data, dict):
+        return data
+    doc = yaml.safe_load(data)
+    if not isinstance(doc, dict):
+        raise Exception("Manifest didn't result in dict.")
+    return doc
+
+
+def apply_default_enabled(default_enabled):
+    """
+    Configures dr and already loaded components with a default enabled
+    value.
+    """
+    for k in dr.ENABLED:
+        dr.ENABLED[k] = default_enabled
+
+    enabled = defaultdict(lambda: default_enabled)
+    enabled.update(dr.ENABLED)
+    dr.ENABLED = enabled
+
+
+def load_packages(pkgs):
+    for p in pkgs:
+        dr.load_components(p, continue_on_error=False)
+
+
+def apply_blacklist(cfg):
+    for b in cfg.get("files", []):
+        blacklist.add_file(b)
+
+    for b in cfg.get("commands", []):
+        blacklist.add_command(b)
+
+    for b in cfg.get("patterns", []):
+        blacklist.add_pattern(b)
+
+    for b in cfg.get("keywords", []):
+        blacklist.add_keyword(b)
+
+
+def create_context(ctx):
+    """
+    Loads and constructs the specified context with the specified arguments.
+    If a '.' isn't in the class name, the 'insights.core.context' package is
+    assumed.
+    """
+    ctx_cls_name = ctx.get("class", "insights.core.context.HostContext")
+    if "." not in ctx_cls_name:
+        ctx_cls_name = "insights.core.context." + ctx_cls_name
+    ctx_cls = dr.get_component(ctx_cls_name)
+    ctx_args = ctx.get("args", {})
+    return ctx_cls(**ctx_args)
+
+
+def get_to_persist(persisters):
+    """
+    Given a specification of what to persist, generates the corresponding set
+    of components.
+    """
+    def specs():
+        for p in persisters:
+            if isinstance(p, dict):
+                yield p["name"], p.get("enabled", True)
+            else:
+                yield p, True
+
+    components = sorted(dr.DELEGATES, key=dr.get_name)
+    names = dict((c, dr.get_name(c)) for c in components)
+
+    results = set()
+    for p, e in specs():
+        for c in components:
+            if names[c].startswith(p):
+                if e:
+                    results.add(c)
+                elif c in results:
+                    results.remove(c)
+    return results
+
+
+def create_archive(path, remove_path=True):
+    """
+    Creates a tar.gz of the path using the path basename + "tar.gz"
+    The resulting file is in the parent directory of the original path, and
+    the original path is removed.
+    """
+    root_path = os.path.dirname(path)
+    relative_path = os.path.basename(path)
+    archive_path = path + ".tar.gz"
+
+    cmd = [["tar", "-C", root_path, "-czf", archive_path, relative_path]]
+    call(cmd, env=SAFE_ENV)
+    if remove_path:
+        fs.remove(path)
+    return archive_path
+
+
+def collect(manifest=default_manifest, tmp_path=None, compress=False):
+    """
+    This is the collection entry point. It accepts a manifest, a temporary
+    directory in which to store output, and a boolean for optional compression.
+
+    Args:
+        manifest (str or dict): json document or dictionary containing the
+            collection manifest. See default_manifest for an example.
+        tmp_path (str): The temporary directory that will be used to create a
+            working directory for storing component output as well as the final
+            tar.gz if one is generated.
+        compress (boolean): True to create a tar.gz and remove the original
+            workspace containing output. False to leave the workspace without
+            creating a tar.gz
+
+    Returns:
+        The full path to the created tar.gz or workspace.
+    """
+
+    manifest = load_manifest(manifest)
+
+    apply_default_enabled(manifest.get("default_component_enabled", False))
+    load_packages(manifest.get("packages", []))
+    apply_blacklist(manifest.get("blacklist", {}))
+    apply_configs(manifest.get("configs", []))
+    to_persist = get_to_persist(manifest.get("persist", set()))
+
+    hostname = call("hostname -f", env=SAFE_ENV).strip()
+    suffix = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    relative_path = "insights-%s-%s" % (hostname, suffix)
+    tmp_path = tmp_path or tempfile.gettempdir()
+    output_path = os.path.join(tmp_path, relative_path)
+    fs.ensure_path(output_path)
+    fs.touch(os.path.join(output_path, "insights_archive.txt"))
+
+    broker = dr.Broker()
+    ctx = create_context(manifest.get("context", {}))
+    broker[ctx.__class__] = ctx
+
+    h = Hydration(output_path)
+    broker.add_observer(h.make_persister(to_persist))
+    list(dr.run_incremental(broker=broker))
+
+    if compress:
+        return create_archive(output_path)
+    return output_path
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("-m", "--manifest", help="Manifest yaml.")
+    p.add_argument("-o", "--out_path", help="Path to write output data.")
+    p.add_argument("-q", "--quiet", help="Error output only.", action="store_true")
+    p.add_argument("-v", "--verbose", help="Verbose output.", action="store_true")
+    p.add_argument("-d", "--debug", help="Debug output.", action="store_true")
+    args = p.parse_args()
+
+    level = logging.WARNING
+    if args.verbose:
+        level = logging.INFO
+    if args.debug:
+        level = logging.DEBUG
+    if args.quiet:
+        level = logging.ERROR
+
+    logging.basicConfig(level=level)
+
+    if args.manifest:
+        with open(args.manifest) as f:
+            manifest = f.read()
+    else:
+        manifest = default_manifest
+
+    out_path = args.out_path or tempfile.gettempdir()
+    archive = collect(manifest, out_path, compress=True)
+    print(archive)
+
+
+if __name__ == "__main__":
+    main()

--- a/insights/combiners/hostname.py
+++ b/insights/combiners/hostname.py
@@ -31,13 +31,13 @@ Hostname = namedtuple("Hostname", field_names=["fqdn", "hostname", "domain"])
 
 
 @serializer(Hostname)
-def serialize(obj):
+def serialize(obj, root=None):
     return {"fqdn": obj.fqdn, "hostname": obj.hostname, "domain": obj.domain}
 
 
 @deserializer(Hostname)
-def deserialize(_type, data):
-    return _type(**data)
+def deserialize(_type, data, root=None):
+    return Hostname(**data)
 
 
 @combiner([hname, facter, systemid])

--- a/insights/combiners/redhat_release.py
+++ b/insights/combiners/redhat_release.py
@@ -24,19 +24,19 @@ from collections import namedtuple
 from insights.core.plugins import combiner
 from insights.parsers.redhat_release import RedhatRelease as rht_release
 from insights.parsers.uname import Uname
-from insights.core.serde import deserializer, serializer
+from insights.core.serde import serializer, deserializer
 
 Release = namedtuple("Release", field_names=["major", "minor"])
 """namedtuple: Type for storing the release information."""
 
 
 @serializer(Release)
-def serialize(obj):
+def serialize(obj, root=None):
     return {"major": obj.major, "minor": obj.minor}
 
 
 @deserializer(Release)
-def deserialize(_type, obj):
+def deserialize(_type, obj, root=None):
     return Release(**obj)
 
 

--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -148,7 +148,7 @@ def _get_from_class(name):
     return getattr(cls, n)
 
 
-def _get_component(name):
+def _import_component(name):
     """
     Returns a class, function, or class method specified by the fully qualified
     name.
@@ -161,12 +161,29 @@ def _get_component(name):
     log.debug("Couldn't load %s" % name)
 
 
-COMPONENT_NAME_CACHE = KeyPassingDefaultDict(_get_component)
+COMPONENT_IMPORT_CACHE = KeyPassingDefaultDict(_import_component)
 
 
 def get_component(name):
     """ Returns the class or function specified, importing it if necessary. """
-    return COMPONENT_NAME_CACHE[name]
+    return COMPONENT_IMPORT_CACHE[name]
+
+
+def _find_component(name):
+    for d in DELEGATES:
+        if get_name(d) == name:
+            return d
+
+
+COMPONENTS_BY_NAME = KeyPassingDefaultDict(_find_component)
+
+
+def get_component_by_name(name):
+    """
+    Look up a component by its fully qualified name. Return None if the
+    component hasn't been loaded.
+    """
+    return COMPONENTS_BY_NAME[name]
 
 
 @defaults(None)

--- a/insights/core/hydration.py
+++ b/insights/core/hydration.py
@@ -2,8 +2,11 @@ import logging
 import os
 
 from insights.core import archives
-from insights.core.archives import COMPRESSION_TYPES
-from insights.core.context import ClusterArchiveContext, JDRContext, HostArchiveContext, SosArchiveContext
+from insights.core.context import (ClusterArchiveContext,
+                                   JDRContext,
+                                   HostArchiveContext,
+                                   SosArchiveContext,
+                                   SerializedArchiveContext)
 
 log = logging.getLogger(__name__)
 
@@ -17,11 +20,13 @@ def get_all_files(path):
 
 
 def determine_context(common_path, files):
-    if any(f.endswith(COMPRESSION_TYPES) for f in os.listdir(common_path)):
+    if any(f.endswith(archives.COMPRESSION_TYPES) for f in os.listdir(common_path)):
         return ClusterArchiveContext
 
     for f in files:
-        if "insights_commands" in f:
+        if "insights_archive.txt" in f:
+            return SerializedArchiveContext
+        elif "insights_commands" in f:
             return HostArchiveContext
         elif "sos_commands" in f:
             return SosArchiveContext

--- a/insights/core/serde.py
+++ b/insights/core/serde.py
@@ -1,8 +1,19 @@
+"""
+The serde module provides decorators that allow developers to register
+serializer and deserializer functions for types. It also provides a
+:py:class`Hydration` class that uses registered serde functions to save and
+load objects from the file system. The Hydration class includes a
+:py:func`Hydration.make_persister` method that returns a function appropriate
+to register as an observer on a :py:class:`Broker`.
+"""
 import json as ser
 import logging
 import os
+import time
+import traceback
+from glob import glob
 
-from insights.core import dr, plugins
+from insights.core import dr
 from insights.util import fs
 
 log = logging.getLogger(__name__)
@@ -12,153 +23,199 @@ DESERIALIZERS = {}
 
 
 def serializer(_type):
-    """ Decorator for serializers."""
+    """
+    Decorator for serializers.
+
+    A serializer should accept two parameters: An object and a path which is
+    a directory on the filesystem where supplementary data can be stored. This
+    is most often useful for datasources. It should return a dictionary version
+    of the original object that contains only elements that can be serialized
+    to json.
+    """
 
     def inner(func):
-        if _type in SERIALIZERS:
+        name = dr.get_name(_type)
+        if name in SERIALIZERS:
             msg = "%s already has a serializer registered: %s"
-            raise Exception(msg % (dr.get_name(_type), dr.get_name(SERIALIZERS[_type])))
-        SERIALIZERS[_type] = func
+            raise Exception(msg % (name, dr.get_name(SERIALIZERS[name])))
+        SERIALIZERS[name] = func
         return func
     return inner
 
 
 def deserializer(_type):
-    """ Decorator for deserializers."""
+    """
+    Decorator for deserializers.
+
+    A deserializer should accept three parameters: A type, a dictionary, and a
+    path that may contain supplementary data stored by its paired serializer.
+    If the serializer stores supplementary data, the relative path to it should
+    be somewhere in the dict of the second parameter.
+    """
 
     def inner(func):
-        if _type in DESERIALIZERS:
+        name = dr.get_name(_type)
+        if name in DESERIALIZERS:
             msg = "%s already has a deserializer registered: %s"
-            raise Exception(msg % (dr.get_name(_type), dr.get_name(DESERIALIZERS[_type])))
-        DESERIALIZERS[_type] = func
+            raise Exception(msg % (dr.get_name(name), dr.get_name(DESERIALIZERS[name])))
+        DESERIALIZERS[name] = (_type, func)
         return func
     return inner
 
 
-def get_serializer_type(obj):
-    _type = type(obj)
-    for o in _type.mro():
-        if o in SERIALIZERS:
-            return o
-
-
-def get_deserializer_type(obj):
-    for o in obj.mro():
-        if o in DESERIALIZERS:
-            return o
-
-
 def get_serializer(obj):
-
     """ Get a registered serializer for the given object.
 
         This function walks the mro of obj looking for serializers.
         Returns None if no valid serializer is found.
     """
-    _type = get_serializer_type(obj)
-    return SERIALIZERS.get(_type)
+    return SERIALIZERS.get(dr.get_name(type(obj)))
 
 
 def get_deserializer(obj):
     """ Returns a deserializer based on the fully qualified name string."""
-    _type = get_deserializer_type(obj)
-    return DESERIALIZERS.get(_type)
+    return DESERIALIZERS.get(dr.get_name(type(obj)))
 
 
-def serialize(obj):
-    the_ser = get_serializer(obj)
-
-    if the_ser:
-        def to_dict(x):
-            return {"type": dr.get_name(type(obj)), "object": the_ser(x)}
-    else:
-        def to_dict(x):
-            return {"type": None, "object": x}
-
-    return to_dict(obj)
+def serialize(obj, root=None):
+    to_dict = get_serializer(obj)
+    return {
+        "type": dr.get_name(type(obj)),
+        "object": to_dict(obj, root=root),
+    }
 
 
-def deserialize(data):
-    if not data.get("type"):
-        return data["object"]
-
-    _type = dr.get_component(data["type"])
-    if not _type:
+def deserialize(data, root=None):
+    try:
+        (_type, from_dict) = DESERIALIZERS.get(data["type"])
+        return from_dict(_type, data["object"], root=root)
+    except Exception:
         raise Exception("Unrecognized type: %s" % data["type"])
 
-    to_obj = get_deserializer(_type)
-    if not to_obj:
-        raise Exception("No deserializer for type: %s" % data["type"])
 
-    return to_obj(_type, data["object"])
-
-
-def marshal(v):
+def marshal(v, root=None):
     if v is None:
-        return None
+        return
     if isinstance(v, list):
-        return [serialize(t) for t in v]
-    return serialize(v)
+        return [serialize(t, root=root) for t in v]
+    return serialize(v, root=root)
 
 
-def unmarshal(data):
+def unmarshal(data, root=None):
     if data is None:
-        return None
+        return
     if isinstance(data, list):
-        return [deserialize(d) for d in data]
-    return deserialize(data)
+        return [deserialize(d, root=root) for d in data]
+    return deserialize(data, root=root)
 
 
-def persister(output_dir, ignore_hidden=True):
-    def observer(c, broker):
-        if ignore_hidden and dr.is_hidden(c):
-            return
+class Hydration(object):
+    """
+    The Hydration class is responsible for saving and loading insights
+    components. It puts metadata about a component's evaluation in a metadata
+    file for the component and allows the serializer for a component to put raw
+    data beneath a working directory.
+    """
+    def __init__(self, root=None, meta_data="meta_data", data="data"):
+        self.root = root
+        self.meta_data = os.path.join(root, meta_data) if root else None
+        self.data = os.path.join(root, data) if root else None
+        self.ser_name = dr.get_base_module_name(ser)
+        self.created = False
 
-        if c not in broker and c not in broker.exceptions:
-            return
+    def _hydrate_one(self, doc):
+        """ Returns (component, results, errors, duration) """
+        name = doc["name"]
 
-        ser_name = dr.get_base_module_name(ser)
-        name = dr.get_name(c)
-        c_type = dr.get_component_type(c)
-        doc = {}
-        doc["name"] = name
-        doc["dr_type"] = dr.get_name(c_type) if c_type else None
-        doc["is_rule"] = plugins.is_rule(c)
-        doc["time"] = broker.exec_times.get(c)
-        doc["results"] = marshal(broker.get(c))
-        doc["errors"] = marshal(broker.exceptions.get(c))
-        path = os.path.join(output_dir, name + "." + ser_name)
+        key = dr.get_component_by_name(name)
+        if key is None:
+            raise ValueError("{} is not a loaded component.".format(name))
+        exec_time = doc["exec_time"]
+        ser_time = doc["ser_time"]
+        results = unmarshal(doc["results"], root=self.data)
+        return (key, results, exec_time, ser_time)
+
+    def hydrate(self, broker=None):
+        """
+        Loads a Broker from a previously saved one. A Broker is created if one
+        isn't provided.
+        """
+        broker = broker or dr.Broker()
+        for path in glob(os.path.join(self.meta_data, "*")):
+            try:
+                with open(path) as f:
+                    doc = ser.load(f)
+                    res = self._hydrate_one(doc)
+                    comp, results, exec_time, ser_time = res
+                    if results:
+                        broker[comp] = results
+                        broker.exec_times[comp] = exec_time + ser_time
+            except Exception as ex:
+                log.warning(ex)
+        return broker
+
+    def dehydrate(self, comp, broker):
+        """
+        Saves a component in the given broker to the file system.
+        """
+        if not self.meta_data:
+            raise Exception("Hydration meta_path not set. Can't dehydrate.")
+
+        if not self.created:
+            fs.ensure_path(self.meta_data, mode=0o770)
+            if self.data:
+                fs.ensure_path(self.data, mode=0o770)
+            self.created = True
+
+        c = comp
+        doc = None
         try:
-            with open(path, "wb") as f:
-                ser.dump(doc, f)
-        except Exception as boom:
-            log.error("Could not serialize %s to %s: %s" % (name, ser_name, boom))
-            fs.remove(path)
+            name = dr.get_name(c)
+            value = broker.get(c)
+            errors = [t for e in broker.exceptions.get(c, [])
+                        for t in broker.tracebacks[e]]
+            doc = {
+                "name": name,
+                "exec_time": broker.exec_times.get(c),
+                "errors": errors
+            }
 
-    return observer
+            try:
+                start = time.time()
+                doc["results"] = marshal(value, root=self.data)
+            except Exception:
+                errors.append(traceback.format_exc())
+                doc["results"] = None
+            finally:
+                doc["ser_time"] = time.time() - start
+        except Exception as ex:
+            log.exception(ex)
+        else:
+            if doc is not None and (doc["results"] or doc["errors"]):
+                try:
+                    path = os.path.join(self.meta_data, name + "." + self.ser_name)
+                    with open(path, "w") as f:
+                        ser.dump(doc, f)
+                except Exception as boom:
+                    log.error("Could not serialize %s to %s: %r" % (name, self.ser_name, boom))
+                    if path:
+                        fs.remove(path)
 
+    def make_persister(self, to_persist):
+        """
+        Returns a function that hydrates components as they are evaluated. The
+        function should be registered as an observer on a Broker just before
+        execution.
 
-def hydrate(payload, broker=None):
-    broker = broker or dr.Broker()
-    name = payload["name"]
-    key = dr.get_component(name) or name
+        Args:
+            to_persist (set): Set of components to persist. Skip everything
+                else.
+        """
 
-    results = unmarshal(payload["results"])
-    if results:
-        broker[key] = results
+        if not self.meta_data:
+            raise Exception("Root not set. Can't create persister.")
 
-    errors = unmarshal(payload["errors"])
-    if errors:
-        broker.exceptions[key] = errors
-
-    return broker
-
-
-@serializer(BaseException)
-def serialize_exception(ex):
-    return ex.args
-
-
-@deserializer(BaseException)
-def deserialize_exception(_type, data):
-    return _type(*data)
+        def persister(c, broker):
+            if c in to_persist:
+                self.dehydrate(c, broker)
+        return persister

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -567,7 +567,7 @@ class DefaultSpecs(Specs):
     rhsm_log = simple_file("/var/log/rhsm/rhsm.log")
     root_crontab = simple_command("/usr/bin/crontab -l -u root")
     route = simple_command("/sbin/route -n")
-    rpm_V_packages = simple_command("/usr/bin/rpm -V coreutils procps procps-ng shadow-utils passwd sudo")
+    rpm_V_packages = simple_command("/usr/bin/rpm -V coreutils procps procps-ng shadow-utils passwd sudo", keep_rc=True)
     rsyslog_conf = simple_file("/etc/rsyslog.conf")
     samba = simple_file("/etc/samba/smb.conf")
     saphostctl_listinstances = simple_command("/usr/sap/hostctrl/exe/saphostctrl -function ListInstances")

--- a/insights/tests/test_query.py
+++ b/insights/tests/test_query.py
@@ -1,0 +1,24 @@
+""" Test the query tool. """
+import inspect
+
+from insights import dr
+from insights.tests import InputData
+from insights.tools.query import load_obj, get_source, get_pydoc
+
+
+def test_load_obj():
+    assert load_obj("insights.dr") is dr
+    assert load_obj("insights.tests.InputData") is InputData
+    assert load_obj("foo.bar") is None
+
+
+def test_get_source():
+    assert get_source("insights.dr") == inspect.getsource(dr)
+    assert get_source("insights.tests.InputData") == inspect.getsource(InputData)
+    assert get_source("foo.bar") is None
+
+
+def test_get_pydoc():
+    assert get_pydoc("insights.dr") is not None
+    assert get_pydoc("insights.tests.InputData") is not None
+    assert get_pydoc("foo.bar") is None

--- a/insights/tests/test_serde.py
+++ b/insights/tests/test_serde.py
@@ -1,0 +1,127 @@
+import os
+
+from tempfile import mkdtemp
+from insights import dr
+from insights.core.plugins import component
+from insights.core.serde import (serializer,
+                                 deserializer,
+                                 Hydration,
+                                 marshal,
+                                 unmarshal)
+from insights.util import fs
+
+
+class Foo(object):
+    def __init__(self):
+        self.a = 1
+        self.b = 2
+
+
+@component()
+def thing():
+    return Foo()
+
+
+@serializer(Foo)
+def serialize_foo(obj, root=None):
+    return {"a": obj.a, "b": obj.b}
+
+
+@deserializer(Foo)
+def deserialize_foo(_type, data, root=None):
+    foo = _type.__new__(_type)
+    foo.a = data.get("a")
+    foo.b = data.get("b")
+    return foo
+
+
+def test_marshal():
+    foo = Foo()
+    data = marshal(foo)
+    assert data is not None
+    d = data["object"]
+    assert d["a"] == 1
+    assert d["b"] == 2
+
+
+def test_unmarshal():
+    d = {
+        "type": "insights.tests.test_serde.Foo",
+        "object": {"a": 1, "b": 2}
+    }
+    foo = unmarshal(d)
+    assert foo is not None
+    assert foo.a == 1
+    assert foo.b == 2
+
+
+def test_hydrate_one():
+    raw = {
+        "name": dr.get_name(thing),
+        "exec_time": 0.25,
+        "ser_time": 0.05,
+        "results": {
+            "type": "insights.tests.test_serde.Foo",
+            "object": {"a": 1, "b": 2}
+        }
+    }
+
+    h = Hydration()
+    key, result, exec_time, ser_time = h._hydrate_one(raw)
+    assert key is thing
+    assert isinstance(result, Foo)
+    assert exec_time == 0.25
+    assert ser_time == 0.05
+
+
+def test_hydrate_one_multiple_results():
+    raw = {
+        "name": dr.get_name(thing),
+        "exec_time": 0.5,
+        "ser_time": 0.1,
+        "results": [
+            {
+                "type": "insights.tests.test_serde.Foo",
+                "object": {"a": 1, "b": 2}
+            },
+            {
+                "type": "insights.tests.test_serde.Foo",
+                "object": {"a": 3, "b": 4}
+            },
+        ]
+    }
+
+    h = Hydration()
+    key, result, exec_time, ser_time = h._hydrate_one(raw)
+    assert key is thing
+    assert len(result) == 2
+    assert exec_time == 0.5
+    assert ser_time == 0.1
+    assert result[0].a == 1
+    assert result[0].b == 2
+    assert result[1].a == 3
+    assert result[1].b == 4
+
+
+def test_round_trip():
+    tmp_path = mkdtemp()
+    try:
+        h = Hydration(tmp_path)
+
+        broker = dr.Broker()
+        broker[thing] = Foo()
+        broker.exec_times[thing] = 0.5
+        h.dehydrate(thing, broker)
+        fn = ".".join([dr.get_name(thing), h.ser_name])
+        assert os.path.exists(os.path.join(h.meta_data, fn))
+
+        broker = h.hydrate()
+        assert thing in broker
+        assert broker.exec_times[thing] >= 0.5
+        foo = broker[thing]
+        assert foo.a == 1
+        assert foo.b == 2
+    finally:
+        pass
+        if os.path.exists(tmp_path):
+            fs.remove(tmp_path)

--- a/insights/tests/test_spec_serialization.py
+++ b/insights/tests/test_spec_serialization.py
@@ -1,0 +1,50 @@
+import os
+from tempfile import mkdtemp
+from insights import dr
+from insights.core.plugins import component
+from insights.core.serde import Hydration
+from insights.core.spec_factory import (
+                                        RawFileProvider,
+                                        TextFileProvider,
+                                       )
+from insights.util import fs
+
+root = os.path.dirname(__file__)
+relative_path = os.path.basename(__file__)
+
+
+@component()
+def thing():
+    pass
+
+
+def test_text_file():
+    before = TextFileProvider(relative_path, root)
+    broker = dr.Broker()
+    broker[thing] = before
+
+    tmp_path = mkdtemp()
+    try:
+        hydra = Hydration(tmp_path)
+        hydra.dehydrate(thing, broker)
+        after = hydra.hydrate()[thing]
+        assert after.content == before.content
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            fs.remove(tmp_path)
+
+
+def test_raw_file():
+    before = RawFileProvider(relative_path, root)
+    broker = dr.Broker()
+    broker[thing] = before
+
+    tmp_path = mkdtemp()
+    try:
+        hydra = Hydration(tmp_path)
+        hydra.dehydrate(thing, broker)
+        after = hydra.hydrate()[thing]
+        assert after.content == before.content
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            fs.remove(tmp_path)

--- a/insights/util/subproc.py
+++ b/insights/util/subproc.py
@@ -44,7 +44,7 @@ class CalledProcessError(Exception):
         rc = self.returncode
         cmd = self.cmd
         output = self.output
-        return '<{c}({r}, {cmd}, {o})>'.format(c=name, r=rc, cmd=cmd, o=output)
+        return '<{}({}, {!r}, {!r})>'.format(name, rc, cmd, output)
 
 
 class Pipeline(object):

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,73 @@
+---
+# version is for the format of the file, not its contents
+version: 0
+
+context:
+    class: insights.core.context.HostContext
+    args:
+        timeout: 10 # timeout in seconds for commands. Doesn't apply to files.
+
+# disable everything by default
+# defaults to false if not specified.
+default_component_enabled: false
+
+# commands and files to ignore
+blacklist:
+    files: []
+    commands: []
+    patterns: []
+    keywords: []
+
+# packages and modules to load
+packages:
+    - insights.specs.default
+    - insights.parsers
+    - insights.combiners
+
+# Can be a list of dictionaries with name/enabled fields or a list of strings
+# where the string is the name and enabled is assumed to be true. Matching is
+# by prefix, and later entries override previous ones. Persistence for a
+# component is disabled by default.
+persist:
+    - name: insights.specs.Specs
+      enabled: true
+
+    - name: insights.combiners.hostname
+      enabled: true
+
+# If a file datasource hasn't already been pulled into memory, its contents are
+# serialized with other info about the datasource if they're smaller than this
+# value. Otherwise, they're copied into a raw_data directory, and a pointer to
+# the file is put into the datasource's record. Set to 0 to put everything into
+# json regardless of file size. Set to a negative number to put everything into
+# a raw data directory. Defaults to 0 if not specified. Below is 2**19.
+# max_serializable_file_size: 524288
+max_serializable_file_size: -1
+
+# configuration of loaded components. names are prefixes, so any component with
+# a fully qualified name that starts with a key will get the associated
+# configuration applied. Can specify timeout, which will apply to command
+# datasources. Can specify metadata, which must be a dictionary and will be
+# merged with the components' default metadata.
+configs:
+    - name: insights.specs.Specs
+      enabled: true
+
+    - name: insights.specs.default.DefaultSpecs
+      enabled: true
+
+    - name: insights.parsers.hostname
+      enabled: true
+
+    - name: insights.parsers.facter
+      enabled: true
+
+    - name: insights.parsers.systemid
+      enabled: true
+
+    - name: insights.combiners.hostname
+      enabled: true
+
+# needed because some specs aren't given names before they're used in DefaultSpecs
+    - name: insights.core.spec_factory
+      enabled: true

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ for name in package_info:
 
 entry_points = {
     'console_scripts': [
+        'insights-collect = insights.collect:main',
         'insights-run = insights:main',
         'insights-cat = insights.tools.cat:main',
         'insights-info = insights.tools.query:main',


### PR DESCRIPTION
This PR supersedes #1455  .

It includes a collection module that produces an archive from datasources or other components that have serializers and deserializers defined for their output types. The module can be invoked with the collect function in python or by running `insights-collect` from the command line. The archive it produces is recognized and processed by the rest of the framework in the same way as other archives.

Both invocations take a manifest with collection parameters and descriptions of which components to enable and persist to the archive. See insights/collect.py or manifest.yaml for an example.

```
mkdir tmp
$ insights-collect -m manifest.yaml -o tmp/
tmp/insights-alonzo-20181212234409.tar.gz
```