### PR TITLE
Update mount

### DIFF
--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -54,6 +54,7 @@ import os
 from insights.specs import Specs
 from insights.parsers import optlist_to_dict, keyword_search, ParseException, SkipException
 from insights import parser, get_active_lines, CommandParser
+from insights.core import LegacyItemAccess
 
 
 class MountOpts(dict):
@@ -88,6 +89,7 @@ class MountOpts(dict):
     }
 
     def __init__(self, data={}):
+        data = {} if data is None else data
         self.update(data)
         for k, v in MountOpts.attrs.items():
             if k not in data:
@@ -117,6 +119,7 @@ class MountEntry(dict):
     }
 
     def __init__(self, data={}):
+        data = {} if data is None else data
         self.update(data)
         for k, v in MountEntry.attrs.items():
             if k not in data:

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -2,13 +2,14 @@
 Mount Entries
 =============
 
+Parsers provided in this module includes:
+
 Mount - command ``/bin/mount``
 ------------------------------
 
 ProcMounts - file ``/proc/mounts``
 ----------------------------------
 
-This module provides parsing for the ``mount`` command and the ``/proc/mounts`` file.
 
 The ``Mount`` class implements parsing for the ``mount`` command output which looks like::
 
@@ -21,9 +22,9 @@ The information is stored as a list of :class:`MountEntry` objects.  Each
 :class:`MountEntry` object contains attributes for the following information that
 are listed in the same order as in the command output:
 
- * ``filesystem`` - Name of filesystem
+ * ``filesystem`` or ``mounted_device`` - Name of filesystem or mounted device
  * ``mount_point`` - Name of mount point for filesystem
- * ``mount_type`` - Name of filesystem type
+ * ``filesystem_type`` or ``mount_type`` - Name of filesystem type
  * ``mount_options`` - Mount options as a dictionary
  * ``mount_label`` - Only present if optional label is present
  * ``mount_clause`` - Full string from command output
@@ -47,40 +48,15 @@ For instance, the option ``rw`` in ``(rw,dmode=0500)`` may be accessed as
 MountEntry lines are also available in a ``mounts`` property, keyed on the
 mount point.
 
-Examples:
-    >>> type(mnt_info)
-    <class 'insights.parsers.mount.Mount'>
-    >>> len(mnt_info)
-    4
-    >>> mnt_info[3].__dict__
-    {'filesystem': 'dev/sr0',
-     'mount_clause': 'dev/sr0 on /run/media/root/VMware Tools type iso9660 (ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2) [VMware Tools]',
-     'mount_label': 'VMware Tools',
-     'mount_options': {'dmode': '0500', 'relatime': True, 'uid': '0',
-         'iocharset': 'utf8', 'gid': '0', 'mode': '0400', 'ro': True,
-         'nosuid': True, 'uhelper': 'udisks2', 'nodev': True}
-     'mount_point': '/run/media/root/VMware Tools',
-     'mount_type': 'iso9660'}
-    >>> mnt_info[3].filesystem
-    'dev/sr0'
-    >>> mnt_info[3].mount_type
-    'iso9660'
-    >>> mnt_info[3].mount_options
-    {'dmode': '0500', 'gid': '0', 'iocharset': 'utf8', 'mode': '0400', 'nodev': True,
-     'nosuid': True, 'relatime': True, 'ro': True, 'uhelper': 'udisks2', 'uid': '0'}
-    >>> mnt_info[3].mount_options.ro
-    True
-    >>> mnt_info.mounts['/run/media/root/VMware Tools'].filesystem
-    'dev/sr0'
 """
 
-import re
+import os
 from insights.specs import Specs
-from ..parsers import optlist_to_dict, keyword_search, ParseException, SkipException
-from .. import parser, get_active_lines, LegacyItemAccess, CommandParser
+from insights.parsers import optlist_to_dict, keyword_search, ParseException, SkipException
+from insights import parser, get_active_lines, CommandParser
 
 
-class MountOpts(object):
+class MountOpts(dict):
     """
     An object representing the mount options found in mount or fstab entry.
     Each option in the comma-separated list is a key, and 'key=value'
@@ -112,46 +88,18 @@ class MountOpts(object):
     }
 
     def __init__(self, data={}):
-        # Use '_data' but not 'data' since the 'data' could be an mount option
-        self._data = data
+        self.update(data)
         for k, v in MountOpts.attrs.items():
             if k not in data:
                 setattr(self, k, v)
         for k, v in data.items():
             setattr(self, k, v)
 
