### PR TITLE
Add error log and load modules conf for httpd24-httpd and jbcs-httpd2…

### DIFF
--- a/insights/parsers/httpd_log.py
+++ b/insights/parsers/httpd_log.py
@@ -10,6 +10,12 @@ HttpdSSLErrorLog - file ``ssl_error_log``
 HttpdErrorLog - file ``error_log``
 ----------------------------------
 
+Httpd24HTTPDErrorLog - file ``httpd24_httpd_error_log``
+--------------------------------------------------------
+
+JBCSHTTPD24HttpdErrorLog - file ``jbcs_httpd24_httpd_error_log``
+-----------------------------------------------------------------
+
 HttpdSSLAccessLog - file ``ssl_access_log``
 -------------------------------------------
 
@@ -34,6 +40,18 @@ class HttpdSSLErrorLog(LogFileOutput):
 
 @parser(Specs.httpd_error_log)
 class HttpdErrorLog(LogFileOutput):
+    """Class for parsing httpd ``error_log`` file."""
+    time_format = '%b %d %H:%M:%S.%f %Y'
+
+
+@parser(Specs.httpd24_httpd_error_log)
+class Httpd24HttpdErrorLog(LogFileOutput):
+    """Class for parsing httpd ``error_log`` file."""
+    time_format = '%b %d %H:%M:%S.%f %Y'
+
+
+@parser(Specs.jbcs_httpd24_httpd_error_log)
+class JBCSHttpd24HttpdErrorLog(LogFileOutput):
     """Class for parsing httpd ``error_log`` file."""
     time_format = '%b %d %H:%M:%S.%f %Y'
 

--- a/insights/parsers/tests/test_httpd_log.py
+++ b/insights/parsers/tests/test_httpd_log.py
@@ -33,6 +33,24 @@ AH00558: httpd: Could not reliably determine the server's fully qualified domain
 [Tue Mar 28 03:56:39.775833 2017] [mpm_worker:notice] [pid 4471:tid 140592082000000] AH00292: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips configured -- resuming normal operations
 """.strip()
 
+HTTPD24_ERROR_LOG = """
+[Fri Mar 29 01:42:23.497294 2019] [suexec:notice] [pid 1967] AH01232: suEXEC mechanism enabled (wrapper: /opt/rh/jbcs-httpd24/root/usr/sbin/suexec)
+[Fri Mar 29 01:42:23.498726 2019] [:notice] [pid 1967] ModSecurity for Apache/2.9.1 (http://www.modsecurity.org/) configured.
+[Fri Mar 29 01:45:23.498736 2019] [:notice] [pid 1967] ModSecurity: APR compiled version="1.6.3"; loaded version="1.6.3-31"
+[Fri Mar 29 01:45:23.498743 2019] [:notice] [pid 1967] ModSecurity: PCRE compiled version="8.32 "; loaded version="8.32 2012-11-30"
+[Fri Mar 29 01:45:23.498745 2019] [:notice] [pid 1967] ModSecurity: LUA compiled version="Lua 5.1"
+[Fri Mar 29 01:47:23.498747 2019] [:notice] [pid 1967] ModSecurity: LIBXML compiled version="2.9.1"
+[Fri Mar 29 01:47:23.498749 2019] [:notice] [pid 1967] ModSecurity: Status engine is currently disabled, enable it by set SecStatusEngine to On.
+"""
+
+JBCS_HTTPD24_ERROR_LOG = """
+Wed Apr 03 03:52:39.014686 2019] [core:notice] [pid 4499] SELinux policy enabled; httpd running as context system_u:system_r:httpd_t:s0
+[Wed Apr 03 03:54:39.016900 2019] [suexec:notice] [pid 4499] AH01232: suEXEC mechanism enabled (wrapper: /opt/rh/httpd24/root/usr/sbin/suexec)
+[Wed Apr 03 03:55:39.038125 2019] [http2:warn] [pid 4499] AH10034: The mpm module (prefork.c) is not supported by mod_http2. The mpm determines how things are processed in your server. HTTP/2 has more demands in this regard and the currently selected mpm will just not do. This is an advisory warning. Your server will continue to work, but the HTTP/2 protocol will be inactive.
+[Wed Apr 03 03:56:39.038140 2019] [http2:warn] [pid 4499] AH02951: mod_ssl does not seem to be enabled
+[Wed Apr 03 03:57:39.038835 2019] [lbmethod_heartbeat:notice] [pid 4499] AH02282: No slotmem from mod_heartmonitor
+"""
+
 SSL_ERROR_LOG = """
 [Tue Mar 28 03:56:00.804140 2017] [core:notice] [pid 4343:tid 139992054929536] AH00094: Command line: '/usr/sbin/httpd -D FOREGROUND'
 [Tue Mar 28 03:56:38.610607 2017] [mpm_worker:notice] [pid 4343:tid 139992054929536] AH00296: caught SIGWINCH, shutting down gracefully
