### PR TITLE
Fix spec errors when running apply_spec_filters

### DIFF
--- a/insights/tools/apply_spec_filters.py
+++ b/insights/tools/apply_spec_filters.py
@@ -24,7 +24,7 @@ if not os.path.exists(json_path):
 with open(json_path) as fp:
     uploader_json = json.load(fp, object_pairs_hook=OrderedDict)
 
-dr.load_components("insights.specs")
+dr.load_components("insights.specs.default")
 dr.load_components("insights.parsers")
 dr.load_components("insights.combiners")
 


### PR DESCRIPTION
If we do not limit the specs to default we run into errors related to
openshift and kubernetes.

We've been running just the default specs. If there is a better way to
solve this, we can do that instead.