### PR TITLE
Revert "Canonical fact fix (#1730)"

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -701,8 +701,6 @@ class InsightsConnection(object):
         """
         file_name = os.path.basename(data_collected)
         upload_url = self.upload_url
-        data = {}
-        headers = {}
 
         try:
             c_facts = json.dumps(get_canonical_facts())
@@ -711,6 +709,7 @@ class InsightsConnection(object):
             logger.debug('Error getting canonical facts: %s', e)
             c_facts = None
 
+        files = {}
         # legacy upload
         if self.config.legacy_upload:
             try:
@@ -733,14 +732,15 @@ class InsightsConnection(object):
                 upload_url = self.upload_url + '/' + generate_machine_id()
             headers = {'x-rh-collection-time': str(duration)}
         else:
-            data = {'metadata': c_facts}
+            headers = {}
+            files['metadata'] = c_facts
 
-        files = {'file': (file_name, open(data_collected, 'rb'), content_type)}
+        files['file'] = (file_name, open(data_collected, 'rb'), content_type)
 
         logger.debug("Uploading %s to %s", data_collected, upload_url)
 
         net_logger.info("POST %s", upload_url)
-        upload = self.session.post(upload_url, files=files, headers=headers, data=data)
+        upload = self.session.post(upload_url, files=files, headers=headers)
 
         logger.debug("Upload status: %s %s %s",
                      upload.status_code, upload.reason, upload.text)

--- a/insights/tests/client/test_platform.py
+++ b/insights/tests/client/test_platform.py
@@ -98,8 +98,8 @@ def test_payload_upload(op, session, c):
     c.session.post.assert_called_with(
         'https://' + c.config.base_url + '/platform/upload/api/v1/upload',
         files={
-            'file': ('testp', ANY, 'testct')},  # ANY = return call from mocked open(), acts as filepointer here
-        data={'metadata': json.dumps({'test': 'facts'})},
+            'file': ('testp', ANY, 'testct'),  # ANY = return call from mocked open(), acts as filepointer here
+            'metadata': json.dumps({'test': 'facts'})},
         headers={})
 
 
@@ -119,5 +119,4 @@ def test_legacy_upload(op, session, c):
         'https://' + c.config.base_url + '/uploads/XXXXXXXX',
         files={
             'file': ('testp', ANY, 'application/gzip')},  # ANY = return call from mocked open(), acts as filepointer here
-        data={},
         headers={'x-rh-collection-time': 'None'})


### PR DESCRIPTION
This reverts commit 04553661ec50c5e918a19f13b438466201682370. Change was based on a mistaken assumption.