### PR TITLE
Added db2licm command parser

### DIFF
--- a/docs/shared_parsers_catalog/db2licm.rst
+++ b/docs/shared_parsers_catalog/db2licm.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.db2licm
+   :members:
+   :show-inheritance:

--- a/insights/parsers/db2licm.py
+++ b/insights/parsers/db2licm.py
@@ -41,8 +41,6 @@ class DB2Info(CommandParser, dict):
 
         >>> parser_result.keys()
         dict_keys(['DB2 Enterprise Server Edition', 'DB2 Connect Server'])
-        >>> parser_result['DB2 Enterprise Server Edition']
-        {'License type': 'CPU Option', 'Expiry date': 'Permanent', 'Product identifier': 'db2ese', 'Version information': '9.7', 'Enforcement policy': 'Soft Stop', 'DB2 Performance Optimization ESE': 'Not licensed', 'DB2 Storage Optimization': 'Not licensed', 'DB2 Advanced Access Control': 'Not licensed', 'IBM Homogeneous Replication ESE': 'Not licensed'}
         >>> parser_result['DB2 Enterprise Server Edition']["Version information"]
         '9.7'
 

--- a/insights/parsers/db2licm.py
+++ b/insights/parsers/db2licm.py
@@ -79,7 +79,7 @@ class DB2Info(LegacyItemAccess, CommandParser):
                 if key == "Features":
                     continue
             else:
-                raise ParseException("Unable to parse db2licm info: {}".format(content))
+                raise ParseException("Unable to parse db2licm info: {0}".format(content))
             if key == "Product name":
                 if name is None:
                     name = val
@@ -97,4 +97,4 @@ class DB2Info(LegacyItemAccess, CommandParser):
             # If no data is obtained in the command execution then throw an exception instead of returning an empty
             # object.  Rules depending solely on this parser will not be invoked, so they don't have to
             # explicitly check for invalid data.
-            raise ParseException("Unable to parse db2licm info: {}".format(content))
+            raise ParseException("Unable to parse db2licm info: {0}".format(content))

--- a/insights/parsers/db2licm.py
+++ b/insights/parsers/db2licm.py
@@ -39,8 +39,8 @@ class DB2Info(CommandParser, dict):
 
     Example:
 
-        >>> parser_result.keys()
-        dict_keys(['DB2 Enterprise Server Edition', 'DB2 Connect Server'])
+        >>> list(parser_result.keys())
+        ['DB2 Enterprise Server Edition', 'DB2 Connect Server']
         >>> parser_result['DB2 Enterprise Server Edition']["Version information"]
         '9.7'
 
@@ -54,7 +54,7 @@ class DB2Info(CommandParser, dict):
 
     def parse_content(self, content):
 
-        name = None
+        # name = None
         body = {}
 
         # Input data is available in text file. Reading each line in file and parsing it to a dictionary.
@@ -65,18 +65,12 @@ class DB2Info(CommandParser, dict):
                     continue
             else:
                 raise ParseException("Unable to parse db2licm info: {0}".format(content))
+
             if key == "Product name":
-                if name is None:
-                    name = val
-                else:
-                    self[name] = body
-                    name = val
-                    body = {}
+                body = {}
+                self[val] = body
             else:
                 body[key] = val
-
-        if name and body:
-            self[name] = body
 
         if not self:
             # If no data is obtained in the command execution then throw an exception instead of returning an empty

