### PR TITLE
Enhance MountEntry and MountOpts of parser mount

### DIFF
--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -75,12 +75,13 @@ Examples:
 """
 
 import re
+import copy
 from insights.specs import Specs
 from ..parsers import optlist_to_dict, keyword_search, ParseException, SkipException
-from .. import parser, get_active_lines, LegacyItemAccess, CommandParser
+from .. import parser, get_active_lines, CommandParser
 
 
-# FIXME: Let's put the LegacyItemAccessPrivate here temporarily.
+# TODO: FIXME: Let's put the LegacyItemAccessPrivate here temporarily.
 #        Should be moved to core/__init__.py later.
 class LegacyItemAccessPrivate(object):
     """
@@ -192,7 +193,7 @@ class MountOpts(LegacyItemAccessPrivate):
         if name == "_data":
             object.__setattr__(self, name, value)
         else:
-            raise AttributeError(name, value, "No allow write")
+            raise AttributeError("MountOpts don't allow attribute writing. Trying set <%s> with <%s> " % (name, value))
 
 
 class MountEntry(LegacyItemAccessPrivate, CommandParser):
@@ -228,7 +229,11 @@ class MountEntry(LegacyItemAccessPrivate, CommandParser):
         if name == "_data":
             object.__setattr__(self, name, value)
         else:
-            raise AttributeError(name, value, "No allow write")
+            raise AttributeError("MountEntry don't allow attribute writing. Trying set <%s> with <%s> " % (name, value))
+
+    @property
+    def data(self):
+        return copy.deepcopy(self._data)
 
 
 @parser(Specs.mount)

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -58,22 +58,6 @@ def test_mount():
     assert sda1.mount_options.data == 'ordered'
     assert 'mount_label' not in sda1
 
-    import pprint
-    print("\n === Take this as an example: ")
-    print("sr0, type(sr0): ", sr0, type(sr0))
-    print("sr0.__dict__ : ")
-    pprint.pprint(sr0.__dict__)
-    print("sr0.data['mount_point'], sr0.mount_point: ", sr0._data['mount_point'], sr0.mount_point)
-    print(" === Do the change now: ")
-    #sr0.mount_point = "attribute mp"
-    #print("sr0.data['mount_point'], sr0.mount_point: ", sr0._data['mount_point'], sr0.mount_point)
-    sr0._data['mount_point'] = "data dict mp"
-    print("sr0.data['mount_point'], sr0.mount_point: ", sr0._data['mount_point'], sr0.mount_point)
-    print(sr0.__dict__)
-
-
-
-
     # Test iteration
     for mount in results:
         assert hasattr(mount, 'filesystem')
@@ -128,6 +112,14 @@ def test_mount_get_dir():
     with pytest.raises(ParseException) as exc:
         Mount(context_wrap(MOUNT_WITHOUT_ROOT))
     assert "Input for mount must contain '/' mount point." in str(exc)
+
+
+def test_mount_attribute_write_error():
+    results = Mount(context_wrap(MOUNT_DATA))
+    sr0 = results.search(filesystem='/dev/sr0')[0]
+    with pytest.raises(AttributeError) as exc:
+        sr0.mount_point = "attribute mp"
+    assert "MountEntry don't allow attribute writing" in str(exc)
 
 
 PROC_MOUNT = """

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -58,6 +58,22 @@ def test_mount():
     assert sda1.mount_options.data == 'ordered'
     assert 'mount_label' not in sda1
 
+    import pprint
+    print("\n === Take this as an example: ")
+    print("sr0, type(sr0): ", sr0, type(sr0))
+    print("sr0.__dict__ : ")
+    pprint.pprint(sr0.__dict__)
+    print("sr0.data['mount_point'], sr0.mount_point: ", sr0._data['mount_point'], sr0.mount_point)
+    print(" === Do the change now: ")
+    #sr0.mount_point = "attribute mp"
+    #print("sr0.data['mount_point'], sr0.mount_point: ", sr0._data['mount_point'], sr0.mount_point)
+    sr0._data['mount_point'] = "data dict mp"
+    print("sr0.data['mount_point'], sr0.mount_point: ", sr0._data['mount_point'], sr0.mount_point)
+    print(sr0.__dict__)
+
+
+
+
     # Test iteration
     for mount in results:
         assert hasattr(mount, 'filesystem')


### PR DESCRIPTION
      Use self._date over self.date to keep data as private.
      Use __getattr__ and __setattr__ for attr access from self._data,
      and protect from attr writing in customer usage.
      Add MountEntry.data property for backwards-compatibility usage.