### PR TITLE
Add Html Format

### DIFF
--- a/insights/formats/__init__.py
+++ b/insights/formats/__init__.py
@@ -1,15 +1,8 @@
 from __future__ import print_function
-import inspect
 import six
 import sys
-from datetime import datetime
-
-from jinja2 import Template
 
 from insights import dr, rule
-from insights.core.context import ExecutionContext
-from insights.core.spec_factory import ContentProvider
-from insights.core.plugins import is_datasource
 
 
 RENDERERS = {}
@@ -107,97 +100,6 @@ class EvaluatorFormatterAdapter(FormatterAdapter):
         self.formatter.postprocess()
 
 
-class TemplateFormat(Formatter):
-    """
-    Subclasses should implement create_template_context to return a dictionary
-    to use when rendering the jinja2 template defined by the class level
-    TEMPLATE attribute.
-    """
-
-    TEMPLATE = ""
-    """ jinja2 template to use for rule result rendering. """
-
-    def find_root(self):
-        """
-        Finds the root directory used during the evaluation. Note this could be
-        a non-existent temporary directory if analyzing an archive.
-        """
-        for comp in self.broker:
-            try:
-                if issubclass(comp, ExecutionContext):
-                    return self.broker[comp].root
-            except:
-                pass
-        return "Unknown"
-
-    def get_datasources(self, comp, broker):
-        """
-        Get the most relevant activated datasources for each rule.
-        """
-        graph = dr.get_dependency_graph(comp)
-        ds = []
-        for cand in graph:
-            if cand in broker and is_datasource(cand):
-                val = broker[cand]
-                if not isinstance(val, list):
-                    val = [val]
-
-                results = []
-                for v in val:
-                    if isinstance(v, ContentProvider):
-                        results.append(v.cmd or v.path or "python implementation")
-                ds.extend(results)
-        return ds
-
-    def collect_rules(self, comp, broker):
-        """
-        Rule results are stored as dictionaries in the ``self.rules`` list.
-        Each dictionary contains the folowing keys:
-            name: fully qualified name of the rule
-            id: fully qualified rule name with "." replaced with "_"
-            response_type: the class name of the response object (make_info, etc.)
-            body: rendered content for the rule as provided in the rule module.
-            mod_doc: pydoc of the module containing the rule
-            rule_doc: pydoc of the rule
-            rule_path: absolute path to the source file of the rule
-            datasources: sorted list of command or files contributing to the rule
-        """
-        if comp in broker:
-            name = dr.get_name(comp)
-            rule_id = name.replace(".", "_")
-            val = broker[comp]
-            self.rules.append({
-                "name": name,
-                "id": rule_id,
-                "response_type": type(val).__name__,
-                "body": render(comp, val),
-                "mod_doc": sys.modules[comp.__module__].__doc__ or "",
-                "rule_doc": comp.__doc__ or "",
-                "source_path": inspect.getabsfile(comp),
-                "datasources": sorted(set(self.get_datasources(comp, broker)))
-            })
-
-    def preprocess(self):
-        """
-        Watches rules go by as they evaluate and collects information about
-        them for later display in postprocess.
-        """
-        self.start_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
-        self.rules = []
-        self.broker.add_observer(self.collect_rules, rule)
-
-    def create_template_context(self):
-        raise NotImplementedError()
-
-    def postprocess(self):
-        """
-        Builds a dictionary of rule data as context for a jinja2 template that
-        renders the final output.
-        """
-        ctx = self.create_template_context()
-        print(Template(self.TEMPLATE).render(ctx), file=self.stream)
-
-
 def get_content(obj, val):
     """
     Attempts to determine a jinja2 content template for a rule's response.
@@ -232,14 +134,18 @@ def get_content(obj, val):
             return c
 
 
-def format_rule(comp, val):
-    content = get_content(comp, val)
-    if content and val.get("type") != "skip":
-        return Template(content).render(val)
-    return str(val)
+try:
+    from jinja2 import Template
 
+    def format_rule(comp, val):
+        content = get_content(comp, val)
+        if content and val.get("type") != "skip":
+            return Template(content).render(val)
+        return str(val)
 
-RENDERERS[rule] = format_rule
+    RENDERERS[rule] = format_rule
+except:
+    pass
 
 
 def render(comp, val):

--- a/insights/formats/__init__.py
+++ b/insights/formats/__init__.py
@@ -107,7 +107,7 @@ class EvaluatorFormatterAdapter(FormatterAdapter):
         self.formatter.postprocess()
 
 
-class TemplateFormatter(Formatter):
+class TemplateFormat(Formatter):
     """
     Subclasses should implement create_template_context to return a dictionary
     to use when rendering the jinja2 template defined by the class level
