### PR TITLE
Protect top level CLI from tracebacks.

### DIFF
--- a/insights/command_parser.py
+++ b/insights/command_parser.py
@@ -85,7 +85,10 @@ def fix_arg_dashes():
 
 def main():
     fix_arg_dashes()
-    InsightsCli()
+    try:
+        InsightsCli()
+    except BaseException as ex:
+        print(ex)
 
 
 if __name__ == "__main__":

--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -376,8 +376,7 @@ def _import(path, continue_on_error):
     log.debug("Importing %s" % path)
     try:
         return importlib.import_module(path)
-    except Exception as ex:
-        log.exception(ex)
+    except BaseException:
         if not continue_on_error:
             raise
 


### PR DESCRIPTION
Errors resulting from bad command line args result in tracebacks. This PR suppresses them and just prints the exception message.

Fixes #2097 

Signed-off-by: Christopher Sams <csams@redhat.com>