### PR TITLE
New spec of foreman task for Satellite 6.4

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -283,7 +283,7 @@ class DefaultSpecs(Specs):
     foreman_satellite_log = simple_file("/var/log/foreman-installer/satellite.log")
     foreman_ssl_access_ssl_log = simple_file("var/log/httpd/foreman-ssl_access_ssl.log")
     foreman_rake_db_migrate_status = simple_command('/usr/sbin/foreman-rake db:migrate:status')
-    foreman_tasks_config = simple_file("/etc/sysconfig/foreman-tasks")
+    foreman_tasks_config = first_file(["/etc/sysconfig/foreman-tasks", "/etc/sysconfig/dynflowd"])
     fstab = simple_file("/etc/fstab")
     galera_cnf = first_file(["/var/lib/config-data/puppet-generated/mysql/etc/my.cnf.d/galera.cnf", "/etc/my.cnf.d/galera.cnf"])
     getcert_list = simple_command("/usr/bin/getcert list")


### PR DESCRIPTION
* From Satellite 6.4, the forman task configuration file changed to
  "/etc/sysconfig/dynflowd"

Signed-off-by: Huanhuan Li <huali@redhat.com>