### PR TITLE
Add display_name spec

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -210,6 +210,7 @@ class DefaultSpecs(Specs):
     dirsrv_access = glob_file("var/log/dirsrv/*/access*")
     dirsrv_errors = glob_file("var/log/dirsrv/*/errors*")
     display_java = simple_command("/usr/sbin/alternatives --display java")
+    display_name = simple_file("/display_name", kind=RawFileProvider)
     dmesg = simple_command("/bin/dmesg")
     dmidecode = simple_command("/usr/sbin/dmidecode")
     dmsetup_info = simple_command("/usr/sbin/dmsetup info -C")


### PR DESCRIPTION
Display name was added to the archive in client 3.0.93. We need to be
able to use this in the platform to gather display name from legacy
archives