### PR TITLE
pyyaml dep set to version 5.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from setuptools import setup, find_packages
 
 __here__ = os.path.dirname(os.path.abspath(__file__))
@@ -25,7 +26,6 @@ entry_points = {
 }
 
 runtime = set([
-    'pyyaml>=3.10,<=3.13',
     'six',
     'requests',
     'redis',
@@ -34,6 +34,11 @@ runtime = set([
     'cachecontrol[filecache]',
     'lockfile',
 ])
+
+if (sys.version_info < (2, 7)):
+    runtime.add('pyyaml>=3.10,<=3.13')
+else:
+    runtime.add('pyyaml==5.1.1')
 
 
 def maybe_require(pkg):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ runtime = set([
 if (sys.version_info < (2, 7)):
     runtime.add('pyyaml>=3.10,<=3.13')
 else:
-    runtime.add('pyyaml==5.1.1')
+    runtime.add('pyyaml')
 
 
 def maybe_require(pkg):


### PR DESCRIPTION
- let's use current version of `pyyaml` if possible, there is security issue in old version, see [CVE-2017-18342](https://nvd.nist.gov/vuln/detail/CVE-2017-18342).
- we can use old version only if it's necessary (python version < 2.7)
- it requires only small change in `setup.py` file