### PR TITLE
Add timeout for host context collection

### DIFF
--- a/insights/core/context.py
+++ b/insights/core/context.py
@@ -170,7 +170,8 @@ class ExecutionContext(object):
 
 @fs_root
 class HostContext(ExecutionContext):
-    pass
+    def __init__(self, root='/', timeout=30, all_files=None):
+        super(HostContext, self).__init__(root, timeout, all_files)
 
 
 @fs_root

--- a/insights/core/context.py
+++ b/insights/core/context.py
@@ -171,7 +171,7 @@ class ExecutionContext(object):
 @fs_root
 class HostContext(ExecutionContext):
     def __init__(self, root='/', timeout=30, all_files=None):
-        super(HostContext, self).__init__(root, timeout, all_files)
+        super(HostContext, self).__init__(root=root, timeout=timeout, all_files=all_files)
 
 
 @fs_root


### PR DESCRIPTION
* Add a timeout value so that when performing host collection a command
  waiting for a response will not lock up insights run
* This is only for collection in the host context and does not
  impact collection from archives or via the client