### PR TITLE
Fix coding to be utf-8 instead of UTF-8

### DIFF
--- a/insights/tests/test_sysconfig_options.py
+++ b/insights/tests/test_sysconfig_options.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from insights.core import SysconfigOptions
 from insights.tests import context_wrap
 


### PR DESCRIPTION
Old UTF-8 resulted in this error from GNU Emacs:
```
   Warning (mule): Invalid coding system 'UTF-8' is specified
   for the current buffer/file by the :coding tag.
   It is highly recommended to fix it before writing to a file.
```