### PR TITLE
[RFC] Add --compliance option to run oscap and upload the report

### DIFF
--- a/insights/client/apps/compliance/__init__.py
+++ b/insights/client/apps/compliance/__init__.py
@@ -1,0 +1,67 @@
+from glob import glob
+from insights.client.connection import InsightsConnection
+from insights.client.constants import InsightsConstants as constants
+from insights.util.canonical_facts import get_canonical_facts
+from logging import getLogger
+from platform import linux_distribution
+from re import findall
+from subprocess import Popen, PIPE, STDOUT
+from sys import exit
+
+OSCAP_RESULTS_OUTPUT = '/tmp/oscap_results.xml'
+NONCOMPLIANT_STATUS = 2
+COMPLIANCE_CONTENT_TYPE = 'application/vnd.redhat.compliance.something+tgz'
+POLICY_FILE_LOCATION = '/usr/share/xml/scap/ssg/content/'
+logger = getLogger(__name__)
+
+
+class ComplianceClient:
+    def __init__(self, config):
+        self.config = config
+        self.conn = InsightsConnection(config)
+        self.hostname = get_canonical_facts().get('fqdn', '')
+
+    def oscap_scan(self):
+        policies = self.get_policies()
+        if not policies:
+            logger.error("ERROR: System does not exist!\n")
+            exit(constants.sig_kill_bad)
+        profile_ref_id = [policy['attributes']['ref_id'] for policy in policies][0]
+        scap_policy_xml = self.find_scap_policy(profile_ref_id)
+        self.run_scan(profile_ref_id, scap_policy_xml)
+        return OSCAP_RESULTS_OUTPUT, COMPLIANCE_CONTENT_TYPE
+
+    # TODO: Not a typo! This endpoint gives OSCAP policies, not profiles
+    # We need to update compliance-backend to fix this
+    def get_policies(self):
+        response = self.conn.session.get("https://{0}/compliance/profiles".format(self.config.base_url), params={'hostname': self.hostname})
+        if response.status_code == 200:
+            return response.json()['data']
+        else:
+            return []
+
+    def os_release(self):
+        _, version, _ = linux_distribution()
+        return findall("^[6-8]", version)[0]
+
+    def profile_files(self):
+        return glob("{0}*rhel{1}*.xml".format(POLICY_FILE_LOCATION, self.os_release()))
+
+    def find_scap_policy(self, profile_ref_id):
+        grep = Popen(["grep", profile_ref_id] + self.profile_files(), stdout=PIPE, stderr=STDOUT)
+        if grep.wait():
+            logger.error('ERROR: XML profile file not found matching ref_id {0}\n{1}\n'.format(profile_ref_id, grep.stderr.read()))
+            exit(constants.sig_kill_bad)
+        filenames = findall('/usr/share/xml/scap/.+xml', grep.stdout.read().decode('utf-8'))
+        if not filenames:
+            logger.error('ERROR: No XML profile files found matching ref_id {0}\n{1}\n'.format(profile_ref_id, ' '.join(filenames)))
+            exit(constants.sig_kill_bad)
+        return filenames[0]
+
+    def run_scan(self, profile_ref_id, policy_xml):
+        logger.info("Running scan... this may take a while")
+        oscap = Popen(["oscap", "xccdf", "eval", "--profile", profile_ref_id, "--results", OSCAP_RESULTS_OUTPUT, policy_xml], stdout=PIPE, stderr=STDOUT)
+        if oscap.wait() and oscap.wait() != NONCOMPLIANT_STATUS:
+            logger.error("ERROR: Scan failed")
+            logger.error(oscap.stderr.read())
+            exit(constants.sig_kill_bad)

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -75,6 +75,12 @@ DEFAULT_OPTS = {
         # non-CLI
         'default': None
     },
