### PR TITLE
Disable reg on platform

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -445,9 +445,6 @@ class InsightsClient(object):
             return None
         return self.connection.get_diagnosis(remediation_id)
 
-    def delete_branch_info(self):
-        return self.connection.delete_branch_info()
-
 
 def format_config(config):
     # Log config except the password

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -445,6 +445,9 @@ class InsightsClient(object):
             return None
         return self.connection.get_diagnosis(remediation_id)
 
+    def delete_branch_info(self):
+        return self.connection.delete_branch_info()
+
 
 def format_config(config):
     # Log config except the password

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -473,16 +473,16 @@ class InsightsConnection(object):
         """
         branch_info = None
         if os.path.exists(constants.cached_branch_info):
-            # use cached branch info file if less than 2 hours old (failsafe)
+            # use cached branch info file if less than 30 days old
             logger.debug(u'Reading branch info from cached file.')
             ctime = datetime.utcfromtimestamp(
                 os.path.getctime(constants.cached_branch_info))
-            if datetime.utcnow() < (ctime + timedelta(hours=2)):
+            if datetime.utcnow() < (ctime + timedelta(days=30)):
                 with io.open(constants.cached_branch_info, encoding='utf8', mode='r') as f:
                     branch_info = json.load(f)
                 return branch_info
             else:
-                logger.debug(u'Cached branch info is older than 2 hours.')
+                logger.debug(u'Cached branch info is older than 30 days.')
 
         logger.debug(u'Obtaining branch information from %s',
                      self.branch_info_url)
@@ -508,10 +508,6 @@ class InsightsConnection(object):
             bi_str = json.dumps(branch_info, ensure_ascii=False)
             f.write(bi_str)
         return branch_info
-
-    def delete_branch_info():
-        if os.path.exists(constants.cached_branch_info):
-            os.remove(constants.cached_branch_info)
 
     def create_system(self, new_machine_id=False):
         """

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -473,16 +473,16 @@ class InsightsConnection(object):
         """
         branch_info = None
         if os.path.exists(constants.cached_branch_info):
-            # use cached branch info file if less than 30 days old
+            # use cached branch info file if less than 2 hours old (failsafe)
             logger.debug(u'Reading branch info from cached file.')
             ctime = datetime.utcfromtimestamp(
                 os.path.getctime(constants.cached_branch_info))
-            if datetime.utcnow() < (ctime + timedelta(days=30)):
+            if datetime.utcnow() < (ctime + timedelta(hours=2)):
                 with io.open(constants.cached_branch_info, encoding='utf8', mode='r') as f:
                     branch_info = json.load(f)
                 return branch_info
             else:
-                logger.debug(u'Cached branch info is older than 30 days.')
+                logger.debug(u'Cached branch info is older than 2 hours.')
 
         logger.debug(u'Obtaining branch information from %s',
                      self.branch_info_url)
@@ -508,6 +508,10 @@ class InsightsConnection(object):
             bi_str = json.dumps(branch_info, ensure_ascii=False)
             f.write(bi_str)
         return branch_info
+
+    def delete_branch_info():
+        if os.path.exists(constants.cached_branch_info):
+            os.remove(constants.cached_branch_info)
 
     def create_system(self, new_machine_id=False):
         """
@@ -655,7 +659,7 @@ class InsightsConnection(object):
         # This will undo a blacklist
         logger.debug("API: Create system")
         system = self.create_system(new_machine_id=False)
-        if not system:
+        if system is False:
             return ('Could not reach the Insights service to register.', '', '', '')
 
         # If we get a 409, we know we need to generate a new machine-id

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -156,8 +156,8 @@ def post_update(client, config):
         else:
             sys.exit(constants.sig_kill_bad)
 
-    if config.payload:
-        logger.debug('Uploading a payload. Bypassing registration.')
+    if not config.legacy_upload:
+        logger.debug('Platform upload. Bypassing registration.')
         return
 
     reg = client.register()
@@ -214,6 +214,7 @@ def collect_and_output(client, config):
                     logger.info('Insights archive retained in ' + insights_archive)
                 else:
                     client.delete_archive(insights_archive, delete_parent_dir=True)
+        client.delete_branch_info()
 
     # rotate eggs once client completes all work successfully
     try:

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -214,7 +214,6 @@ def collect_and_output(client, config):
                     logger.info('Insights archive retained in ' + insights_archive)
                 else:
                     client.delete_archive(insights_archive, delete_parent_dir=True)
-        client.delete_branch_info()
 
     # rotate eggs once client completes all work successfully
     try:

--- a/insights/tests/client/phase/test_post_update.py
+++ b/insights/tests/client/phase/test_post_update.py
@@ -21,11 +21,11 @@ def patch_insights_config(old_function):
 
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_payload_on(insights_config, insights_client):
+def test_post_update_legacy_upload_off(insights_config, insights_client):
     """
-    Registration is not processed when a payload is uploaded
+    Registration is not processed when platform upload
     """
-    insights_config.return_value.load_all.return_value.payload = True
+    insights_config.return_value.load_all.return_value.legacy_upload = False
     try:
         post_update()
     except SystemExit:
@@ -35,11 +35,11 @@ def test_post_update_payload_on(insights_config, insights_client):
 
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_payload_off(insights_config, insights_client):
+def test_post_update_legacy_upload_on(insights_config, insights_client):
     """
-    Registration is processed in normal operation (no payload)
+    Registration is processed in legacy_upload=True
     """
-    insights_config.return_value.load_all.return_value.payload = False
+    insights_config.return_value.load_all.return_value.legacy_upload = True
     try:
         post_update()
     except SystemExit:


### PR DESCRIPTION
Also modify how 4xx requests are handled by system creation function. 4xx response objects from python-requests are treated as "falsy" so there was an incorrect check happening when a 409 "duplicate machine id" error came back from the API.