### PR TITLE
YAMLParser: remove call to from_dict (#2060)

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -697,8 +697,6 @@ class YAMLParser(Parser, LegacyItemAccess):
             msg = "%s couldn't parse yaml." % name
             six.reraise(ParseException, ParseException(msg), tb)
 
-        self.doc = from_dict(self.data)
-
 
 class JSONParser(Parser, LegacyItemAccess):
     """

--- a/insights/tests/test_yaml_parser.py
+++ b/insights/tests/test_yaml_parser.py
@@ -18,12 +18,12 @@ class MyYamlParser(YAMLParser):
     pass
 
 
-def test_json_parser_success():
+def test_yaml_parser_success():
     ctx = context_wrap('a: 2')
     assert FakeYamlParser(ctx)
 
 
-def test_json_parser_failure():
+def test_yaml_parser_failure():
     ctx = context_wrap("boom /")
     with pytest.raises(ParseException) as ex:
         FakeYamlParser(ctx)

--- a/insights/tests/test_yaml_parser.py
+++ b/insights/tests/test_yaml_parser.py
@@ -1,3 +1,4 @@
+import datetime
 import pytest
 
 from insights.core import YAMLParser, ParseException
@@ -7,6 +8,17 @@ from insights.tests import context_wrap
 bi_conf_content = """
 {"remote_branch": -1, "remote_leaf": -1}
 """.strip()
+
+yaml_test_strings = {"""
+type:        Acquisition
+date:        2019-07-09
+""": {'type': 'Acquisition', 'date': datetime.date(2019, 7, 9)}, """
+- Hesperiidae
+- Papilionidae
+- Apatelodidae
+- Epiplemidae
+""": ['Hesperiidae', 'Papilionidae', 'Apatelodidae', 'Epiplemidae']
+}
 
 
 class FakeYamlParser(YAMLParser):
@@ -19,8 +31,9 @@ class MyYamlParser(YAMLParser):
 
 
 def test_yaml_parser_success():
-    ctx = context_wrap('a: 2')
-    assert FakeYamlParser(ctx)
+    for ymlstr in yaml_test_strings:
+        ctx = context_wrap(ymlstr)
+        assert FakeYamlParser(ctx).data == yaml_test_strings[ymlstr]
 
 
 def test_yaml_parser_failure():


### PR DESCRIPTION
YAMLParser currently fails to parse list-like YAML texts
as calling from_dict will fail.
Remove 'self.doc = from_dict' as it seems unused.
    
Signed-off-by: François Cami <fcami@redhat.com>
