### PR TITLE
Delay setting permissions when untarring. Adjust how roots are found.

### DIFF
--- a/insights/core/archives.py
+++ b/insights/core/archives.py
@@ -70,7 +70,7 @@ class TarExtractor(object):
             tar_flag = self._tar_flag_for_content_type(self.content_type)
             self.tmp_dir = tempfile.mkdtemp(prefix="insights-", dir=extract_dir)
             self.created_tmp_dir = True
-            command = "tar %s -x --exclude=*/dev/null -f %s -C %s" % (tar_flag, path, self.tmp_dir)
+            command = "tar --delay-directory-restore %s -x --exclude=*/dev/null -f %s -C %s" % (tar_flag, path, self.tmp_dir)
             logging.debug("Extracting files in '%s'", self.tmp_dir)
             subproc.call(command, timeout=self.timeout)
         return self

--- a/insights/core/hydration.py
+++ b/insights/core/hydration.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from itertools import product
 
 from insights.core import archives
 from insights.core.context import (ClusterArchiveContext,
@@ -19,21 +20,27 @@ def get_all_files(path):
     return all_files
 
 
-def determine_context(common_path, files):
+def identify(files):
+    markers = {"insights_archive.txt": SerializedArchiveContext,
+               "insights_commands": HostArchiveContext,
+               "sos_commands": SosArchiveContext,
+               "JBOSS_HOME": JDRContext}
+
+    for f, m in product(files, markers):
+        if m in f:
+            i = f.find(m)
+            common_path = os.path.dirname(f[:i])
+            ctx = markers[m]
+            return common_path, ctx
+
+    common_path = os.path.dirname(os.path.commonprefix(files))
+    if not common_path:
+        raise archives.InvalidArchive("Unable to determine common path")
+
     if any(f.endswith(archives.COMPRESSION_TYPES) for f in os.listdir(common_path)):
-        return ClusterArchiveContext
+        return common_path, ClusterArchiveContext
 
-    for f in files:
-        if "insights_archive.txt" in f:
-            return SerializedArchiveContext
-        elif "insights_commands" in f:
-            return HostArchiveContext
-        elif "sos_commands" in f:
-            return SosArchiveContext
-        elif "JBOSS_HOME" in f:
-            return JDRContext
-
-    return HostArchiveContext
+    return common_path, HostArchiveContext
 
 
 def create_context(path, context=None):
@@ -41,9 +48,6 @@ def create_context(path, context=None):
     if not all_files:
         raise archives.InvalidArchive("No files in archive")
 
-    common_path = os.path.dirname(os.path.commonprefix(all_files))
-    if not common_path:
-        raise archives.InvalidArchive("Unable to determine common path")
-
-    context = context or determine_context(common_path, all_files)
+    common_path, ctx = identify(all_files)
+    context = context or ctx
     return context(common_path, all_files=all_files)


### PR DESCRIPTION
Some archives have directories with permissions that make it impossible
to write to them. Without delaying the permission set on those directories,
any files they contain will fail to extract due to PermissionDenied.

Archives that have multiple directories in the root evaluated the common
prefix to be too high in the directory structure. This change looks for
marker files (sos_commands, insights_commands, etc.) and take the immediate
parent as the archive root.