### PR TITLE
Remove prefix "!" or "*" for yum repolist

### DIFF
--- a/insights/parsers/tests/test_yum_repolist.py
+++ b/insights/parsers/tests/test_yum_repolist.py
@@ -42,6 +42,15 @@ repo id                              repo name                                  
 repolist: 21,581
 """
 
+YUM_REPOLIST_CONTENT_OUT_OF_DATE_AND_NOT_MATCH_METADATA = """
+Loaded plugins: product-id, search-disabled-repos, subscription-manager
+Repodata is over 2 weeks old. Install yum-cron? Or run: yum makecache fast
+repo id                              repo name                                          status
+!rhel-7-server-extras-rpms/x86_64    Red Hat Enterprise Linux 7 Server - Extras (RPMs)  877
+*rhel-7-server-rpms/7Server/x86_64   Red Hat Enterprise Linux 7 Server (RPMs)           20,704
+repolist: 21,581
+"""
+
 YUM_REPOLIST_DOC = """
 Loaded plugins: langpacks, product-id, search-disabled-repos, subscription-manager
 repo id                                             repo name                                                                                                    status
@@ -99,6 +108,13 @@ def test_rhel_repos_out_of_date():
     assert len(repo_list) == 2
     assert set(repo_list.rhel_repos) == set(['rhel-7-server-extras-rpms',
                                              'rhel-7-server-rpms'])
+
+
+def test_rhel_repos_out_of_date_2():
+    repo_list = YumRepoList(context_wrap(YUM_REPOLIST_CONTENT_OUT_OF_DATE_AND_NOT_MATCH_METADATA))
+    assert len(repo_list) == 2
+    assert 'rhel-7-server-extras-rpms/x86_64' in repo_list
+    assert 'rhel-7-server-rpms/7Server/x86_64' in repo_list
 
 
 def test_invalid_get_type():

--- a/insights/parsers/tests/test_yum_repolist.py
+++ b/insights/parsers/tests/test_yum_repolist.py
@@ -55,11 +55,10 @@ YUM_REPOLIST_DOC = """
 Loaded plugins: langpacks, product-id, search-disabled-repos, subscription-manager
 repo id                                             repo name                                                                                                    status
 rhel-7-server-e4s-rpms/x86_64                       Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (RPMs)                                 12,250
-rhel-ha-for-rhel-7-server-e4s-rpms/x86_64           Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)         272
-rhel-ha-for-rhel-7-server-rpms/x86_64               Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (RPMs)                                           225
-rhel-sap-hana-for-rhel-7-server-e4s-rpms/x86_64     RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)                                   21
+!rhel-ha-for-rhel-7-server-e4s-rpms/x86_64          Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)         272
+*rhel-sap-hana-for-rhel-7-server-e4s-rpms/x86_64    RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)                                   21
 repolist: 12,768
-"""
+""".strip()
 
 
 def test_yum_repolist():
@@ -115,6 +114,8 @@ def test_rhel_repos_out_of_date_2():
     assert len(repo_list) == 2
     assert 'rhel-7-server-extras-rpms/x86_64' in repo_list
     assert 'rhel-7-server-rpms/7Server/x86_64' in repo_list
+    assert "!rhel-7-server-extras-rpms/x86_64" == repo_list['rhel-7-server-extras-rpms/x86_64']['id']
+    assert "*rhel-7-server-rpms/7Server/x86_64" == repo_list['rhel-7-server-rpms/7Server/x86_64']['id']
 
 
 def test_invalid_get_type():

--- a/insights/parsers/yum.py
+++ b/insights/parsers/yum.py
@@ -50,13 +50,12 @@ class YumRepoList(CommandParser):
         repo id                                             repo name                                                                                                    status
         rhel-7-server-e4s-rpms/x86_64                       Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (RPMs)                                 12,250
         !rhel-ha-for-rhel-7-server-e4s-rpms/x86_64          Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)         272
-        rhel-ha-for-rhel-7-server-rpms/x86_64               Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (RPMs)                                           225
         *rhel-sap-hana-for-rhel-7-server-e4s-rpms/x86_64    RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)                                   21
         repolist: 12,768
 
     Examples:
         >>> len(repolist)
-        4
+        3
         >>> 'rhel-7-server-e4s-rpms/x86_64' in repolist.repos
         True
         >>> 'rhel-7-server-e4s-rpms' in repolist.repos
@@ -67,25 +66,35 @@ class YumRepoList(CommandParser):
         'Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (RPMs)'
         >>> repolist[0]['name']
         'Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (RPMs)'
+        >>> repolist['rhel-ha-for-rhel-7-server-e4s-rpms/x86_64']['id']
+        '!rhel-ha-for-rhel-7-server-e4s-rpms/x86_64'
 
     Attributes:
         data (list): list of repos wrapped in dictionaries
-        repos (dict): dict of all listed repos where the key is the full repo-id. For example::
+        repos (dict): dict of all listed repos where the key is the full repo-id without "!" or "*".
+            But you can get it from the value part if needed. For example::
 
-            self.repos =
-                {
+                self.repos = {
                     'rhel-7-server-e4s-rpms/x86_64': {
                         'id': 'rhel-7-server-e4s-rpms/x86_64',
                         'name': 'Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (RPMs)',
-                        'status': '12,250'},
+                        'status': '12,250'
+                    },
+                    'rhel-ha-for-rhel-7-server-e4s-rpms/x86_64': {
+                        'id': '!rhel-ha-for-rhel-7-server-e4s-rpms/x86_64',
+                        'name': 'Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)',
+                        'status': '272'
+                    },
                     'rhel-sap-hana-for-rhel-7-server-e4s-rpms/x86_64': {
-                        'id': 'rhel-sap-hana-for-rhel-7-server-e4s-rpms/x86_64',
+                        'id': '*rhel-sap-hana-for-rhel-7-server-e4s-rpms/x86_64',
                         'name': 'RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)',
-                        'status': '21'}
+                        'status': '21'
+                    }
                 }
+
         rhel_repos(list): list of all the rhel repos and the item is just the repo id without server and arch info. For example::
 
-            self.rhel_repos = ['rhel-7-server-e4s-rpms', 'rhel-sap-hana-for-rhel-7-server-e4s-rpms']
+            self.rhel_repos = ['rhel-7-server-e4s-rpms', 'rhel-ha-for-rhel-7-server-e4s-rpms', 'rhel-sap-hana-for-rhel-7-server-e4s-rpms']
     """
     def parse_content(self, content):
         self.data = []
