### PR TITLE
Handle invalid characters from command line

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -338,6 +338,13 @@ def run(component=None, root=None, print_summary=False,
         else:
             raise
 
+    except UnicodeEncodeError as e:
+        if "codec can't encode character" in str(e):
+            msg = "Invalid character provided in command option/argument: {}"
+            log.error(msg.format(e))
+        else:
+            raise
+
 
 def main(argv=sys.argv[1:]):
     if "" not in sys.path:


### PR DESCRIPTION
When accidentally passing in an invalid character e.g. in case of
copy-pasting from web and getting an em dash instead of -- in front
of "help" option we fail with traceback.

Let's print an user friendly error instead.