### PR TITLE
Update entry classes in mount and fstab

### DIFF
--- a/insights/parsers/fstab.py
+++ b/insights/parsers/fstab.py
@@ -37,13 +37,14 @@ The :class:`FSTabEntry` for each mount point is also available via the
 
 
 from insights import Parser, parser, get_active_lines
-from insights.parsers import optlist_to_dict, parse_delimited_table, keyword_search
 from insights.specs import Specs
+from insights.parsers import optlist_to_dict, parse_delimited_table, keyword_search
+from insights.parsers.mount import MountOpts, AttributeAsDict
 
 FS_HEADINGS = "fs_spec fs_file fs_vfstype raw_fs_mntops fs_freq fs_passno"
 
 
-class FSTabEntry(object):
+class FSTabEntry(AttributeAsDict):
     """
     An object representing an entry in ``/etc/fstab``.  Each entry contains
     below fixed attributes:
@@ -59,26 +60,14 @@ class FSTabEntry(object):
         raw (str): the RAW line which is useful to front-end
     """
 
-    def __init__(self, data={}):
-        self.__attrs = {'fs_spec': '', 'fs_file': '', 'fs_vfstype': '',
-                'raw_fs_mntops': '', 'fs_mntops': {}, 'fs_freq': 0,
-                'fs_passno': 0, 'raw': ''}
+    def __init__(self, data=None):
         data = {} if data is None else data
-        for k, v in self.__attrs.items():
-            setattr(self, k, data.get(k, v))
-
-    def __getitem__(self, item):
-        return self.__getattribute__(item)
-
-    def __contains__(self, item):
-        return item in self.__attrs
-
-    def get(self, item, default=None):
-        return self.__getattribute__(item) if item in self.__attrs else default
+        for k, v in data.items():
+            setattr(self, k, v)
 
     def items(self):
-        for k in self.__attrs:
-            yield k, self.__getattribute__(k)
+        for k, v in self.__dict__.items():
+            yield k, v
 
 
 @parser(Specs.fstab)

--- a/insights/parsers/fstab.py
+++ b/insights/parsers/fstab.py
@@ -22,81 +22,28 @@ option's value set to True so it can be conveniently searched.
 
 This data, as above, is available in the ``data`` property:
 
-* Wrapped as an :class:`FSTabEntry`, each column can also be accessed as a
-  property with the same name.
-* The ``fs_mntops`` is wrapped as a :class:`insights.parsers.mount.MountOpts`
-  which contains below fixed attributes:
-
-* ``rw`` - Read write
-* ``ro`` - Read only
-* ``defaults`` - Use default options: rw, suid, dev, exec, auto, nouser, async, and relatime
-* ``relatime`` - Inode access times relative to modify or change time
-* ``seclabel`` - `seclabel` is enabled or not
-* ``attr2`` - `opportunistic` improvement is enabled or not
-* ``inode64`` - `inode64` is enabled or not
-* ``noquota`` - Disk quotas are enforced or not
-
-For instance, the option ``rw`` in ``rw,dmode=0500`` may be accessed as
-``mnt_row_info.rw`` with the value ``True``, and the ``dmode`` can be accessed
-as ``mnt_row_info.dmode`` with the value ``0500``.
+* Wrapped as an :class:`FSTabEntry`, each column can also be accessed as an
+  attribute with the same name.
+* The ``fs_mntops`` is wrapped as a dictionary.  For instance, the option
+  ``rw`` in ``(rw,dmode=0500)`` may be accessed as ``mnt_opts['rw']`` with the
+  value ``True``, the ``dmode`` can be accessed as ``mnt_opts.get('dmode')``
+  with the value ``0500``.
 
 The :class:`FSTabEntry` for each mount point is also available via the
 :attr:`FSTab.mounted_on` property; the data is the same as that stored in the
 :attr:`FSTab.data` list.
 
