### PR TITLE
Remove getcert list command from insights specs

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -297,7 +297,6 @@ class DefaultSpecs(Specs):
     foreman_tasks_config = first_file(["/etc/sysconfig/foreman-tasks", "/etc/sysconfig/dynflowd"])
     fstab = simple_file("/etc/fstab")
     galera_cnf = first_file(["/var/lib/config-data/puppet-generated/mysql/etc/my.cnf.d/galera.cnf", "/etc/my.cnf.d/galera.cnf"])
-    getcert_list = simple_command("/usr/bin/getcert list")
     getconf_page_size = simple_command("/usr/bin/getconf PAGE_SIZE")
     getenforce = simple_command("/usr/sbin/getenforce")
     getsebool = simple_command("/usr/sbin/getsebool -a")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -60,7 +60,6 @@ class InsightsArchiveSpecs(Specs):
     fcoeadm_i = simple_file("insights_commands/fcoeadm_-i")
     fdisk_l = simple_file("insights_commands/fdisk_-l")
     foreman_rake_db_migrate_status = simple_file('insights_commands/foreman-rake_db_migrate_status')
-    getcert_list = simple_file("insights_commands/getcert_list")
     getconf_page_size = simple_file("insights_commands/getconf_PAGE_SIZE")
     getenforce = simple_file("insights_commands/getenforce")
     getsebool = simple_file("insights_commands/getsebool_-a")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -60,6 +60,7 @@ class InsightsArchiveSpecs(Specs):
     fcoeadm_i = simple_file("insights_commands/fcoeadm_-i")
     fdisk_l = simple_file("insights_commands/fdisk_-l")
     foreman_rake_db_migrate_status = simple_file('insights_commands/foreman-rake_db_migrate_status')
+    getcert_list = simple_file("insights_commands/getcert_list")
     getconf_page_size = simple_file("insights_commands/getconf_PAGE_SIZE")
     getenforce = simple_file("insights_commands/getenforce")
     getsebool = simple_file("insights_commands/getsebool_-a")


### PR DESCRIPTION
* Remove this command from insights due to bug described in
  bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1731496
* Spec is still enabled for sosreport

Signed-off-by: Bob Fahr <bfahr@redhat.com>