### PR TITLE
Correct an issue where only the first rpm that matches the rpm pattern

### DIFF
--- a/insights/combiners/cloud_provider.py
+++ b/insights/combiners/cloud_provider.py
@@ -122,7 +122,8 @@ class CloudProvider(object):
         if rpms:
             for p in self.__PROVIDERS:
                 for key, val in rpms.packages.items():
-                    prov[p.name].append(val[0].package) if p.rpm in val[0].package.lower() else prov
+                    for v in val:
+                        prov[p.name].append(v.package) if p.rpm in v.package.lower() else prov
 
         return prov
 

--- a/insights/combiners/tests/test_cloud_provider.py
+++ b/insights/combiners/tests/test_cloud_provider.py
@@ -24,6 +24,7 @@ gnome-terminal-3.28.2-2.fc28.x86_64
 python3-IPy-0.81-21.fc28.noarch
 gnu-free-serif-fonts-20120503-17.fc28.noarch
 google-rhui-client-5.1.100-1.el7
+google-rhui-client-5.1.100-1.el6
 """.strip()
 
 RPMS_AZURE = """
@@ -421,7 +422,8 @@ def test_rpm_google():
     yrl = YumRepoList(context_wrap(YUM_REPOLIST_NOT_AZURE))
     ret = CloudProvider(irpms, dmi, yrl)
     assert ret.cloud_provider == 'google'
-    assert ret.cp_rpms.get('google')[0] == 'google-rhui-client-5.1.100-1.el7'
+    assert 'google-rhui-client-5.1.100-1.el7' in ret.cp_rpms.get('google')
+    assert 'google-rhui-client-5.1.100-1.el6' in ret.cp_rpms.get('google')
 
 
 def test_rpm_aws():


### PR DESCRIPTION
Correct an issue where only the first rpm that matches the rpm pattern
for a provider is stored in the list.
Does not affect provide selection.