### PR TITLE
Add new parser for installed product IDs

### DIFF
--- a/docs/shared_parsers_catalog/installed_product_ids.rst
+++ b/docs/shared_parsers_catalog/installed_product_ids.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.installed_product_ids
+   :members:
+   :show-inheritance:

--- a/insights/parsers/installed_product_ids.py
+++ b/insights/parsers/installed_product_ids.py
@@ -98,7 +98,7 @@ class InstalledProductIDs(CommandParser):
         >>> type(products)
         <class 'insights.parsers.installed_product_ids.InstalledProductIDs'>
         >>> products.ids
-        {'69'}
+        set(['69'])
 
     """
     def parse_content(self, content):

--- a/insights/parsers/installed_product_ids.py
+++ b/insights/parsers/installed_product_ids.py
@@ -97,8 +97,8 @@ class InstalledProductIDs(CommandParser):
     Examples:
         >>> type(products)
         <class 'insights.parsers.installed_product_ids.InstalledProductIDs'>
-        >>> products.ids
-        set(['69'])
+        >>> list(products.ids)
+        ['69']
 
     """
     def parse_content(self, content):

--- a/insights/parsers/installed_product_ids.py
+++ b/insights/parsers/installed_product_ids.py
@@ -1,0 +1,110 @@
+"""
+Installed product IDs
+=====================
+
+InstalledProductIDs - command ``find /etc/pki/product-default/ /etc/pki/product/ -name '*pem' -exec rct cat-cert --no-content '{}' \;``
+---------------------------------------------------------------------------------------------------------------------------------------
+
+This module provides a parser for information about certificates for
+Red Hat product subscriptions.
+
+"""
+from insights.core.filters import add_filter
+from insights.specs import Specs
+from .. import parser, CommandParser
+
+add_filter(Specs.subscription_manager_installed_product_ids, 'ID:')
+
+
+@parser(Specs.subscription_manager_installed_product_ids)
+class InstalledProductIDs(CommandParser):
+    """
+    Parses the output of the comand::
+
+        find /etc/pki/product-default/ /etc/pki/product/ -name '*pem' -exec rct cat-cert --no-content '{}' \;
+
+    Sample output from the unfiltered command looks like::
+
+        +-------------------------------------------+
+        Product Certificate
+        +-------------------------------------------+
+
+        Certificate:
+            Path: /etc/pki/product-default/69.pem
+            Version: 1.0
+            Serial: 12750047592154749739
+            Start Date: 2017-06-28 18:05:10+00:00
+            End Date: 2037-06-23 18:05:10+00:00
+
+        Subject:
+            CN: Red Hat Product ID [4f9995e0-8dc4-4b4f-acfe-4ef1264b94f3]
+
+        Issuer:
+            C: US
+            CN: Red Hat Entitlement Product Authority
+            O: Red Hat, Inc.
+            OU: Red Hat Network
+            ST: North Carolina
+            emailAddress: ca-support@redhat.com
+
+        Product:
+            ID: 69
+            Name: Red Hat Enterprise Linux Server
+            Version: 7.4
+            Arch: x86_64
+            Tags: rhel-7,rhel-7-server
+            Brand Type:
+            Brand Name:
+
+
+        +-------------------------------------------+
+            Product Certificate
+        +-------------------------------------------+
+
+        Certificate:
+            Path: /etc/pki/product/69.pem
+            Version: 1.0
+            Serial: 12750047592154751271
+            Start Date: 2018-04-13 11:23:50+00:00
+            End Date: 2038-04-08 11:23:50+00:00
+
+        Subject:
+            CN: Red Hat Product ID [f3c92a95-26be-4bdf-800f-02c044503896]
+
+        Issuer:
+            C: US
+            CN: Red Hat Entitlement Product Authority
+            O: Red Hat, Inc.
+            OU: Red Hat Network
+            ST: North Carolina
+            emailAddress: ca-support@redhat.com
+
+        Product:
+            ID: 69
+            Name: Red Hat Enterprise Linux Server
+            Version: 7.6
+            Arch: x86_64
+            Tags: rhel-7,rhel-7-server
+            Brand Type:
+            Brand Name:
+
+    Filters have been added to the parser so that only the ``ID`` element will
+    be collected.
+
+    Attributes:
+        ids (set): set of strings of the unique IDs collected by the command
+
+    Examples:
+        >>> type(products)
+        <class 'insights.parsers.installed_product_ids.InstalledProductIDs'>
+        >>> products.ids
+        {'69'}
+
+    """
+    def parse_content(self, content):
+        """ Parse command output """
+        self.ids = set()
+        for line in content:
+            if line.strip().startswith('ID:'):
+                _, id = line.strip().split(':', 1)
+                self.ids.add(id.strip())

--- a/insights/parsers/tests/test_installed_product_ids.py
+++ b/insights/parsers/tests/test_installed_product_ids.py
@@ -70,8 +70,8 @@ Product:
 """
 
 NONE_FOUND = """
-find: ‘/etc/pki/product-default/’: No such file or directory
-find: ‘/etc/pki/product/’: No such file or directory
+find: '/etc/pki/product-default/': No such file or directory
+find: '/etc/pki/product/': No such file or directory
 """
 
 BAD_FILE = """