@@ -173,7 +173,7 @@ class TemplateFormatter(Formatter):
                 "body": render(comp, val),
                 "mod_doc": sys.modules[comp.__module__].__doc__ or "",
                 "rule_doc": comp.__doc__ or "",
-                "rule_path": inspect.getabsfile(comp),
+                "source_path": inspect.getabsfile(comp),
                 "datasources": sorted(set(self.get_datasources(comp, broker)))
             })
 

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -27,89 +27,89 @@ class HtmlFormat(Formatter):
     """
 
     CONTENT = """
-    <!doctype html>
-    <html lang="en">
-      <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-        <!-- Bootstrap CSS -->
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 
-        <title>{{root}}</title>
-      </head>
-      <body>
-        <div class="container">
-          <p>
-            <h2>Analysis of {{root}}</h2>
-            <h4>Performed at {{start_time}} UTC</h4>
-          </p>
-          <div class="card">
-            <div class="card-header">System Information</div>
-            <div class="card-body">
-            <pre>
+    <title>{{root}}</title>
+  </head>
+  <body>
+    <div class="container">
+      <p>
+        <h2>Analysis of {{root}}</h2>
+        <h4>Performed at {{start_time}} UTC</h4>
+      </p>
+      <div class="card">
+        <div class="card-header">System Information</div>
+        <div class="card-body">
+        <pre>
 {% for rule in rules.make_info %}
 {{-rule.body}}
 {% endfor -%}
-            </pre
-            </div>
-          </div>
-          <div class="card">
-            <div class="card-header">Rule Results</div>
-            <div class="card-body">
-              <div class="accordion" id="ruleAccordion">
-              {%- for group, results in rules.items() %}
-              {%- if group != "make_info" %}
-              {%- for rule in results %}
-                <div class="card">
-                  <div class="card-header bg-{% if group == "make_pass" %}success{% else %}danger{% endif %}" id="heading_{{rule.id}}">
-                    <h2 class="mb-0">
-                      <button class="btn btn-{% if group == "make_pass" %}success{% else %}danger{% endif %} text-white" type="button" data-toggle="collapse" data-target="#{{rule.id}}" aria-expanded="true" aria-controls="{{rule.id}}">
-                      {{rule.name}}
-                      </button>
-                    </h2>
-                  </div>
-                  <div id="{{rule.id}}" class="collapse" aria-labelledby="heading_{{rule.id}}" data-parent="#ruleAccordion">
-                    <div class="card-body">
-                    <pre>
+        </pre>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-header">Rule Results</div>
+        <div class="card-body">
+          <div class="accordion" id="ruleAccordion">
+          {%- for group, results in rules.items() %}
+          {%- if group != "make_info" %}
+          {%- for rule in results %}
+            <div class="card">
+              <div class="card-header bg-{% if group == "make_pass" %}success{% else %}danger{% endif %}" id="heading_{{rule.id}}">
+                <h2 class="mb-0">
+                  <button class="btn btn-{% if group == "make_pass" %}success{% else %}danger{% endif %} text-white" type="button" data-toggle="collapse" data-target="#{{rule.id}}" aria-expanded="true" aria-controls="{{rule.id}}">
+                  {{rule.name}}
+                  </button>
+                </h2>
+              </div>
+              <div id="{{rule.id}}" class="collapse" aria-labelledby="heading_{{rule.id}}" data-parent="#ruleAccordion">
+                <div class="card-body">
+                <pre>
 {{rule.body}}
-                    </pre>
-                    <hr />
-                    Contributing data:
-                    <ol>
-                    {% for d in rule.datasources %}
-                      <li>
-                      {{d}}
-                      </li>
-                    {% endfor %}
-                    </ol>
-                    <hr />
-              Documentation:
-                    <pre>
+                </pre>
+                <hr />
+                Contributing data:
+                <ol>
+                {% for d in rule.datasources %}
+                  <li>
+                  {{d}}
+                  </li>
+                {%- endfor %}
+                </ol>
+                <hr />
+          Documentation:
+                <pre>
 {{rule.mod_doc}}
 {{rule.rule_doc}}
-                    </pre>
-                    <hr />
-                    Rule source: {{rule.rule_path}}
-                    </div>
-                  </div>
+                </pre>
+                <hr />
+                Rule source: {{rule.rule_path}}
                 </div>
-              {%- endfor %}
-              {% endif %}
-              {% endfor %}
               </div>
             </div>
+          {%- endfor %}
+          {% endif %}
+          {% endfor %}
           </div>
         </div>