--- a/insights/parsers/db2licm.py
+++ b/insights/parsers/db2licm.py
@@ -1,0 +1,100 @@
+"""
+IBM DB2 Sever details
+=====================
+
+Module for the processing of output from the ``db2licm -l`` command.
+Data is avaliable as rows of the output contained
+in one ``Record`` object for each line of output.
+"""
+from insights.core.plugins import parser
+from insights.core import CommandParser, LegacyItemAccess
+from insights.parsers import ParseException, get_active_lines
+from insights.specs import Specs
+
+
+@parser(Specs.db2licm_l)
+class DB2Info(LegacyItemAccess, CommandParser):
+    """
+    This parser processes the output of the command `db2licm_l` and provides
+    the information as a dictionary.
+
+    The LegacyItemAccess class provides some helper functions for dealing with a
+    class having a `data` attribute.
+
+    Sample input::
+
+        Product name:                     "DB2 Enterprise Server Edition"
+        License type:                     "CPU Option"
+        Expiry date:                      "Permanent"
+        Product identifier:               "db2ese"
+        Version information:              "9.7"
+        Enforcement policy:               "Soft Stop"
+        Features:
+        DB2 Performance Optimization ESE: "Not licensed"
+        DB2 Storage Optimization:         "Not licensed"
+        DB2 Advanced Access Control:      "Not licensed"
+        IBM Homogeneous Replication ESE:  "Not licensed"
+
+        Product name:                     "DB2 Connect Server"
+        Expiry date:                      "Expired"
+        Product identifier:               "db2consv"
+        Version information:              "9.7"
+        Concurrent connect user policy:   "Disabled"
+        Enforcement policy:               "Soft Stop"
+
+    Example:
+
+        >>> parser_result.data.keys()
+        dict_keys(['DB2 Enterprise Server Edition', 'DB2 Connect Server'])
+        >>> parser_result.data['DB2 Enterprise Server Edition']
+        {'License type': 'CPU Option', 'Expiry date': 'Permanent', 'Product identifier': 'db2ese', 'Version information': '9.7', 'Enforcement policy': 'Soft Stop', 'DB2 Performance Optimization ESE': 'Not licensed', 'DB2 Storage Optimization': 'Not licensed', 'DB2 Advanced Access Control': 'Not licensed', 'IBM Homogeneous Replication ESE': 'Not licensed'}
+        >>> parser_result.data['DB2 Enterprise Server Edition']["Version information"]
+        '9.7'
+
+    Override the base class parse_content to parse the output of the '''db2licm -l'''  command.
+    Information that is stored in the object is made available to the rule plugins.
+
+    Attributes:
+        data (dict): Dictionary containing each of the key:value pairs from the command
+            output.
+
+    Raises:
+        ParseException: raised if data is not parsable.
+    """
+
+    def parse_content(self, content):
+
+        # Stored data in a dictionary data structure
+        self.data = {}
+
+        name = None
+        body = {}
+
+        # Input data is available in text file. Reading each line in file and parsing it to a dictionary.
+        for line in get_active_lines(content):
+            if ':' in line:
+                key, val = line.strip().split(":", 1)
+                key = key.strip()
+                val = val.lstrip()
+                if key == "Features":
+                    continue
+            else:
+                raise ParseException("Unable to parse db2licm info: {}".format(content))
+            if key == "Product name":
+                if name is None:
+                    name = val
+                else:
+                    self.data[name] = body
+                    name = val
+                    body = {}
+            else:
+                body[key.strip()] = val.lstrip(" ")
+
+        if name and body:
+            self.data[name] = body
+
+        if not self.data:
+            # If no data is obtained in the command execution then throw an exception instead of returning an empty
+            # object.  Rules depending solely on this parser will not be invoked, so they don't have to
+            # explicitly check for invalid data.
+            raise ParseException("Unable to parse db2licm info: {}".format(content))

--- a/insights/parsers/db2licm.py
+++ b/insights/parsers/db2licm.py
@@ -3,23 +3,18 @@ IBM DB2 Sever details
 =====================
 
 Module for the processing of output from the ``db2licm -l`` command.
-Data is avaliable as rows of the output contained
-in one ``Record`` object for each line of output.
 """
 from insights.core.plugins import parser
-from insights.core import CommandParser, LegacyItemAccess
+from insights.core import CommandParser
 from insights.parsers import ParseException, get_active_lines
 from insights.specs import Specs
 
 
 @parser(Specs.db2licm_l)
-class DB2Info(LegacyItemAccess, CommandParser):
+class DB2Info(CommandParser, dict):
     """
     This parser processes the output of the command `db2licm_l` and provides
     the information as a dictionary.
-
-    The LegacyItemAccess class provides some helper functions for dealing with a
-    class having a `data` attribute.
 
     Sample input::
 
@@ -44,19 +39,16 @@ class DB2Info(LegacyItemAccess, CommandParser):
 
     Example:
 
-        >>> parser_result.data.keys()
+        >>> parser_result.keys()
         dict_keys(['DB2 Enterprise Server Edition', 'DB2 Connect Server'])
-        >>> parser_result.data['DB2 Enterprise Server Edition']
+        >>> parser_result['DB2 Enterprise Server Edition']
         {'License type': 'CPU Option', 'Expiry date': 'Permanent', 'Product identifier': 'db2ese', 'Version information': '9.7', 'Enforcement policy': 'Soft Stop', 'DB2 Performance Optimization ESE': 'Not licensed', 'DB2 Storage Optimization': 'Not licensed', 'DB2 Advanced Access Control': 'Not licensed', 'IBM Homogeneous Replication ESE': 'Not licensed'}