--- a/insights/parsers/tests/test_installed_product_ids.py
+++ b/insights/parsers/tests/test_installed_product_ids.py
@@ -1,0 +1,101 @@
+import doctest
+from ...parsers.installed_product_ids import InstalledProductIDs
+from ...parsers import installed_product_ids
+from ...tests import context_wrap
+
+
+COMMAND_OUTPUT = """
++-------------------------------------------+
+Product Certificate
++-------------------------------------------+
+
+Certificate:
+    Path: /etc/pki/product-default/69.pem
+    Version: 1.0
+    Serial: 12750047592154749739
+    Start Date: 2017-06-28 18:05:10+00:00
+    End Date: 2037-06-23 18:05:10+00:00
+
+Subject:
+    CN: Red Hat Product ID [4f9995e0-8dc4-4b4f-acfe-4ef1264b94f3]
+
+Issuer:
+    C: US
+    CN: Red Hat Entitlement Product Authority
+    O: Red Hat, Inc.
+    OU: Red Hat Network
+    ST: North Carolina
+    emailAddress: ca-support@redhat.com
+
+Product:
+    ID: 69
+    Name: Red Hat Enterprise Linux Server
+    Version: 7.4
+    Arch: x86_64
+    Tags: rhel-7,rhel-7-server
+    Brand Type:
+    Brand Name:
+
+
++-------------------------------------------+
+    Product Certificate
++-------------------------------------------+
+
+Certificate:
+    Path: /etc/pki/product/69.pem
+    Version: 1.0
+    Serial: 12750047592154751271
+    Start Date: 2018-04-13 11:23:50+00:00
+    End Date: 2038-04-08 11:23:50+00:00
+
+Subject:
+    CN: Red Hat Product ID [f3c92a95-26be-4bdf-800f-02c044503896]
+
+Issuer:
+    C: US
+    CN: Red Hat Entitlement Product Authority
+    O: Red Hat, Inc.
+    OU: Red Hat Network
+    ST: North Carolina
+    emailAddress: ca-support@redhat.com
+
+Product:
+    ID: 69
+    Name: Red Hat Enterprise Linux Server
+    Version: 7.6
+    Arch: x86_64
+    Tags: rhel-7,rhel-7-server
+    Brand Type:
+    Brand Name:
+"""
+
+NONE_FOUND = """
+find: ‘/etc/pki/product-default/’: No such file or directory
+find: ‘/etc/pki/product/’: No such file or directory
+"""
+
+BAD_FILE = """
+Unable to read certificate file '/etc/pki/product/some_file.pem': Error loading certificate
+"""
+
+
+def test_installed_product_ids():
+    results = InstalledProductIDs(context_wrap(COMMAND_OUTPUT))
+    assert results is not None
+    assert results.ids == set(['69', '69'])
+
+    results = InstalledProductIDs(context_wrap(NONE_FOUND))
+    assert results is not None
+    assert results.ids == set([])
+
+    results = InstalledProductIDs(context_wrap(BAD_FILE))
+    assert results is not None
+    assert results.ids == set([])
+
+
+def test_installed_product_ids_docs():
+    env = {
+        'products': InstalledProductIDs(context_wrap(COMMAND_OUTPUT)),
+    }
+    failed, total = doctest.testmod(installed_product_ids, globs=env)
+    assert failed == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -513,6 +513,7 @@ class Specs(SpecSet):
     subscription_manager_id = RegistryPoint()
     subscription_manager_list_consumed = RegistryPoint()
     subscription_manager_list_installed = RegistryPoint()
+    subscription_manager_installed_product_ids = RegistryPoint(filterable=True)
     subscription_manager_release_show = RegistryPoint()
     swift_conf = RegistryPoint()
     swift_log = RegistryPoint(filterable=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -849,6 +849,7 @@ class DefaultSpecs(Specs):
     sshd_config_perms = simple_command("/bin/ls -l /etc/ssh/sshd_config")
     sssd_config = simple_file("/etc/sssd/sssd.conf")
     subscription_manager_id = simple_command("/usr/bin/subscription-manager identity")
+    subscription_manager_installed_product_ids = simple_command("/usr/bin/find /etc/pki/product-default/ /etc/pki/product/ -name '*pem' -exec rct cat-cert --no-content '{}' \;")
     subscription_manager_release_show = simple_command('/usr/bin/subscription-manager release --show')
     swift_conf = first_file(["/var/lib/config-data/puppet-generated/swift/etc/swift/swift.conf", "/etc/swift/swift.conf"])
     swift_log = first_file(["/var/log/containers/swift/swift.log", "/var/log/swift/swift.log"])

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -228,6 +228,7 @@ class InsightsArchiveSpecs(Specs):
     software_collections_list = simple_file('insights_commands/scl_--list')
     ss = simple_file("insights_commands/ss_-tupna")
     sshd_config_perms = simple_file("insights_commands/ls_-l_.etc.ssh.sshd_config")
+    subscription_manager_installed_product_ids = "insights_commands/find_.etc.pki.product-default._.etc.pki.product._-name_pem_-exec_rct_cat-cert_--no-content"
     subscription_manager_id = simple_file("insights_commands/subscription-manager_identity")
     subscription_manager_release_show = simple_file('insights_commands/subscription-manager_release_--show')
     sysctl = simple_file("insights_commands/sysctl_-a")


### PR DESCRIPTION
* Parser for command rct cat-cert command to be run on each pem file in
  the directories /etc/pki/product-default/ and /etc/pki/product/
* Add filter for the command output to only capture ID field
* Add tests for parser
* Add documentation for parser

Signed-off-by: Bob Fahr <bfahr@redhat.com>