-        <!-- Optional JavaScript -->
-        <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
-      </body>
-    </html>
-    """
+      </div>
+    </div>
+    <!-- Optional JavaScript -->
+    <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+  </body>
+</html>
+    """.strip()
 
     def find_root(self):
         """

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -9,6 +9,7 @@ from jinja2 import Template
 
 from insights import dr, rule, make_info, make_fail, make_pass, make_response
 from insights.core.context import ExecutionContext
+from insights.core.spec_factory import ContentProvider
 from insights.core.plugins import is_datasource
 from insights.formats import render, Formatter, FormatterAdapter
 
@@ -121,18 +122,16 @@ class HtmlFormatter(Formatter):
         Get the most relevant activated datasources for each rule.
         """
         graph = dr.get_dependency_graph(comp)
-        template = "{name}: {detail}"
         for cand in graph:
-            if cand in broker and is_datasource(cand) and not any(is_datasource(d) for d in dr.get_dependencies(cand)):
+            if cand in broker and is_datasource(cand):
                 val = broker[cand]
                 if not isinstance(val, list):
                     val = [val]
 
-                name = cand.__name__
                 results = []
                 for v in val:
-                    detail = v.cmd or v.path or "python implementation"
-                    results.append(template.format(name=name, detail=detail))
+                    if isinstance(v, ContentProvider):
+                        results.append(v.cmd or v.path or "python implementation")
 
                 self.datasources[comp].extend(results)
 

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -14,7 +14,18 @@ from insights.core.plugins import is_datasource
 from insights.formats import render, Formatter, FormatterAdapter
 
 
