### PR TITLE
fix "__getattr__" missing an underscore

### DIFF
--- a/insights/tools/insights_inspect.py
+++ b/insights/tools/insights_inspect.py
@@ -109,7 +109,7 @@ try:
     C.init()
 except:
     class Pass(object):
-        def _getattr__(self, name):
+        def __getattr__(self, name):
             return ""
 
     class C(object):


### PR DESCRIPTION
When invoking "insights-inspect" command without colorama
installed, we fake having the module by returning an empty
string using "__getattr__". However the magic method was
missing one of the leading underscores and thus not
having any effect.

Fixes https://github.com/RedHatInsights/insights-core/issues/1956