### PR TITLE
Remove the '/cpuinfo' from cpuinfo's spec

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -189,8 +189,7 @@ class DefaultSpecs(Specs):
     cpu_vulns_spectre_v1 = simple_file("sys/devices/system/cpu/vulnerabilities/spectre_v1")
     cpu_vulns_spectre_v2 = simple_file("sys/devices/system/cpu/vulnerabilities/spectre_v2")
     cpu_vulns_spec_store_bypass = simple_file("sys/devices/system/cpu/vulnerabilities/spec_store_bypass")
-    # why the /cpuinfo?
-    cpuinfo = first_file(["/proc/cpuinfo", "/cpuinfo"])
+    cpuinfo = simple_file("/proc/cpuinfo")
     cpuinfo_max_freq = simple_file("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq")
     cpuset_cpus = simple_file("/sys/fs/cgroup/cpuset/cpuset.cpus")
     crypto_policies_config = simple_file("/etc/crypto-policies/config")


### PR DESCRIPTION
- '/cpuinfo' is for foreman-debug archive, and should be placed in a
  separated spec file

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>