@@ -68,3 +86,17 @@ def test_error_log():
     assert "AH00558" in log
     # Includes continuation line
     assert len(list(log.get_after(datetime(2017, 3, 28, 3, 56, 39)))) == 6
+
+def test_httpd24_error_log():
+    log = HttpdErrorLog(context_wrap(HTTPD24_ERROR_LOG))
+    assert 1 == len(log.get("suexec:notice"))
+    assert "ModSecurity" in log
+    # Includes continuation line
+    assert len(list(log.get_after(datetime(2019, 3, 29, 1, 45, 23)))) == 5
+
+def test_jbcs_httpd24_error_log():
+    log = HttpdErrorLog(context_wrap(JBCS_HTTPD24_ERROR_LOG))
+    assert 2 == len(log.get("http2:warn"))
+    assert "suEXEC" in log
+    # Includes continuation line
+    assert len(list(log.get_after(datetime(2019, 4, 3, 3, 54, 39)))) == 4

--- a/insights/parsers/tests/test_httpd_log.py
+++ b/insights/parsers/tests/test_httpd_log.py
@@ -87,12 +87,14 @@ def test_error_log():
     # Includes continuation line
     assert len(list(log.get_after(datetime(2017, 3, 28, 3, 56, 39)))) == 6
 
+
 def test_httpd24_error_log():
     log = HttpdErrorLog(context_wrap(HTTPD24_ERROR_LOG))
     assert 1 == len(log.get("suexec:notice"))
     assert "ModSecurity" in log
     # Includes continuation line
     assert len(list(log.get_after(datetime(2019, 3, 29, 1, 45, 23)))) == 5
+
 
 def test_jbcs_httpd24_error_log():
     log = HttpdErrorLog(context_wrap(JBCS_HTTPD24_ERROR_LOG))

