### PR TITLE
Add combiner for rsyslog_conf

### DIFF
--- a/insights/combiners/rsyslog_confs.py
+++ b/insights/combiners/rsyslog_confs.py
@@ -14,7 +14,7 @@ from .. import LegacyItemAccess
 
 
 @combiner(RsyslogConf)
-class RsyslogAllConf(LegacyItemAccess):
+class RsyslogAllConf(dict):
     """
     Combiner for accessing all the krb5 configuration files.
 
@@ -40,6 +40,8 @@ class RsyslogAllConf(LegacyItemAccess):
                     self.data[conf.file_path] = conf.data
                     break
             self.data[conf.file_path] = conf.data
+
+        self.update(self.data)
 
         super(RsyslogAllConf, self).__init__()
 

--- a/insights/combiners/rsyslog_confs.py
+++ b/insights/combiners/rsyslog_confs.py
@@ -10,7 +10,6 @@ files, user needs to check this situation in plugin if it is necessary.
 """
 from insights.core.plugins import combiner
 from insights.parsers.rsyslog_conf import RsyslogConf
-from .. import LegacyItemAccess
 
 
 @combiner(RsyslogConf)
@@ -27,7 +26,7 @@ class RsyslogAllConf(dict):
         '$ModLoad imuxsock'
     """
     def __init__(self, confs):
-        self.data = {}
+        data = {}
 
         for conf in confs:
             if conf.file_path == "/etc/rsyslog.conf":
@@ -36,14 +35,11 @@ class RsyslogAllConf(dict):
                     if "include(" in item or "$IncludeConfig" in item:
                         include = True
                 if not include:
-                    self.data.clear()
-                    self.data[conf.file_path] = conf.data
+                    data.clear()
+                    data[conf.file_path] = conf.data
                     break
-            self.data[conf.file_path] = conf.data
+            data[conf.file_path] = conf.data
 
-        self.update(self.data)
+        self.update(data)
 
         super(RsyslogAllConf, self).__init__()
-
-    def __len__(self):
-        return len(self.data)

--- a/insights/combiners/rsyslog_confs.py
+++ b/insights/combiners/rsyslog_confs.py
@@ -15,7 +15,7 @@ from insights.parsers.rsyslog_conf import RsyslogConf
 @combiner(RsyslogConf)
 class RsyslogAllConf(dict):
     """
-    Combiner for accessing all the krb5 configuration files.
+    Combiner for accessing all the rsyslog configuration files.
 
     Examples:
         >>> type(confs)
@@ -29,13 +29,12 @@ class RsyslogAllConf(dict):
         super(RsyslogAllConf, self).__init__()
         data = {}
 
+        # Combine rsyslog configuration files into one dict. Key is file name, value is content of configuration file.
         for conf in confs:
             if conf.file_path == "/etc/rsyslog.conf":
-                include = False
-                for item in conf:
-                    if "include(" in item or "$IncludeConfig" in item:
-                        include = True
-                if not include:
+                # Check if there is include option, if not, only parse /etc/rsyslog.conf even
+                # /etc/rsyslog.d/*.conf exist.
+                if not any(["include(" in item or "$IncludeConfig" in item for item in conf]):
                     data.clear()
                     data[conf.file_path] = conf
                     break

