### PR TITLE
Fix docstring for modprobe parser

### DIFF
--- a/insights/parsers/modprobe.py
+++ b/insights/parsers/modprobe.py
@@ -1,6 +1,6 @@
 """
-Modprobe configuration - files ``/etc/modprobe.conf`` and ``/etc/modprobe.d/*``
-===============================================================================
+Modprobe configuration - files ``/etc/modprobe.conf`` and ``/etc/modprobe.d/*.conf``
+====================================================================================
 
 This parser collects command information from the Modprobe configuration
 files and stores information about each module mentioned. Lines such as


### PR DESCRIPTION
Modprobe parser reads data from the file `/etc/modprobe.d/*.conf`
[Specs for modprobe parser](https://github.com/RedHatInsights/insights-core/blob/master/insights/specs/default.py#L484)