### PR TITLE
remove pyopenssl req, add new require

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,6 @@ pipeline {
                 source .testenv/bin/activate
                 pip install "idna<=2.7"
                 pip install "pycparser<=2.18"
-                pip install "pyOpenSSL<=17.5.0"
                 pip install -e .[testing]
                 pytest
             """
@@ -33,7 +32,6 @@ pipeline {
                 source .lintenv/bin/activate
                 pip install "idna<=2.7"
                 pip install "pycparser<=2.18"
-                pip install "pyOpenSSL<=17.5.0"
                 pip install -e .[linting]
                 flake8
             """

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,7 @@ maybe_require("argparse")
 
 
 client = set([
-    'requests',
-    'pyOpenSSL',
+    'requests'
 ])
 
 develop = set([
@@ -122,6 +121,7 @@ if __name__ == "__main__":
             'develop': list(runtime | develop | client | docs | linting | testing | cluster),
             'develop26': list(runtime | develop | client | linting | testing | cluster),
             'client': list(runtime | client),
+            'client-develop': list(runtime | develop | client | linting | testing),
             'cluster': list(runtime | cluster),
             'openshift': list(runtime | openshift),
             'optional': list(optional),


### PR DESCRIPTION
Removing unnecessary PyOpenSSL and adding an additional require tag for QE RHEL 6 testing