### PR TITLE
Added parser for Candlepin PostgreSQL cp_event table recrd count

### DIFF
--- a/insights/parsers/candlepin_events_psql_count.py
+++ b/insights/parsers/candlepin_events_psql_count.py
@@ -1,0 +1,42 @@
+"""
+Candlepin Events table size
+===========================
+
+Module for parsing size of cp_event table.
+
+This module is supposed to consume this output:
+
+```
+# su - postgres -c "echo 'select count(*) from cp_event' | psql -d candlepin"
+ count 
+-------
+  8061
+(1 row)
+```
+
+and provides `count` value.
+
+"""   # noqa: W291
+
+from insights import Parser, parser, get_active_lines
+from insights.parsers import ParseException, SkipException
+from insights.specs import Specs
+
+
+@parser(Specs.candlepin_events_psql_count)
+class CandlepinEventsPsqlCount(Parser):
+
+    def parse_content(self, content):
+        next_line = False
+        for line in get_active_lines(content):
+            if line.strip().startswith('---'):
+                next_line = True
+                continue
+            if next_line:
+                try:
+                    self.count = int(line.strip())
+                except ValueError:
+                    raise ParseException("Failed to parse count from '%s'" % line)
+                break
+        else:
+            raise SkipException("Empty or unexpected content '%s'." % content)

--- a/insights/parsers/tests/test_candlepin_events_psql_count.py
+++ b/insights/parsers/tests/test_candlepin_events_psql_count.py
@@ -1,0 +1,32 @@
+import pytest
+from insights.parsers import ParseException, SkipException
+from insights.parsers.candlepin_events_psql_count import CandlepinEventsPsqlCount
+from insights.tests import context_wrap
+
+
+EXPECTED = 8037
+EXAMPLE_OK = """
+ count 
+-------
+  8037
+(1 row)
+
+"""   # noqa: W291
+EXAMPLE_STRANGE = """
+ count 
+-------
+  hello
+(1 row)
+
+"""   # noqa: W291
+EXAMPLE_EMPTY = ""
+
+
+def test_candlepin_events_psql_count():
+    candlepin_events_psql_count = CandlepinEventsPsqlCount(context_wrap(EXAMPLE_OK))
+    assert candlepin_events_psql_count is not None
+    assert candlepin_events_psql_count.count == EXPECTED
+    with pytest.raises(ParseException):
+        candlepin_events_psql_count = CandlepinEventsPsqlCount(context_wrap(EXAMPLE_STRANGE))
+    with pytest.raises(SkipException):
+        candlepin_events_psql_count = CandlepinEventsPsqlCount(context_wrap(EXAMPLE_EMPTY))

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -31,6 +31,7 @@ class Specs(SpecSet):
     branch_info = RegistryPoint()
     brctl_show = RegistryPoint()
     candlepin_error_log = RegistryPoint(filterable=True)
+    candlepin_events_psql_count = RegistryPoint()
     candlepin_log = RegistryPoint(filterable=True)
     checkin_conf = RegistryPoint()
     catalina_out = RegistryPoint(multi_output=True, filterable=True)


### PR DESCRIPTION
This is related to https://github.com/RedHatInsights/insights-core/pull/1860 - same product (Satellite 6), but different table (cp_event) in a different database (candlepin).

CC @mccun934