### PR TITLE
Updated parser ip_netns_exec_namespace_lsof to add specs for insights_archive

### DIFF
--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -89,6 +89,7 @@ class InsightsArchiveSpecs(Specs):
     iptables = simple_file("insights_commands/iptables-save")
     ipv4_neigh = simple_file("insights_commands/ip_-4_neighbor_show_nud_all")
     ipv6_neigh = simple_file("insights_commands/ip_-6_neighbor_show_nud_all")
+    ip_netns_exec_namespace_lsof = glob_file("insights_commands/ip_netns_exec_*_lsof_-i")
     iscsiadm_m_session = simple_file("insights_commands/iscsiadm_-m_session")
     katello_service_status = simple_file("insights_commands/katello-service_status")
     keystone_crontab = simple_file("insights_commands/crontab_-l_-u_keystone")


### PR DESCRIPTION
Parser for parsing output of command `ip netns exec <namespace > lsof -i`.
Merged Parser PR: https://github.com/RedHatInsights/insights-core/pull/1745

This PR adds spec in insights_archive for parser **ip_netns_exec_namespace_lsof**.