### PR TITLE
Collect nested httpd config files

### DIFF
--- a/insights/combiners/tests/test_httpd_conf_tree.py
+++ b/insights/combiners/tests/test_httpd_conf_tree.py
@@ -531,7 +531,7 @@ def test_httpd_nested_conf_file():
     httpd3 = _HttpdConf(context_wrap(HTTPD_CONF_FILE_2, path='/etc/httpd/conf.d/d1/hello.conf'))
     result = HttpdConfTree([httpd1, httpd2, httpd3])
 
-    server_root = result['ServerRoot'][last]
+    server_root = result['ServerRoot'][-1]
     assert server_root.value == '/home/skontar/www'
     assert server_root.line == 'ServerRoot "/home/skontar/www"'
     assert server_root.file_name == 'hello.conf'

--- a/insights/combiners/tests/test_httpd_conf_tree.py
+++ b/insights/combiners/tests/test_httpd_conf_tree.py
@@ -130,6 +130,7 @@ ServerRoot "/etc/httpd"
 
 # Load config files in the "/etc/httpd/conf.d" directory, if any.
 IncludeOptional conf.d/*.conf
+IncludeOptional conf.d/*/*.conf
 
 Listen 80
 '''.strip()
@@ -522,3 +523,16 @@ def test_httpd_conf_jbcs_httpd24_tree():
     assert len(load_module_list) == 4
     assert result['LoadModule'][3].value == 'mpm_prefork_module modules/mod_mpm_prefork.so'
     assert result['LoadModule'][3].file_path == '/opt/rh/jbcs-httpd24/root/etc/httpd/conf.modules.d/02-c.conf'
+
+
+def test_httpd_nested_conf_file():
+    httpd1 = _HttpdConf(context_wrap(HTTPD_CONF_MAIN_3, path='/etc/httpd/conf/httpd.conf'))
+    httpd2 = _HttpdConf(context_wrap(HTTPD_CONF_FILE_1, path='/etc/httpd/conf.d/00-a.conf'))
+    httpd3 = _HttpdConf(context_wrap(HTTPD_CONF_FILE_2, path='/etc/httpd/conf.d/d1/hello.conf'))
+    result = HttpdConfTree([httpd1, httpd2, httpd3])
+
+    server_root = result['ServerRoot'][last]
+    assert server_root.value == '/home/skontar/www'
+    assert server_root.line == 'ServerRoot "/home/skontar/www"'
+    assert server_root.file_name == 'hello.conf'
+    assert server_root.file_path == '/etc/httpd/conf.d/d1/hello.conf'

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -324,6 +324,7 @@ class DefaultSpecs(Specs):
         [
             "/etc/httpd/conf/httpd.conf",
             "/etc/httpd/conf.d/*.conf",
+            "/etc/httpd/conf.d/*/*.conf",
             "/etc/httpd/conf.modules.d/*.conf"
         ]
     )


### PR DESCRIPTION
* For satellite 6.2, foreman config file located at
  "/etc/httpd/conf.d/05-foreman-ssl.d/katello.conf"