-Typical content of the ``fstab`` looks like::
-
-    #
-    # /etc/fstab
-    # Created by anaconda on Fri May  6 19:51:54 2016
-    #
-    /dev/mapper/rhel_hadoop--test--1-root /                       xfs     defaults        0 0
-    UUID=2c839365-37c7-4bd5-ac47-040fba761735 /boot               xfs     defaults        0 0
-    /dev/mapper/rhel_hadoop--test--1-home /home                   xfs     defaults        0 0
-    /dev/mapper/rhel_hadoop--test--1-swap swap                    swap    defaults        0 0
-
-    /dev/sdb1 /hdfs/data1 xfs rw,relatime,seclabel,attr2,inode64,noquota 0 0
-    /dev/sdc1 /hdfs/data2 xfs rw,relatime,seclabel,attr2,inode64,noquota 0 0
-    /dev/sdd1 /hdfs/data3 xfs rw,relatime,seclabel,attr2,inode64,noquota 0 0
-
-    localhost:/ /mnt/hdfs nfs rw,vers=3,proto=tcp,nolock,timeo=600 0 0
-
-    /dev/mapper/vg0-lv2     /test1     ext4 defaults,data=writeback     1 1
-    nfs_hostname.redhat.com:/nfs_share/data     /srv/rdu/cases/000  nfs     ro,defaults,hard,intr,bg,noatime,nodev,nosuid,nfsvers=3,tcp,rsize=32768,wsize=32768     0
-
-Examples:
-
-    >>> type(fstab)
-    <class 'insights.parsers.fstab.FSTab'>
-    >>> len(fstab)
-    9
-    >>> fstab.data[0]['fs_spec'] # Note that data is a list not a dict here
-    '/dev/mapper/rhel_hadoop--test--1-root'
-    >>> fstab.data[0].fs_spec
-    '/dev/mapper/rhel_hadoop--test--1-root'
-    >>> fstab.data[0].raw
-    '/dev/mapper/rhel_hadoop--test--1-root /                       xfs    defaults        0 0'
-    >>> fstab.data[0].fs_mntops.defaults
-    True
-    >>> 'relatime' in fstab.data[0].fs_mntops
-    False
-    >>> fstab.data[0].fs_mntops.get('relatime')
-    None
-    >>> fstab.mounted_on['/hdfs/data3'].fs_spec
-    '/dev/sdd1'
-
 """
 
 
-from .. import Parser, parser, get_active_lines, LegacyItemAccess
-from ..parsers import optlist_to_dict, parse_delimited_table, keyword_search
-from ..parsers.mount import MountOpts
+from insights import Parser, parser, get_active_lines
+from insights.parsers import optlist_to_dict, parse_delimited_table, keyword_search
 from insights.specs import Specs
 
-FS_HEADINGS = "fs_spec                               fs_file                 fs_vfstype raw_fs_mntops    fs_freq fs_passno"
+FS_HEADINGS = "fs_spec fs_file fs_vfstype raw_fs_mntops fs_freq fs_passno"
 
 
-class FSTabEntry(LegacyItemAccess):
+class FSTabEntry(object):
     """
     An object representing an entry in ``/etc/fstab``.  Each entry contains
     below fixed attributes:
@@ -106,37 +53,32 @@ class FSTabEntry(LegacyItemAccess):
         fs_file (str): the mount point
         fs_vfstype (str): the type of file system
         raw_fs_mntops (str): the mount options as a string