@@ -101,14 +110,14 @@ class YumRepoList(CommandParser):
                 except ValueError:
                     raise SkipException("Incorrect line: '{0}'".format(line))
                 self.data.append({
-                    "id": _id.lstrip('!').lstrip('*').strip(),
+                    "id": _id.strip(),
                     "name": name.strip(),
                     "status": status.strip()})
             if not found_start:
                 found_start = line.startswith("repo id")
         if not self.data:
             raise SkipException('No repolist.')
-        self.repos = dict((d['id'], d) for d in self.data)
+        self.repos = dict((d['id'].lstrip('!').lstrip('*'), d) for d in self.data)
 
     def __len__(self):
         return len(self.data)

--- a/insights/parsers/yum.py
+++ b/insights/parsers/yum.py
@@ -49,9 +49,9 @@ class YumRepoList(CommandParser):
         Loaded plugins: langpacks, product-id, search-disabled-repos, subscription-manager
         repo id                                             repo name                                                                                                    status
         rhel-7-server-e4s-rpms/x86_64                       Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (RPMs)                                 12,250
-        rhel-ha-for-rhel-7-server-e4s-rpms/x86_64           Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)         272
+        !rhel-ha-for-rhel-7-server-e4s-rpms/x86_64          Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)         272
         rhel-ha-for-rhel-7-server-rpms/x86_64               Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (RPMs)                                           225
-        rhel-sap-hana-for-rhel-7-server-e4s-rpms/x86_64     RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)                                   21
+        *rhel-sap-hana-for-rhel-7-server-e4s-rpms/x86_64    RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)                                   21
         repolist: 12,768
 
     Examples:
@@ -70,8 +70,22 @@ class YumRepoList(CommandParser):
 
     Attributes:
         data (list): list of repos wrapped in dictionaries
-        repos (dict): dict of all listed repos where the key is the full repo-id
+        repos (dict): dict of all listed repos where the key is the full repo-id. For example::
 
+            self.repos =
+                {
+                    'rhel-7-server-e4s-rpms/x86_64': {
+                        'id': 'rhel-7-server-e4s-rpms/x86_64',
+                        'name': 'Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (RPMs)',
+                        'status': '12,250'},
+                    'rhel-sap-hana-for-rhel-7-server-e4s-rpms/x86_64': {
+                        'id': 'rhel-sap-hana-for-rhel-7-server-e4s-rpms/x86_64',
+                        'name': 'RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)',
+                        'status': '21'}
+                }
+        rhel_repos(list): list of all the rhel repos and the item is just the repo id without server and arch info. For example::
+
+            self.rhel_repos = ['rhel-7-server-e4s-rpms', 'rhel-sap-hana-for-rhel-7-server-e4s-rpms']
     """
     def parse_content(self, content):
         self.data = []
@@ -87,7 +101,7 @@ class YumRepoList(CommandParser):
                 except ValueError:
                     raise SkipException("Incorrect line: '{0}'".format(line))
                 self.data.append({
-                    "id": _id.strip(),
+                    "id": _id.lstrip('!').lstrip('*').strip(),
                     "name": name.strip(),
                     "status": status.strip()})
             if not found_start:
@@ -122,6 +136,6 @@ class YumRepoList(CommandParser):
     @property
     def rhel_repos(self):
         '''list of RHEL repos/Repo IDs'''
-        return [i.split('/')[0].lstrip('!')
+        return [i.split('/')[0]
                 for i in self.repos
-                if i.startswith(('!rhel', 'rhel'))]
+                if i.startswith('rhel')]


### PR DESCRIPTION
I found this parser is used in a lot of plugins, and many of them don't consider that maybe
it starts with exclamation mark. I think it is useless for comparation, so we can remove
it in the parser.