-class HtmlFormatter(Formatter):
+class HtmlFormat(Formatter):
+    """
+    This class prints a html summary of rule hits. It should be used
+    as a context manager and given an instance of an
+    ``insights.core.dr.Broker``. ``dr.run`` should be called within the context
+    using the same broker.
+
+    Args:
+        broker (Broker): the broker to watch and provide a summary about.
+        stream (file-like): Output is written to stream. Defaults to sys.stdout.
+    """
+
     CONTENT = """
     <!doctype html>
     <html lang="en">
@@ -184,8 +195,10 @@ class HtmlFormatter(Formatter):
 
 # this connects the formatter to the insights run CLI bits
 class HtmlFormatterAdapter(FormatterAdapter):
+    """ Displays results in html format. """
+
     def preprocess(self, broker):
-        self.formatter = HtmlFormatter(broker)
+        self.formatter = HtmlFormat(broker)
         self.formatter.preprocess()
 
     def postprocess(self, broker):

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -4,7 +4,8 @@ from itertools import groupby
 from operator import itemgetter
 
 from insights import make_info, make_fail, make_response, make_pass
-from insights.formats import TemplateFormat, FormatterAdapter
+from insights.formats import FormatterAdapter
+from insights.formats.template import TemplateFormat
 
 
 class HtmlFormat(TemplateFormat):

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -79,13 +79,13 @@ class HtmlFormat(TemplateFormat):
                 {%- endfor %}
                 </ol>
                 <hr />
+                Rule source: {{rule.source_path}}
+                <hr />
           Documentation:
                 <pre>
 {{rule.mod_doc}}
 {{rule.rule_doc}}
                 </pre>
-                <hr />
-                Rule source: {{rule.source_path}}
                 </div>
               </div>
             </div>

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -40,7 +40,7 @@ class HtmlFormatter(Formatter):
             <pre>
 {% for rule in rules.make_info %}
 {{-rule.body}}
-{% endfor %}
+{% endfor -%}
             </pre
             </div>
           </div>

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -2,113 +2,124 @@ from __future__ import print_function
 import inspect
 import sys
 from collections import defaultdict
+from collections import OrderedDict
 from datetime import datetime
 
 from jinja2 import Template
 
 from insights import dr, rule, make_info, make_fail, make_pass, make_response
-from insights.core.plugins import is_datasource
 from insights.core.context import ExecutionContext
+from insights.core.plugins import is_datasource
 from insights.formats import render, Formatter, FormatterAdapter
-
-CONTENT = """
-<!doctype html>
-<html lang="en">
-  <head>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-    <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
-
-    <title>{{root}}</title>
-  </head>
-  <body>
-    <div class="container">
-      <p>
-        <h2>Analysis of {{root}}</h2>
-        <h4>Performed at {{start_time}} UTC</h4>
-      </p>
-      <div class="card">
-        <div class="card-header">System Information</div>
-        <div class="card-body">
-        <pre>
-        {% for rule in rules.make_info %}
-{{-rule.body}}
-        {% endfor %}
-        </pre
-        </div>
-      </div>
-      <div class="card">
-        <div class="card-header">Rule Results</div>
-        <div class="card-body">
-          <div class="accordion" id="ruleAccordion">
-          {% for group, results in rules.items() %}
-          {% if group != "make_info" %}
-          {% for rule in results %}
-            <div class="card">
-              <div class="card-header bg-{% if group == "make_pass" %}success{% else %}danger{% endif %}" id="heading_{{rule.id}}">
-                <h2 class="mb-0">
-                  <button class="btn btn-{% if group == "make_pass" %}success{% else %}danger{% endif %} text-white" type="button" data-toggle="collapse" data-target="#{{rule.id}}" aria-expanded="true" aria-controls="{{rule.id}}">
-                  {{rule.name}}
-                  </button>
-                </h2>
-              </div>
-              <div id="{{rule.id}}" class="collapse" aria-labelledby="heading_{{rule.id}}" data-parent="#ruleAccordion">
-                <div class="card-body">
-                <pre>
-{{rule.body}}
-                </pre>
-                <hr />
-          Documentation:
-                <pre>
-{{rule.mod_doc}}
-{{rule.rule_doc}}
-                </pre>
-                <hr />
-                Rule source: {{rule.rule_path}}
-                <hr />
-                Contributing data:
-                <ol>
-                {% for d in rule.datasources %}
-                  <li>
-                  {{d}}
-                  </li>
-                {% endfor %}
-                </ol>
-                </div>
-              </div>
-            </div>
-          {%- endfor %}
-          {% endif %}
-          {% endfor %}
-          </div>
-        </div>
-      </div>
-    </div>
-    <!-- Optional JavaScript -->
-    <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
-  </body>
-</html>
-"""
 
 
 class HtmlFormatter(Formatter):
+    CONTENT = """
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+        <!-- Bootstrap CSS -->
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+
+        <title>{{root}}</title>
+      </head>
+      <body>
+        <div class="container">
+          <p>
+            <h2>Analysis of {{root}}</h2>
+            <h4>Performed at {{start_time}} UTC</h4>
+          </p>
+          <div class="card">
+            <div class="card-header">System Information</div>
+            <div class="card-body">
+            <pre>
+{% for rule in rules.make_info %}
+{{-rule.body}}
+{% endfor %}
+            </pre
+            </div>
+          </div>
+          <div class="card">
+            <div class="card-header">Rule Results</div>
+            <div class="card-body">
+              <div class="accordion" id="ruleAccordion">
+              {%- for group, results in rules.items() %}
+              {%- if group != "make_info" %}
+              {%- for rule in results %}
+                <div class="card">
+                  <div class="card-header bg-{% if group == "make_pass" %}success{% else %}danger{% endif %}" id="heading_{{rule.id}}">
+                    <h2 class="mb-0">
+                      <button class="btn btn-{% if group == "make_pass" %}success{% else %}danger{% endif %} text-white" type="button" data-toggle="collapse" data-target="#{{rule.id}}" aria-expanded="true" aria-controls="{{rule.id}}">
+                      {{rule.name}}
+                      </button>
+                    </h2>
+                  </div>
+                  <div id="{{rule.id}}" class="collapse" aria-labelledby="heading_{{rule.id}}" data-parent="#ruleAccordion">
+                    <div class="card-body">
+                    <pre>
+{{rule.body}}
+                    </pre>
+                    <hr />
+              Documentation:
+                    <pre>
+{{rule.mod_doc}}
+{{rule.rule_doc}}
+                    </pre>
+                    <hr />
+                    Rule source: {{rule.rule_path}}
+                    <hr />
+                    Contributing data:
+                    <ol>
+                    {% for d in rule.datasources %}
+                      <li>
+                      {{d}}
+                      </li>
+                    {% endfor %}
+                    </ol>
+                    </div>
+                  </div>
+                </div>
+              {%- endfor %}
+              {% endif %}
+              {% endfor %}
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Optional JavaScript -->
+        <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+      </body>
+    </html>
+    """
+
     def find_root(self):
+        """
+        Finds the root directory used during the evaluation. Note this could be
+        a non-existent temporary directory if analyzing an archive.
+        """
         for comp in self.broker:
             if issubclass(comp, ExecutionContext):
                 return self.broker[comp].root
 
     def collect(self, comp, broker):
+        """
+        Store rule results organized by response type.
+        """
         if comp in broker:
             val = broker[comp]
             self.groups[type(val)].append((comp, val))
 
-    def get_data_locations(self, comp, broker):
+    def get_datasources(self, comp, broker):
+        """
+        Get the most relevant activated datasources for each rule.
+        """
         graph = dr.get_dependency_graph(comp)
         template = "{name}: {detail}"
         for cand in graph:
@@ -117,42 +128,50 @@ class HtmlFormatter(Formatter):
                 if not isinstance(val, list):
                     val = [val]
 
+                name = cand.__name__
                 results = []
                 for v in val:
-                    name = cand.__name__
                     detail = v.cmd or v.path or "python implementation"
                     results.append(template.format(name=name, detail=detail))
 
                 self.datasources[comp].extend(results)
 
     def preprocess(self):
+        """
+        Watches rules go by as they evaluate and collects information about
+        them for later display in postprocess.
+        """
         self.start_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
         self.groups = defaultdict(list)
         self.datasources = defaultdict(list)
         self.broker.add_observer(self.collect, rule)
-        self.broker.add_observer(self.get_data_locations, rule)
+        self.broker.add_observer(self.get_datasources, rule)
 
     def postprocess(self):
+        """
+        Builds a dictionary of rule data as context for a jinja2 template that
+        renders the final output.
+        """
         root = self.find_root() or "Unknown"
 
-        data = {
+        ctx = {
             "root": root,
             "start_time": self.start_time,
-            "rules": {},
+            "rules": OrderedDict(),
         }
         types = (make_info, make_fail, make_response, make_pass)
         for key in types:
             group = self.groups[key]
             response_type = key.__name__
-            data["rules"][response_type] = []
+            ctx["rules"][response_type] = []
             for comp, val in sorted(group, key=lambda g: dr.get_name(g[0])):
-                if type(val) in types:
+                if isinstance(val, types):
                     rule_path = inspect.getabsfile(comp)
                     mod_doc = sys.modules[comp.__module__].__doc__ or ""
                     rule_doc = comp.__doc__ or ""
                     name = dr.get_name(comp)
                     rule_id = name.replace(".", "_")
-                    data["rules"][response_type].append({
+                    ctx["rules"][response_type].append({
                         "id": rule_id,
                         "name": name,
                         "body": render(comp, val),
@@ -161,7 +180,7 @@ class HtmlFormatter(Formatter):
                         "rule_path": rule_path,
                         "datasources": sorted(set(self.datasources[comp]))
                     })
-        print(Template(CONTENT).render(data), file=self.stream)
+        print(Template(self.CONTENT).render(ctx), file=self.stream)
 
 
 # this connects the formatter to the insights run CLI bits

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -1,0 +1,124 @@
+import sys
+from collections import defaultdict
+from datetime import datetime
+
+from jinja2 import Template
+
+from insights import dr, rule, make_info, make_fail, make_pass, make_response
+from insights.core.context import ExecutionContext
+from insights.formats import render, Formatter, FormatterAdapter
+
+CONTENT = """
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+
+    <title>{{root}}</title>
+  </head>
+  <body>
+    <div class="container">
+      <p>
+        <h2>Analysis of {{root}}</h2>
+        <h4>{{start_time}}</h4>
+      </p>
+      <hr />
+      <div class="accordion" id="ruleAccordion">
+      {% for group, results in rules.items() %}
+      {% for rule in results %}
+        <div class="card">
+          <div class="card-header bg-{{rule.color}}" id="heading_{{rule.id}}">
+            <h2 class="mb-0">
+              <button class="btn btn-{{rule.color}} text-white" type="button" data-toggle="collapse" data-target="#{{rule.id}}" aria-expanded="true" aria-controls="{{rule.id}}">
+              {{rule.name}}
+              </button>
+            </h2>
+          </div>
+          <div id="{{rule.id}}" class="collapse" aria-labelledby="heading_{{rule.id}}" data-parent="#ruleAccordion">
+            <div class="card-body">
+            <pre>
+{{rule.body}}
+            </pre>
+            <hr />
+      Documentation:
+            <pre>
+{{rule.mod_doc}}
+{{rule.rule_doc}}
+            </pre>
+            </div>
+          </div>
+        </div>
+      {%- endfor %}
+      {% endfor %}
+      </div>
+    </div>
+    <!-- Optional JavaScript -->
+    <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+  </body>
+</html>
+"""
+
+COLORS = {
+    make_info: "info",
+    make_fail: "danger",
+    make_pass: "success",
+}
+
+
+class HtmlFormatter(Formatter):
+    def find_root(self):
+        for comp in self.broker:
+            if issubclass(comp, ExecutionContext):
+                return self.broker[comp].root
+
+    def preprocess(self):
+        self.start_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S %Z")
+
+    def postprocess(self):
+        root = self.find_root() or "Unknown"
+        rules = self.broker.get_by_type(rule)
+        groups = defaultdict(list)
+        for comp, val in rules.items():
+            groups[type(val)].append((comp, val))
+
+        data = {
+            "root": root,
+            "start_time": self.start_time,
+            "rules": {}
+        }
+        for key in (make_info, make_fail, make_pass):
+            group = groups[key]
+            data["rules"][key.__name__] = []
+            for comp, val in sorted(group, key=lambda g: dr.get_name(g[0])):
+                if type(val) in (make_pass, make_fail, make_info, make_response):
+                    mod_doc = sys.modules[comp.__module__].__doc__ or ""
+                    rule_doc = comp.__doc__ or ""
+                    name = dr.get_name(comp)
+                    rule_id = name.replace(".", "_")
+                    data["rules"][key.__name__].append({
+                        "color": COLORS[key],
+                        "id": rule_id,
+                        "name": name,
+                        "body": render(comp, val),
+                        "mod_doc": mod_doc,
+                        "rule_doc": rule_doc,
+                    })
+        print(Template(CONTENT).render(data), file=self.stream)
+
+
+# this connects the formatter to the insights run CLI bits
+class HtmlFormatterAdapter(FormatterAdapter):
+    def preprocess(self, broker):
+        self.formatter = HtmlFormatter(broker)
+        self.formatter.preprocess()
+
+    def postprocess(self, broker):
+        self.formatter.postprocess()

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -106,8 +106,11 @@ class HtmlFormatter(Formatter):
         a non-existent temporary directory if analyzing an archive.
         """
         for comp in self.broker:
-            if issubclass(comp, ExecutionContext):
-                return self.broker[comp].root
+            try:
+                if issubclass(comp, ExecutionContext):
+                    return self.broker[comp].root
+            except:
+                pass
 
     def collect(self, comp, broker):
         """

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -64,14 +64,6 @@ class HtmlFormatter(Formatter):
 {{rule.body}}
                     </pre>
                     <hr />
-              Documentation:
-                    <pre>
-{{rule.mod_doc}}
-{{rule.rule_doc}}
-                    </pre>
-                    <hr />
-                    Rule source: {{rule.rule_path}}
-                    <hr />
                     Contributing data:
                     <ol>
                     {% for d in rule.datasources %}
@@ -80,6 +72,14 @@ class HtmlFormatter(Formatter):
                       </li>
                     {% endfor %}
                     </ol>
+                    <hr />
+              Documentation:
+                    <pre>
+{{rule.mod_doc}}
+{{rule.rule_doc}}
+                    </pre>
+                    <hr />
+                    Rule source: {{rule.rule_path}}
                     </div>
                   </div>
                 </div>

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -4,10 +4,10 @@ from itertools import groupby
 from operator import itemgetter
 
 from insights import make_info, make_fail, make_response, make_pass
-from insights.formats import TemplateFormatter, FormatterAdapter
+from insights.formats import TemplateFormat, FormatterAdapter
 
 
-class HtmlFormat(TemplateFormatter):
+class HtmlFormat(TemplateFormat):
     """
     This class prints a html summary of rule hits. It should be used
     as a context manager and given an instance of an