-        fs_mntops (MountOpts): the mount options as a :class:`insights.parsers.mount.MountOpts` object
+        fs_mntops (dict): the mount options as a dictionary
         fs_freq (int): the dump frequency
         fs_passno (int): check the filesystem on reboot in this pass number
         raw (str): the RAW line which is useful to front-end
     """
-    attrs = {
-        'fs_spec': '',
-        'fs_file': '',
-        'fs_vfstype': '',
-        'raw_fs_mntops': '',
-        'fs_mntops': MountOpts(),
-        'fs_freq': 0,
-        'fs_passno': 0,
-        'raw': '',
-    }
 
     def __init__(self, data={}):
-        self.data = data
-        for k, v in FSTabEntry.attrs.items():
-            if k not in data:
-                setattr(self, k, v)
-        for k, v in data.items():
-            setattr(self, k, v)
+        self.__attrs = {'fs_spec': '', 'fs_file': '', 'fs_vfstype': '',
+                'raw_fs_mntops': '', 'fs_mntops': {}, 'fs_freq': 0,
+                'fs_passno': 0, 'raw': ''}
+        data = {} if data is None else data
+        for k, v in self.__attrs.items():
+            setattr(self, k, data.get(k, v))
+
+    def __getitem__(self, item):
+        return self.__getattribute__(item)
+
+    def __contains__(self, item):
+        return item in self.__attrs
+
+    def get(self, item, default=None):
+        return self.__getattribute__(item) if item in self.__attrs else default
 
     def items(self):
-        """
-        To keep backward compatibility and let it can be iterated as a
-        dictionary.
-        """
-        for k, v in self.data.items():
-            yield k, v
+        for k in self.__attrs:
+            yield k, self.__getattribute__(k)
 
 
 @parser(Specs.fstab)
@@ -144,13 +86,47 @@ class FSTab(Parser):
     """
     Parse the content of ``/etc/fstab``.
 
-    This object provides the '__len__' and '__iter__' methods to allow it to
-    be used as a list to iterate over the ``data`` data, e.g.::
+    Typical content of the ``fstab`` looks like::
 
-        >>> if len(fstab) > 0:
-        >>>     for fs in fstab:
-        >>>         print fs.fs_file
-        >>>         print fs.raw
+        #
+        # /etc/fstab
+        # Created by anaconda on Fri May  6 19:51:54 2016
+        #
+        /dev/mapper/rhel_hadoop--test--1-root /                       xfs     defaults        0 0
+        UUID=2c839365-37c7-4bd5-ac47-040fba761735 /boot               xfs     defaults        0 0
+        /dev/mapper/rhel_hadoop--test--1-home /home                   xfs     defaults        0 0
+        /dev/mapper/rhel_hadoop--test--1-swap swap                    swap    defaults        0 0
+
+        /dev/sdb1 /hdfs/data1 xfs rw,relatime,seclabel,attr2,inode64,noquota 0 0
+        /dev/sdc1 /hdfs/data2 xfs rw,relatime,seclabel,attr2,inode64,noquota 0 0
+        /dev/sdd1 /hdfs/data3 xfs rw,relatime,seclabel,attr2,inode64,noquota 0 0
+
+        localhost:/ /mnt/hdfs nfs rw,vers=3,proto=tcp,nolock,timeo=600 0 0
+
+        /dev/mapper/vg0-lv2     /test1     ext4 defaults,data=writeback     1 1
+        nfs_hostname.redhat.com:/nfs_share/data     /srv/rdu/cases/000  nfs     ro,defaults,hard,intr,bg,noatime,nodev,nosuid,nfsvers=3,tcp,rsize=32768,wsize=32768     0
+
+    Examples:
+
+        >>> type(fstab)
+        <class 'insights.parsers.fstab.FSTab'>
+        >>> len(fstab)
+        9
+        >>> fstab.data[0]['fs_spec'] # Note that data is a list not a dict here
+        '/dev/mapper/rhel_hadoop--test--1-root'
+        >>> fstab.data[0].fs_spec
+        '/dev/mapper/rhel_hadoop--test--1-root'
+        >>> fstab.data[0].raw
+        '/dev/mapper/rhel_hadoop--test--1-root /                       xfs    defaults        0 0'
+        >>> fstab.data[0].fs_mntops.defaults
+        True
+        >>> 'relatime' in fstab.data[0].fs_mntops
+        False
+        >>> fstab.data[0].fs_mntops.get('relatime')
+        None
+        >>> fstab.mounted_on['/hdfs/data3'].fs_spec
+        '/dev/sdd1'
+
 
     Attributes:
         data (list): a list of parsed fstab entries as :class:`FSTabEntry` objects.
@@ -180,11 +156,11 @@ class FSTab(Parser):
             # optlist_to_dict converts 'key=value' to key: value and
             # 'key' to key: True
             if 'raw_fs_mntops' in line:
-                line['fs_mntops'] = MountOpts(optlist_to_dict(line.get('raw_fs_mntops')))
+                line['fs_mntops'] = optlist_to_dict(line.get('raw_fs_mntops'))
             else:
                 # if there is no mntops, it is defaults.
                 # (/dev/foo /foo somefs defaults   0 0) and (/dev/foo /foo somefs) are same
-                line['fs_mntops'] = MountOpts(optlist_to_dict('defaults'))
+                line['fs_mntops'] = optlist_to_dict('defaults')
             # add `raw` here for displaying convenience on front-end
             line['raw'] = [l for l in content if l.strip().startswith(line['fs_spec'])][0]
             self.data.append(FSTabEntry(line))

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -54,6 +54,10 @@ class AttributeAsDict(object):
     def get(self, item, default=None):
         return self.__dict__.get(item, default)
 
+    def items(self):
+        for k, v in self.__dict__.items():
+            yield k, v
+
 
 class MountOpts(AttributeAsDict):
     """
@@ -89,10 +93,6 @@ class MountEntry(AttributeAsDict):
         data = {} if data is None else data
         for k, v in data.items():
             setattr(self, k, v)
-
-    def items(self):
-        for k, v in self.__dict__.items():
-            yield k, v
 
 
 class MountedFileSystems(CommandParser):
@@ -214,7 +214,7 @@ class Mount(MountedFileSystems):
             mount['mount_point'] = line_sp[0]
             mount['mount_type'] = line_sp[1].split()[0]
             line_sp = _customized_split(raw=line, l=mnt_pt_sp[1], sep=None, check=False)
-            mount['mount_options'] = optlist_to_dict(line_sp[0].strip('()'))
+            mount['mount_options'] = MountOpts(optlist_to_dict(line_sp[0].strip('()')))
             if len(line_sp) == 2:
                 mount['mount_label'] = line_sp[1]
 
@@ -273,7 +273,7 @@ class ProcMounts(MountedFileSystems):
             line_sp = _customized_split(raw=line, l=line_sp[1], num=3, reverse=True)
             mount['mount_label'] = line_sp[-2:]
             line_sp = _customized_split(raw=line, l=line_sp[0], reverse=True)
-            mount['mount_options'] = optlist_to_dict(line_sp[1])
+            mount['mount_options'] = MountOpts(optlist_to_dict(line_sp[1]))
             line_sp = _customized_split(raw=line, l=line_sp[0], reverse=True)
             mount['mount_type'] = mount['filesystem_type'] = line_sp[1]
             mount['mount_point'] = line_sp[0]

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -196,7 +196,7 @@ class Mount(MountedFileSystems):
         'dev/sr0'
         >>> mnt_info['/run/media/root/VMware Tools'].mount_label
         '[VMware Tools]'
-        >>> mnt_info['/run/media/root/VMware Tools'].mount_options.get('ro')
+        >>> mnt_info['/run/media/root/VMware Tools'].mount_options.ro
         True
     """
     def _parse_mounts(self, content):
@@ -253,7 +253,7 @@ class ProcMounts(MountedFileSystems):
         True
         >>> proc_mnt_info['/run/media/root/VMware Tools'].mount_label == ['0', '0']
         True
-        >>> proc_mnt_info['/run/media/root/VMware Tools'].mount_options['ro']
+        >>> proc_mnt_info['/run/media/root/VMware Tools'].mount_options.ro
         True
         >>> proc_mnt_info['/run/media/root/VMware Tools'].mounted_device == 'dev/sr0'
         True

--- a/insights/parsers/tests/test_fstab.py
+++ b/insights/parsers/tests/test_fstab.py
@@ -61,9 +61,9 @@ def test_fstab():
     assert sdb1 is not None
     assert sdb1.fs_file == "/hdfs/data1"
     assert sdb1.fs_vfstype == "xfs"
