### PR TITLE
Gather modularity related information

### DIFF
--- a/docs/shared_parsers_catalog/dnf_modules.rst
+++ b/docs/shared_parsers_catalog/dnf_modules.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.dnf_modules
+    :members:
+    :show-inheritance:

--- a/insights/parsers/dnf_modules.py
+++ b/insights/parsers/dnf_modules.py
@@ -1,0 +1,25 @@
+"""
+DnfModules - files under in the ``/etc/dnf/modules.d/`` directory
+=================================================================
+
+Modularity configuration
+"""
+from insights import IniConfigFile, parser
+from insights.specs import Specs
+
+
+@parser(Specs.dnf_modules)
+class DnfModules(IniConfigFile):
+    """
+    Provides access to state of enabled modules/streams/profiles
+    which is located in the /etc/dnf/modules.d/ directory
+
+    Examples:
+        >>> len(dnf_modules.sections())
+        3
+        >>> str(dnf_modules.get("postgresql", "stream"))
+        '9.6'
+        >>> str(dnf_modules.get("postgresql", "profiles"))
+        'client'
+    """
+    pass

--- a/insights/parsers/tests/test_dnf_modules.py
+++ b/insights/parsers/tests/test_dnf_modules.py
@@ -1,0 +1,38 @@
+import doctest
+from insights.parsers import dnf_modules
+from insights.tests import context_wrap
+
+DNF_MODULES_INPUT = """
+[postgresql]
+name=postgresql
+profiles=client
+state=enabled
+stream=9.6
+[python36]
+name=python36
+profiles=
+state=enabled
+stream=3.6
+[virt]
+name=virt
+profiles=
+state=enabled
+stream=rhel
+"""
+
+
+def test_dnf_modules():
+    modules_config = dnf_modules.DnfModules(context_wrap(DNF_MODULES_INPUT))
+    assert modules_config is not None
+    assert 'postgresql' in modules_config.sections()
+    assert 'python36' in modules_config.sections()
+    assert 'virt' in modules_config.sections()
+    assert 'enabled' == modules_config.get('postgresql', 'state')
+
+
+def test_dnf_modules_doc_examples():
+    failed, total = doctest.testmod(
+        dnf_modules,
+        globs={'dnf_modules': dnf_modules.DnfModules(context_wrap(DNF_MODULES_INPUT))}
+    )
+    assert failed == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -84,6 +84,7 @@ class Specs(SpecSet):
     dmesg = RegistryPoint(filterable=True)
     dmidecode = RegistryPoint()
     dmsetup_info = RegistryPoint()
+    dnf_modules = RegistryPoint()
     docker_container_inspect = RegistryPoint(multi_output=True)
     docker_host_machine_id = RegistryPoint()
     docker_image_inspect = RegistryPoint(multi_output=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -155,6 +155,7 @@ class DefaultSpecs(Specs):
     dmesg = simple_command("/bin/dmesg")
     dmidecode = simple_command("/usr/sbin/dmidecode")
     dmsetup_info = simple_command("/usr/sbin/dmsetup info -C")
+    dnf_modules = glob_file("/etc/dnf/modules.d/*.module")
     docker_info = simple_command("/usr/bin/docker info")
     docker_list_containers = simple_command("/usr/bin/docker ps --all --no-trunc")
     docker_list_images = simple_command("/usr/bin/docker images --all --no-trunc --digests")


### PR DESCRIPTION
Newer versions of YUM (based on DNF) are storing
additional metadata related to modularity functionality
in the /etc/dnf/modules.d/ directory.
These files are needed in order to properly calculate
package updates.

Signed-off-by: Tomas Kasparek <tkasparek@redhat.com>