### PR TITLE
Fix flake8 error due to extra import

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -11,7 +11,7 @@ import six
 from fnmatch import fnmatch
 
 from insights.parsr import iniparser
-from insights.parsr.query import (Directive, Entry, from_dict, Result, Section,
+from insights.parsr.query import (Directive, Entry, Result, Section,
                                   compile_queries)
 from insights.contrib.ConfigParser import RawConfigParser
 


### PR DESCRIPTION
This was covered up by two other PRs (#2057, #2061) that each removed the call, and after those were both merged the error showed up.

Signed-off-by: Bob Fahr <bfahr@redhat.com>