-    def __getitem__(self, item):
-        return self._data[item]
 
-    def __contains__(self, item):
-        return item in self._data
-
-    def get(self, item, default=None):
-        """Returns value of key ``item`` in self._data or ``default``
-        if key is not present.
-
-        Parameters:
-            item: Key to get from ``self.data``.
-            default: Default value to return if key is not present.
-
-        Returns:
-            (str): String value of the stored item, or the default if not found.
-        """
-        return self._data.get(item, default)
-
-    def items(self):
-        """
-        To keep backward compatibility and let it can be iterated as a
-        dictionary.
-        """
-        for k, v in self._data.items():
-            yield k, v
-
-
-class MountEntry(LegacyItemAccess, CommandParser):
+class MountEntry(dict):
     """
-    An object representing an entry in the output of ``mount`` command.  Each
-    entry contains below fixed attributes:
+    An object representing an mount entry of ``mount`` command or
+    ``/proc/mounts`` file.  Each entry contains below fixed attributes:
 
     Attributes:
         mount_clause (str): Full string from command output
@@ -169,34 +117,19 @@ class MountEntry(LegacyItemAccess, CommandParser):
     }
 
     def __init__(self, data={}):
-        self.data = data
+        self.update(data)
         for k, v in MountEntry.attrs.items():
             if k not in data:
                 setattr(self, k, v)
         for k, v in data.items():
             setattr(self, k, v)
 
-    def items(self):
-        """
-        To keep backward compatibility and let it can be iterated as a
-        dictionary.
-        """
-        for k, v in self.data.items():
-            yield k, v
 
-
-@parser(Specs.mount)
-class Mount(CommandParser):
-    """Class of information for all output from ``mount`` command.
-
-    Attributes:
-        rows (list of MountEntry): List of :class:`MountEntry` objects for
-            each row of the command output.
-
-    Raises:
-        ParseException: Raised when any problem parsing the command output.
+class MountedFileSystems(CommandParser):
     """
+    Base Class for :class:`Mount` and :class:`ProcMounts`.
 
+    """
     def __len__(self):
         return len(self.rows)
 
@@ -212,34 +145,13 @@ class Mount(CommandParser):
         else:
             raise TypeError("Mounts can only be indexed by mount string or line number")
 
-    # /dev/mapper/fedora-home on /home type ext4 (rw,relatime,seclabel,data=ordered) [HOME]
-    mount_line_re = r'^(?P<filesystem>\S+) on (?P<mount_point>.+?) type ' + \
-        r'(?P<mount_type>\S+) \((?P<mount_options>[^)]+)\)' + \
-        r'(?: \[(?P<mount_label>.*)\])?$'
-    mount_line_rex = re.compile(mount_line_re)
-
     def parse_content(self, content):
-        self.rows = []
-        self.mounts = {}
-        for line in get_active_lines(content):
-            mount = {}
-            mount['mount_clause'] = line
-            match = self.mount_line_rex.search(line)
-            if match:
-                mount['filesystem'] = match.group('filesystem')
-                mount['mount_point'] = match.group('mount_point')
-                mount['mount_type'] = match.group('mount_type')
-                mount_options = match.group('mount_options')
-                mount['mount_options'] = MountOpts(optlist_to_dict(mount_options))
-                if match.group('mount_label'):
-                    mount['mount_label'] = match.group('mount_label')
-            else:
-                mount['parse_error'] = 'Unable to parse line'
+        # No content found or file is empty
+        if not content:
+            raise SkipException('Empty content')
 
-            entry = MountEntry(mount)
-            self.rows.append(entry)
-            if match:
-                self.mounts[mount['mount_point']] = entry
+        self._parse_mounts(content)
+
         if '/' not in self.mounts:
             raise ParseException("Input for mount must contain '/' mount point.")
 
