### PR TITLE
Use package-data for spec installed_rpms too

### DIFF
--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -57,7 +57,7 @@ class SosSpecs(Specs):
     hostname = first_file(["sos_commands/general/hostname_-f", "sos_commands/host/hostname_-f"])
     hostname_default = first_file(["sos_commands/general/hostname", "sos_commands/host/hostname", "/etc/hostname", "hostname"])
     hostname_short = first_file(["sos_commands/general/hostname", "sos_commands/host/hostname", "/etc/hostname", "hostname"])
-    installed_rpms = simple_file("installed-rpms")
+    installed_rpms = first_file(["sos_commands/rpm/package-data", "installed-rpms"])
     ip_addr = first_of([simple_file("sos_commands/networking/ip_-d_address"), simple_file("sos_commands/networking/ip_address")])
     ip_route_show_table_all = simple_file("sos_commands/networking/ip_route_show_table_all")
     ip_s_link = first_of([simple_file("sos_commands/networking/ip_-s_-d_link"), simple_file("sos_commands/networking/ip_-s_link"), simple_file("sos_commands/networking/ip_link")])


### PR DESCRIPTION
* The content in package-data is the same with installed-rpms but it includes more extra fields
  like redhat sign info
Signed-off-by: Huanhuan Li <huali@redhat.com>