### PR TITLE
Fix unicode read error for files with byte chars

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -243,8 +243,12 @@ class TextFileProvider(FileProvider):
             rc, out = self.ctx.shell_out(args, keep_rc=True, env=SAFE_ENV)
             self.rc = rc
             return out
-        with open(self.path, "rU") as f:  # universal newlines
-            return [l.rstrip("\n") for l in f]
+        if six.PY3:
+            with open(self.path, "r", encoding="ascii", errors="surrogateescape") as f:
+                return [l.rstrip("\n") for l in f]
+        else:
+            with open(self.path, "rU") as f:  # universal newlines
+                return [l.rstrip("\n") for l in f]
 
     def _stream(self):
         """
@@ -261,8 +265,12 @@ class TextFileProvider(FileProvider):
                     with streams.connect(*args, env=SAFE_ENV) as s:
                         yield s
                 else:
-                    with open(self.path, "rU") as f:  # universal newlines
-                        yield f
+                    if six.PY3:
+                        with open(self.path, "r", encoding="ascii", errors="surrogateescape") as f:
+                            yield f
+                    else:
+                        with open(self.path, "rU") as f:  # universal newlines
+                            yield f
         except StopIteration:
             raise
         except Exception as ex:


### PR DESCRIPTION
* Fixes error in TextFileProvider when using Python 3 and reading
  files that have byte chars.
* Fix #2163 

Signed-off-by: Bob Fahr <bfahr@redhat.com>