### PR TITLE
Fix ceph version - add 'downstream_release' field

### DIFF
--- a/insights/parsers/ceph_version.py
+++ b/insights/parsers/ceph_version.py
@@ -18,7 +18,7 @@ Note:
 
 Example:
     >>> ceph_ver = shared[CephVersion]
-    >>> ceph_ver.release
+    >>> ceph_ver.version
     '1.3.3'
     >>> ceph_ver.major
     '1.3'
@@ -31,18 +31,18 @@ import re
 from insights.specs import Specs
 
 community_to_release_map = {
-    "0.94.1": {'release': "1.3.0", 'major': '1.3', 'minor': '0'},
-    "0.94.3": {'release': "1.3.1", 'major': '1.3', 'minor': '1'},
-    "0.94.5": {'release': "1.3.2", 'major': '1.3', 'minor': '2'},
-    "0.94.9": {'release': "1.3.3", 'major': '1.3', 'minor': '3'},
-    "10.2.2": {'release': "2.0", 'major': '2', 'minor': '0'},
-    "10.2.3": {'release': "2.1", 'major': '2', 'minor': '1'},
-    "10.2.5": {'release': "2.2", 'major': '2', 'minor': '2'},
-    "10.2.7": {'release': "2.3", 'major': '2', 'minor': '3'},
-    "10.2.10": {'release': "2.5", 'major': '2', 'minor': '5'},
-    "12.2.4": {'release': "3.0", 'major': '3', 'minor': '0'},
-    "12.2.5": {'release': "3.1", 'major': '3', 'minor': '1'},
-    "12.2.8": {'release': "3.2", 'major': '3', 'minor': '2'}
+    "0.94.1": {'version': "1.3.0", 'major': '1.3', 'minor': '0'},
+    "0.94.3": {'version': "1.3.1", 'major': '1.3', 'minor': '1'},
+    "0.94.5": {'version': "1.3.2", 'major': '1.3', 'minor': '2'},
+    "0.94.9": {'version': "1.3.3", 'major': '1.3', 'minor': '3'},
+    "10.2.2": {'version': "2.0", 'major': '2', 'minor': '0'},
+    "10.2.3": {'version': "2.1", 'major': '2', 'minor': '1'},
+    "10.2.5": {'version': "2.2", 'major': '2', 'minor': '2'},
+    "10.2.7": {'version': "2.3", 'major': '2', 'minor': '3'},
+    "10.2.10": {'version': "2.5", 'major': '2', 'minor': '5'},
+    "12.2.4": {'version': "3.0", 'major': '3', 'minor': '0'},
+    "12.2.5": {'version': "3.1", 'major': '3', 'minor': '1'},
+    "12.2.8": {'version': "3.2", 'major': '3', 'minor': '2'}
 }
 
 
@@ -86,6 +86,6 @@ class CephVersion(CommandParser):
         if not release_data:
             raise CephVersionError("No Mapping Release Version. Ceph Release Number is Null", content)
 
-        self.release = release_data['release']
+        self.version = release_data['version']
         self.major = release_data['major']
         self.minor = release_data['minor']

--- a/insights/parsers/ceph_version.py
+++ b/insights/parsers/ceph_version.py
@@ -31,18 +31,29 @@ import re
 from insights.specs import Specs
 
 community_to_release_map = {
-    "0.94.1": {'version': "1.3.0", 'major': '1.3', 'minor': '0'},
-    "0.94.3": {'version': "1.3.1", 'major': '1.3', 'minor': '1'},
-    "0.94.5": {'version': "1.3.2", 'major': '1.3', 'minor': '2'},
-    "0.94.9": {'version': "1.3.3", 'major': '1.3', 'minor': '3'},
-    "10.2.2": {'version': "2.0", 'major': '2', 'minor': '0'},
-    "10.2.3": {'version': "2.1", 'major': '2', 'minor': '1'},
-    "10.2.5": {'version': "2.2", 'major': '2', 'minor': '2'},
-    "10.2.7": {'version': "2.3", 'major': '2', 'minor': '3'},
-    "10.2.10": {'version': "2.5", 'major': '2', 'minor': '5'},
-    "12.2.4": {'version': "3.0", 'major': '3', 'minor': '0'},
-    "12.2.5": {'version': "3.1", 'major': '3', 'minor': '1'},
-    "12.2.8": {'version': "3.2", 'major': '3', 'minor': '2'}
+    "0.94.1-15": {'version': "1.3.0", 'major': '1.3', 'minor': '0', 'downstream_release': 'NA'},
+    "0.94.3-3": {'version': "1.3.1", 'major': '1.3', 'minor': '1', 'downstream_release': 'NA'},
+    "0.94.5-9": {'version': "1.3.2", 'major': '1.3', 'minor': '2', 'downstream_release': 'NA'},
+    "0.94.9-3": {'version': "1.3.3", 'major': '1.3', 'minor': '3', 'downstream_release': 'NA'},
+    "0.94.9-9": {'version': "1.3.3", 'major': '1.3', 'minor': '3', 'downstream_release': 'async 2'},
+    "0.94.10-2": {'version': "1.3.4", 'major': '1.3', 'minor': '4', 'downstream_release': 'NA'},
+    "10.2.2-38": {'version': "2.0", 'major': '2', 'minor': '0', 'downstream_release': '0'},
+    "10.2.3-13": {'version': "2.1", 'major': '2', 'minor': '1', 'downstream_release': '0'},
+    "10.2.5-37": {'version': "2.2", 'major': '2', 'minor': '2', 'downstream_release': '0'},
+    "10.2.7-27": {'version': "2.3", 'major': '2', 'minor': '3', 'downstream_release': '0'},
+    "10.2.7-28": {'version': "2.3", 'major': '2', 'minor': '3', 'downstream_release': 'async'},
+    "10.2.7-48": {'version': "2.4", 'major': '2', 'minor': '4', 'downstream_release': 'async'},
+    "10.2.10-16": {'version': "2.5", 'major': '2', 'minor': '5', 'downstream_release': '0'},
+    "10.2.10-28": {'version': "2.5.1", 'major': '2', 'minor': '5', 'downstream_release': '1'},
+    "10.2.10-40": {'version': "2.5.2", 'major': '2', 'minor': '5', 'downstream_release': '2'},
+    "10.2.10-43": {'version': "2.5.3", 'major': '2', 'minor': '5', 'downstream_release': '3'},
+    "12.2.4-6": {'version': "3.0.2", 'major': '3', 'minor': '0', 'downstream_release': '2'},
+    "12.2.4-10": {'version': "3.0.3", 'major': '3', 'minor': '0', 'downstream_release': '3'},
+    "12.2.4-30": {'version': "3.0.4", 'major': '3', 'minor': '0', 'downstream_release': '4'},
+    "12.2.4-42": {'version': "3.0.5", 'major': '3', 'minor': '0', 'downstream_release': '5'},
+    "12.2.5-42": {'version': "3.1", 'major': '3', 'minor': '1', 'downstream_release': '0'},
+    "12.2.5-59": {'version': "3.1.1", 'major': '3', 'minor': '1', 'downstream_release': '1'},
+    "12.2.8-52": {'version': "3.2", 'major': '3', 'minor': '2', 'downstream_release': '0'}
 }
 
 
