### PR TITLE
Improve sshd_config parsing for BZ 1697477

### DIFF
--- a/insights/parsers/ssh.py
+++ b/insights/parsers/ssh.py
@@ -80,11 +80,15 @@ class SshDConfig(Parser):
     # `parse_content()` doesn't split the individual values because some
     # keywords don't have a list of values (just one string).
     # See the docstring in `line_uses_plus()` for more details.
+    # Re: BZ#1697477
+    # Config lines may also be delimited by `=`, and values may be quoted
+    # with `"`. Here it is assumed that config lines are well-formed.
     def parse_content(self, content):
         self.lines = []
         for line in get_active_lines(content):
-            line_splits = [s.strip() for s in line.split(None, 1)]
-            kw, val = line_splits[0], line_splits[1] if len(line_splits) == 2 else ''
+            line_splits = [s.strip() for s in re.split(r"[\s=]+", line, 1)]
+            kw, val = line_splits[0], line_splits[1].strip('"') if \
+                len(line_splits) == 2 else ''
             self.lines.append(self.KeyValue(
                 kw, val, kw.lower(), line
             ))

--- a/insights/parsers/tests/test_ssh.py
+++ b/insights/parsers/tests/test_ssh.py
@@ -42,12 +42,12 @@ HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 SyslogFacility AUTHPRIV
 AuthorizedKeysFile	.ssh/authorized_keys
-PasswordAuthentication yes
+PasswordAuthentication=yes
 ChallengeResponseAuthentication no
 GSSAPIAuthentication yes
 GSSAPICleanupCredentials no
 UsePAM yes
-X11Forwarding yes
+X11Forwarding = "yes"
 UsePrivilegeSeparation sandbox		# Default for new installations.
 AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
 AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
@@ -83,6 +83,8 @@ def test_sshd_config_complete():
     assert config.last('ClientAliveInterval') is None
     assert config.last('ClientAliveCountMax', '0') == '0'
     assert config.get_line('UsePAM') == 'UsePAM yes'
+    assert config['PasswordAuthentication'] == ['yes']
+    assert config['X11Forwarding'] == ['yes']
     assert config.get_line('ClientAliveInterval') == 'ClientAliveInterval   # Implicit default'
     assert config.get_line('ClientAliveCountMax', '0') == 'ClientAliveCountMax 0  # Implicit default'
     assert config.get_values('SyslogFacility') == ['AUTHPRIV']


### PR DESCRIPTION
When parsing ssh config, equals signs are permitted but were not correctly handled by the parser. Additionally, provided values may be quoted, and the quotes are stripped.

See https://github.com/RedHatInsights/insights-core/issues/1807