### PR TITLE
Fix a bug that it can not parse output when there is no yum name

### DIFF
--- a/insights/parsers/__init__.py
+++ b/insights/parsers/__init__.py
@@ -307,6 +307,7 @@ def parse_fixed_table(table_lines,
             rows of the content.  Lines starting with these strings will be ignored,
             thereby truncating the rows of data.
         empty_exception (bool): If True, raise a ParseException when the value if empty.
+            False by default.
 
     Returns:
         list: Returns a list of dict for each row of column data.  Dict keys
@@ -314,7 +315,7 @@ def parse_fixed_table(table_lines,
 
     Raises:
         ValueError: Raised if `heading_ignore` is specified and not found in `table_lines`.
-        ParseException: Raised if `empty_exception` is True and there are empty values.
+        ParseException: Raised if there are empty values when `empty_exception` is True
 
     Sample input::
 

--- a/insights/parsers/__init__.py
+++ b/insights/parsers/__init__.py
@@ -281,7 +281,8 @@ def calc_offset(lines, target, invert_search=False):
 def parse_fixed_table(table_lines,
                       heading_ignore=[],
                       header_substitute=[],
-                      trailing_ignore=[]):
+                      trailing_ignore=[],
+                      empty_exception=False):
     """
     Function to parse table data containing column headings in the first row and
     data in fixed positions in each remaining row of table data.
@@ -305,6 +306,7 @@ def parse_fixed_table(table_lines,
         trailing_ignore (list): Optional list of strings to look for at the end
             rows of the content.  Lines starting with these strings will be ignored,
             thereby truncating the rows of data.
+        empty_exception (bool): If True, raise a ParseException when the value if empty.
 
     Returns:
         list: Returns a list of dict for each row of column data.  Dict keys
@@ -312,6 +314,7 @@ def parse_fixed_table(table_lines,
 
     Raises:
         ValueError: Raised if `heading_ignore` is specified and not found in `table_lines`.
+        ParseException: Raised if `empty_exception` is True and there are empty values.
 
     Sample input::
 
@@ -345,15 +348,17 @@ def parse_fixed_table(table_lines,
         for old_val, new_val in header_substitute:
             header = header.replace(old_val, new_val)
     col_headers = header.strip().split()
-    col_index = calc_column_indices(header, col_headers)
+    col_index = calc_column_indices(header, col_headers) + [None]
+    idx_pairs = [(c, col_index[i + 1]) for i, c in enumerate(col_index) if c is not None]
 
     table_data = []
     for line in table_lines[first_line + 1:last_line]:
-        col_data = dict(
-            (col_headers[c], line[col_index[c]:col_index[c + 1]].strip())
-            for c in range(len(col_index) - 1)
-        )
-        col_data[col_headers[-1]] = line[col_index[-1]:].strip()
+        col_data = {}
+        for i, (s, e) in enumerate(idx_pairs):
+            val = line[s:e].strip()
+            if not val and empty_exception:
+                raise ParseException('Incorrect line: \'{0}\'', line)
+            col_data[col_headers[i]] = val
         table_data.append(col_data)
 
     return table_data

--- a/insights/parsers/__init__.py
+++ b/insights/parsers/__init__.py
@@ -357,7 +357,7 @@ def parse_fixed_table(table_lines,
         col_data = {}
         for i, (s, e) in enumerate(idx_pairs):
             val = line[s:e].strip()
-            if not val and empty_exception:
+            if empty_exception and not val:
                 raise ParseException('Incorrect line: \'{0}\'', line)
             col_data[col_headers[i]] = val
         table_data.append(col_data)

--- a/insights/parsers/tests/test_parsers_module.py
+++ b/insights/parsers/tests/test_parsers_module.py
@@ -290,6 +290,12 @@ def test_parse_fixed_table():
     assert data[0] == {'NAMESPACE': 'default', 'NAME': 'foo', 'LABELS': 'app=superawesome'}
 
 
+def test_parse_fixed_table_empty_exception():
+    with pytest.raises(ParseException) as pe:
+        parse_fixed_table(FIXED_CONTENT_1B.splitlines(), empty_exception=True)
+    assert "Incorrect line:" in str(pe.value)
+
+
 def test_optlist_standard():
     d = optlist_to_dict('key1,key2=val2,key1=val1,key3')
     assert sorted(d.keys()) == sorted(['key1', 'key2', 'key3'])

--- a/insights/parsers/tests/test_yum_repolist.py
+++ b/insights/parsers/tests/test_yum_repolist.py
@@ -60,6 +60,22 @@ rhel-7-server-e4s-rpms/x86_64                       Red Hat Enterprise Linux 7 S
 repolist: 12,768
 """.strip()
 
+YUM_REPO_1 = """
+Loaded plugins: enabled_repos_upload, package_upload, priorities, product-id,
+              : search-disabled-repos, security, subscription-manager
+repo id                                                                               status
+LME_EPEL_6_x86_64                                                                     26123
+LME_HP_-_Software_Delivery_Repository_Firmware_Pack_for_ProLiant_-_6Server_-_Current   1163
+LME_HP_-_Software_Delivery_Repository_Scripting_Took_Kit_-_6Server                       17
+LME_HP_-_Software_Delivery_Repository_Service_Pack_for_ProLiant_-_6Server_-_Current    1861
+LME_HP_-_Software_Delivery_Repository_Smart_Update_Manager_-_6Server                     21
+rhel-6-server-optional-rpms                                                           11358
+rhel-6-server-rpms                                                                    19753
+repolist: 60296
+Uploading Enabled Reposistories Report
+Loaded plugins: priorities, product-id
+""".strip()
+
 
 def test_yum_repolist():
     repo_list = YumRepoList(context_wrap(YUM_REPOLIST_CONTENT))
@@ -129,3 +145,8 @@ def test_doc_examples():
           }
     failed, total = doctest.testmod(yum, globs=env)
     assert failed == 0
