### PR TITLE
Enhance parser for rabbitmq_report

### DIFF
--- a/insights/parsers/rabbitmq.py
+++ b/insights/parsers/rabbitmq.py
@@ -35,7 +35,7 @@ def erlblock_parser():
 
     key = p.Word(p.alphas + '_')
     value_tnum = p.Word(p.nums + '.')
-    value_tword = p.Word(p.alphanums + '/"-[]:.()')
+    value_tword = p.Word(p.alphanums + '/"-[]:.()\\')
     value_tstr = p.OneOrMore(value_tword)
     value_tdoustrs = value_tstr + COMMA + value_tstr
     value_tnumstr = value_tnum + value_tstr
@@ -126,10 +126,10 @@ class RabbitMQReport(CommandParser):
                         'redhat':['redhat.*', '.*', '.*']},
                     'test_vhost': ''}}
         """
-        try:
-            self.result = create_parser().parseString("\n".join(content)).asDict()
-        except p.ParseException:
-            self.result = None
+        # During the below parsing process, p.ParseException might be thrown.
+        # No handler will be applied here.
+        # And such p.ParseException won't be hidden, showing for debug usage.
+        self.result = create_parser().parseString("\n".join(content)).asDict()
 
 
 @parser(Specs.rabbitmq_users)

--- a/insights/parsers/tests/test_rabbitmq_report.py
+++ b/insights/parsers/tests/test_rabbitmq_report.py
@@ -1,4 +1,5 @@
 from insights.core.context import OSP
+from insights.contrib.pyparsing import ParseException as PyparsingParseException
 from insights.parsers.rabbitmq import RabbitMQReport
 from insights.tests import context_wrap
 
@@ -142,12 +143,81 @@ Parameters on /:
 ...done.
 """
 
+RABBITMQCTL_REPORT_3 = """
+Reporting server status on {{2019,5,2},{18,57,48}}
+
+ ...
+Status of node rabbit@controller1 ...
+[{pid,76101},
+ {running_applications,[{rabbit,"RabbitMQ","3.6.3"},
+                        {os_mon,"CPO  CXC 138 46","2.4"},
+                        {rabbit_common,[],"3.6.3"},
+                        {mnesia,"MNESIA  CXC 138 12","4.13.4"},
+                        {ranch,"Socket acceptor pool for TCP protocols.",
+                               "1.2.1"},
+                        {xmerl,"XML parser","1.3.10"},
+                        {sasl,"SASL  CXC 138 11","2.7"},
+                        {stdlib,"ERTS  CXC 138 10","2.8"},
+                        {kernel,"ERTS  CXC 138 10","4.2"}]},
+ {os,{unix,linux}},
+ {erlang_version,"Erlang/OTP 18 [erts-7.3.1.2] [source] [64-bit] [smp:56:56] [async-threads:896] [hipe] [kernel-poll:true]\x5c\x6e"},
+ {memory,[{total,7198193032},
+          {connection_readers,2582888},
+          {connection_writers,611032},
+          {connection_channels,3622776},
+          {connection_other,6805920},
+          {queue_procs,113304336},
+          {queue_slave_procs,2454511224},
+          {plugins,0},
+          {other_proc,59823544},
+          {mnesia,18861888},
+          {mgmt_db,0},
+          {msg_index,2912704},
+          {other_ets,3109632},
+          {binary,4460926336},
+          {code,19689791},
+          {atom,752537},
+          {other_system,50678424}]},
+ {alarms,[]},
+ {listeners,[{clustering,25672,"::"},{amqp,5672,"172.16.64.62"}]},
+ {vm_memory_high_watermark,0.4},
+ {vm_memory_limit,162189606912},
+ {disk_free_limit,50000000},
+ {disk_free,151495786496},
+ {file_descriptors,[{total_limit,16284},
+                    {total_used,222},
+                    {sockets_limit,14653},
+                    {sockets_used,220}]},
+ {processes,[{limit,1048576},{used,16029}]},
+ {run_queue,0},
+ {uptime,1986766},
+ {kernel,{net_ticktime,60}}]
+
+Cluster status of node rabbit@controller1 ...
+[{nodes,[{disc,[rabbit@controller0,rabbit@controller1,rabbit@controller2]}]},
+ {running_nodes,[rabbit@controller0,rabbit@controller2,rabbit@controller1]},
+ {cluster_name,<<"rabbit@controller0.external.s4-southlake.vcp.vzwops.com">>},
+ {partitions,[]},
+ {alarms,[{rabbit@controller0,[]},
+          {rabbit@controller2,[]},
+          {rabbit@controller1,[]}]}]
+
+Permissions on /:
+user	configure	write	read
+guest	.*	.*	.*
+
+Policies on /:
+vhost	name	apply-to	pattern	definition	priority
+/	ha-all	all	^(?!amq\\.).*	{"ha-mode":"all"}	0
+
+Parameters on /:
+
+...done.
+
+"""
+
 
 def test_rabbitmq_report():
-    result = RabbitMQReport(context_wrap(RABBITMQCTL_REPORT_0,
-            hostname="controller_1", osp=osp_controller)).result
-    assert result is None
-
     result = RabbitMQReport(context_wrap(RABBITMQCTL_REPORT_1,
             hostname="controller_1", osp=osp_controller)).result
     assert result.get("nstat").get("rabbit@rabbitmq0").\
@@ -165,3 +235,20 @@ def test_rabbitmq_report():
     assert len(result.get("nstat")) == 3
     permissions = {'/': {'guest': ['.*', '.*', '.*']}}
     assert result.get("perm") == permissions
+
+    result = RabbitMQReport(context_wrap(RABBITMQCTL_REPORT_3,
+            hostname="controller_1", osp=osp_controller)).result
+    assert result.get("nstat").get("rabbit@controller1").\
+            get("file_descriptors").get("total_limit") == '16284'
+    assert len(result.get("nstat")) == 1
+    assert result.get("nstat").get("rabbit@controller1").\
+            get("erlang_version")[-1] == '[kernel-poll:true]\x5cn"'
+
+
+def test_rabbitmq_report_with_parse_exception():
+    try:
+        RabbitMQReport(context_wrap(RABBITMQCTL_REPORT_0,
+            hostname="controller_1", osp=osp_controller))
+        assert False
+    except PyparsingParseException:
+        assert True

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -96,6 +96,7 @@ class SosSpecs(Specs):
         simple_file("sos_commands/foreman/foreman-debug/qpid_stat_subscriptions"),
         simple_file("sos_commands/foreman/foreman-debug/qpid-stat-u")
     ])
+    rabbitmq_report = simple_file("sos_commands/rabbitmq/rabbitmqctl_report")
     rhn_charsets = simple_file("database-character-sets")
     root_crontab = simple_file("sos_commands/cron/root_crontab")
     route = simple_file("sos_commands/networking/route_-n")


### PR DESCRIPTION
  1. Fix the issue occurs when handling '\n' in content.
    When the '\n' is read from archive-files, it means letters ('\\', 'n'),
    and when from local test-data variables, it will be treated as 'a-new-line'.
    Base on these, the parsing failed toward archive-files.
    To fix this issue, let 'value_tword' can also cover letter '\'.
  2. Remove the hiding of parsing errors for friendly debug usage.

Signed-off-by: XiaoXue Wang <xiaoxwan@redhat.com>