### PR TITLE
tweak how options are validated after load

### DIFF
--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -588,8 +588,7 @@ class InsightsConfig(object):
            self.analyze_mountpoint or
            self.analyze_image_id):
             self.analyze_container = True
-        self.to_json = ((self.to_json or self.analyze_container) and
-                        not self.to_stdout)
+        self.to_json = self.to_json or self.analyze_container
         self.register = (self.register or self.reregister) and not self.offline
         self.keep_archive = self.keep_archive or self.no_upload
         if self.payload:

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -376,6 +376,8 @@ class InsightsConfig(object):
         if args:
             self._update_dict(args[0])
         self._update_dict(kwargs)
+        self._imply_options()
+        self._validate_options()
         self._cli_opts = None
 
     def __str__(self):
@@ -420,10 +422,8 @@ class InsightsConfig(object):
         for u in unknown_opts:
             dict_.pop(u, None)
         self.__dict__.update(dict_)
-        self._imply_options()
-        self._validate_options()
 
-    def load_env(self):
+    def _load_env(self):
         '''
         Options can be set as environment variables
         The formula for the key is `"INSIGHTS_%s" % key.upper()`
@@ -460,7 +460,7 @@ class InsightsConfig(object):
                         'ERROR: Invalid value specified for {0}: {1}.'.format(k, v))
         self._update_dict(insights_env_opts)
 
-    def load_command_line(self, conf_only=False):
+    def _load_command_line(self, conf_only=False):
         '''
         Load config from command line switches.
         NOTE: Not all config is available on the command line.
@@ -497,7 +497,7 @@ class InsightsConfig(object):
 
         self._update_dict(self._cli_opts)
 
-    def load_config_file(self, fname=None):
+    def _load_config_file(self, fname=None):
         '''
         Load config from config file. If fname is not specified,
         config is loaded from the file named by InsightsConfig.conf
@@ -546,10 +546,12 @@ class InsightsConfig(object):
         Helper function for actual Insights client use
         '''
         # check for custom conf file before loading conf
-        self.load_command_line(conf_only=True)
-        self.load_config_file()
-        self.load_env()
-        self.load_command_line()
+        self._load_command_line(conf_only=True)
+        self._load_config_file()
+        self._load_env()
+        self._load_command_line()
+        self._imply_options()
+        self._validate_options()
         return self
 
     def _validate_options(self):

--- a/insights/tests/client/test_config.py
+++ b/insights/tests/client/test_config.py
@@ -81,4 +81,3 @@ def test_env_number_bad_values():
     c = InsightsConfig()
     with pytest.raises(ValueError):
         c._load_env()
-        c._load_env()

--- a/insights/tests/client/test_config.py
+++ b/insights/tests/client/test_config.py
@@ -9,7 +9,7 @@ def test_config_load(open_):
     open_.return_value = TextIOWrapper(
         BytesIO(b'[insights-client]\nusername=AMURO'))
     c = InsightsConfig()
-    c.load_config_file()
+    c._load_config_file()
     assert c.username == 'AMURO'
 
 
@@ -18,7 +18,7 @@ def test_config_load_legacy(open_):
     open_.return_value = TextIOWrapper(
         BytesIO(b'[redhat-access-insights]\nusername=BRIGHT'))
     c = InsightsConfig()
-    c.load_config_file()
+    c._load_config_file()
     assert c.username == 'BRIGHT'
 
 
@@ -28,7 +28,7 @@ def test_config_load_legacy_ignored(open_):
         BytesIO(b'[insights-client]\nusername=CASVAL\n'
                 b'[redhat-access-insights]\nusername=SAYLA'))
     c = InsightsConfig()
-    c.load_config_file()
+    c._load_config_file()
     assert c.username == 'CASVAL'
 
 
@@ -38,7 +38,7 @@ def test_config_load_section_error(open_):
     open_.return_value = TextIOWrapper(
         BytesIO(b'aFUHAEFJhFhlAFJKhnfjeaf\nusername=RAMBA'))
     c = InsightsConfig()
-    c.load_config_file()
+    c._load_config_file()
     assert c.username == DEFAULT_OPTS['username']['default']
 
 
@@ -48,7 +48,7 @@ def test_config_load_value_error(open_):
     open_.return_value = TextIOWrapper(
         BytesIO(b'[insights-client]\nhttp_timeout=ZGOK'))
     c = InsightsConfig()
-    c.load_config_file()
+    c._load_config_file()
     assert c.http_timeout == DEFAULT_OPTS['http_timeout']['default']
 
 
@@ -66,7 +66,7 @@ def test_defaults():
        })
 def test_env_number_parsing():
     c = InsightsConfig()
-    c.load_env()
+    c._load_env()
     assert isinstance(c.cmd_timeout, int)
     assert isinstance(c.retries, int)
     assert isinstance(c.http_timeout, float)
@@ -80,4 +80,5 @@ def test_env_number_parsing():
 def test_env_number_bad_values():
     c = InsightsConfig()
     with pytest.raises(ValueError):
-        c.load_env()
+        c._load_env()
+        c._load_env()


### PR DESCRIPTION
- make env, CLI, conf load functions private (should only be using load_all outside this module)
- move validate and imply calls to after sources are loaded, both in init and load_all