@@ -84,7 +84,7 @@ class HtmlFormat(TemplateFormatter):
 {{rule.rule_doc}}
                 </pre>
                 <hr />
-                Rule source: {{rule.rule_path}}
+                Rule source: {{rule.source_path}}
                 </div>
               </div>
             </div>

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -166,18 +166,15 @@ class HtmlFormatter(Formatter):
             ctx["rules"][response_type] = []
             for comp, val in sorted(group, key=lambda g: dr.get_name(g[0])):
                 if isinstance(val, types):
-                    rule_path = inspect.getabsfile(comp)
-                    mod_doc = sys.modules[comp.__module__].__doc__ or ""
-                    rule_doc = comp.__doc__ or ""
                     name = dr.get_name(comp)
                     rule_id = name.replace(".", "_")
                     ctx["rules"][response_type].append({
                         "id": rule_id,
                         "name": name,
                         "body": render(comp, val),
-                        "mod_doc": mod_doc,
-                        "rule_doc": rule_doc,
-                        "rule_path": rule_path,
+                        "mod_doc": sys.modules[comp.__module__].__doc__ or "",
+                        "rule_doc": comp.__doc__ or "",
+                        "rule_path": inspect.getabsfile(comp),
                         "datasources": sorted(set(self.datasources[comp]))
                     })
         print(Template(self.CONTENT).render(ctx), file=self.stream)

--- a/insights/formats/simple_html.py
+++ b/insights/formats/simple_html.py
@@ -44,7 +44,7 @@ class SimpleHtmlFormat(HtmlFormat):
   <body>
   <div class="main">
   <h2 align="center">Analysis of {{root}}</h2>
-  <h4 align="center">Performed at {{start_time}}</h4>
+  <h4 align="center">Performed at {{start_time}} UTC</h4>
     <section>
       <h2>System Information</h2>
         <pre>

--- a/insights/formats/simple_html.py
+++ b/insights/formats/simple_html.py
@@ -128,7 +128,7 @@ Contributing Data:
 
 
 # this connects the formatter to the insights run CLI bits
-class HtmlFormatterAdapter(FormatterAdapter):
+class SimpleHtmlFormatterAdapter(FormatterAdapter):
     """ Displays results in a simple html format. """
 
     def preprocess(self, broker):

