### PR TITLE
Fixed problem with --logging-file switch

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -39,7 +39,9 @@ def do_log_rotation():
 def get_file_handler(config):
     log_file = config.logging_file
     log_dir = os.path.dirname(log_file)
-    if not os.path.exists(log_dir):
+    if not log_dir:
+        log_dir = os.getcwd()
+    elif not os.path.exists(log_dir):
         os.makedirs(log_dir, 0o700)
     file_handler = logging.handlers.RotatingFileHandler(
         log_file, backupCount=3)

--- a/insights/tests/client/test_client.py
+++ b/insights/tests/client/test_client.py
@@ -436,3 +436,17 @@ def test_platform_upload_systemd(_, path_exists, read_pidfile, systemd_notify):
     client.upload('test.gar.gz', 'test.content.type')
     read_pidfile.assert_called_once()
     systemd_notify.assert_called_once_with(read_pidfile.return_value)
+
+
+@patch('insights.client.os.path.exists', return_value=True)
+@patch('insights.client.connection.InsightsConnection.upload_archive')
+@patch('insights.client.client._legacy_upload')
+def test_platform_upload_with_no_log_path(_legacy_upload, _, path_exists):
+    '''
+    testing logger when no path is given
+    '''
+    config = InsightsConfig(legacy_upload=True, logging_file='tmp.log')
+    client = InsightsClient(config)
+    response = client.upload('test.gar.gz', 'test.content.type')
+    _legacy_upload.assert_called_once()
+    assert response is not None


### PR DESCRIPTION
Signed-off-by: Alec Cohan <acohale97@gmail.com>

Made fixes to --logging-file switch which now allows files without paths to be logged in the current directory.  

See:  https://projects.engineering.redhat.com/browse/RHCLOUD-2147
for more details on the bug.