### PR TITLE
Let cat use colorama but fall back to regular text if its not installed.

### DIFF
--- a/insights/tools/cat.py
+++ b/insights/tools/cat.py
@@ -28,11 +28,20 @@ import yaml
 
 from contextlib import contextmanager
 
-import colorama as C
 from insights import apply_configs, create_context, dr, extract, HostContext
 from insights.core.spec_factory import ContentProvider
 
-C.init()
+try:
+    import colorama as C
+    C.init()
+except:
+    class Pass(object):
+        def __getattr__(self, name):
+            return ""
+
+    class C(object):
+        Fore = Pass()
+        Style = Pass()
 
 
 def parse_args():


### PR DESCRIPTION
Cat failed to load if colorama wasn't available. This PR lets cat use it if it's there but fall back to plain text if it isn't.