### PR TITLE
cpuinfo - x86 stepping & other architectures

### DIFF
--- a/insights/parsers/cpuinfo.py
+++ b/insights/parsers/cpuinfo.py
@@ -128,13 +128,26 @@ class CpuInfo(LegacyItemAccess, Parser):
             "cpu MHz": "clockspeeds",
             "cache size": "cache_sizes",
             "cpu cores": "cpu_cores",
-            "flags": "flags"
+            "flags": "flags",
+            "stepping": "stepping",
+            "Features": "features",
+            "CPU implementer": "cpu_implementer",
+            "CPU architecture": "cpu_architecture",
+            "CPU variant": "cpu_variant",
+            "CPU part": "cpu_part",
+            "CPU revision": "cpu_revision",
+            "cpu": "cpu",
+            "revision": "revision",
         }
 
         for line in get_active_lines(content, comment_char="COMMAND>"):
             key, value = [p.strip() for p in line.split(":", 1)]
             if key in mappings:
                 self.data[mappings[key]].append(value)
+
+        if "cpu" in self.data and "POWER" in self.data["cpu"][0]:
+            # this works differently than on x86 and is not per-cpu
+            del self.data["model_ids"]
 
         self.data = dict(self.data)
 

--- a/insights/parsers/tests/test_cpuinfo.py
+++ b/insights/parsers/tests/test_cpuinfo.py
@@ -248,6 +248,199 @@ power management:
 
 """
 
+ARM_CPUINFO = """
+processor       : 0
+model name      : ARMv7 Processor rev 5 (v7l)
+BogoMIPS        : 38.40
+Features        : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant     : 0x0
+CPU part        : 0xc07
+CPU revision    : 5
+
+processor       : 1
+model name      : ARMv7 Processor rev 5 (v7l)
+BogoMIPS        : 38.40
+Features        : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant     : 0x0
+CPU part        : 0xc07
+CPU revision    : 5
+
+processor       : 2
+model name      : ARMv7 Processor rev 5 (v7l)
+BogoMIPS        : 38.40
+Features        : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant     : 0x0
+CPU part        : 0xc07
+CPU revision    : 5
+
+processor       : 3
+model name      : ARMv7 Processor rev 5 (v7l)
+BogoMIPS        : 38.40
+Features        : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant     : 0x0
+CPU part        : 0xc07
+CPU revision    : 5
+
+Hardware        : BCM2709
+Revision        : a01041
+"""
+
+
+POWER_CPUINFO = """
+processor	: 0
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 1
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 2
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 3
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 4
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 5
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 6
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 7
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 8
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 9
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 10
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 11
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 12
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 13
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 14
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 15
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 16
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 17
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 18
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 19
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 20
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 21
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 22
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 23
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 24
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 25
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 26
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+processor	: 27
+cpu		: POWER7 (architected), altivec supported
+clock		: 3612.000000MHz
+revision	: 2.0 (pvr 004a 0200)
+
+timebase	: 512000000
+platform	: pSeries
+model		: IBM,8231-E2D
+machine		: CHRP IBM,8231-E2D
+"""
+
 
 def test_cpuinfo():
     cpu_info = CpuInfo(context_wrap(CPUINFO))
@@ -265,7 +458,8 @@ def test_cpuinfo():
         "clockspeeds": "2900.000",
         "cache_sizes": "20480 KB",
         "cpu_cores": "1",
-        "flags": "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch epb intel_pt tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx rdseed adx smap clflushopt xsaveopt xsavec xgetbv1 dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp"
+        "flags": "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch epb intel_pt tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx rdseed adx smap clflushopt xsaveopt xsavec xgetbv1 dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp",
+        "stepping": "2",
     }
     assert cpu_info.cpu_speed == "2900.000"
     assert cpu_info.cache_size == "20480 KB"
@@ -286,3 +480,26 @@ def test_one_socket_cpuinfo():
 def test_empty_cpuinfo():
     cpu_info = CpuInfo(context_wrap(""))
     assert cpu_info.cpu_count == 0
+
+
+def test_arm_cpuinfo():
+    cpu_info = CpuInfo(context_wrap(ARM_CPUINFO))
+    assert cpu_info.cpu_count == 4
+    assert cpu_info.socket_count == 0
+    for i, cpu in enumerate(cpu_info):
+        assert cpu["models"] == "ARMv7 Processor rev 5 (v7l)"
+        assert cpu["features"] == "half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm"
+        assert cpu["cpu_implementer"] == "0x41"
+        assert cpu["cpu_architecture"] == "7"
+        assert cpu["cpu_variant"] == "0x0"
+        assert cpu["cpu_part"] == "0xc07"
+        assert cpu["cpu_revision"] == "5"
+
+
+def test_power_cpuinfo():
+    cpu_info = CpuInfo(context_wrap(POWER_CPUINFO))
+    assert cpu_info.cpu_count == 28
+    assert cpu_info.socket_count == 0
+    for i, cpu in enumerate(cpu_info):
+        assert cpu["cpu"] == "POWER7 (architected), altivec supported"
+        assert cpu["revision"] == "2.0 (pvr 004a 0200)"


### PR DESCRIPTION
* fixes https://github.com/RedHatInsights/insights-core/pull/1965
* added x86 stepping
* added other architectures
* it is the same mess as before and the new things are accessible only through `["str indexes"]`, not through properties
* rules have to be changed to support non-x86 archs (no change for rules here - they crashed with the previous cpuinfo parser on non-x86 anyway)
* no change necessary for existing rules that support only x86
* if we want to make a deeper and more systematic refactoring, I'm interested in a discussion as to how to achieve it (I see multiple possible ways, e.g. concerning backwards compatibility or the level of abstraction from the raw cpuinfo data)