### PR TITLE
Fix parsing of /etc/krb5.conf.d/crypto-policies on RHEL8.

### DIFF
--- a/insights/combiners/krb5.py
+++ b/insights/combiners/krb5.py
@@ -8,6 +8,7 @@ Krb5Configuration objects.
 from .. import LegacyItemAccess
 from insights.core.plugins import combiner
 from insights.parsers.krb5 import Krb5Configuration
+from insights.parsers.httpd_conf import dict_deep_merge
 
 
 @combiner(Krb5Configuration)
@@ -81,7 +82,7 @@ class AllKrb5Conf(LegacyItemAccess):
                 self.include = krb5_parser.include
                 self.module = krb5_parser.module
             else:
-                self.data.update(krb5_parser.data)
+                dict_deep_merge(self.data, krb5_parser.data)
         # Same options in same section from other configuration files will be covered by the option
         # from main configuration, but different options in same section will be kept.
         for key, value in main_data.items():

--- a/insights/combiners/tests/test_krb5.py
+++ b/insights/combiners/tests/test_krb5.py
@@ -9,6 +9,9 @@ includedir /etc/krb5.conf.d/
 include /etc/krb5test.conf
 module /etc/krb5test.conf:residual
 
+[libdefaults]
+ donotoverwrite1 = true
+
 [logging]
  default = FILE:/var/log/krb5libs.log
  kdc = FILE:/var/log/krb5kdc.log
@@ -55,6 +58,7 @@ KRB5CONFIG2 = """
  admin_server = FILE:/var/log/kadmind2.log
 
 [libdefaults]
+ donotoverwrite2 = true
  dnsdsd = false
  tilnvs = 24h
  default_ccache_name = KEYRING:%{uid}:persistent
@@ -69,10 +73,24 @@ KRB5CONFIG2 = """
 """.strip()
 
 
+KRB5CONFIG3 = """
+
+[libdefaults]
+ donotoverwrite3 = true
+
+""".strip()
+
+
+
+
 def test_active_krb5_nest():
     krb51 = Krb5Configuration(context_wrap(KRB5CONFIG, path='/etc/krb5.conf'))
     krb52 = Krb5Configuration(context_wrap(KRB5CONFIG2, path='/etc/krb5.conf.d/test.conf'))
-    result = AllKrb5Conf([krb51, krb52])
+    krb53 = Krb5Configuration(context_wrap(KRB5CONFIG3, path='/etc/krb5.conf.d/test2.conf'))
+    result = AllKrb5Conf([krb51, krb52, krb53])
+    assert result.has_option("libdefaults", "donotoverwrite1")
+    assert result.has_option("libdefaults", "donotoverwrite2")
+    assert result.has_option("libdefaults", "donotoverwrite3")
     assert result["logging"]["kdc"] == "FILE:/var/log/krb5kdc.log"
     assert result.has_option("logging", "admin_server")
     assert result["libdefaults"]["EXAMPLE2.COM"]["kdc"] == "kerberos.example2.com"

--- a/insights/combiners/tests/test_krb5.py
+++ b/insights/combiners/tests/test_krb5.py
@@ -81,8 +81,6 @@ KRB5CONFIG3 = """
 """.strip()
 
 
-
-
 def test_active_krb5_nest():
     krb51 = Krb5Configuration(context_wrap(KRB5CONFIG, path='/etc/krb5.conf'))
     krb52 = Krb5Configuration(context_wrap(KRB5CONFIG2, path='/etc/krb5.conf.d/test.conf'))


### PR DESCRIPTION
When multiple config files in /etc/krb5.conf.d/ have the same section, the sections are not merged by the combiner. However, they should get merged.