--- a/insights/parsers/tests/test_httpd_log.py
+++ b/insights/parsers/tests/test_httpd_log.py
@@ -44,7 +44,7 @@ HTTPD24_ERROR_LOG = """
 """
 
 JBCS_HTTPD24_ERROR_LOG = """
-Wed Apr 03 03:52:39.014686 2019] [core:notice] [pid 4499] SELinux policy enabled; httpd running as context system_u:system_r:httpd_t:s0
+[Wed Apr 03 03:52:39.014686 2019] [core:notice] [pid 4499] SELinux policy enabled; httpd running as context system_u:system_r:httpd_t:s0
 [Wed Apr 03 03:54:39.016900 2019] [suexec:notice] [pid 4499] AH01232: suEXEC mechanism enabled (wrapper: /opt/rh/httpd24/root/usr/sbin/suexec)
 [Wed Apr 03 03:55:39.038125 2019] [http2:warn] [pid 4499] AH10034: The mpm module (prefork.c) is not supported by mod_http2. The mpm determines how things are processed in your server. HTTP/2 has more demands in this regard and the currently selected mpm will just not do. This is an advisory warning. Your server will continue to work, but the HTTP/2 protocol will be inactive.
 [Wed Apr 03 03:56:39.038140 2019] [http2:warn] [pid 4499] AH02951: mod_ssl does not seem to be enabled

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -179,6 +179,8 @@ class Specs(SpecSet):
     httpd_conf_scl_httpd24 = RegistryPoint(multi_output=True)
     httpd_conf_scl_jbcs_httpd24 = RegistryPoint(multi_output=True)
     httpd_error_log = RegistryPoint(filterable=True)
+    httpd24_httpd_error_log = RegistryPoint(filterable=True)
+    jbcs_httpd24_httpd_error_log = RegistryPoint(filterable=True)
     httpd_limits = RegistryPoint(multi_output=True)
     httpd_M = RegistryPoint(multi_output=True)
     httpd_on_nfs = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -287,9 +287,23 @@ class DefaultSpecs(Specs):
     hponcfg_g = simple_command("/sbin/hponcfg -g")
     httpd_access_log = simple_file("/var/log/httpd/access_log")
     httpd_conf = glob_file(["/etc/httpd/conf/httpd.conf", "/etc/httpd/conf.d/*.conf"])
-    httpd_conf_scl_httpd24 = glob_file(["/opt/rh/httpd24/root/etc/httpd/conf/httpd.conf", "/opt/rh/httpd24/root/etc/httpd/conf.d/*.conf"])
-    httpd_conf_scl_jbcs_httpd24 = glob_file(["/opt/rh/jbcs-httpd24/root/etc/httpd/conf/httpd.conf", "/opt/rh/jbcs-httpd24/root/etc/httpd/conf.d/*.conf"])
+    httpd_conf_scl_httpd24 = glob_file(
+        [
+            "/opt/rh/httpd24/root/etc/httpd/conf/httpd.conf",
+            "/opt/rh/httpd24/root/etc/httpd/conf.d/*.conf",
+            "/opt/rh/httpd24/root/etc/httpd/conf.modules.d/*.conf"
+        ]
+    )
+    httpd_conf_scl_jbcs_httpd24 = glob_file(
+        [
+            "/opt/rh/jbcs-httpd24/root/etc/httpd/conf/httpd.conf",
+            "/opt/rh/jbcs-httpd24/root/etc/httpd/conf.d/*.conf",
+            "/opt/rh/jbcs-httpd24/root/etc/httpd/conf.modules.d/*.conf",
+        ]
+    )
     httpd_error_log = simple_file("var/log/httpd/error_log")
+    httpd24_httpd_error_log = simple_file("/opt/rh/httpd24/root/etc/httpd/logs/error_log")
+    jbcs_httpd24_httpd_error_log = simple_file("/opt/rh/jbcs-httpd24/root/etc/httpd/logs/error_log")
     httpd_pid = simple_command("/usr/bin/pgrep -o httpd")
     httpd_limits = foreach_collect(httpd_pid, "/proc/%s/limits")
     virt_uuid_facts = simple_file("/etc/rhsm/facts/virt_uuid.facts")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -298,7 +298,7 @@ class DefaultSpecs(Specs):
         [
             "/opt/rh/jbcs-httpd24/root/etc/httpd/conf/httpd.conf",
             "/opt/rh/jbcs-httpd24/root/etc/httpd/conf.d/*.conf",
-            "/opt/rh/jbcs-httpd24/root/etc/httpd/conf.modules.d/*.conf",
+            "/opt/rh/jbcs-httpd24/root/etc/httpd/conf.modules.d/*.conf"
         ]
     )
     httpd_error_log = simple_file("var/log/httpd/error_log")


### PR DESCRIPTION
…4-httpd

* Add error log file "/opt/rh/httpd24/root/etc/httpd/logs/error_log" for httd24-httpd
* Add conf modules config file "/opt/rh/httpd24/root/etc/httpd/conf.modules.d/*.conf" for httpd24-httpd
* Add error log file "/opt/rh/jbcs-httpd24/root/etc/httpd/logs/error_log" for jbcs-httd24-httpd
* Add conf modules config file "/opt/rh/jbcs-httpd24/root/etc/httpd/conf.modules.d/*.conf" for jbcs-httpd24-httpd