### PR TITLE
New "find" helper for streamlining log handling

### DIFF
--- a/insights/core/filters.py
+++ b/insights/core/filters.py
@@ -79,6 +79,9 @@ def add_filter(ds, patterns):
         raise TypeError("patterns must be string, list, or set.")
 
 
+_add_filter = add_filter
+
+
 def get_filters(component):
     """
     Get the set of filters for the given datasource.

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -10,7 +10,7 @@ from glob import glob
 from subprocess import call
 
 from insights.core import blacklist, dr
-from insights.core.filters import add_filter, get_filters
+from insights.core.filters import _add_filter, get_filters
 from insights.core.context import ExecutionContext, FSRoots, HostContext
 from insights.core.plugins import component, datasource, ContentException, is_datasource
 from insights.util import fs, streams, which
@@ -901,7 +901,7 @@ class find(object):
         self.__module__ = self.__class__.__module__
 
         if getattr(spec, "filterable", False):
-            add_filter(spec, pattern)
+            _add_filter(spec, pattern)
 
         component(spec)(self)
 

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -888,6 +888,10 @@ class find(object):
         spec (datasource): some datasource, ideally filterable.
         pattern (string / list): a string or list of strings to match (no
             patterns supported)
+
+    Returns:
+        A dict where each key is a command, path, or spec name, and each
+        value is a list of matching lines.
     """
 
     def __init__(self, spec, pattern):

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -10,9 +10,9 @@ from glob import glob
 from subprocess import call
 
 from insights.core import blacklist, dr
-from insights.core.filters import get_filters
+from insights.core.filters import add_filter, get_filters
 from insights.core.context import ExecutionContext, FSRoots, HostContext
-from insights.core.plugins import datasource, ContentException, is_datasource
+from insights.core.plugins import component, datasource, ContentException, is_datasource
 from insights.util import fs, streams, which
 from insights.util.subproc import Pipeline
 from insights.core.serde import deserializer, serializer
@@ -92,7 +92,7 @@ class ContentProvider(object):
         self._exception = None
 
     def load(self):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def stream(self):
         """
@@ -869,6 +869,58 @@ class first_of(object):
         for c in self.deps:
             if c in broker:
                 return broker[c]
+
+
+class find(object):
+    """
+    Helper class for extracting specific lines from a datasource for direct
+    consumption by a rule.
+
+    .. code:: python
+
+        service_starts = find(Specs.audit_log, "SERVICE_START")
+
+        @rule(service_starts)
+        def report(starts):
+            return make_info("SERVICE_STARTS", num_starts=len(starts))
+
+    Args:
+        spec (datasource): some datasource, ideally filterable.
+        pattern (string / list): a string or list of strings to match (no
+            patterns supported)
+    """
+
+    def __init__(self, spec, pattern):
+        if getattr(spec, "raw", False):
+            name = dr.get_name(spec)
+            raise ValueError("{}: Cannot filter raw files.".format(name))
+
+        self.spec = spec
+        self.pattern = pattern if isinstance(pattern, list) else [pattern]
+        self.__name__ = self.__class__.__name__
+        self.__module__ = self.__class__.__module__
+
+        if getattr(spec, "filterable", False):
+            add_filter(spec, pattern)
+
+        component(spec)(self)
+
+    def __call__(self, ds):
+        # /usr/bin/grep level filtering is applied behind .content or
+        # .stream(), but we still need to ensure we get only what *this* find
+        # instance wants. This can be inefficient on files where many lines
+        # match.
+        results = defaultdict(list)
+        ds = ds if isinstance(ds, list) else [ds]
+        for d in ds:
+            origin = d.cmd or d.path or dr.get_name(self.spec)
+            stream = d.content if d.loaded else d.stream()
+            lines = []
+            for line in stream:
+                if any(p in line for p in self.pattern):
+                    lines.append(line)
+            results[origin].append(line)
+        return dict(results)
 
 
 @serializer(CommandOutputProvider)

--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -17,7 +17,7 @@ except ImportError:
 
 import insights
 from insights import apply_filters
-from insights.core import dr, filters
+from insights.core import dr, filters, spec_factory
 from insights.core.context import Context
 from insights.core.spec_factory import RegistryPoint
 from insights.specs import Specs
@@ -27,9 +27,10 @@ from insights.specs import Specs
 # that rules add filters to datasources that *should* be filterable
 ADDED_FILTERS = defaultdict(set)
 add_filter = filters.add_filter
+find = spec_factory.find
 
 
-def _intercept(func):
+def _intercept_add_filter(func):
     @wraps(func)
     def inner(ds, pattern):
         ret = add_filter(ds, pattern)
@@ -39,8 +40,20 @@ def _intercept(func):
     return inner
 
 
-filters.add_filter = _intercept(filters.add_filter)
-insights.add_filter = _intercept(insights.add_filter)
+def _intercept_find(func):
+    @wraps(func)
+    def inner(ds, pattern):
+        ret = find(ds, pattern)
+        calling_module = inspect.stack()[1][0].f_globals.get("__name__")
+        ADDED_FILTERS[calling_module].add(ds)
+        return ret
+    return inner
+
+
+filters.add_filter = _intercept_add_filter(filters.add_filter)
+insights.add_filter = _intercept_add_filter(insights.add_filter)
+
+spec_factory.find = _intercept_find(spec_factory.find)
 
 
 def _get_registry_points(component):

--- a/insights/tests/test_find.py
+++ b/insights/tests/test_find.py
@@ -1,0 +1,38 @@
+import operator
+
+from functools import reduce
+from insights import datasource, dr, rule, make_info
+from insights.core.spec_factory import DatasourceProvider, find, RegistryPoint, SpecSet
+
+
+class Specs(SpecSet):
+    the_data = RegistryPoint(filterable=True)
+
+
+class MySpecs(Specs):
+
+    @datasource()
+    def the_data(broker):
+        data = """
+        foo bar baz
+        baz bar
+        """.strip()
+        return DatasourceProvider(data, "the_data")
+
+
+foos = find(Specs.the_data, "foo")
+direct_foos = find(MySpecs.the_data, "foo")
+
+
+@rule(foos, direct_foos)
+def report(f, d):
+    all_foos = reduce(operator.__iadd__, f.values(), [])
+    all_direct_foos = reduce(operator.__iadd__, d.values(), [])
+    return make_info("FOO", num_all_foos=len(all_foos), num_direct_foos=len(all_direct_foos))
+
+
+def test_find():
+    broker = dr.run(report)
+    results = broker[report]
+    assert "num_all_foos" in results
+    assert "num_direct_foos" in results


### PR DESCRIPTION
Contains a new helper class to wrap up adding a filter and selecting just the relevant lines for it.

```python
from insights import make_info, rule
from insights.core.spec_factory import find
from insights.specs import Specs

service_starts = find(Specs.audit_log, "SERVICE_START")
service_stops = find(Specs.audit_log, "SERVICE_STOP")

@rule(service_starts, service_stops)
def report(starts, stops):
    return make_info("STARTS_STOPS", num_starts=len(starts), num_stops=len(stops))
```

The result of a `find` is a dictionary with key as the command or file string and value as the list of matching lines.