--- a/insights/combiners/rsyslog_confs.py
+++ b/insights/combiners/rsyslog_confs.py
@@ -1,0 +1,47 @@
+"""
+RsyslogConfAll - files ``/etc/rsyslog.conf`` and ``/etc/rsyslog.d/*.conf``
+==========================================================================
+
+Combiner for accessing all the rsyslog comfiguration files. There may be
+multiple rsyslog configuration, and the main configuration file is
+``/etc/rsyslog.conf``. This combiner will not check same option in multi
+files, user needs to check this situation in plugin if it is necessary.
+
+"""
+from insights.core.plugins import combiner
+from insights.parsers.rsyslog_conf import RsyslogConf
+from .. import LegacyItemAccess
+
+
+@combiner(RsyslogConf)
+class RsyslogAllConf(LegacyItemAccess):
+    """
+    Combiner for accessing all the krb5 configuration files.
+
+    Examples:
+        >>> type(confs)
+        <class 'insights.combiners.rsyslog_confs.RsyslogAllConf'>
+        >>> len(confs)
+        2
+        >>> confs['/etc/rsyslog.conf'][0]
+        '$ModLoad imuxsock'
+    """
+    def __init__(self, confs):
+        self.data = {}
+
+        for conf in confs:
+            if conf.file_path == "/etc/rsyslog.conf":
+                include = False
+                for item in conf.data:
+                    if "include(" in item or "$IncludeConfig" in item:
+                        include = True
+                if not include:
+                    self.data.clear()
+                    self.data[conf.file_path] = conf.data
+                    break
+            self.data[conf.file_path] = conf.data
+
+        super(RsyslogAllConf, self).__init__()
+
+    def __len__(self):
+        return len(self.data)