--- a/insights/formats/simple_html.py
+++ b/insights/formats/simple_html.py
@@ -1,0 +1,139 @@
+from insights.formats import FormatterAdapter
+from insights.formats.html import HtmlFormat
+
+
+class SimpleHtmlFormat(HtmlFormat):
+    """
+    This class prints a html summary of rule hits. It should be used
+    as a context manager and given an instance of an
+    ``insights.core.dr.Broker``. ``dr.run`` should be called within the context
+    using the same broker.
+
+    Args:
+        broker (Broker): the broker to watch and provide a summary about.
+        stream (file-like): Output is written to stream. Defaults to sys.stdout.
+    """
+
+    TEMPLATE = """
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <title>{{root}}</title>
+    <style>
+    a.pass {
+      color: green;
+    }
+    a.fail {
+      color: red;
+    }
+    a.source {
+      color: orange;
+    }
+    .main {
+      margin-top: 100px;
+      margin-bottom: 100px;
+      margin-right: 150px;
+      margin-left: 80px;
+    }
+    </style>
+  </head>
+  <body>
+  <div class="main">
+  <h2 align="center">Analysis of {{root}}</h2>
+  <h4 align="center">Performed at {{start_time}}</h4>
+    <section>
+      <h2>System Information</h2>
+        <pre>
+        {%- for rule in rules.make_info %}
+{{rule.body}}
+        {%- endfor %}
+        </pre>
+    </section>
+    <h2>Rule Results</h2>
+    <nav>
+      <ul>
+        {%- for response_type, rule_group in rules.items() %}
+        {%- if response_type != "make_info" %}
+        {%- for rule in rule_group %}
+        <ul>
+          <a id="{{rule.id}}_top"
+             class="{% if response_type !='make_pass' %}fail{% else %}pass{% endif %}"
+             href="#{{rule.id}}">
+          {{rule.name}}
+          </a>
+        </ul>
+        {%- endfor %}
+        {%- endif %}
+        {%- endfor %}
+      </ul>
+    </nav>
+    <section>
+    <h2>Rule Result Details</h2>
+        {%- for response_type, rule_group in rules.items() %}
+        {%- if response_type != "make_info" %}
+        {%- for rule in rule_group %}
+        <article>
+          <header>
+          <a id="{{rule.id}}"
+             class="{% if response_type !='make_pass' %}fail{% else %}pass{% endif %}"
+             href="#{{rule.id}}_top">
+          {{rule.name}}
+          </a>
+          </header>
+          <p>
+          <pre>
+{{rule.body}}
+          </pre>
+          </p>
+
+          <hr />
+          <p>
+Contributing Data:
+          <ol>
+          {%- for d in rule.datasources %}
+          <li>{{d}}</li>
+          {%- endfor %}
+          </ol>
+          </p>
+
+          <hr />
+          <p> Rule Source: <a class="source" href="file://{{rule.source_path}}">{{rule.source_path}}</a></p>
+
+          <hr />
+          <div>
+          <p>
+          Documentation:
+          <div>
+          <pre>
+{{rule.mod_doc}}
+{{rule.rule_doc}}
+          </pre>
+          </div>
+          </p>
+          </div>
+          <hr />
+        </article>
+        {%- endfor %}
+        {%- endif %}
+        {%- endfor %}
+    </section>
+  </div>
+  </body>
+</html>
+    """.strip()
+
+
+# this connects the formatter to the insights run CLI bits
+class HtmlFormatterAdapter(FormatterAdapter):
+    """ Displays results in a simple html format. """
+
+    def preprocess(self, broker):
+        self.formatter = SimpleHtmlFormat(broker)
+        self.formatter.preprocess()
+
+    def postprocess(self, broker):
+        self.formatter.postprocess()

--- a/insights/formats/template.py
+++ b/insights/formats/template.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import inspect
 import sys
 from datetime import datetime