+    'compliance': {
+        'default': False,
+        'opt': ['--compliance'],
+        'help': 'Scan the system using openscap and upload the report',
+        'action': 'store_true'
+    },
     'compressor': {
         'default': 'gz',
         'opt': ['--compressor'],

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -13,6 +13,7 @@ from insights.client.constants import InsightsConstants as constants
 from insights.client.support import InsightsSupport
 from insights.client.utilities import validate_remove_file, print_egg_versions
 from insights.client.schedule import get_scheduler
+from insights.client.apps.compliance import ComplianceClient
 
 logger = logging.getLogger(__name__)
 
@@ -249,6 +250,9 @@ def post_update(client, config):
 
 @phase
 def collect_and_output(client, config):
+    # --compliance was called
+    if config.compliance:
+        config.payload, config.content_type = ComplianceClient(config).oscap_scan()
     if config.payload:
         insights_archive = config.payload
     else:

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -1,0 +1,90 @@
+# -*- coding: UTF-8 -*-
+
+from insights.client.apps.compliance import ComplianceClient, OSCAP_RESULTS_OUTPUT, COMPLIANCE_CONTENT_TYPE
+from mock.mock import patch, MagicMock, Mock
+from pytest import raises
+from subprocess import PIPE, STDOUT
+
+
+@patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
+def test_oscap_scan(config):
+    compliance_client = ComplianceClient(config)
+    compliance_client.get_policies = lambda: [{'attributes': {'ref_id': 'foo'}}]
+    compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
+    compliance_client.run_scan = lambda ref_id, policy_xml: None
+    payload, content_type = compliance_client.oscap_scan()
+    assert payload == OSCAP_RESULTS_OUTPUT
+    assert content_type == COMPLIANCE_CONTENT_TYPE
+
+
+@patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
+def test_get_policies(config):
+    compliance_client = ComplianceClient(config)
+    compliance_client.hostname = 'foo'
+    compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': 'data'})))
+    assert compliance_client.get_policies() == 'data'
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'hostname': 'foo'})
+
+
+@patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
+def test_get_policies_error(config):
+    compliance_client = ComplianceClient(config)
+    compliance_client.hostname = 'foo'
+    compliance_client.conn.session.get = Mock(return_value=Mock(status_code=500))
+    assert compliance_client.get_policies() == []
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'hostname': 'foo'})
+
+
+@patch("insights.client.config.InsightsConfig")
+def test_os_release(config):
+    compliance_client = ComplianceClient(config)
+    assert int(compliance_client.os_release()) in range(6, 9)
+
+
+@patch("insights.client.config.InsightsConfig")
+def test_profile_files(config):
+    compliance_client = ComplianceClient(config)
+    compliance_client.os_release = lambda: '7'
+    assert compliance_client.profile_files() == []
+
+
+@patch("insights.client.apps.compliance.Popen")
+@patch("insights.client.config.InsightsConfig")
+def test_find_scap_policy(config, Popen):
+    PATH = '/usr/share/xml/scap/ref_id.xml'
+    Popen().wait = MagicMock(return_value=0)
+    Popen().stdout.read = MagicMock(return_value=PATH.encode('utf-8'))
+    compliance_client = ComplianceClient(config)
+    compliance_client.profile_files = lambda: ['/something']
+    assert compliance_client.find_scap_policy('ref_id') == PATH
+
+
+@patch("insights.client.apps.compliance.Popen")
+@patch("insights.client.config.InsightsConfig")
+def test_find_scap_policy_not_found(config, Popen):
+    Popen().wait = MagicMock(return_value=1)
+    Popen().stderr.read = MagicMock(return_value='bad things happened')
+    compliance_client = ComplianceClient(config)
+    compliance_client.profile_files = lambda: ['/something']
+    with raises(SystemExit):
+        compliance_client.find_scap_policy('ref_id')
+
+
+@patch("insights.client.apps.compliance.Popen")
+@patch("insights.client.config.InsightsConfig")
+def test_run_scan(config, Popen):
+    Popen().wait = MagicMock(return_value=0)
+    compliance_client = ComplianceClient(config)
+    compliance_client.run_scan('ref_id', '/nonexistent')
+    Popen.assert_called_with(["oscap", "xccdf", "eval", "--profile", 'ref_id', "--results", OSCAP_RESULTS_OUTPUT, '/nonexistent'], stdout=PIPE, stderr=STDOUT)
+
+
+@patch("insights.client.apps.compliance.Popen")
+@patch("insights.client.config.InsightsConfig")
+def test_run_scan_fail(config, Popen):
+    Popen().wait = MagicMock(return_value=1)
+    Popen().stderr.read = MagicMock(return_value='bad things happened')
+    compliance_client = ComplianceClient(config)
+    with raises(SystemExit):
+        compliance_client.run_scan('ref_id', '/nonexistent')
+    Popen.assert_called_with(["oscap", "xccdf", "eval", "--profile", 'ref_id', "--results", OSCAP_RESULTS_OUTPUT, '/nonexistent'], stdout=PIPE, stderr=STDOUT)

--- a/insights/tests/client/phase/test_collect_and_upload.py
+++ b/insights/tests/client/phase/test_collect_and_upload.py
@@ -33,6 +33,7 @@ def test_collect_and_output_payload_on(insights_config, insights_client):
     """
     insights_config.return_value.load_all.return_value.payload = 'testp'
     insights_config.return_value.load_all.return_value.content_type = 'testct'
+    insights_config.return_value.load_all.return_value.compliance = False
     try:
         collect_and_output()
     except SystemExit:
@@ -51,6 +52,7 @@ def test_collect_and_output_payload_off(insights_config, insights_client):
     Archive deleted after upload
     """
     insights_config.return_value.load_all.return_value.payload = False
+    insights_config.return_value.load_all.return_value.compliance = False
     try:
         collect_and_output()
     except SystemExit:
@@ -70,6 +72,7 @@ def test_exit_ok(insights_config, insights_client):
     """
     Support collection replaces the normal client run.
     """
+    insights_config.return_value.load_all.return_value.compliance = False
     with raises(SystemExit) as exc_info:
         collect_and_output()
     assert exc_info.value.code == 0


### PR DESCRIPTION
This is currently how I'm running it locally, but the x-rh-identity isn't necessary for production.
```
sudo x-rh-identity=$X_RH_IDENTITY BYPASS_GPG=true insights-client --no-gpg --compliance
Running scan... this may take a while
Uploading Insights data.
Successfully uploaded report for rhel7-insights-client.virbr0.akofink-laptop.
```