-    assert sdb1.fs_mntops.get('rw')
-    assert sdb1.fs_mntops['relatime']
-    assert 'noquota' in sdb1.get('fs_mntops')
+    assert sdb1.fs_mntops.rw
+    assert sdb1.fs_mntops.relatime
+    assert 'noquota' in sdb1.fs_mntops
     assert sdb1.fs_freq == 0
     assert sdb1.fs_passno == 0
     assert sdb1.raw == '/dev/sdb1 /hdfs/data1 xfs rw,relatime,seclabel,attr2,inode64,noquota 0 0'
@@ -71,13 +71,13 @@ def test_fstab():
     assert nfs_host.fs_spec == "nfs_hostname.example.com:/nfs_share/data"
     assert nfs_host.fs_file == "/srv/rdu/data/000"
     assert nfs_host.fs_vfstype == "nfs"
-    assert nfs_host.fs_mntops['ro']
-    assert nfs_host.fs_mntops.get('hard')
+    assert nfs_host.fs_mntops.ro
+    assert nfs_host.fs_mntops.hard
     assert 'bg' in nfs_host.fs_mntops
-    assert nfs_host.fs_mntops['rsize'] == "32768"
+    assert nfs_host.fs_mntops.rsize == "32768"
     assert nfs_host.fs_freq == 0
     assert nfs_host.fs_passno == 0
-    assert dev_vg0.fs_mntops.get('data') == 'writeback'
+    assert dev_vg0.fs_mntops.data == 'writeback'
     assert dev_vg0.raw == '/dev/mapper/vg0-lv2 /test1             ext4 defaults,data=writeback     1 1'
     for opt, v in dev_vg0.fs_mntops.items():
         if opt.startswith('data'):

--- a/insights/parsers/tests/test_fstab.py
+++ b/insights/parsers/tests/test_fstab.py
@@ -61,9 +61,9 @@ def test_fstab():
     assert sdb1 is not None
     assert sdb1.fs_file == "/hdfs/data1"
     assert sdb1.fs_vfstype == "xfs"
-    assert sdb1.fs_mntops.rw
-    assert sdb1.fs_mntops.relatime
-    assert 'noquota' in sdb1.fs_mntops
+    assert sdb1.fs_mntops.get('rw')
+    assert sdb1.fs_mntops['relatime']
+    assert 'noquota' in sdb1.get('fs_mntops')
     assert sdb1.fs_freq == 0
     assert sdb1.fs_passno == 0
     assert sdb1.raw == '/dev/sdb1 /hdfs/data1 xfs rw,relatime,seclabel,attr2,inode64,noquota 0 0'
@@ -71,13 +71,13 @@ def test_fstab():
     assert nfs_host.fs_spec == "nfs_hostname.example.com:/nfs_share/data"
     assert nfs_host.fs_file == "/srv/rdu/data/000"
     assert nfs_host.fs_vfstype == "nfs"
-    assert nfs_host.fs_mntops.ro
-    assert nfs_host.fs_mntops.hard
+    assert nfs_host.fs_mntops['ro']
+    assert nfs_host.fs_mntops.get('hard')
     assert 'bg' in nfs_host.fs_mntops
-    assert nfs_host.fs_mntops.rsize == "32768"
+    assert nfs_host.fs_mntops['rsize'] == "32768"
     assert nfs_host.fs_freq == 0
     assert nfs_host.fs_passno == 0
-    assert dev_vg0.fs_mntops.data == 'writeback'
+    assert dev_vg0.fs_mntops.get('data') == 'writeback'
     assert dev_vg0.raw == '/dev/mapper/vg0-lv2 /test1             ext4 defaults,data=writeback     1 1'
     for opt, v in dev_vg0.fs_mntops.items():
         if opt.startswith('data'):

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -188,12 +188,12 @@ def test_proc_mount():
     results = ProcMounts(context_wrap(PROC_MOUNT))
     assert results is not None
     assert len(results) == 19
-    sda1 = results.search(mounted_device='/dev/sda1')[0]
+    sda1 = results.search(filesystem='/dev/sda1')[0]
 
     # Test get method
     assert sda1 is not None
     assert sda1['mount_point'] == '/boot'
-    assert sda1['filesystem_type'] == 'ext4'
+    assert sda1['mount_type'] == 'ext4'
     assert 'rw' in sda1['mount_options']
     assert 'relatime' in sda1['mount_options']
     assert sda1['mount_options']['data'] == 'ordered'