@@ -253,7 +165,113 @@ class Mount(CommandParser):
         terminate since / is always a mount point.  Strings that are not
         absolute paths will return None.
         """
-        import os
+        while path != '':
+            if path in self.mounts:
+                return self.mounts[path]
+            path = os.path.split(path)[0]
+        return None
+
+    def search(self, **kwargs):
+        """
+        Returns a list of the mounts (in order) matching the given criteria.
+        Keys are searched for directly - see the
+        :py:func:`insights.parsers.keyword_search` utility function for more
+        details.  If no search parameters are given, no rows are returned.
+
+        Examples:
+
+            >>> mounts.search(filesystem='/dev/sda1')
+            [{'filesystem': '/dev/sda1', 'mount_point': '/boot', ...}]
+            >>> mounts.search(mount_options__contains='ro')
+            [{'filesystem': '/dev/sr0', 'mount_point', '/mnt/CDROM', ...}, ...]
+
+        Arguments:
+            **kwargs (dict): Dictionary of key-value pairs to search for.
+
+        Returns:
+            (list): The list of mount points matching the given criteria.
+        """
+        return keyword_search(self.rows, **kwargs)
+
+
+@parser(Specs.mount)
+class Mount(MountedFileSystems):
+    """
+    Class of information for all output from ``mount`` command.
+
+    Examples:
+        >>> type(mnt_info)
+        <class 'insights.parsers.mount.Mount'>
+        >>> len(mnt_info)
+        4
+        >>> mnt_info[3].__dict__
+        {'filesystem': 'dev/sr0',
+         'mount_clause': 'dev/sr0 on /run/media/root/VMware Tools type iso9660 (ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2) [VMware Tools]',
+         'mount_label': 'VMware Tools',
+         'mount_options': {'dmode': '0500', 'relatime': True, 'uid': '0',
+             'iocharset': 'utf8', 'gid': '0', 'mode': '0400', 'ro': True,
+             'nosuid': True, 'uhelper': 'udisks2', 'nodev': True}
+         'mount_point': '/run/media/root/VMware Tools',
+         'mount_type': 'iso9660'}
+        >>> mnt_info[3].filesystem
+        'dev/sr0'
+        >>> mnt_info[3].mount_type
+        'iso9660'
+        >>> mnt_info[3].mount_options
+        {'dmode': '0500', 'gid': '0', 'iocharset': 'utf8', 'mode': '0400', 'nodev': True,
+         'nosuid': True, 'relatime': True, 'ro': True, 'uhelper': 'udisks2', 'uid': '0'}
+        >>> mnt_info[3].mount_options.ro
+        True
+        >>> mnt_info.mounts['/run/media/root/VMware Tools'].filesystem
+        'dev/sr0'
+
+    Attributes:
+        rows (list of MountEntry): List of :class:`MountEntry` objects for
+            each row of the command output.
+
+    Raises:
+        SkipException: When the file is empty.
+        ParseException: Raised when any problem parsing the command output.
+    """
+    def _parse_mounts(self, content):
+
+        def _split(line_sp, sep=None, num=2, check=True):
+            if num >= 2:
+                line_sp = line_sp.split(sep, num - 1)
+                if check and len(line_sp) < num:
+                    raise ParseException('Unable to parse: "{0}"'.format(line))
+            return line_sp
+
+        self.rows = []
+        self.mounts = {}
+        for line in get_active_lines(content):
+            mount = {}
+            line_sp = mount['mount_clause'] = line
+            line_sp = _split(line_sp, ' on ', 2)
+            mount['filesystem'] = line_sp[0]
+            line_sp = _split(line_sp[1], ' type ', 2)
+            mount['mount_point'] = line_sp[0]
+            line_sp = _split(line_sp[1], None, 3, False)
+            mount['mount_type'] = line_sp[0]
+            if len(line_sp) >= 2:
+                mount['mount_options'] = MountOpts(optlist_to_dict(line_sp[1].strip('()')))
+            if len(line_sp) == 3:
+                mount['mount_label'] = line_sp[2].strip('[]')
+
+            entry = MountEntry(mount)
+            self.rows.append(entry)
+            self.mounts[mount['mount_point']] = entry
+
+    def get_dir(self, path):
+        """
+        MountEntry: returns the mount point that contains the given path.
+
+        This finds the most specific mount path that contains the given path,
+        by successively removing the directory or file name on the end of
+        the path and seeing if that is a mount point.  This will always
+        terminate since / is always a mount point.  Strings that are not
+        absolute paths will return None.
+        """
         while path != '':
             if path in self.mounts:
                 return self.mounts[path]
@@ -284,15 +302,12 @@ class Mount(CommandParser):
 
 
 @parser(Specs.mounts)
-class ProcMounts(Mount):
+class ProcMounts(MountedFileSystems):
     """Class to parse the content of ``/proc/mounts`` file.
     This class is required to parse the ``/proc/mounts`` file in addition to the
     ``/bin/mount`` command because it lists the mount points of those process's
     which are not present in the output of the ``/bin/mount`` command.
 