-        >>> parser_result.data['DB2 Enterprise Server Edition']["Version information"]
+        >>> parser_result['DB2 Enterprise Server Edition']["Version information"]
         '9.7'
 
     Override the base class parse_content to parse the output of the '''db2licm -l'''  command.
     Information that is stored in the object is made available to the rule plugins.
 
-    Attributes:
-        data (dict): Dictionary containing each of the key:value pairs from the command
-            output.
 
     Raises:
         ParseException: raised if data is not parsable.
@@ -64,18 +56,13 @@ class DB2Info(LegacyItemAccess, CommandParser):
 
     def parse_content(self, content):
 
-        # Stored data in a dictionary data structure
-        self.data = {}
-
         name = None
         body = {}
 
         # Input data is available in text file. Reading each line in file and parsing it to a dictionary.
         for line in get_active_lines(content):
             if ':' in line:
-                key, val = line.strip().split(":", 1)
-                key = key.strip()
-                val = val.lstrip()
+                key, val = [i.strip() for i in line.strip().split(":", 1)]
                 if key == "Features":
                     continue
             else:
@@ -84,16 +71,16 @@ class DB2Info(LegacyItemAccess, CommandParser):
                 if name is None:
                     name = val
                 else:
-                    self.data[name] = body
+                    self[name] = body
                     name = val
                     body = {}
             else:
-                body[key.strip()] = val.lstrip(" ")
+                body[key] = val
 
         if name and body:
-            self.data[name] = body
+            self[name] = body
 
-        if not self.data:
+        if not self:
             # If no data is obtained in the command execution then throw an exception instead of returning an empty
             # object.  Rules depending solely on this parser will not be invoked, so they don't have to
             # explicitly check for invalid data.

--- a/insights/parsers/tests/test_db2licm.py
+++ b/insights/parsers/tests/test_db2licm.py
@@ -1,6 +1,8 @@
+import doctest
 import pytest
 from insights.parsers import ParseException
 from insights.tests import context_wrap
+from insights.parsers import db2licm
 from insights.parsers.db2licm import DB2Info
 
 INVALID_OUTPUT = "".strip()
@@ -81,3 +83,12 @@ def test_invalid_command_output():
     with pytest.raises(ParseException) as e:
         DB2Info(context_wrap(INVALID_OUTPUT))
     assert "Unable to parse db2licm info: []" == str(e.value)
+
+
+def test_db2licm_doc_examples():
+    env = {
+        'parser_result': DB2Info(
+            context_wrap(VALID_OUTPUT_MULTIPLE)),
+    }
+    failed, total = doctest.testmod(db2licm, globs=env)
+    assert failed == 0