--- a/insights/combiners/rsyslog_confs.py
+++ b/insights/combiners/rsyslog_confs.py
@@ -26,20 +26,19 @@ class RsyslogAllConf(dict):
         '$ModLoad imuxsock'
     """
     def __init__(self, confs):
+        super(RsyslogAllConf, self).__init__()
         data = {}
 
         for conf in confs:
             if conf.file_path == "/etc/rsyslog.conf":
                 include = False
-                for item in conf.data:
+                for item in conf:
                     if "include(" in item or "$IncludeConfig" in item:
                         include = True
                 if not include:
                     data.clear()
-                    data[conf.file_path] = conf.data
+                    data[conf.file_path] = conf
                     break
-            data[conf.file_path] = conf.data
+            data[conf.file_path] = conf
 
         self.update(data)
-
-        super(RsyslogAllConf, self).__init__()

--- a/insights/combiners/tests/test_rsyslog_confs.py
+++ b/insights/combiners/tests/test_rsyslog_confs.py
@@ -1,0 +1,138 @@
+from insights.combiners.rsyslog_confs import RsyslogAllConf
+from insights.combiners import rsyslog_confs
+from insights.parsers.rsyslog_conf import RsyslogConf
+from insights.tests import context_wrap
+import doctest
+
+
+RSYSLOG_CONF_MAIN_7 = r"""
+$ModLoad imuxsock # provides support for local system logging (e.g. via logger command)
+$ModLoad imjournal # provides access to the systemd journal
+$WorkDirectory /var/lib/rsyslog
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+$IncludeConfig /etc/rsyslog.d/*.conf
+$OmitLocalLogging on
+$IMJournalStateFile imjournal.state
+*.info;mail.none;authpriv.none;cron.none                /var/log/messages
+authpriv.*                                              /var/log/secure
+mail.*                                                  -/var/log/maillog
+cron.*                                                  /var/log/cron
+*.emerg                                                 :omusrmsg:*
+uucp,news.crit                                          /var/log/spooler
+local7.*                                                /var/log/boot.log
+""".strip()
+
+RSYSLOG_CONF_MAIN_NO_INCLUDE_7 = r"""
+$ModLoad imuxsock # provides support for local system logging (e.g. via logger command)
+$ModLoad imjournal # provides access to the systemd journal
+$WorkDirectory /var/lib/rsyslog
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+$OmitLocalLogging on
+$IMJournalStateFile imjournal.state
+*.info;mail.none;authpriv.none;cron.none                /var/log/messages
+authpriv.*                                              /var/log/secure
+mail.*                                                  -/var/log/maillog
+cron.*                                                  /var/log/cron
+*.emerg                                                 :omusrmsg:*
+uucp,news.crit                                          /var/log/spooler
+local7.*                                                /var/log/boot.log
+""".strip()
+
+RSYSLOG_CONF_MAIN_CONF_DIR_7 = r"""
+$WorkDirectory /tmp
+*.info -/var/log/test.log
+""".strip()
+
+RSYSLOG_CONF_MAIN_8 = r"""
+module(load="imuxsock"    # provides support for local system logging (e.g. via logger command)
+       SysSock.Use="off") # Turn off message reception via local log socket;
+module(load="imjournal"             # provides access to the systemd journal
+       StateFile="imjournal.state") # File to store the position in the journal
+global(workDirectory="/var/lib/rsyslog")
+module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
+include(file="/etc/rsyslog.d/*.conf" mode="optional")
+*.info;mail.none;authpriv.none;cron.none                /var/log/messages
+authpriv.*                                              /var/log/secure
+mail.*                                                  -/var/log/maillog
+cron.*                                                  /var/log/cron
+if $programname == 'prog1' then {
+   action(type="omfile" file="/var/log/prog1.log")
+   if $msg contains 'test' then
+     action(type="omfile" file="/var/log/prog1test.log")
+   else
+     action(type="omfile" file="/var/log/prog1notest.log")
+}
+""".strip()
+
+RSYSLOG_CONF_MAIN_NO_INCLUDE_8 = r"""
+module(load="imuxsock"    # provides support for local system logging (e.g. via logger command)
+       SysSock.Use="off") # Turn off message reception via local log socket;
+module(load="imjournal"             # provides access to the systemd journal
+       StateFile="imjournal.state") # File to store the position in the journal
+global(workDirectory="/var/lib/rsyslog")
+module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
+*.info;mail.none;authpriv.none;cron.none                /var/log/messages
+authpriv.*                                              /var/log/secure
+mail.*                                                  -/var/log/maillog
+cron.*                                                  /var/log/cron
+if $programname == 'prog1' then {
+   action(type="omfile" file="/var/log/prog1.log")
+   if $msg contains 'test' then
+     action(type="omfile" file="/var/log/prog1test.log")
+   else
+     action(type="omfile" file="/var/log/prog1notest.log")
+}
+""".strip()
+
+RSYSLOG_CONF_MAIN_CONF_DIR_8 = r"""
+*.info {
+   action(
+     type="omfile"
+     name="hehe"
+     file="/tmp/test")
+}
+""".strip()
+
+
+def test_conf_7_include_dir():
+    rsyslog1 = RsyslogConf(context_wrap(RSYSLOG_CONF_MAIN_7, path="/etc/rsyslog.conf"))
+    rsyslog2 = RsyslogConf(context_wrap(RSYSLOG_CONF_MAIN_CONF_DIR_7, path="/etc/rsyslog.d/test.conf"))
+    result = RsyslogAllConf([rsyslog1, rsyslog2])
+    assert len(result) == 2
+    assert result['/etc/rsyslog.conf'][0] == '$ModLoad imuxsock'
+
+
+def test_conf_7_no_include_dir():
+    rsyslog1 = RsyslogConf(context_wrap(RSYSLOG_CONF_MAIN_NO_INCLUDE_7, path="/etc/rsyslog.conf"))
+    rsyslog2 = RsyslogConf(context_wrap(RSYSLOG_CONF_MAIN_CONF_DIR_7, path="/etc/rsyslog.d/test.conf"))
+    result = RsyslogAllConf([rsyslog1, rsyslog2])
+    assert len(result) == 1
+    assert result['/etc/rsyslog.conf'][0] == '$ModLoad imuxsock'
+
+
+def test_conf_8_include_dir():
+    rsyslog1 = RsyslogConf(context_wrap(RSYSLOG_CONF_MAIN_8, path="/etc/rsyslog.conf"))
+    rsyslog2 = RsyslogConf(context_wrap(RSYSLOG_CONF_MAIN_CONF_DIR_8, path="/etc/rsyslog.d/test.conf"))
+    result = RsyslogAllConf([rsyslog1, rsyslog2])
+    assert len(result) == 2
+    assert result['/etc/rsyslog.d/test.conf'] == ['*.info { action( type="omfile" name="hehe" file="/tmp/test") }']
+
+
+def test_conf_8_no_include_dir():
+    rsyslog1 = RsyslogConf(context_wrap(RSYSLOG_CONF_MAIN_NO_INCLUDE_8, path="/etc/rsyslog.conf"))
+    rsyslog2 = RsyslogConf(context_wrap(RSYSLOG_CONF_MAIN_CONF_DIR_8, path="/etc/rsyslog.d/test.conf"))
+    result = RsyslogAllConf([rsyslog1, rsyslog2])
+    assert len(result) == 1
+    assert result['/etc/rsyslog.conf'][2] == 'global(workDirectory="/var/lib/rsyslog")'
+
+
+def test_rsyslog_confs_doc_examples():
+    env = {
+            'confs': RsyslogAllConf(
+                [
+                    RsyslogConf(context_wrap(RSYSLOG_CONF_MAIN_7, path='/etc/rsyslog.conf')),
+                    RsyslogConf(context_wrap(RSYSLOG_CONF_MAIN_CONF_DIR_7, path='/etc/rsyslog.d/test.conf'))
+                ])
+          }
+    failed, total = doctest.testmod(rsyslog_confs, globs=env)
+    assert failed == 0

--- a/insights/parsers/rsyslog_conf.py
+++ b/insights/parsers/rsyslog_conf.py
@@ -13,6 +13,10 @@ view of the file that meets the needs of the current rules.
 """
 from .. import Parser, parser, get_active_lines
 from insights.specs import Specs
+from insights.core.filters import add_filter
+
+
+add_filter(Specs.rsyslog_conf, ["{", "}", "(", ")"])
 
 
 @parser(Specs.rsyslog_conf)

--- a/insights/parsers/rsyslog_conf.py
+++ b/insights/parsers/rsyslog_conf.py
@@ -44,8 +44,6 @@ class RsyslogConf(Parser, LegacyItemAccess):
         parenthesis_string = ""
         brace_string = ""
 
-        self.config_items = {}
-
         for line in get_active_lines(content):
             lstrip = line.strip()
             # Combine multi lines in brace into one line

--- a/insights/parsers/tests/test_rsyslog_conf.py
+++ b/insights/parsers/tests/test_rsyslog_conf.py
@@ -1,51 +1,49 @@
+import doctest
 from insights.tests import context_wrap
+from insights.parsers import rsyslog_conf
 from insights.parsers.rsyslog_conf import RsyslogConf
 
-RSYSLOG_CONF_0 = """
-:fromhost-ip, regex, "10.0.0.[0-9]" /tmp/my_syslog.log
+
+RSYSLOG_CONF = r"""
+# Provides TCP syslog reception
+:msg, regex, "\/vob\/.*\.[cpp|c|java]" /var/log/appMessages
+*.info;mail.none;authpriv.none;cron.none                /var/log/messages
+authpriv.*                                              /var/log/secure
 $ModLoad imtcp
 $InputTCPServerRun 10514
-$template SpiceTmpl,"%TIMESTAMP%.%TIMESTAMP:::date-subseconds% %syslogtag% %syslogseverity-text%:%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\\n"
-$WorkDirectory /var/opt/rsyslog # where to place spool files
+module(load="imuxsock"    # provides support for local system logging (e.g. via logger command)
+       SysSock.Use="off") # Turn off message reception via local log socket;
+module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
+include(file="/etc/rsyslog.d/*.conf" mode="optional")
+global(workDirectory="/var/lib/rsyslog")
+*.info {
+   action(
+     type="omfile"
+     name="hehe"
+     file="/tmp/testnimei")
+}
+if $programname == 'prog1' then {
+   action(type="omfile" file="/var/log/prog1.log")
+   if $msg contains 'test' then
+     action(type="omfile" file="/var/log/prog1test.log")
+   else
+     action(type="omfile" file="/var/log/prog1notest.log")
+}
+include(file="/etc/rsyslog.d/*.conf" mode="optional")
+cron.*                                                  /var/log/cron
 """.strip()
-
-RSYSLOG_CONF_1 = r"""
-# Provides TCP syslog reception
-#$ModLoad imtcp.so
-#$InputTCPServerRun 514
-:msg, regex, "\/vob\/.*\.[cpp|c|java]" /var/log/appMessages
-""".strip()
-
-
-def test_rsyslog_conf_0():
-    ctx = context_wrap(RSYSLOG_CONF_0)
-    m = RsyslogConf(ctx)
-    d = list(m)
-    assert len(m) == 5
-    assert len(d) == 5
-    # Test configuration item detection in dictionary
-    assert hasattr(m, 'config_items')
-    assert isinstance(m.config_items, dict)
-    assert 'ModLoad' in m.config_items
-    assert m.config_items['ModLoad'] == 'imtcp'
-    assert m.config_items['InputTCPServerRun'] == '10514'
-    assert m.config_items['template'] == 'SpiceTmpl,"%TIMESTAMP%.%TIMESTAMP:::date-subseconds% %syslogtag% %syslogseverity-text%:%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\\n"'
-    assert 'ForwardSyslogHost' not in m.config_items
-    # configuration items should not include the comment.
-    assert 'WorkDirectory' in m.config_items
-    assert m.config_items['WorkDirectory'] == '/var/opt/rsyslog'
-    # Test configuration item accessor
-    assert hasattr(m, 'config_val')
-    assert m.config_val('ModLoad') == 'imtcp'
-    assert m.config_val('ForwardSyslogHost', 'syslog.example.com') == 'syslog.example.com'
 
 
 def test_rsyslog_conf_1():
-    ctx = context_wrap(RSYSLOG_CONF_1)
-    m = RsyslogConf(ctx)
-    d = list(m)
-    assert len(m) == 1
-    assert len(d) == 1
-    # Test that commented-out config items are not detected
-    assert 'ModLoad' not in m.config_items
-    assert 'InputTCPServerRun' not in m.config_items
+    rsyslogconf = RsyslogConf(context_wrap(RSYSLOG_CONF))
+    assert len(rsyslogconf) == 13
+    assert rsyslogconf[2] == "authpriv.*                                              /var/log/secure"
+    assert rsyslogconf[9] == """*.info { action( type="omfile" name="hehe" file="/tmp/testnimei") }"""
+
+
+def test_rsyslog_doc_examples():
+    env = {
+        'rsysconf': RsyslogConf(context_wrap(RSYSLOG_CONF)),
+    }
+    failed, total = doctest.testmod(rsyslog_conf, globs=env)
+    assert failed == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -537,7 +537,7 @@ class Specs(SpecSet):
     root_crontab = RegistryPoint()
     route = RegistryPoint()
     rpm_V_packages = RegistryPoint()
-    rsyslog_conf = RegistryPoint(filterable=True)
+    rsyslog_conf = RegistryPoint(filterable=True, multi_output=True)
     samba = RegistryPoint(filterable=True)
     sap_dev_disp = RegistryPoint(multi_output=True, filterable=True)
     sap_dev_rd = RegistryPoint(multi_output=True, filterable=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -578,7 +578,7 @@ class DefaultSpecs(Specs):
     rhsm_releasever = simple_file('/var/lib/rhsm/cache/releasever.json')
     rndc_status = simple_command("/usr/sbin/rndc status")
     rpm_V_packages = simple_command("/bin/rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony", keep_rc=True)
-    rsyslog_conf = simple_file("/etc/rsyslog.conf")
+    rsyslog_conf = glob_file(["/etc/rsyslog.conf", "/etc/rsyslog.d/test.conf"])
     samba = simple_file("/etc/samba/smb.conf")
 
     @datasource(Sap)


### PR DESCRIPTION
Before RHEL8, the format of rsyslog.conf is like:
~~~
$IncludeConfig /etc/rsyslog.d/*.conf
$ModLoad imtcp
~~~

However, it changes like following in RHEL8:
~~~
include(file="/etc/rsyslog.d/*.conf" mode="optional")
module(load="imuxsock" 
       SysSock.Use="off")
~~~

We also need to consider the `RainerScript` when parsing rsyslog.conf, then it becomes too complicated if we want to parse this file in detail. Per our discussion in https://github.com/RedHatInsights/insights-core/pull/1952, we decide to return the content directly with format line by line. As `LogFileOutput` can not handle multi lines, I do not use this class, and parse the content with my own code. Also, if we use filter for multi lines, we will get only one line and it may not be useful for plugin check, so I remove the filter.