+
+
+def test_invalid_get_type_1():
+    repo_list = YumRepoList(context_wrap(YUM_REPO_1))
+    assert 2 == len(repo_list.rhel_repos)

--- a/insights/parsers/tests/test_yum_repolist.py
+++ b/insights/parsers/tests/test_yum_repolist.py
@@ -1,6 +1,6 @@
 from insights.parsers import yum
 from insights.parsers.yum import YumRepoList
-from insights.parsers import SkipException
+from insights.parsers import SkipException, ParseException
 from insights.tests import context_wrap
 import doctest
 import pytest
@@ -31,6 +31,7 @@ Loaded plugins: product-id, rhnplugin, security, subscription-manager
 Updating certificate-based repositories.
 repo id                              repo name                            status
 clone-6u5-server-x86_64              clone-6u5-server-x86_64
+repolist: 3,787
 """
 
 YUM_REPOLIST_CONTENT_OUT_OF_DATE = """
@@ -51,16 +52,7 @@ repo id                              repo name                                  
 repolist: 21,581
 """
 
-YUM_REPOLIST_DOC = """
-Loaded plugins: langpacks, product-id, search-disabled-repos, subscription-manager
-repo id                                             repo name                                                                                                    status
-rhel-7-server-e4s-rpms/x86_64                       Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (RPMs)                                 12,250
-!rhel-ha-for-rhel-7-server-e4s-rpms/x86_64          Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)         272
-*rhel-sap-hana-for-rhel-7-server-e4s-rpms/x86_64    RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)                                   21
-repolist: 12,768
-""".strip()
-
-YUM_REPO_1 = """
+YUM_REPO_NO_REPO_NAME = """
 Loaded plugins: enabled_repos_upload, package_upload, priorities, product-id,
               : search-disabled-repos, security, subscription-manager
 repo id                                                                               status
@@ -74,6 +66,45 @@ rhel-6-server-rpms                                                              
 repolist: 60296
 Uploading Enabled Reposistories Report
 Loaded plugins: priorities, product-id
+""".strip()
+
+YUM_REPOLIST_CONTENT_MISSING_END = """
+Loaded plugins: product-id, rhnplugin, security, subscription-manager
+Updating certificate-based repositories.
+repo id                              repo name                            status
+clone-6u5-server-x86_64              clone-6u5-server-x86_64              1234
+"""
+
+YUM_REPOLIST_CONTENT_EMPTY = """
+repo id                              repo name                            status
+"""
+
+YUM_REPOLIST_DOC = """
+Loaded plugins: langpacks, product-id, search-disabled-repos, subscription-manager
+repo id                                             repo name                                                                                                    status
+rhel-7-server-e4s-rpms/x86_64                       Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (RPMs)                                 12,250
+!rhel-ha-for-rhel-7-server-e4s-rpms/x86_64          Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)         272
+*rhel-sap-hana-for-rhel-7-server-e4s-rpms/x86_64    RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)                                   21
+repolist: 12,768
+""".strip()
+
+YUM_REPOLIST_DOC_NO_REPONAME = """
+Loaded plugins: package_upload, product-id, search-disabled-repos, security, subscription-manager
+repo id                                                                               status
+LME_EPEL_6_x86_64                                                                        26123
+LME_FSMLabs_Timekeeper_timekeeper                                                            2
+LME_HP_-_Software_Delivery_Repository_Firmware_Pack_for_ProLiant_-_6Server_-_Current      1163
+LME_HP_-_Software_Delivery_Repository_Scripting_Took_Kit_-_6Server                          17
+LME_HP_-_Software_Delivery_Repository_Service_Pack_for_ProLiant_-_6Server_-_Current       1915
+LME_HP_-_Software_Delivery_Repository_Smart_Update_Manager_-_6Server                        30
+LME_LME_Custom_Product_Mellanox_OFED                                                       114
+LME_LME_Custom_Product_OMD_RPMS                                                             14
+LME_LME_Custom_Product_RPMs                                                                  5
+LME_LME_Custom_Product_SNOW_Repository                                                       2
+rhel-6-server-optional-rpms                                                            10400+1
+rhel-6-server-rpms                                                                    18256+12
+rhel-6-server-satellite-tools-6.2-rpms                                                      55
+repolist: 58096
 """.strip()
 
 