-    .. note::
-        Please refer to its super-class :class:`Mount` for more
-        details.
 
     Attributes:
         rows (list of MountEntry): List of :class:`MountEntry` objects for
@@ -303,11 +318,7 @@ class ProcMounts(Mount):
         ParseException: When '/' mount point is not present.
     """
 
-    def parse_content(self, content):
-        # No content found or file is empty
-        if not content:
-            raise SkipException('Empty file')
-
+    def _parse_mounts(self, content):
         self.rows = []
         self.mounts = {}
         for line in get_active_lines(content):
@@ -315,19 +326,15 @@ class ProcMounts(Mount):
             mount['mount_clause'] = line
             data = line.split()
             if len(data) == 6:
-                mount['mounted_device'] = data[0]
+                mount['filesystem'] = mount['mounted_device'] = data[0]
                 mount['mount_point'] = data[1]
-                mount['filesystem_type'] = data[2]
+                mount['mount_type'] = mount['filesystem_type'] = data[2]
                 mount_options = data[3]
                 mount['mount_options'] = MountOpts(optlist_to_dict(mount_options))
                 mount['mount_labels'] = data[4:]
             else:
-                mount['parse_error'] = 'Unable to parse line'
+                raise ParseException('Unable to parse: "{0}"'.format(line))
 
             entry = MountEntry(mount)
             self.rows.append(entry)
-            if len(data) == 6:
-                self.mounts[mount['mount_point']] = entry
-
-        if '/' not in self.mounts:
-            raise ParseException("Input for mount must contain '/' mount point.")
+            self.mounts[mount['mount_point']] = entry

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -189,10 +189,10 @@ class MountedFileSystems(CommandParser):
 
         Examples:
 
-            >>> mounts.search(filesystem='proc')
-            [{'mount_type': 'proc', 'mount_point': '/proc', 'filesystem': 'proc', 'mount_options': {'noexec': True, 'relatime': True, 'rw': True, 'nosuid': True, 'nodev': True}, 'mount_clause': 'proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)'}]
-            >>> mounts.search(mount_options__contains='seclabel')
-            [{'mount_type': 'ext4', 'mount_point': '/etc/shadow', 'filesystem': '/dev/mapper/HostVG-Config', 'mount_options': {'rw': True, 'data': 'ordered', 'stripe': '256', 'noatime': True, 'seclabel': True}, 'mount_clause': '/dev/mapper/HostVG-Config on /etc/shadow type ext4 (rw,noatime,seclabel,stripe=256,data=ordered)'}]
+            >>> mounts.search(filesystem='proc')[0].mount_clause
+            'proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)'
+            >>> mounts.search(mount_options__contains='seclabel')[0].mount_clause
+            '/dev/mapper/HostVG-Config on /etc/shadow type ext4 (rw,noatime,seclabel,stripe=256,data=ordered)'
 
         Arguments:
             **kwargs (dict): Dictionary of key-value pairs to search for.

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -54,7 +54,6 @@ import os
 from insights.specs import Specs
 from insights.parsers import optlist_to_dict, keyword_search, ParseException, SkipException
 from insights import parser, get_active_lines, CommandParser
-from insights.core import LegacyItemAccess
 
 
 class MountOpts(dict):

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -164,7 +164,7 @@ def test_proc_mount():
     assert 'relatime' in sda1['mount_options']
     assert sda1['mount_options']['data'] == 'ordered'
     assert sda1.mount_options.data == 'ordered'
-    assert sda1['mount_labels'] == ['0', '0']
+    assert sda1['mount_label'] == ['0', '0']
 
     # Test iteration
     for mnt in results:
@@ -234,7 +234,9 @@ dev/sr0 /run/media/root/VMware\040Tools iso9660 ro,nosuid,nodev,relatime,uid=0,g
 def test_doc_examples():
     env = {
             'mnt_info': Mount(context_wrap(MOUNT_DOC)),
-            'proc_mnt_info': ProcMounts(context_wrap(PROC_MOUNT_DOC))
+            'proc_mnt_info': ProcMounts(context_wrap(PROC_MOUNT_DOC)),
+            'mounts': Mount(context_wrap(MOUNT_DOC))
+
           }
     failed, total = doctest.testmod(mount, globs=env)
     assert failed == 0

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -32,6 +32,72 @@ hugetlbfs /dev/hugepages type hugetlbfs (rw,relatime,seclabel)
 /dev/mapper/fedora-root on / type ext4 (rw,relatime,seclabel,data=ordered)
 """.strip()
 
