### PR TITLE
Ensure rpms is not None before getting attribute

### DIFF
--- a/insights/combiners/cloud_provider.py
+++ b/insights/combiners/cloud_provider.py
@@ -154,9 +154,9 @@ class CloudProvider(object):
 
         prov = {'aws': '', 'google': '', 'azure': ''}
 
-        for p in self.__PROVIDERS:
-            if dmidcd and dmidcd.bios and p.vv:
-                prov[p.name] = dmidcd.bios.get('vendor') if p.vv in dmidcd.bios.get('vendor').lower() \
+        if dmidcd and dmidcd.bios:
+            for p in self.__PROVIDERS:
+                prov[p.name] = dmidcd.bios.get('vendor') if p.vv and p.vv in dmidcd.bios.get('vendor').lower() \
                     else ''
         return prov
 
@@ -164,9 +164,9 @@ class CloudProvider(object):
 
         prov = {'aws': '', 'google': '', 'azure': ''}
 
-        for p in self.__PROVIDERS:
-            if dmidcd and dmidcd.bios and p.vv:
-                prov[p.name] = dmidcd.bios.get('version') if p.vv in dmidcd.bios.get('version').lower() \
+        if dmidcd and dmidcd.bios:
+            for p in self.__PROVIDERS:
+                prov[p.name] = dmidcd.bios.get('version') if p.vv and p.vv in dmidcd.bios.get('version').lower() \
                     else ''
         return prov
 

--- a/insights/combiners/cloud_provider.py
+++ b/insights/combiners/cloud_provider.py
@@ -119,9 +119,10 @@ class CloudProvider(object):
 
         prov = {'aws': [], 'google': [], 'azure': []}
 
-        for p in self.__PROVIDERS:
-            for key, val in rpms.packages.items():
-                prov[p.name].append(val[0].package) if p.rpm in val[0].package.lower() else prov
+        if rpms:
+            for p in self.__PROVIDERS:
+                for key, val in rpms.packages.items():
+                    prov[p.name].append(val[0].package) if p.rpm in val[0].package.lower() else prov
 
         return prov
 

--- a/insights/combiners/tests/test_cloud_provider.py
+++ b/insights/combiners/tests/test_cloud_provider.py
@@ -163,6 +163,71 @@ Handle 0x0037, DMI type 127, 4 bytes.
 End Of Table
 '''
 
+DMIDECODE_BARE_METAL = '''
+# dmidecode 3.0
+Getting SMBIOS data from sysfs.
+SMBIOS 2.7 present.
+56 structures occupying 2407 bytes.
+Table at 0x000EB4C0.
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+\tVendor: American Megatrends Inc.
+\tVersion: 2.0a
+\tRelease Date: 06/08/2012
+\tAddress: 0xF0000
+\tRuntime Size: 64 kB
+\tROM Size: 8192 kB
+\tCharacteristics:
+\t\tPCI is supported
+\t\tBIOS is upgradeable
+\t\tBIOS shadowing is allowed
+\t\tBoot from CD is supported
+\t\tSelectable boot is supported
+\t\tBIOS ROM is socketed
+\t\tEDD is supported
+\t\t5.25"/1.2 MB floppy services are supported (int 13h)
+\t\t3.5"/720 kB floppy services are supported (int 13h)
+\t\t3.5"/2.88 MB floppy services are supported (int 13h)
+\t\tPrint screen service is supported (int 5h)
+\t\t8042 keyboard services are supported (int 9h)
+\t\tSerial services are supported (int 14h)
+\t\tPrinter services are supported (int 17h)
+\t\tACPI is supported
+\t\tUSB legacy is supported
+\t\tBIOS boot specification is supported
+\t\tFunction key-initiated network boot is supported
+\t\tTargeted content distribution is supported
+\t\tUEFI is supported
+\tBIOS Revision: 2.10
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+\tManufacturer: Supermicro
+\tProduct Name: X9SCL/X9SCM
+\tVersion: 0123456789
+\tSerial Number: 0123456789
+\tUUID: 12345678-1234-1234-1234-123456681234
+\tWake-up Type: Power Switch
+\tSKU Number: To be filled by O.E.M.
+\tFamily: To be filled by O.E.M.
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+\tManufacturer: Supermicro
+\tProduct Name: X9SCL/X9SCM
+\tVersion: 0123456789
+\tSerial Number: 1234567812
+\tAsset Tag: To be filled by O.E.M.
+\tFeatures:
+\t\tBoard is a hosting board
+\t\tBoard is replaceable
+\tLocation In Chassis: To be filled by O.E.M.
+\tChassis Handle: 0x0003
+\tType: Motherboard
+\tContained Object Handles: 0
+'''.strip()
+
 DMIDECODE_AWS = '''
 # dmidecode 2.12-dmifs
 SMBIOS 2.4 present.
@@ -370,7 +435,7 @@ def test_rpm_aws():
 
 def test_rpm_azure():
     irpms = IRPMS(context_wrap(RPMS_AZURE))
-    dmi = DMIDecode(context_wrap(DMIDECODE))
+    dmi = DMIDecode(context_wrap(DMIDECODE_BARE_METAL))
     yrl = YumRepoList(context_wrap(YUM_REPOLIST_NOT_AZURE))
     ret = CloudProvider(irpms, dmi, yrl)
     assert ret.cloud_provider == 'azure'


### PR DESCRIPTION
This small patch fix the following Issue:

```
../insights-core/insights/tests/__init__.py:77: AssertionError
---------------------------------------- Captured stdout call ----------------------------------------
Traceback (most recent call last):
  File "/pub/INSIGHTS/insights-core/insights/core/dr.py", line 952, in run
    result = DELEGATES[component].process(broker)
  File "/pub/INSIGHTS/insights-core/insights/core/dr.py", line 673, in process
    return self.invoke(broker)
  File "/pub/INSIGHTS/insights-core/insights/core/plugins.py", line 63, in invoke
    return super(PluginType, self).invoke(broker)
  File "/pub/INSIGHTS/insights-core/insights/core/dr.py", line 653, in invoke
    return self.component(*args)
  File "/pub/INSIGHTS/insights-core/insights/combiners/cloud_provider.py", line 80, in __init__
    self.cp_rpms = self._get_rpm_cp_info(rpms)
  File "/pub/INSIGHTS/insights-core/insights/combiners/cloud_provider.py", line 123, in _get_rpm_cp_info
    for key, val in rpms.packages.items():
AttributeError: 'NoneType' object has no attribute 'packages'
```