### PR TITLE
Remove the subscription_manager_list_installed from insights_archive.py

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -808,7 +808,6 @@ class DefaultSpecs(Specs):
     subscription_manager_facts_list = simple_command("/usr/bin/subscription-manager facts --list")
     subscription_manager_id = simple_command("/usr/bin/subscription-manager identity")
     subscription_manager_list_consumed = simple_command('/usr/bin/subscription-manager list --consumed')
-    subscription_manager_list_installed = simple_command('/usr/bin/subscription-manager list --installed')
     subscription_manager_release_show = simple_command('/usr/bin/subscription-manager release --show')
     subscription_manager_repos_list_enabled = simple_command('/usr/bin/subscription-manager repos --list-enabled')
     swift_conf = first_file(["/var/lib/config-data/puppet-generated/swift/etc/swift/swift.conf", "/etc/swift/swift.conf"])

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -223,7 +223,6 @@ class InsightsArchiveSpecs(Specs):
     subscription_manager_facts_list = simple_file("insights_commands/subscription-manager_facts_--list")
     subscription_manager_id = simple_file("insights_commands/subscription-manager_identity")
     subscription_manager_list_consumed = simple_file('insights_commands/subscription-manager_list_--consumed')
-    subscription_manager_list_installed = simple_file('insights_commands/subscription-manager_list_--installed')
     subscription_manager_release_show = simple_file('insights_commands/subscription-manager_release_--show')
     subscription_manager_repos_list_enabled = simple_file('insights_commands/subscription-manager_repos_--list-enabled')
     sysctl = simple_file("insights_commands/sysctl_-a")


### PR DESCRIPTION
- The plugins using this rule are against sosreport archives and it's not added to uploader.json ever