### PR TITLE
Updated parser ovs_vsctl_list_bridge to add spec for insights_archive

### DIFF
--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -176,6 +176,7 @@ class InsightsArchiveSpecs(Specs):
     oc_get_configmap = simple_file("insights_commands/oc_get_configmap_-o_yaml_--all-namespaces")
     openvswitch_other_config = simple_file("insights_commands/ovs-vsctl_-t_5_get_Open_vSwitch_._other_config")
     ovs_appctl_fdb_show_bridge = glob_file("insights_commands/ovs-appctl_fdb.show_*")
+    ovs_vsctl_list_bridge = simple_file("insights_commands/ovs-vsctl_list_bridge")
     ovs_vsctl_show = simple_file("insights_commands/ovs-vsctl_show")
     parted__l = simple_file("insights_commands/parted_-l_-s")
     passenger_status = simple_file("insights_commands/passenger-status")


### PR DESCRIPTION
Parser for parsing command `ovs-vsctl list bridge`.
Merged Parser PR: https://github.com/RedHatInsights/insights-core/pull/1733

This PR adds spec for **insights_archive** for parser `ovs_vsctl_list_bridge`.