+MOUNT_WITHOUT_ROOT = """
+tmpfs on /tmp type tmpfs (rw,seclabel)
+hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime,seclabel)
+/dev/sda1 on /boot type ext4 (rw,relatime,seclabel,data=ordered)
+""".strip()
+
+
+PROC_MOUNT = """
+proc /proc proc rw,relatime 0 0
+sysfs /sys sysfs rw,relatime 0 0
+devtmpfs /dev devtmpfs rw,relatime,size=8155456k,nr_inodes=2038864,mode=755 0 0
+devpts /dev/pts devpts rw,relatime,gid=5,mode=620,ptmxmode=000 0 0
+tmpfs /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime 0 0
+/dev/mapper/rootvg-rootlv / ext4 rw,relatime,barrier=1,data=ordered 0 0
+/proc/bus/usb /proc/bus/usb usbfs rw,relatime 0 0
+/dev/sda1 /boot ext4 rw,relatime,barrier=1,data=ordered 0 0
+/dev/mapper/rootvg-homelv /home ext4 rw,relatime,barrier=1,data=ordered 0 0
+/dev/mapper/rootvg-optlv /opt ext4 rw,relatime,barrier=1,data=ordered 0 0
+/dev/mapper/rootvg-tmplv /tmp ext4 rw,relatime,barrier=1,data=ordered 0 0
+/dev/mapper/rootvg-usrlv /usr ext4 rw,relatime,barrier=1,data=ordered 0 0
+/dev/mapper/rootvg-varlv /var ext4 rw,relatime,barrier=1,data=ordered 0 0
+/dev/mapper/rootvg-tmplv /var/tmp ext4 rw,relatime,barrier=1,data=ordered 0 0
+none /proc/sys/fs/binfmt_misc binfmt_misc rw,relatime 0 0
+sunrpc /var/lib/nfs/rpc_pipefs rpc_pipefs rw,relatime 0 0
+/vol/vol3/wpsanet /sa/net nfs rw,relatime,vers=3,rsize=8192,wsize=8192,namlen=255,soft,proto=tcp,timeo=14,retrans=2,sec=sys,mountaddr=10.xx.xx.xx,mountvers=3,mountport=4046,mountproto=udp,local_lock=none 0 0
+/vol/vol9/home /users nfs rw,relatime,vers=3,rsize=8192,wsize=8192,namlen=255,soft,proto=tcp,timeo=14,retrans=2,sec=sys,mountaddr=10.xx.xx.xx,mountvers=3,mountport=4046,mountproto=udp,local_lock=none,addr=10.xx.xx.xx 0 0
+/etc/auto.misc /misc autofs rw,relatime,fd=7,pgrp=1936,timeout=300,minproto=5,maxproto=5,indirect 0 0
+""".strip()
+
+PROCMOUNT_ERR_DATA = """
+rootfs / rootfs rw 0 0
+sysfs /sys sysfs rw,relatime
+""".strip()
+
+PROC_EXCEPTION1 = """
+""".strip()
+
+PROC_EXCEPTION2 = """
+proc /proc proc rw,relatime 0 0
+sysfs /sys sysfs rw,relatime 0 0
+devtmpfs /dev devtmpfs rw,relatime,size=8155456k,nr_inodes=2038864,mode=755 0 0
+""".strip()
+
+MOUNT_DOC = """
+/dev/mapper/rootvg-rootlv on / type ext4 (rw,relatime,barrier=1,data=ordered)
+proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
+/dev/mapper/HostVG-Config on /etc/shadow type ext4 (rw,noatime,seclabel,stripe=256,data=ordered)
+dev/sr0 on /run/media/root/VMware Tools type iso9660 (ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2) [VMware Tools]
+""".strip()
+
+PROC_MOUNT_DOC = """
+/dev/mapper/rootvg-rootlv / ext4 rw,relatime,barrier=1,data=ordered 0 0
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+/dev/mapper/HostVG-Config /etc/shadow ext4 rw,noatime,seclabel,stripe=256,data=ordered 0 0
+dev/sr0 /run/media/root/VMware\040Tools iso9660 ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2 0 0
+""".strip()
+
+MOUNT_DATA_WITH_SPECIAL_MNT_POINT = """
+hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime,seclabel)
+/dev/sda1 on /boot type ext4 (rw,relatime,seclabel,data=ordered)
+/dev/mapper/fedora-root on / type ext4 (rw,relatime,seclabel,data=ordered)
+/dev/mapper/HostVG-Config on /etc/shadow type ext4 (rw,noatime,seclabel,stripe=256,data=ordered) [CONFIG]
+/dev/sr0 on /run/media/root/VMware Tools type iso9660 (ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2) [VMware Tools]
+/dev/sr1 on /run/media/Disk on C type NFS type iso9660 (ro,uid=0,gid=0,iocharset=utf8,uhelper=udisks2) [C type Disk]
+""".strip()
+
 
 def test_mount():
     results = Mount(context_wrap(MOUNT_DATA))