@@ -202,9 +202,9 @@ def test_proc_mount():
 
     # Test iteration
     for mnt in results:
-        assert hasattr(mnt, 'mounted_device')
+        assert hasattr(mnt, 'filesystem')
         assert hasattr(mnt, 'mount_point')
-        assert hasattr(mnt, 'filesystem_type')
+        assert hasattr(mnt, 'mount_type')
         assert hasattr(mnt, 'mount_options')
 
     # Test getitem
@@ -219,12 +219,12 @@ def test_proc_mount():
     assert results.mounts['/boot'] == sda1
 
     # Test get_dir
-    assert results.get_dir('/var/lib/nfs/rpc_pipefs') == results.search(mounted_device='sunrpc')[0]
+    assert results.get_dir('/var/lib/nfs/rpc_pipefs') == results.search(filesystem='sunrpc')[0]
     assert results.get_dir('/etc') == results['/']
 
     # Test search
-    assert results.search(mounted_device='/dev/sda1') == [sda1]
-    assert results.search(filesystem_type='nfs') == [
+    assert results.search(filesystem='/dev/sda1') == [sda1]
+    assert results.search(mount_type='nfs') == [
         results.rows[n] for n in (16, 17)
     ]
     assert results.search(mount_options__contains='mode') == [

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -112,7 +112,6 @@ def test_mount():
     assert sr0.get('does not exist', 'failure') == 'failure'
     assert sr0['mount_type'] == 'iso9660'
     assert 'ro' in sr0['mount_options']
-    assert sr0.mount_options.ro
     assert 'relatime' in sr0['mount_options']
     assert sr0['mount_options']['uhelper'] == 'udisks2'
     assert sr0['mount_label'] == '[VMware Tools]'
@@ -122,8 +121,6 @@ def test_mount():
     assert 'rw' in sda1['mount_options']
     assert 'seclabel' in sda1['mount_options']
     assert sda1['mount_options']['data'] == 'ordered'
-    assert sda1.mount_options.data == 'ordered'
-    assert 'mount_label' not in sda1
 
     # Test iteration
     for mnt in results:
@@ -197,7 +194,6 @@ def test_proc_mount():
     assert 'rw' in sda1['mount_options']
     assert 'relatime' in sda1['mount_options']
     assert sda1['mount_options']['data'] == 'ordered'
-    assert sda1.mount_options.data == 'ordered'
     assert sda1['mount_label'] == ['0', '0']
 
     # Test iteration

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -112,6 +112,7 @@ def test_mount():
     assert sr0.get('does not exist', 'failure') == 'failure'
     assert sr0['mount_type'] == 'iso9660'
     assert 'ro' in sr0['mount_options']
+    assert sr0.mount_options.ro
     assert 'relatime' in sr0['mount_options']
     assert sr0['mount_options']['uhelper'] == 'udisks2'
     assert sr0['mount_label'] == '[VMware Tools]'
@@ -121,6 +122,8 @@ def test_mount():
     assert 'rw' in sda1['mount_options']
     assert 'seclabel' in sda1['mount_options']
     assert sda1['mount_options']['data'] == 'ordered'
+    assert sda1.mount_options.data == 'ordered'
+    assert 'mount_label' not in sda1
 
     # Test iteration
     for mnt in results:
@@ -194,6 +197,7 @@ def test_proc_mount():
     assert 'rw' in sda1['mount_options']
     assert 'relatime' in sda1['mount_options']
     assert sda1['mount_options']['data'] == 'ordered'
+    assert sda1.mount_options.data == 'ordered'
     assert sda1['mount_label'] == ['0', '0']
 
     # Test iteration


### PR DESCRIPTION
- fix: #2081 
- revert the AttributrAsDict as the base class of MountEntry, MountOpts, and FSTabEntry
- remove the fixed attributes from MountOpts, change to all dynamic attributes
- change dynamic attributes of MountEntry and FSTabEntry to fixed attributes
- update docstring

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>