### PR TITLE
JSONParser: protect call to from_dict (#2056)

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -714,8 +714,6 @@ class JSONParser(Parser, LegacyItemAccess):
             msg = "%s couldn't parse json." % name
             six.reraise(ParseException, ParseException(msg), tb)
 
-        self.doc = from_dict(self.data)
-
 
 class ScanMeta(type):
     def __new__(cls, name, parents, dct):

--- a/insights/tests/test_json_parser.py
+++ b/insights/tests/test_json_parser.py
@@ -7,10 +7,17 @@ from insights.tests import context_wrap
 class MyJsonParser(JSONParser):
     pass
 
+json_test_strings = {
+    '{"a": "1", "b": "2"}': {'a': '1', 'b': '2'},
+    '[{"a": "1", "b": "2"},{"a": "3", "b": "4"}]':
+        [{'a': '1', 'b': '2'}, {'a': '3', 'b': '4'}]
+}
+
 
 def test_json_parser_success():
-    ctx = context_wrap('{"a": "2"}')
-    assert MyJsonParser(ctx)
+    for jsonstr in json_test_strings:
+        ctx = context_wrap(jsonstr)
+        assert MyJsonParser(ctx).data == json_test_strings[jsonstr]
 
 
 def test_json_parser_failure():


### PR DESCRIPTION
JSONParser currently expects to parse JSON objects only.
Calling from_dict will fail if the JSON text is an array.
Protect the call to from_dict and do nothing if the text is
an array.

Signed-off-by: François Cami <fcami@redhat.com>