### PR TITLE
[DateUTC] Fix typo in the command

### DIFF
--- a/insights/parsers/date.py
+++ b/insights/parsers/date.py
@@ -13,8 +13,8 @@ this command looks like::
 
     Fri Jun 24 09:13:34 CST 2016
 
-DateUTC - command ``dateutc``
------------------------------
+DateUTC - command ``date --utc``
+--------------------------------
 
 Class ``DateUTC`` parses the output of the ``date --utc`` command.  Output is
 similar to the ``date`` command except that the `Timezone` column uses UTC.


### PR DESCRIPTION
There's no `dateutc` binary. The correct command is `date --utc`

This is a minor change.

Signed-off-by: Sachin Patil <psachin@redhat.com>