@@ -81,7 +92,7 @@ class CephVersion(CommandParser):
         if not community_version_mo:
             raise CephVersionError("Wrong Format Ceph Version", content)
 
-        community_version = community_version_mo.group(1)
+        community_version = community_version_mo.group(0)
         release_data = community_to_release_map.get(community_version, None)
         if not release_data:
             raise CephVersionError("No Mapping Release Version. Ceph Release Number is Null", content)
@@ -89,3 +100,4 @@ class CephVersion(CommandParser):
         self.version = release_data['version']
         self.major = release_data['major']
         self.minor = release_data['minor']
+        self.downstream_release = release_data['downstream_release']

--- a/insights/parsers/tests/test_ceph_version.py
+++ b/insights/parsers/tests/test_ceph_version.py
@@ -28,20 +28,20 @@ def test_ceph_version():
     assert 'No Mapping Release Version' in str(error_context6)
 
     ceph_version1 = CephVersion(context_wrap(CV1))
-    assert ceph_version1.release == "1.3.3"
+    assert ceph_version1.version == "1.3.3"
     assert ceph_version1.major == '1.3'
     assert ceph_version1.minor == "3"
     ceph_version4 = CephVersion(context_wrap(CV4))
-    assert ceph_version4.release == "2.0"
+    assert ceph_version4.version == "2.0"
     assert ceph_version4.major == '2'
     assert ceph_version4.minor == "0"
 
     ceph_version7 = CephVersion(context_wrap(CV7))
-    assert ceph_version7.release == "2.2"
+    assert ceph_version7.version == "2.2"
     assert ceph_version7.major == '2'
     assert ceph_version7.minor == "2"
 
     ceph_version8 = CephVersion(context_wrap(CV8))
-    assert ceph_version8.release == "2.3"
+    assert ceph_version8.version == "2.3"
     assert ceph_version8.major == '2'
     assert ceph_version8.minor == "3"

--- a/insights/parsers/tests/test_ceph_version.py
+++ b/insights/parsers/tests/test_ceph_version.py
@@ -11,6 +11,7 @@ CV5 = "ceph version 1"
 CV6 = "ceph version 1.2.3-5"
 CV7 = "ceph version 10.2.5-37.el7cp (033f137cde8573cfc5a4662b4ed6a63b8a8d1464)"
 CV8 = "ceph version 10.2.7-27.el7cp (abcd137cde8573cfc5a4662b4ed6a63b8a8kadf1)"
+CV9 = "ceph version 12.2.5-59.el7cp (d4b9f17b56b3348566926849313084dd6efc2ca2)"
 
 
 def test_ceph_version():
@@ -31,17 +32,28 @@ def test_ceph_version():
     assert ceph_version1.version == "1.3.3"
     assert ceph_version1.major == '1.3'
     assert ceph_version1.minor == "3"
+    assert ceph_version1.downstream_release == "async 2"
+
     ceph_version4 = CephVersion(context_wrap(CV4))
     assert ceph_version4.version == "2.0"
     assert ceph_version4.major == '2'
     assert ceph_version4.minor == "0"
+    assert ceph_version4.downstream_release == "0"
 
     ceph_version7 = CephVersion(context_wrap(CV7))
     assert ceph_version7.version == "2.2"
     assert ceph_version7.major == '2'
     assert ceph_version7.minor == "2"
+    assert ceph_version7.downstream_release == "0"
 
     ceph_version8 = CephVersion(context_wrap(CV8))
     assert ceph_version8.version == "2.3"
     assert ceph_version8.major == '2'
     assert ceph_version8.minor == "3"
+    assert ceph_version8.downstream_release == "0"
+
+    ceph_version9 = CephVersion(context_wrap(CV9))
+    assert ceph_version9.version == "3.1.1"
+    assert ceph_version9.major == '3'
+    assert ceph_version9.minor == "1"
+    assert ceph_version9.downstream_release == "1"


### PR DESCRIPTION
1. Fix the confusion between 'release' and 'version' according to N-V-R convention (note - this WILL BREAK existing rules)
2. Add 'downstream_release' field, to distinguish between (for example) 3.1.0 and 3.1.1.