@@ -107,7 +138,7 @@ def test_rhel_repos():
 
 
 def test_rhel_repos_missing_status():
-    with pytest.raises(SkipException) as se:
+    with pytest.raises(ParseException) as se:
         YumRepoList(context_wrap(YUM_REPOLIST_CONTENT_MISSING_STATUS))
     assert 'Incorrect line:' in str(se)
 
@@ -115,6 +146,10 @@ def test_rhel_repos_missing_status():
 def test_rhel_repos_empty():
     with pytest.raises(SkipException) as se:
         YumRepoList(context_wrap(''))
+    assert 'No repolist.' in str(se)
+
+    with pytest.raises(SkipException) as se:
+        YumRepoList(context_wrap(YUM_REPOLIST_CONTENT_EMPTY))
     assert 'No repolist.' in str(se)
 
 
@@ -125,7 +160,7 @@ def test_rhel_repos_out_of_date():
                                              'rhel-7-server-rpms'])
 
 
-def test_rhel_repos_out_of_date_2():
+def test_rhel_repos_out_of_date_and_no_match_metadata():
     repo_list = YumRepoList(context_wrap(YUM_REPOLIST_CONTENT_OUT_OF_DATE_AND_NOT_MATCH_METADATA))
     assert len(repo_list) == 2
     assert 'rhel-7-server-extras-rpms/x86_64' in repo_list
@@ -142,11 +177,19 @@ def test_invalid_get_type():
 def test_doc_examples():
     env = {
             'repolist': YumRepoList(context_wrap(YUM_REPOLIST_DOC)),
+            'repolist_no_reponame': YumRepoList(context_wrap(YUM_REPOLIST_DOC_NO_REPONAME)),
           }
     failed, total = doctest.testmod(yum, globs=env)
     assert failed == 0
 
 
-def test_invalid_get_type_1():
-    repo_list = YumRepoList(context_wrap(YUM_REPO_1))
+def test_repos_without_repo_name():
+    repo_list = YumRepoList(context_wrap(YUM_REPO_NO_REPO_NAME))
+    assert 7 == len(repo_list)
     assert 2 == len(repo_list.rhel_repos)
+
+
+def test_repos_without_ends():
+    repo_list = YumRepoList(context_wrap(YUM_REPOLIST_CONTENT_MISSING_END))
+    assert 1 == len(repo_list)
+    assert 0 == len(repo_list.rhel_repos)


### PR DESCRIPTION
* On production, some of the outputs have no column of "yum name"
- fix: #2149 

Signed-off-by: Huanhuan Li <huali@redhat.com>