### PR TITLE
Add display_name spec to insights_archive.py

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -103,6 +103,7 @@ class Specs(SpecSet):
     dirsrv_access = RegistryPoint(multi_output=True, filterable=True)
     dirsrv_errors = RegistryPoint(multi_output=True, filterable=True)
     display_java = RegistryPoint()
+    display_name = RegistryPoint()
     dmesg = RegistryPoint(filterable=True)
     dmidecode = RegistryPoint()
     dmsetup_info = RegistryPoint()

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -39,6 +39,7 @@ class InsightsArchiveSpecs(Specs):
     dig_edns = simple_file("insights_commands/dig_edns_0_._SOA")
     dig_noedns = simple_file("insights_commands/dig_noedns_._SOA")
     display_java = simple_file("insights_commands/alternatives_--display_java")
+    display_name = simple_file("display_name")
     dmesg = simple_file("insights_commands/dmesg")
     dmidecode = simple_file("insights_commands/dmidecode")
     dmsetup_info = simple_file("insights_commands/dmsetup_info_-C")


### PR DESCRIPTION
The client drops a display_name file into the root of the archive to get around
the fact that metadata isn't forwarded for legacy uploads.  This spec collects
it from the insights archive so canonical fact gathering in pup can pick it up.

Closes #1891