### PR TITLE
Remove subscription_manager_list_consumed from insights_archive.py

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -809,7 +809,6 @@ class DefaultSpecs(Specs):
     sshd_config_perms = simple_command("/bin/ls -l /etc/ssh/sshd_config")
     sssd_config = simple_file("/etc/sssd/sssd.conf")
     subscription_manager_id = simple_command("/usr/bin/subscription-manager identity")
-    subscription_manager_list_consumed = simple_command('/usr/bin/subscription-manager list --consumed')
     subscription_manager_release_show = simple_command('/usr/bin/subscription-manager release --show')
     swift_conf = first_file(["/var/lib/config-data/puppet-generated/swift/etc/swift/swift.conf", "/etc/swift/swift.conf"])
     swift_log = first_file(["/var/log/containers/swift/swift.log", "/var/log/swift/swift.log"])

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -224,7 +224,6 @@ class InsightsArchiveSpecs(Specs):
     ss = simple_file("insights_commands/ss_-tupna")
     sshd_config_perms = simple_file("insights_commands/ls_-l_.etc.ssh.sshd_config")
     subscription_manager_id = simple_file("insights_commands/subscription-manager_identity")
-    subscription_manager_list_consumed = simple_file('insights_commands/subscription-manager_list_--consumed')
     subscription_manager_release_show = simple_file('insights_commands/subscription-manager_release_--show')
     sysctl = simple_file("insights_commands/sysctl_-a")
     sysctl_conf_initramfs = simple_file("insights_commands/lsinitrd_.boot.initramfs-_kdump.img_-f_.etc.sysctl.conf_.etc.sysctl.d._.conf")


### PR DESCRIPTION
- Need to change to use other specs in the related rule
- Will also remove it from the uploader.json