--- a/insights/parsers/tests/test_db2licm.py
+++ b/insights/parsers/tests/test_db2licm.py
@@ -1,0 +1,83 @@
+import pytest
+from insights.parsers import ParseException
+from insights.tests import context_wrap
+from insights.parsers.db2licm import DB2Info
+
+INVALID_OUTPUT = "".strip()
+
+VALID_OUTPUT = """
+Product name:                     DB2 Enterprise Server Edition
+License type:                     CPU Option
+Expiry date:                      Permanent
+Product identifier:               db2ese
+Version information:              9.7
+Enforcement policy:               Soft Stop
+Features:
+DB2 Performance Optimization ESE: Not licensed
+DB2 Storage Optimization:         Not licensed
+DB2 Advanced Access Control:      Not licensed
+IBM Homogeneous Replication ESE:  Not licensed
+""".strip()
+
+VALID_OUTPUT_MULTIPLE = """
+Product name:                     DB2 Enterprise Server Edition
+License type:                     CPU Option
+Expiry date:                      Permanent
+Product identifier:               db2ese
+Version information:              9.7
+Enforcement policy:               Soft Stop
+Features:
+DB2 Performance Optimization ESE: Not licensed
+DB2 Storage Optimization:         Not licensed
+DB2 Advanced Access Control:      Not licensed
+IBM Homogeneous Replication ESE:  Not licensed
+
+Product name:                     DB2 Connect Server
+Expiry date:                      Expired
+Product identifier:               db2consv
+Version information:              9.7
+Concurrent connect user policy:   Disabled
+Enforcement policy:               Soft Stop
+""".strip()
+
+
+def test_valid_command_output_1():
+    parser_result = DB2Info(context_wrap(VALID_OUTPUT))
+    assert parser_result is not None
+
+    assert parser_result["DB2 Enterprise Server Edition"]["License type"] == "CPU Option"
+    assert parser_result["DB2 Enterprise Server Edition"]["Expiry date"] == "Permanent"
+    assert parser_result["DB2 Enterprise Server Edition"]["Product identifier"] == "db2ese"
+    assert parser_result["DB2 Enterprise Server Edition"]["Version information"] == "9.7"
+    assert parser_result["DB2 Enterprise Server Edition"]["Enforcement policy"] == "Soft Stop"
+    assert parser_result["DB2 Enterprise Server Edition"]["DB2 Performance Optimization ESE"] == "Not licensed"
+    assert parser_result["DB2 Enterprise Server Edition"]["DB2 Storage Optimization"] == "Not licensed"
+    assert parser_result["DB2 Enterprise Server Edition"]["DB2 Advanced Access Control"] == "Not licensed"
+    assert parser_result["DB2 Enterprise Server Edition"]["IBM Homogeneous Replication ESE"] == "Not licensed"
+
+
+def test_valid_command_output_2():
+    parser_result = DB2Info(context_wrap(VALID_OUTPUT_MULTIPLE))
+    assert parser_result is not None
+
+    assert parser_result["DB2 Enterprise Server Edition"]["License type"] == "CPU Option"
+    assert parser_result["DB2 Enterprise Server Edition"]["Expiry date"] == "Permanent"
+    assert parser_result["DB2 Enterprise Server Edition"]["Product identifier"] == "db2ese"
+    assert parser_result["DB2 Enterprise Server Edition"]["Version information"] == "9.7"
+    assert parser_result["DB2 Enterprise Server Edition"]["Enforcement policy"] == "Soft Stop"
+    assert parser_result["DB2 Enterprise Server Edition"]["DB2 Performance Optimization ESE"] == "Not licensed"
+    assert parser_result["DB2 Enterprise Server Edition"]["DB2 Storage Optimization"] == "Not licensed"
+    assert parser_result["DB2 Enterprise Server Edition"]["DB2 Advanced Access Control"] == "Not licensed"
+    assert parser_result["DB2 Enterprise Server Edition"]["IBM Homogeneous Replication ESE"] == "Not licensed"
+
+    assert parser_result["DB2 Connect Server"]["Expiry date"] == "Expired"
+    assert parser_result["DB2 Connect Server"]["Product identifier"] == "db2consv"
+    assert parser_result["DB2 Connect Server"]["Version information"] == "9.7"
+    assert parser_result["DB2 Connect Server"]["Enforcement policy"] == "Soft Stop"
+    assert parser_result["DB2 Connect Server"]["Concurrent connect user policy"] == "Disabled"
+
+
+def test_invalid_command_output():
+    with pytest.raises(ParseException) as e:
+        DB2Info(context_wrap(INVALID_OUTPUT))
+    assert "Unable to parse db2licm info: []" == str(e.value)

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -96,6 +96,7 @@ class Specs(SpecSet):
     date_iso = RegistryPoint()
     date = RegistryPoint()
     date_utc = RegistryPoint()
+    db2licm_l = RegistryPoint()
     dcbtool_gc_dcb = RegistryPoint(multi_output=True)
     df__alP = RegistryPoint()
     df__al = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -209,6 +209,7 @@ class DefaultSpecs(Specs):
     date = simple_command("/bin/date")
     date_iso = simple_command("/bin/date --iso-8601=seconds")
     date_utc = simple_command("/bin/date --utc")
+    db2licm_l = simple_command("/usr/bin/db2licm -l")
     df__al = simple_command("/bin/df -al")
     df__alP = simple_command("/bin/df -alP")
     df__li = simple_command("/bin/df -li")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -32,6 +32,7 @@ class InsightsArchiveSpecs(Specs):
     date = simple_file("insights_commands/date")
     date_iso = simple_file("insights_commands/date_--iso-8601_seconds")
     date_utc = simple_file("insights_commands/date_--utc")
+    db2licm_l = simple_file("insights_commands/db2licm_l")
     df__al = simple_file("insights_commands/df_-al")
     df__alP = simple_file("insights_commands/df_-alP")
     df__li = simple_file("insights_commands/df_-li")


### PR DESCRIPTION
Adde SPEC collects `db2licm -l` command stdout:

```sh
Product name:                     "DB2 Enterprise Server Edition" 
License type:                     "CPU Option" 
Expiry date:                      "Permanent" 
Product identifier:               "db2ese" 
Version information:              "9.7" 
Enforcement policy:               "Soft Stop" 
Features: 
DB2 Performance Optimization ESE: "Not licensed" 
DB2 Storage Optimization:         "Not licensed" 
DB2 Advanced Access Control:      "Not licensed" 
IBM Homogeneous Replication ESE:  "Not licensed" 
```