### PR TITLE
Added a doc string for RHEL-6/7

### DIFF
--- a/insights/parsers/software_collections_list.py
+++ b/insights/parsers/software_collections_list.py
@@ -1,9 +1,11 @@
 """
-Software Collections list output - command ``scl --list`` RHEL-6
-================================================================
+Software Collections list output - command ``scl --list`` RHEL-6/7
+==================================================================
 
 This module provides parser for list output of ``scl``. This spec
-is valid for ``RHEL-6`` only, ``-l|--list`` is ``depricated`` in RHEL-7/8.
+is valid for ``RHEL-6/7`` only, ``-l|--list`` is ``deprecated`` in
+``RHEL-8``. On ``RHEL-8`` same functionality can be achieved by
+``scl list-collections`` spec.
 
 Parser provided by this module is:
 

--- a/insights/parsers/software_collections_list.py
+++ b/insights/parsers/software_collections_list.py
@@ -1,13 +1,14 @@
 """
-Software Collections list output - command ``scl --list``
-=========================================================================
+Software Collections list output - command ``scl --list`` RHEL-6
+================================================================
 
-This module provides parser for list output of ``scl``.
+This module provides parser for list output of ``scl``. This spec
+is valid for ``RHEL-6`` only, ``-l|--list`` is ``depricated`` in RHEL-7/8.
 
 Parser provided by this module is:
 
 SoftwareCollectionsListInstalled - command ``scl --list``
-------------------------------------------------------------------------------------
+---------------------------------------------------------
 
 """
 


### PR DESCRIPTION
Parser for the spec `scl --list`  is not in use, also the spec is ``deprecated`` in RHEL-8 and there is no such a requirement of the new specs `scl list-collections` for any of the plugin code hence just enhanced doc to inform that the spec is valid for RHEL-6/7 only.