### PR TITLE
Add Ceph version from RHOSP 10 environment

### DIFF
--- a/insights/parsers/ceph_version.py
+++ b/insights/parsers/ceph_version.py
@@ -39,6 +39,7 @@ community_to_release_map = {
     "0.94.10-2": {'version': "1.3.4", 'major': '1.3', 'minor': '4', 'downstream_release': 'NA'},
     "10.2.2-38": {'version': "2.0", 'major': '2', 'minor': '0', 'downstream_release': '0'},
     "10.2.3-13": {'version': "2.1", 'major': '2', 'minor': '1', 'downstream_release': '0'},
+    "10.2.5": {'version': "2.2", 'major': '2', 'minor': '2', 'downstream_release': '0'},
     "10.2.5-37": {'version': "2.2", 'major': '2', 'minor': '2', 'downstream_release': '0'},
     "10.2.7-27": {'version': "2.3", 'major': '2', 'minor': '3', 'downstream_release': '0'},
     "10.2.7-28": {'version': "2.3", 'major': '2', 'minor': '3', 'downstream_release': 'async'},

--- a/insights/parsers/tests/test_ceph_version.py
+++ b/insights/parsers/tests/test_ceph_version.py
@@ -9,6 +9,7 @@ CV3 = "error"
 CV4 = "ceph version 10.2.2-38.el7cp (b83334e01379f267fb2f9ce729d74a0a8fa1e92c)"
 CV5 = "ceph version 1"
 CV6 = "ceph version 1.2.3-5"
+CV_5 = "ceph version 10.2.5 (c461ee19ecbc0c5c330aca20f7392c9a00730367)"
 CV7 = "ceph version 10.2.5-37.el7cp (033f137cde8573cfc5a4662b4ed6a63b8a8d1464)"
 CV8 = "ceph version 10.2.7-27.el7cp (abcd137cde8573cfc5a4662b4ed6a63b8a8kadf1)"
 CV9 = "ceph version 12.2.5-59.el7cp (d4b9f17b56b3348566926849313084dd6efc2ca2)"
@@ -39,6 +40,12 @@ def test_ceph_version():
     assert ceph_version4.major == '2'
     assert ceph_version4.minor == "0"
     assert ceph_version4.downstream_release == "0"
+
+    ceph = CephVersion(context_wrap(CV_5))
+    assert ceph.version == "2.2"
+    assert ceph.major == '2'
+    assert ceph.minor == '2'
+    assert ceph.downstream_release == "0"
 
     ceph_version7 = CephVersion(context_wrap(CV7))
     assert ceph_version7.version == "2.2"


### PR DESCRIPTION
I noticed that in RHOSP 10 environment the output of command `ceph -v` is

  ceph version 10.2.5 (c461ee19ecbc0c5c330aca20f7392c9a00730367)

which is not listed in the `community_to_release_map` and hence cause one of the
playbook(insights-playbooks PR#1783) to fail locally during breakit. This change includes the ceph version as listed in latest RHOSP 10 Controller node.

Signed-off-by: Sachin Patil <psachin@redhat.com>