### PR TITLE
Replace xml.etree.ElementTree with defusedxml.ElementTree to protect against malicious xml

### DIFF
--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -183,6 +183,9 @@ class DataCollector(object):
             elif self.mountpoint == "/" or c.get("image"):
                 cmd_specs = self._parse_command_spec(c, conf['pre_commands'])
                 for s in cmd_specs:
+                    if s['command'] in rm_commands:
+                        logger.warn("WARNING: Skipping command %s", s['command'])
+                        continue
                     cmd_spec = InsightsCommand(self.config, s, exclude, self.mountpoint)
                     self.archive.add_to_archive(cmd_spec)
         for f in conf['files']:

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -28,7 +28,7 @@ import sys
 if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
     import insights.contrib.ElementTree as ET
 else:
-    import xml.etree.ElementTree as ET
+    import defusedxml.ElementTree as ET
 
 log = logging.getLogger(__name__)
 

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -24,11 +24,15 @@ import sys
 # Since XPath expression is not supported by the ElementTree in Python 2.6,
 # import insights.contrib.ElementTree when running python is prior to 2.6 for compatibility.
 # Script insights.contrib.ElementTree is the same with xml.etree.ElementTree in Python 2.7.14
-# Otherwise, import xml.etree.ElementTree instead.
+# Otherwise, import defusedxml.ElementTree to avoid XML vulnerabilities,
+# if dependency not installed import xml.etree.ElementTree instead.
 if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
     import insights.contrib.ElementTree as ET
 else:
-    import defusedxml.ElementTree as ET
+    try:
+        import defusedxml.ElementTree as ET
+    except:
+        import xml.etree.ElementTree as ET
 
 log = logging.getLogger(__name__)
 

--- a/insights/tests/client/test_skip_commands_files.py
+++ b/insights/tests/client/test_skip_commands_files.py
@@ -97,3 +97,18 @@ def test_dont_archive_when_command_not_found(write_data_to_file):
 
     arch.add_to_archive(cmd)
     write_data_to_file.assert_called_once()
+
+
+@patch("insights.client.data_collector.DataCollector._run_pre_command", return_value=['eth0'])
+@patch("insights.client.data_collector.InsightsCommand")
+def test_omit_after_parse_command(InsightsCommand, run_pre_command):
+    """
+    Files are omitted based on the expanded paths of the uploader.json path
+    """
+    c = InsightsConfig()
+    data_collector = DataCollector(c)
+
+    collection_rules = {'commands': [{"command": "/sbin/ethtool -i", "pattern": [], "pre_command": "iface", "symbolic_name": "ethtool"}], 'files': [], "pre_commands": {"iface": "/sbin/ip -o link | awk -F ': ' '/.*link\\/ether/ {print $2}'"}}
+    rm_conf = {'commands': ["/sbin/ethtool -i eth0"]}
+    data_collector.run_collection(collection_rules, rm_conf, {})
+    InsightsCommand.assert_not_called()

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ runtime = set([
     'cachecontrol',
     'cachecontrol[redis]',
     'cachecontrol[filecache]',
+    'defusedxml',
     'lockfile',
 ])
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ maybe_require("argparse")
 
 client = set([
     'requests',
-    'defusedxml',
     'pyOpenSSL',
 ])
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ maybe_require("argparse")
 
 client = set([
     'requests',
+    'defusedxml',
     'pyOpenSSL',
 ])
 


### PR DESCRIPTION
Replaced 'xml.etree.ElementTree as ET' with
'defusedxml.ElementTree as ET' for secure xml parsing.