### PR TITLE
Fix issue when using local spec with bare file

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -332,7 +332,7 @@ def run(component=None, root=None, print_summary=False,
         broker = dr.Broker()
         broker[ExecutionContext] = ctx
         for spec, content in specs.items():
-            broker[spec] = content if hasattr(spec, 'multi_output') and spec.multi_output else content[-1]
+            broker[spec] = content if dr.DELEGATES[spec].multi_output else content[-1]
     try:
         if formatters:
             for formatter in formatters:

--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -332,7 +332,7 @@ def run(component=None, root=None, print_summary=False,
         broker = dr.Broker()
         broker[ExecutionContext] = ctx
         for spec, content in specs.items():
-            broker[spec] = content if spec.multi_output else content[-1]
+            broker[spec] = content if hasattr(spec, 'multi_output') and spec.multi_output else content[-1]
     try:
         if formatters:
             for formatter in formatters:


### PR DESCRIPTION
* When using a local spec with bare file it may not
  include all attributes such as multi_output.  This
  change insures that the bare file option will still
  work with locally defined specs.

Signed-off-by: Bob Fahr <bfahr@redhat.com>