### PR TITLE
Add alternative integration test fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
 import logging
+import pytest
 import warnings
+from insights.tests import InputData, run_test
 warnings.simplefilter('always', DeprecationWarning)
 
 
@@ -12,3 +14,52 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     level = logging.DEBUG if config.getoption("--appdebug") else logging.ERROR
     logging.basicConfig(level=level)
+
+
+@pytest.fixture
+def run_rule():
+    """
+    Pytest fixture to allows execution of integration tests without using
+    ``archive_provider``.  See arguments to use in inner function below.
+
+    This fixture still runs the same dependency tree as when testing with
+    ``archive_provider``.
+    """
+    def _run_rule(name, rule, input_data):
+        """
+        Fixture for rule integration testing
+
+        Use this fixture to create an integration test for your rule plugin.
+
+        Sample code::
+
+            def test_myrule(run_rule):
+                input_data = {'spec': Specs.installed_rpms, 'data': RPMS_DATA}
+                expected = make_fail(ERROR_KEY, bad_data=data_expected)
+                results = run_rule('my test name', my_rule, input_data)
+                assert results == expected
+
+        Arguments:
+            name (str): Name to identify this test in output.
+            rule (object): Your rule function object.
+            data (list or dict):  List of dict of each data spec your rule requires
+                to trigger.  If a single input data spec then a dict can be passed instead.
+                Each dict must include both ``spec`` and ``data`` keys, and may optionally
+                include ``path`` if necessary for the spec.
+
+        Return:
+            results of call to make_pass, make_fail, etc., or None
+
+        Raises:
+            KeyError: Raises if either spec or data keywords are not present.
+        """
+        idata = InputData(name)
+        input_data = input_data if isinstance(input_data, list) else [input_data]
+        for d in input_data:
+            if 'path' in d:
+                idata.add(d['spec'], d['data'], path=d['path'])
+            else:
+                idata.add(d['spec'], d['data'])
+        return run_test(rule, idata)
+
+    return _run_rule

--- a/insights/plugins/rules_fixture_plugin.py
+++ b/insights/plugins/rules_fixture_plugin.py
@@ -1,0 +1,14 @@
+from insights.core.plugins import rule, make_fail, make_pass
+from insights.parsers import installed_rpms, uname as uname_mod
+
+
+@rule(optional=[installed_rpms.InstalledRpms, uname_mod.Uname])
+def report(rpms, uname):
+    if rpms is not None:
+        bash_ver = rpms.get_max('bash')
+        if uname is not None:
+            return make_pass('PASS', bash_ver=bash_ver.nvr, uname_ver=uname.version)
+        else:
+            return make_fail('FAIL', bash_ver=bash_ver.nvr, path=rpms.file_path)
+
+    # implicit return None

--- a/insights/tests/test_rules_fixture.py
+++ b/insights/tests/test_rules_fixture.py
@@ -1,0 +1,42 @@
+from insights.core.plugins import make_pass, make_fail
+from insights.specs import Specs
+from insights.plugins import rules_fixture_plugin
+
+
+UNAME = {
+    'spec': Specs.uname,
+    'data': """
+Linux ceehadoop1.gsslab.rdu2.redhat.com 2.6.32-642.el6.x86_64 #1 SMP Tue Sep 16 01:56:35 EDT 2014 x86_64 x86_64 x86_64 GNU/Linux
+""".strip()
+}
+RPMS = {
+    'spec': Specs.installed_rpms,
+    'path': '/etc/yum.repos.d/stuff',
+    'data': """
+kernel-2.6.32-573.el6.x86_64
+bash-4.1.23-6.fc29.x86_64
+rh-nginx112-nginx-1.12.1-2.el7.x86_64
+""".strip()
+}
+
+
+def test_rules_fixture(run_rule):
+    input_data = [UNAME, RPMS]
+    expected = make_pass('PASS', bash_ver='bash-4.1.23-6.fc29', uname_ver='2.6.32')
+    results = run_rule('test_pass', rules_fixture_plugin.report, input_data)
+    assert results == expected
+
+    input_data = [RPMS]
+    expected = make_fail('FAIL', bash_ver='bash-4.1.23-6.fc29', path=RPMS['path'])
+    results = run_rule('test_fail_list', rules_fixture_plugin.report, input_data)
+    assert results == expected
+
+    input_data = RPMS
+    expected = make_fail('FAIL', bash_ver='bash-4.1.23-6.fc29', path=RPMS['path'])
+    results = run_rule('test_fail_dict', rules_fixture_plugin.report, input_data)
+    assert results == expected
+
+    input_data = []
+    expected = None
+    results = run_rule('test_ret_none', rules_fixture_plugin.report, input_data)
+    assert results == expected

--- a/insights/tests/test_rules_fixture.py
+++ b/insights/tests/test_rules_fixture.py
@@ -6,7 +6,7 @@ from insights.plugins import rules_fixture_plugin
 UNAME = {
     'spec': Specs.uname,
     'data': """
-Linux ceehadoop1.gsslab.rdu2.redhat.com 2.6.32-642.el6.x86_64 #1 SMP Tue Sep 16 01:56:35 EDT 2014 x86_64 x86_64 x86_64 GNU/Linux
+Linux testbox.redhat.com 2.6.32-642.el6.x86_64 #1 SMP Tue Sep 16 01:56:35 EDT 2014 x86_64 x86_64 x86_64 GNU/Linux
 """.strip()
 }
 RPMS = {


### PR DESCRIPTION
* Add test fixture run_rule that provides integration test
  functionality like @archive_provider, but runs as a normal
  pytest.
* Add plugin and tests for new fixture.

Signed-off-by: Bob Fahr <bfahr@redhat.com>