### PR TITLE
Propogate SystemExit so insights run -h doesn't print '0'.

### DIFF
--- a/insights/command_parser.py
+++ b/insights/command_parser.py
@@ -87,6 +87,8 @@ def main():
     fix_arg_dashes()
     try:
         InsightsCli()
+    except SystemExit:
+        raise
     except BaseException as ex:
         print(ex)
 


### PR DESCRIPTION
The top level try/except around the InsightsCli caught BaseException.
That included SystemExit, which is raised by argparse parsers at the
end of handling the -h option. This PR allows SystemExit to propogate.

Signed-off-by: Christopher Sams <csams@redhat.com>