@@ -49,7 +115,7 @@ def test_mount():
     assert sr0.mount_options.ro
     assert 'relatime' in sr0['mount_options']
     assert sr0['mount_options']['uhelper'] == 'udisks2'
-    assert sr0['mount_label'] == 'VMware Tools'
+    assert sr0['mount_label'] == '[VMware Tools]'
     assert sda1 is not None
     assert sda1['mount_point'] == '/boot'
     assert sda1['mount_type'] == 'ext4'
@@ -93,6 +159,18 @@ def test_mount():
     ]
 
 
+def test_mount_with_special_mnt_point():
+    results = Mount(context_wrap(MOUNT_DATA_WITH_SPECIAL_MNT_POINT))
+    assert len(results) == 6
+    sr0 = results.search(filesystem='/dev/sr0')[0]
+    sr1 = results.search(filesystem='/dev/sr1')[0]
+    assert sr0['mount_point'] == '/run/media/root/VMware Tools'
+    assert sr1['mount_point'] == '/run/media/Disk on C type NFS'
+    assert sr0.get('mount_label') == '[VMware Tools]'
+    assert sr1.get('mount_label') == '[C type Disk]'
+    assert results['/run/media/Disk on C type NFS'].get('mount_label') == '[C type Disk]'
+
+
 def test_mount_exception1():
     # Test parse failure
     with pytest.raises(ParseException) as pe:
@@ -100,54 +178,10 @@ def test_mount_exception1():
     assert 'Unable to parse' in str(pe.value)
 
 
-MOUNT_WITHOUT_ROOT = """
-tmpfs on /tmp type tmpfs (rw,seclabel)
-hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime,seclabel)
-/dev/sda1 on /boot type ext4 (rw,relatime,seclabel,data=ordered)
-""".strip()
-
-
 def test_mount_exception2():
     with pytest.raises(ParseException) as exc:
         Mount(context_wrap(MOUNT_WITHOUT_ROOT))
     assert "Input for mount must contain '/' mount point." in str(exc)
