### PR TITLE
Add freeipa healthcheck log parser (#2071)

### DIFF
--- a/docs/shared_parsers_catalog/freeipa_healthcheck_log.rst
+++ b/docs/shared_parsers_catalog/freeipa_healthcheck_log.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.freeipa_healthcheck_log
+   :members:
+   :show-inheritance:

--- a/insights/parsers/freeipa_healthcheck_log.py
+++ b/insights/parsers/freeipa_healthcheck_log.py
@@ -1,0 +1,108 @@
+"""
+freeipa_healthcheck_log - File ``/var/log/ipa/healthcheck/healthcheck.log``
+===========================================================================
+
+This module provides plugins access to file ``/var/log/ipa/healthcheck/healthcheck.log``
+
+This file contains a list of items, each item representing a check made on the local IPA server.
+The file can be either single-line or multi-line indented.
+
+Typical content of file ``/var/log/ipa/healthcheck/healthcheck.log`` is::
+
+    [
+      {
+        "source": "ipahealthcheck.dogtag.ca",
+        "check": "DogtagCertsConfigCheck",
+        "severity": 0,
+        "uuid": "57f7d2c9-f71f-4c2f-b831-9e30250b18b2",
+        "when": "20190726213428Z",
+        "duration": "0.150333",
+        "kw": {
+          "key": "subsystemCert cert-pki-ca",
+          "configfile": "/var/lib/pki/pki-tomcat/conf/ca/CS.cfg"
+        }
+      },
+      {
+        "source": "ipahealthcheck.ipa.certs",
+        "check": "IPACertmongerExpirationCheck",
+        "severity": 0,
+        "uuid": "afd047c2-d78b-4c5c-b3a4-f68578ee1595",
+        "when": "20190726213429Z",
+        "duration": "0.007105",
+        "kw": {
+          "key": "20190620165230"
+        }
+      },
+      {
+        "source": "ipahealthcheck.ds.replication",
+        "check": "ReplicationConflictCheck",
+        "severity": 0,
+        "uuid": "99c0a513-447c-46f1-95ea-058fc0db6075",
+        "when": "20190726213429Z",
+        "duration": "0.001409",
+        "kw": {}
+      },
+      {
+        "source": "ipahealthcheck.ipa.files",
+        "check": "IPAFileNSSDBCheck",
+        "severity": 0,
+        "uuid": "7e8a7739-c4d6-4b97-b602-9f9e981f793c",
+        "when": "20190726213432Z",
+        "duration": "0.000765",
+        "kw": {
+          "key": "_etc_pki_pki-tomcat_alias_cert9.db_owner",
+          "type": "owner",
+          "path": "/etc/pki/pki-tomcat/alias/cert9.db"
+        }
+      },
+      {
+        "source": "ipahealthcheck.ipa.topology",
+        "check": "IPATopologyDomainCheck",
+        "severity": 0,
+        "uuid": "c5ee8ee1-98d1-4696-bbf1-8243677b8918",
+        "when": "20190726213432Z",
+        "duration": "0.019070",
+        "kw": {
+          "suffix": "ca"
+        }
+      },
+      {
+        "source": "ipahealthcheck.system.filesystemspace",
+        "check": "FileSystemSpaceCheck",
+        "severity": 2,
+        "uuid": "4d1c71c5-cc37-4ebf-b53c-34f4e4534437",
+        "when": "20190726213432Z",
+        "duration": null,
+        "kw": {
+          "msg": "/var/lib/dirsrv/: free space percentage under threshold: 1% < 20%",
+          "store": "/var/lib/dirsrv/",
+          "percent_free": 1,
+          "threshold": 20
+        }
+      }
+    ]
+
+The list of errors can be accessed via the errors property.
+
+Examples:
+
+    >>> len(healthcheck.errors)
+    1
+    >>> healthcheck.errors[0]['check'] == 'FileSystemSpaceCheck'
+    True
+
+"""
+
+from insights import parser
+from insights import JSONParser
+from insights.specs import Specs
+
+
+@parser(Specs.freeipa_healthcheck_log)
+class FreeIPAHealthCheckLog(JSONParser):
+    """Parses the content of file ``/var/log/ipa/healthcheck/healthcheck.log``."""
+
+    @property
+    def errors(self):
+        """ list: errors in healthcheck log."""
+        return [entry for entry in self.data if entry['severity'] > 0]

--- a/insights/parsers/tests/test_freeipa_healthcheck_log.py
+++ b/insights/parsers/tests/test_freeipa_healthcheck_log.py
@@ -1,0 +1,117 @@
+import doctest
+from insights.parsers import freeipa_healthcheck_log
+from insights.parsers.freeipa_healthcheck_log import FreeIPAHealthCheckLog
+from insights.tests import context_wrap
+
+LONG_FREEIPA_HEALTHCHECK_LOG_OK = """
+[{"source": "ipahealthcheck.meta.services", "check": "certmonger",
+"severity": 0, "uuid": "693c526c-2261-44fe-98e0-94c6b76bf79b",
+"when": "20190711141703Z", "duration": "0.012848", "kw": {"status": true}}]
+""".strip()
+
+LONG_FREEIPA_HEALTHCHECK_LOG_FAILURES = """
+[{"source": "ipahealthcheck.system.filesystemspace", "check": "FileSystemSpaceCheck",
+"severity": 2, "uuid": "ceadd564-f42f-4640-a3ae-b67f1aa29dc4", "when": "20190711141807Z",
+"duration": null, "kw": {"msg": "/var/log/: free space under threshold: 400 MiB < 1024 MiB",
+"store": "/var/log/", "free_space": 400, "threshold": 1024}}]
+""".strip()
+
+FREEIPA_HEALTHCHECK_LOG_DOCS_EXAMPLE = '''
+    [
+      {
+        "source": "ipahealthcheck.dogtag.ca",
+        "check": "DogtagCertsConfigCheck",
+        "severity": 0,
+        "uuid": "57f7d2c9-f71f-4c2f-b831-9e30250b18b2",
+        "when": "20190726213428Z",
+        "duration": "0.150333",
+        "kw": {
+          "key": "subsystemCert cert-pki-ca",
+          "configfile": "/var/lib/pki/pki-tomcat/conf/ca/CS.cfg"
+        }
+      },
+      {
+        "source": "ipahealthcheck.ipa.certs",
+        "check": "IPACertmongerExpirationCheck",
+        "severity": 0,
+        "uuid": "afd047c2-d78b-4c5c-b3a4-f68578ee1595",
+        "when": "20190726213429Z",
+        "duration": "0.007105",
+        "kw": {
+          "key": "20190620165230"
+        }
+      },
+      {
+        "source": "ipahealthcheck.ds.replication",
+        "check": "ReplicationConflictCheck",
+        "severity": 0,
+        "uuid": "99c0a513-447c-46f1-95ea-058fc0db6075",
+        "when": "20190726213429Z",
+        "duration": "0.001409",
+        "kw": {}
+      },
+      {
+        "source": "ipahealthcheck.ipa.files",
+        "check": "IPAFileNSSDBCheck",
+        "severity": 0,
+        "uuid": "7e8a7739-c4d6-4b97-b602-9f9e981f793c",
+        "when": "20190726213432Z",
+        "duration": "0.000765",
+        "kw": {
+          "key": "_etc_pki_pki-tomcat_alias_cert9.db_owner",
+          "type": "owner",
+          "path": "/etc/pki/pki-tomcat/alias/cert9.db"
+        }
+      },
+      {
+        "source": "ipahealthcheck.ipa.topology",
+        "check": "IPATopologyDomainCheck",
+        "severity": 0,
+        "uuid": "c5ee8ee1-98d1-4696-bbf1-8243677b8918",
+        "when": "20190726213432Z",
+        "duration": "0.019070",
+        "kw": {
+          "suffix": "ca"
+        }
+      },
+      {
+        "source": "ipahealthcheck.system.filesystemspace",
+        "check": "FileSystemSpaceCheck",
+        "severity": 2,
+        "uuid": "4d1c71c5-cc37-4ebf-b53c-34f4e4534437",
+        "when": "20190726213432Z",
+        "duration": null,
+        "kw": {
+          "msg": "/var/lib/dirsrv/: free space percentage under threshold: 1% < 20%",
+          "store": "/var/lib/dirsrv/",
+          "percent_free": 1,
+          "threshold": 20
+        }
+      }
+    ]
+'''.strip()
+
+
+FREEIPA_HEALTHCHECK_LOG_OK = "".join(LONG_FREEIPA_HEALTHCHECK_LOG_OK.splitlines())
+FREEIPA_HEALTHCHECK_LOG_FAILURES = "".join(LONG_FREEIPA_HEALTHCHECK_LOG_FAILURES.splitlines())
+
+
+def test_freeipa_healthcheck_log_ok():
+    log_obj = FreeIPAHealthCheckLog(context_wrap(FREEIPA_HEALTHCHECK_LOG_OK))
+    assert len(log_obj.errors) == 0
+
+
+def test_freeipa_healthcheck_log_not_ok():
+    log_obj = FreeIPAHealthCheckLog(context_wrap(FREEIPA_HEALTHCHECK_LOG_FAILURES))
+    assert len(log_obj.errors) > 0
+    for error in log_obj.errors:
+        assert error['check'] == 'FileSystemSpaceCheck'
+        assert error['source'] == 'ipahealthcheck.system.filesystemspace'
+
+
+def test_freeipa_healthcheck_log__documentation():
+    env = {
+        'healthcheck': FreeIPAHealthCheckLog(context_wrap(FREEIPA_HEALTHCHECK_LOG_DOCS_EXAMPLE)),
+    }
+    failed, total = doctest.testmod(freeipa_healthcheck_log, globs=env)
+    assert failed == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -154,6 +154,7 @@ class Specs(SpecSet):
     foreman_ssl_access_ssl_log = RegistryPoint(filterable=True)
     foreman_rake_db_migrate_status = RegistryPoint()
     foreman_tasks_config = RegistryPoint(filterable=True)
+    freeipa_healthcheck_log = RegistryPoint()
     fstab = RegistryPoint()
     galera_cnf = RegistryPoint()
     getcert_list = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -304,6 +304,7 @@ class DefaultSpecs(Specs):
     foreman_ssl_access_ssl_log = simple_file("var/log/httpd/foreman-ssl_access_ssl.log")
     foreman_rake_db_migrate_status = simple_command('/usr/sbin/foreman-rake db:migrate:status')
     foreman_tasks_config = first_file(["/etc/sysconfig/foreman-tasks", "/etc/sysconfig/dynflowd"])
+    freeipa_healthcheck_log = simple_file("/var/log/ipa/healthcheck/healthcheck.log")
     fstab = simple_file("/etc/fstab")
     galera_cnf = first_file(["/var/lib/config-data/puppet-generated/mysql/etc/my.cnf.d/galera.cnf", "/etc/my.cnf.d/galera.cnf"])
     getconf_page_size = simple_command("/usr/bin/getconf PAGE_SIZE")


### PR DESCRIPTION
    
* add data source for FreeIPA HealthCheck logs
* add parser for /var/log/ipa/healthcheck/healthcheck.log
    
Signed-off-by: François Cami <fcami@redhat.com>

Requires the fix for issue https://github.com/RedHatInsights/insights-core/issues/2056 e.g. PR https://github.com/RedHatInsights/insights-core/pull/2057 