### PR TITLE
include tools parsers and combiners in the trimmed version of the egg

### DIFF
--- a/build_client_egg.sh
+++ b/build_client_egg.sh
@@ -1,30 +1,21 @@
 #!/bin/bash
+PYTHON=${1:-python}
 
 rm -f insights.zip
 rm -rf insights_core.egg-info
 cp MANIFEST.in.client MANIFEST.in
-python setup.py egg_info
+$PYTHON setup.py egg_info
 mkdir -p tmp/EGG-INFO
 cp insights_core.egg-info/* tmp/EGG-INFO
 cp -r insights tmp
 cd tmp
+# remove unneeded bits to save on space
 rm -rf insights/archive
-rm -rf insights/contrib/pyparsing.py
-rm -rf insights/plugins
-rm -rf insights/tests
-rm -rf insights/tools
+find insights -path '*tests/*' -delete
+find insights -name '*.pyc' -delete
+
 git rev-parse --short HEAD > insights/COMMIT
 
-# Remove all parsers/combiners but keep the packages because they're imported
-# in core/__init__.py
-rm -rf insights/parsers/*
-cp ../insights/parsers/__init__.py insights/parsers
-cp ../insights/parsers/mount.py insights/parsers
-
-rm -rf insights/combiners/*
-cp ../insights/combiners/__init__.py insights/combiners
-
-find insights -name '*.pyc' -delete
 find . -type f -exec touch -c -t 201801010000.00 {} \;
 find . -type f -exec chmod 0444 {} \;
 find . -type f -print | sort -df | xargs zip -X --no-dir-entries -r ../insights.zip


### PR DESCRIPTION
This change modifies the egg building script to include the tools as well as parsers and combiners.  This enables core collection for new use cases.

I decided to preserve the archive/ and test removal bits.  This keeps the archive size fairly small (750k vs over 3MB for the current set).