--- a/insights/formats/template.py
+++ b/insights/formats/template.py
@@ -1,0 +1,102 @@
+import inspect
+import sys
+from datetime import datetime
+
+from jinja2 import Template
+
+from insights import dr, rule
+from insights.core.context import ExecutionContext
+from insights.core.spec_factory import ContentProvider
+from insights.core.plugins import is_datasource
+from insights.formats import render, Formatter
+
+
+class TemplateFormat(Formatter):
+    """
+    Subclasses should implement create_template_context to return a dictionary
+    to use when rendering the jinja2 template defined by the class level
+    TEMPLATE attribute.
+    """
+
+    TEMPLATE = ""
+    """ jinja2 template to use for rule result rendering. """
+
+    def find_root(self):
+        """
+        Finds the root directory used during the evaluation. Note this could be
+        a non-existent temporary directory if analyzing an archive.
+        """
+        for comp in self.broker:
+            try:
+                if issubclass(comp, ExecutionContext):
+                    return self.broker[comp].root
+            except:
+                pass
+        return "Unknown"
+
+    def get_datasources(self, comp, broker):
+        """
+        Get the most relevant activated datasources for each rule.
+        """
+        graph = dr.get_dependency_graph(comp)
+        ds = []
+        for cand in graph:
+            if cand in broker and is_datasource(cand):
+                val = broker[cand]
+                if not isinstance(val, list):
+                    val = [val]
+
+                results = []
+                for v in val:
+                    if isinstance(v, ContentProvider):
+                        results.append(v.cmd or v.path or "python implementation")
+                ds.extend(results)
+        return ds
+
+    def collect_rules(self, comp, broker):
+        """
+        Rule results are stored as dictionaries in the ``self.rules`` list.
+        Each dictionary contains the folowing keys:
+            name: fully qualified name of the rule
+            id: fully qualified rule name with "." replaced with "_"
+            response_type: the class name of the response object (make_info, etc.)
+            body: rendered content for the rule as provided in the rule module.
+            mod_doc: pydoc of the module containing the rule
+            rule_doc: pydoc of the rule
+            rule_path: absolute path to the source file of the rule
+            datasources: sorted list of command or files contributing to the rule
+        """
+        if comp in broker:
+            name = dr.get_name(comp)
+            rule_id = name.replace(".", "_")
+            val = broker[comp]
+            self.rules.append({
+                "name": name,
+                "id": rule_id,
+                "response_type": type(val).__name__,
+                "body": render(comp, val),
+                "mod_doc": sys.modules[comp.__module__].__doc__ or "",
+                "rule_doc": comp.__doc__ or "",
+                "source_path": inspect.getabsfile(comp),
+                "datasources": sorted(set(self.get_datasources(comp, broker)))
+            })
+
+    def preprocess(self):
+        """
+        Watches rules go by as they evaluate and collects information about
+        them for later display in postprocess.
+        """
+        self.start_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        self.rules = []
+        self.broker.add_observer(self.collect_rules, rule)
+
+    def create_template_context(self):
+        raise NotImplementedError()
+
+    def postprocess(self):
+        """
+        Builds a dictionary of rule data as context for a jinja2 template that
+        renders the final output.
+        """
+        ctx = self.create_template_context()
+        print(Template(self.TEMPLATE).render(ctx), file=self.stream)

--- a/insights/tests/test_formats.py
+++ b/insights/tests/test_formats.py
@@ -4,6 +4,7 @@ from insights.formats.text import HumanReadableFormat
 from insights.formats._yaml import YamlFormat
 from insights.formats._json import JsonFormat
 from insights.formats._syslog import SysLogFormat
+from insights.formats.html import HtmlFormat
 
 
 SL_MSG = "Running insights.tests.test_formats.report"
@@ -50,6 +51,17 @@ def test_yaml_format():
     broker = dr.Broker()
     output = StringIO()
     with YamlFormat(broker, stream=output):
+        dr.run(report, broker=broker)
+    output.seek(0)
+    data = output.read()
+    assert "foo" in data
+    assert "bar" in data
+
+
+def test_html_format():
+    broker = dr.Broker()
+    output = StringIO()
+    with HtmlFormat(broker, stream=output):
         dr.run(report, broker=broker)
     output.seek(0)
     data = output.read()

--- a/insights/tests/test_formats.py
+++ b/insights/tests/test_formats.py
@@ -5,6 +5,7 @@ from insights.formats._yaml import YamlFormat
 from insights.formats._json import JsonFormat
 from insights.formats._syslog import SysLogFormat
 from insights.formats.html import HtmlFormat
+from insights.formats.simple_html import SimpleHtmlFormat
 
 
 SL_MSG = "Running insights.tests.test_formats.report"
@@ -62,6 +63,17 @@ def test_html_format():
     broker = dr.Broker()
     output = StringIO()
     with HtmlFormat(broker, stream=output):
+        dr.run(report, broker=broker)
+    output.seek(0)
+    data = output.read()
+    assert "foo" in data
+    assert "bar" in data
+
+
+def test_simple_html_format():
+    broker = dr.Broker()
+    output = StringIO()
+    with SimpleHtmlFormat(broker, stream=output):
         dr.run(report, broker=broker)
     output.seek(0)
     data = output.read()

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ runtime = set([
     'cachecontrol[filecache]',
     'defusedxml',
     'lockfile',
+    'jinja2',
 ])
 
 if (sys.version_info < (2, 7)):
@@ -82,7 +83,6 @@ testing = set([
 cluster = set([
     'ansible',
     'pandas',
-    'jinja2',
     'colorama',
 ])
 


### PR DESCRIPTION
`insights run -p<rules> -f html ...` generates an html page with `make_info` results in a card at the top and other results in a color coded accordion beneath. Rule cards include the rule name, result, rule module doc, rule doc, path to rule source, and all data files or commands that may have contributed to the results.

`insights run -p<rules> -f simple_html ...` generates a similar html that's easier to navigate with console browsers like elinks.