### PR TITLE
Fix SysconfigOptions class to parse unpaired quotated lines

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -486,8 +486,12 @@ class SysconfigOptions(Parser, LegacyItemAccess):
                 words = shlex.split(line)
             except ValueError:
                 # Handle foo=bar # unpaired ' or " here
-                line, comment = line.split(' #', 1)
-                words = shlex.split(line)
+                if ' #' in line:
+                    line, comment = line.split(' #', 1)
+                    words = shlex.split(line)
+                else:
+                    # Line contains unpaired quotes
+                    words = line.split()
 
             # Either only one thing or line or rest starts with comment
             # but either way we need to have an equals in the first word.

--- a/insights/tests/test_sysconfig_options.py
+++ b/insights/tests/test_sysconfig_options.py
@@ -34,6 +34,10 @@ this line should be in unparsed lines afterward
 AND = 'so should this'
 """ + "SPACES_AFTER_VALUE=should_be_ignored    \n" + "  \n"
 
+NO_CLOSING_QUOTATION = """
+KEY='VALUE_WITHOUT_CLOSING_QUOTATION"
+""".split()
+
 
 def test_standard_config():
     config = SysconfigOptions(context_wrap(STANDARD_CONFIG))
@@ -93,3 +97,6 @@ def test_tricky_config():
         'this line should be in unparsed lines afterward',
         "AND = 'so should this'",
     ]
+
+    config = SysconfigOptions(context_wrap(NO_CLOSING_QUOTATION))
+    assert config.data['KEY'] == '\'VALUE_WITHOUT_CLOSING_QUOTATION"'


### PR DESCRIPTION
- This fixes SysconfigOptions base parser to parse lines that has
  unpaired quotations.

  For example:
     ```
      key='value"
     ```

Fixes #1946 