### PR TITLE
Enhance lspci parser

### DIFF
--- a/insights/parsers/tests/test_lspci.py
+++ b/insights/parsers/tests/test_lspci.py
@@ -204,8 +204,18 @@ LSPCI_DRIVER_DOC = """
         Kernel modules: ixgbe
 """.strip()
 
+LSPCI_OUTPUT_WITH_BAD_LINES = """
+03:00.0 Network controller: Intel Corporation Wireless 7260 (rev bb)
+        Subsystem: Intel Corporation Dual Band Wireless-AC 7260
+
+        Kernel driver in use: iwlwifi
+# a comment
+        Kernel modules: iwlwifi
+""".strip()
+
 
 def test_lspci():
+    LsPci.token_scan('centrino', 'Centrino')
     lspci_0 = LsPci(context_wrap(LSPCI_0))
     assert [i['raw_message'] for i in lspci_0.get("Intel Corporation")] == INTEL.splitlines()
     assert len(lspci_0.get("Network controller")) == 1
@@ -236,6 +246,10 @@ def test_lspci_driver():
     lspci_obj = LsPci(context_wrap(LSPCI_DRIVER_DETAILS_3))
     assert len(lspci_obj.data) == 0
     assert len(lspci_obj.pci_dev_list) == 0
+
+    output = LsPci(context_wrap(LSPCI_OUTPUT_WITH_BAD_LINES))
+    assert len(output.data) == 1
+    assert len(output.pci_dev_list) == 1
 
 
 def test_doc_examples():

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -58,7 +58,11 @@ class SosSpecs(Specs):
     lsblk = simple_file("sos_commands/block/lsblk")
     lsof = simple_file("lsof")
     lsmod = simple_file("lsmod")
-    lspci = simple_file("lspci")
+    lspci = first_of([
+        simple_file("sos_commands/pci/lspci_-nnvv"),
+        simple_file("sos_commands/pci/lspci_-nvv"),
+        simple_file("sos_commands/pci/lspci")
+    ])
     lsscsi = simple_file("sos_commands/scsi/lsscsi")
     ls_dev = simple_file("sos_commands/block/ls_-lanR_.dev")
     lvs = simple_file("sos_commands/lvm2/lvs_-a_-o_lv_tags_devices_--config_global_locking_type_0")


### PR DESCRIPTION
- This includes
  * Add lspci files from sosreport in the `sos_archive` specs.
  * Modify lspci parser to make it compatible with output of `lspci -nnvv`, `lspci -nvv` and `lspci -k`

Signed-off-by: Akshay Gaikwad <akgaikwa@redhat.com>