### PR TITLE
Adding a try/except to the request made when trying to update the egg

### DIFF
--- a/insights/tests/client/init/test_fetch.py
+++ b/insights/tests/client/init/test_fetch.py
@@ -1,4 +1,5 @@
 import pytest
+from requests import ConnectionError
 from insights.client import InsightsClient
 from insights.client.config import InsightsConfig
 from mock.mock import Mock
@@ -45,3 +46,12 @@ def test_request_forced(insights_client):
     url = "{0}{1}".format(insights_client.connection.base_url, source_path)
     timeout = insights_client.config.http_timeout
     insights_client.session.get.assert_called_once_with(url, timeout=timeout)
+
+
+def test_fetch_with_bad_url(insights_client):
+    insights_client.session.get.side_effect = ConnectionError
+    
+    source_path = 'some-source-path'
+    with pytest.raises(SystemExit) as pytest_error:
+        insights_client._fetch(source_path, "", "", force=False)
+    assert pytest_error.type == SystemExit

--- a/insights/tests/client/init/test_fetch.py
+++ b/insights/tests/client/init/test_fetch.py
@@ -50,7 +50,7 @@ def test_request_forced(insights_client):
 
 def test_fetch_with_bad_url(insights_client):
     insights_client.session.get.side_effect = ConnectionError
-    
+
     source_path = 'some-source-path'
     with pytest.raises(SystemExit) as pytest_error:
         insights_client._fetch(source_path, "", "", force=False)


### PR DESCRIPTION
For BZ-1708682. This change will prevent the 'no such option' error from occurring when the the client cannot connect (if base_url was set to a bad value, for example), and will instead log the correct error and terminate the process if a connection cannot be made.