### PR TITLE
Dmesg combiner requires at least one valid dependency.

### DIFF
--- a/insights/combiners/dmesg.py
+++ b/insights/combiners/dmesg.py
@@ -48,7 +48,7 @@ from insights.parsers.dmesg import DmesgLineList
 from insights.parsers.dmesg_log import DmesgLog
 
 
-@combiner(optional=[DmesgLineList, DmesgLog])
+@combiner([DmesgLineList, DmesgLog])
 class Dmesg(object):
     """
     Combiner for ``dmesg`` command and ``/var/log/dmesg`` file.


### PR DESCRIPTION
Fixes #2084

Signed-off-by: Christopher Sams <csams@redhat.com>