### PR TITLE
Reorder lspci file path from sos archive

### DIFF
--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -69,8 +69,8 @@ class SosSpecs(Specs):
     lsmod = simple_file("sos_commands/kernel/lsmod")
     lspci = first_of([
         simple_file("sos_commands/pci/lspci_-nnvv"),
-        simple_file("sos_commands/pci/lspci"),
-        simple_file("sos_commands/pci/lspci_-nvv")
+        simple_file("sos_commands/pci/lspci_-nvv"),
+        simple_file("sos_commands/pci/lspci")
     ])
     lsscsi = simple_file("sos_commands/scsi/lsscsi")
     ls_dev = first_file(["sos_commands/block/ls_-lanR_.dev", "sos_commands/devicemapper/ls_-lanR_.dev"])


### PR DESCRIPTION
`lspci_-nvv` provides more verbose information than `lspci`. Hence, reordering
list of lspci files.