-
-
-PROC_MOUNT = """
-proc /proc proc rw,relatime 0 0
-sysfs /sys sysfs rw,relatime 0 0
-devtmpfs /dev devtmpfs rw,relatime,size=8155456k,nr_inodes=2038864,mode=755 0 0
-devpts /dev/pts devpts rw,relatime,gid=5,mode=620,ptmxmode=000 0 0
-tmpfs /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime 0 0
-/dev/mapper/rootvg-rootlv / ext4 rw,relatime,barrier=1,data=ordered 0 0
-/proc/bus/usb /proc/bus/usb usbfs rw,relatime 0 0
-/dev/sda1 /boot ext4 rw,relatime,barrier=1,data=ordered 0 0
-/dev/mapper/rootvg-homelv /home ext4 rw,relatime,barrier=1,data=ordered 0 0
-/dev/mapper/rootvg-optlv /opt ext4 rw,relatime,barrier=1,data=ordered 0 0
-/dev/mapper/rootvg-tmplv /tmp ext4 rw,relatime,barrier=1,data=ordered 0 0
-/dev/mapper/rootvg-usrlv /usr ext4 rw,relatime,barrier=1,data=ordered 0 0
-/dev/mapper/rootvg-varlv /var ext4 rw,relatime,barrier=1,data=ordered 0 0
-/dev/mapper/rootvg-tmplv /var/tmp ext4 rw,relatime,barrier=1,data=ordered 0 0
-none /proc/sys/fs/binfmt_misc binfmt_misc rw,relatime 0 0
-sunrpc /var/lib/nfs/rpc_pipefs rpc_pipefs rw,relatime 0 0
-/vol/vol3/wpsanet /sa/net nfs rw,relatime,vers=3,rsize=8192,wsize=8192,namlen=255,soft,proto=tcp,timeo=14,retrans=2,sec=sys,mountaddr=10.xx.xx.xx,mountvers=3,mountport=4046,mountproto=udp,local_lock=none 0 0
-/vol/vol9/home /users nfs rw,relatime,vers=3,rsize=8192,wsize=8192,namlen=255,soft,proto=tcp,timeo=14,retrans=2,sec=sys,mountaddr=10.xx.xx.xx,mountvers=3,mountport=4046,mountproto=udp,local_lock=none,addr=10.xx.xx.xx 0 0
-/etc/auto.misc /misc autofs rw,relatime,fd=7,pgrp=1936,timeout=300,minproto=5,maxproto=5,indirect 0 0
-""".strip()
-
-PROCMOUNT_ERR_DATA = """
-rootfs / rootfs rw 0 0
-sysfs /sys sysfs rw,relatime
-""".strip()
-
-PROC_EXCEPTION1 = """
-""".strip()
-
-PROC_EXCEPTION2 = """
-proc /proc proc rw,relatime 0 0
-sysfs /sys sysfs rw,relatime 0 0
-devtmpfs /dev devtmpfs rw,relatime,size=8155456k,nr_inodes=2038864,mode=755 0 0
-""".strip()
 
 
 def test_proc_mount():
@@ -214,21 +248,6 @@ def test_proc_mount_exception3():
     with pytest.raises(ParseException) as pe:
         ProcMounts(context_wrap(PROCMOUNT_ERR_DATA))
     assert 'Unable to parse' in str(pe.value)
-
-
-MOUNT_DOC = """
-/dev/mapper/rootvg-rootlv on / type ext4 (rw,relatime,barrier=1,data=ordered)
-proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
-/dev/mapper/HostVG-Config on /etc/shadow type ext4 (rw,noatime,seclabel,stripe=256,data=ordered)
-dev/sr0 on /run/media/root/VMware Tools type iso9660 (ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2) [VMware Tools]
-""".strip()
-
-PROC_MOUNT_DOC = """
-/dev/mapper/rootvg-rootlv / ext4 rw,relatime,barrier=1,data=ordered 0 0
-proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
-/dev/mapper/HostVG-Config /etc/shadow ext4 rw,noatime,seclabel,stripe=256,data=ordered 0 0
-dev/sr0 /run/media/root/VMware\040Tools iso9660 ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2 0 0
-""".strip()
 
 
 def test_doc_examples():

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -123,7 +123,6 @@ class Specs(SpecSet):
     docker_storage = RegistryPoint()
     docker_storage_setup = RegistryPoint()
     docker_sysconfig = RegistryPoint()
-    dumpdev = RegistryPoint()
     dumpe2fs_h = RegistryPoint(multi_output=True)
     engine_config_all = RegistryPoint()
     engine_log = RegistryPoint(filterable=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -258,8 +258,6 @@ class DefaultSpecs(Specs):
     docker_storage_setup = simple_file("/etc/sysconfig/docker-storage-setup")
     docker_sysconfig = simple_file("/etc/sysconfig/docker")
 
-    dumpdev = simple_command("/bin/awk '/ext[234]/ { print $1; }' /proc/mounts")
-
     @datasource(ProcMounts)
     def dumpdev(broker):
         mnt = broker[ProcMounts]

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -46,7 +46,6 @@ class InsightsArchiveSpecs(Specs):
     docker_info = simple_file("insights_commands/docker_info")
     docker_list_containers = simple_file("insights_commands/docker_ps_--all_--no-trunc")
     docker_list_images = simple_file("insights_commands/docker_images_--all_--no-trunc_--digests")
-    dumpdev = simple_file("insights_commands/awk_.ext_234_._print_1_.proc.mounts")
     engine_config_all = simple_file("insights_commands/engine-config_--all")
     ethtool = glob_file("insights_commands/ethtool_*", ignore="ethtool_-.*")
     ethtool_S = glob_file("insights_commands/ethtool_-S_*")


### PR DESCRIPTION
- Remove the `regex` and use `split` instead
- Refine the related classes
- Keep compatible with the original version
- fix: #2059
- fix: #2069 