### PR TITLE
initialize formatters var

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -237,6 +237,7 @@ def run(component=None, root=None, print_summary=False,
 
     args = None
     formatter = None
+    formatters = None
     if print_summary:
         import argparse
         import logging


### PR DESCRIPTION
before fix, the following exception appears when running the `canonical_facts` module:
```
UnboundLocalError: local variable 'formatters' referenced before assignment
```