### PR TITLE
Enhance _start_of_distribution method in installed_rpm module 

### DIFF
--- a/insights/parsers/installed_rpms.py
+++ b/insights/parsers/installed_rpms.py
@@ -356,6 +356,12 @@ class InstalledRpm(object):
                     nondigit_flag = True
                 elif nondigit_flag and r.isdigit():
                     return len(rest_split) - i
+            # obviously to check last two fields
+            if rest_split and 'el' in rest_split[-1]:
+                return len(rest_split) - 1
+            elif len(rest_split) > 1 and 'el' in rest_split[-2]:
+                return len(rest_split) - 2
+
 
         self._release_sep = self.release
         self._distribution = None

--- a/insights/parsers/installed_rpms.py
+++ b/insights/parsers/installed_rpms.py
@@ -362,7 +362,6 @@ class InstalledRpm(object):
             elif len(rest_split) > 1 and 'el' in rest_split[-2]:
                 return len(rest_split) - 2
 
-
         self._release_sep = self.release
         self._distribution = None
         rl_split = self._release_sep.split('.') if self._release_sep else None

--- a/insights/parsers/tests/test_installed_rpms.py
+++ b/insights/parsers/tests/test_installed_rpms.py
@@ -183,7 +183,6 @@ def test_max_min():
     assert rpms.get_min('nagios-plugins-disk').package == 'nagios-plugins-disk-2.2.1-9git5c7eb5b9.el7'
 
 
-
 def test_max_min_not_found():
     rpms = InstalledRpms(context_wrap(RPMS_MULTIPLE_KERNEL))
     assert rpms.get_min('abc') is None

--- a/insights/parsers/tests/test_installed_rpms.py
+++ b/insights/parsers/tests/test_installed_rpms.py
@@ -66,6 +66,10 @@ RPMS_JSON = '''
 RPMS_MULTIPLE = '''
 yum-3.4.3-132.el7.noarch
 yum-3.4.2-132.el7.noarch
+xaaz-5.2.2-1alpha.el7.x86_64
+xaaz-5.2.2-1.el7.x86_64
+nagios-plugins-disk-2.2.1-9git5c7eb5b9.el7
+nagios-plugins-disk-2.2.1-16.20180725git3429dad.el7
 '''
 
 RPMS_MULTIPLE_KERNEL = '''
@@ -175,6 +179,9 @@ def test_max_min():
     rpms = InstalledRpms(context_wrap(RPMS_MULTIPLE))
     assert rpms.get_min('yum').package == 'yum-3.4.2-132.el7'
     assert rpms.get_max('yum').package == 'yum-3.4.3-132.el7'
+    assert rpms.get_max('xaaz').package == 'xaaz-5.2.2-1alpha.el7'
+    assert rpms.get_min('nagios-plugins-disk').package == 'nagios-plugins-disk-2.2.1-9git5c7eb5b9.el7'
+
 
 
 def test_max_min_not_found():


### PR DESCRIPTION
To fix below kind of value error

ValueError: Cannot compare packages that one has distribution while the other does not xz-5.2.2-1.el7 != xz-5.1.2-12alpha.el7'\|