### PR TITLE
dupkeycheck util for finding rules with possible key collisions.

### DIFF
--- a/insights/tools/dupkeycheck.py
+++ b/insights/tools/dupkeycheck.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""
+Given a list of plugins to load, print a report of any containing rules that
+might produce the same result keys.
+"""
+from __future__ import print_function
+import argparse
+import inspect
+from collections import defaultdict
+
+from insights import dr, parse_plugins, rule
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Find rule modules that could produce the same response keys.")
+    p.add_argument("-p",
+                   "--plugins",
+                   default="",
+                   help="Comma separated list of package(s) or module(s) containing plugins.")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    plugins = parse_plugins(args.plugins)
+    for p in plugins:
+        dr.load_components(p, continue_on_error=False)
+
+    results = defaultdict(list)
+    for comp, delegate in dr.DELEGATES.items():
+        if isinstance(delegate, rule):
+            results[dr.get_base_module_name(comp)].append(comp)
+
+    results = dict((key, comps) for key, comps in results.items() if len(comps) > 1)
+
+    if results:
+        print("Potential key conflicts:")
+        print()
+        for key in sorted(results):
+            print("{key}:".format(key=key))
+            for comp in sorted(results[key], key=dr.get_name):
+                name = comp.__name__
+                path = inspect.getabsfile(comp)
+                print("    {name} in {path}".format(name=name, path=path))
+            print()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ entry_points = {
         'insights-run = insights:main',
         'insights = insights.command_parser:main',
         'insights-cat = insights.tools.cat:main',
+        'insights-dupkeycheck = insights.tools.dupkeycheck:main',
         'insights-inspect = insights.tools.insights_inspect:main',
         'insights-info = insights.tools.query:main',
         'gen_api = insights.tools.generate_api_config:main',


### PR DESCRIPTION
This utility can be run against several sets of plugins and checks to see if the base names of any modules containing rules are the same. I think this is as close as we can get to rule result key collision detection before run time.

Fixes #2082 

Signed-off-by: Christopher Sams <csams@redhat.com>