### PR TITLE
Allow filtering by full module name and tags. Add rule tags to response json doc.

### DIFF
--- a/docs/api_index.rst
+++ b/docs/api_index.rst
@@ -62,6 +62,14 @@ insights.core.spec_factory
     :show-inheritance:
     :undoc-members:
 
+insights.core.taglang
+--------------------------
+
+.. automodule:: insights.core.taglang
+    :members:
+    :show-inheritance:
+    :undoc-members:
+
 insights.parsers
 ----------------
 

--- a/docs/manpages/insights-info.rst
+++ b/docs/manpages/insights-info.rst
@@ -37,6 +37,9 @@ OPTIONS
     -i COMPONENT --info COMPONENT
         Comma separated list of components to get dependency info about.
 
+    -k --pkg-query
+        Expression to select rules by package.
+
     -p PLUGINS --preload PLUGINS
         Comma separated list of packages or modules to preload.
 
@@ -49,6 +52,9 @@ OPTIONS
     -t TYPES --types TYPES
         Filter results based on component type; e.g. 'rule,parser'. Names without '.'
         are assumed to be in insights.core.plugins.
+
+    \-\-tags EXPRESSION
+        An expression for selecting which loaded rules to run based on their tags.
 
     -v --verbose
         Print component dependencies.

--- a/docs/manpages/insights-run.rst
+++ b/docs/manpages/insights-run.rst
@@ -63,6 +63,9 @@ OPTIONS
         Ansible inventory file for cluster analysis.  See INVENTORY(5) for more information
         about the options for format of the inventory file.
 
+    -k --pkg-query
+        Expression to select rules by package.
+
     -m --missing
         Show missing requirements.
 
@@ -75,6 +78,9 @@ OPTIONS
 
     -t --tracebacks
         Show stack traces when there are errors in components.
+
+    \-\-tags EXPRESSION
+        An expression for selecting which loaded rules to run based on their tags.
 
     -v --verbose
         Verbose output.

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -93,11 +93,13 @@ Options::
    -i --info                                  Comma separated list to get dependency info about
    -p PLUGINS --preload PLUGINS               Comma separated list of packages or modules to preload
    -d --pydoc                                 Show pydoc for the given object. E.g.: insights-info -d insights.rule
+   -k --pkg-query EXPRESSION                  Expression to select rules by package.
    -s --source                                Show source for the given object. E.g.:
                                               Insights-info  -s Insights.core.plugins.rule
    -S --specs                                 Show specs for the given  name. E.g.: insights-info -S uname
    -t TYPES --types TYPES                     Filter results based on component type; e.g. 'rule,parser'.
                                               Names without  '.'  are assumed to be in Insights.core.plugins.
+   \-\-tags EXPRESSION                        An expression for selecting which loaded rules to run based on their tags.
    -v --verbose                               Print component  dependencies.
 
 Examples:

--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -29,6 +29,7 @@ from .core import FileListing, LegacyItemAccess, SysconfigOptions  # noqa: F401
 from .core import YAMLParser, JSONParser, XMLParser, CommandParser  # noqa: F401
 from .core import AttributeDict  # noqa: F401
 from .core import Syslog  # noqa: F401
+from .core import taglang
 from .core.archives import COMPRESSION_TYPES, extract, InvalidArchive, InvalidContentType  # noqa: F401
 from .core import dr  # noqa: F401
 from .core.context import ClusterArchiveContext, HostContext, HostArchiveContext, SerializedArchiveContext, ExecutionContext  # noqa: F401
@@ -180,7 +181,7 @@ def apply_configs(config):
     Args:
         config (dict): a dictionary with the following keys:
             default_component_enabled (bool, optional): default value for
-                whether compoments are enable if not specifically declared in
+                whether components are enable if not specifically declared in
                 the config section. Defaults to True.
 
             configs (list): list of dictionaries with the following keys:
@@ -251,9 +252,11 @@ def run(component=None, root=None, print_summary=False,
                        default="")
         p.add_argument("-c", "--config", help="Configure components.")
         p.add_argument("-i", "--inventory", help="Ansible inventory file for cluster analysis.")
+        p.add_argument("-k", "--pkg-query", help="Expression to select rules by package.")
         p.add_argument("-v", "--verbose", help="Verbose output.", action="store_true")
         p.add_argument("-f", "--format", help="Output format.", default="insights.formats.text")
         p.add_argument("-s", "--syslog", help="Log results to syslog.", action="store_true")
+        p.add_argument("--tags", help="Expression to select rules by tag.")
         p.add_argument("-D", "--debug", help="Verbose debug output.", action="store_true")
         p.add_argument("--context", help="Execution Context. Defaults to HostContext if an archive isn't passed.")
 
@@ -316,6 +319,21 @@ def run(component=None, root=None, print_summary=False,
     if component:
         if not isinstance(component, (list, set)):
             component = [component]
+
+        if args and args.pkg_query:
+            pred = taglang.parse(args.pkg_query)
+            component = [c for c in component if pred([dr.get_module_name(c)])]
+            if not component:
+                msg = "No components for pkg-query expression: %s" % args.pkg_query
+                raise Exception(msg)
+
+        if args and args.tags:
+            pred = taglang.parse(args.tags)
+            component = [c for c in component if pred(dr.get_tags(c))]
+            if not component:
+                msg = "No components for tag expression: %s" % args.tags
+                raise Exception(msg)
+
         graph = {}
         for c in component:
             graph.update(dr.get_dependency_graph(c))

--- a/insights/core/evaluators.py
+++ b/insights/core/evaluators.py
@@ -110,7 +110,8 @@ class SingleEvaluator(Evaluator):
                 "component": dr.get_name(plugin),
                 "type": type_,
                 "key": key,
-                "details": r
+                "details": r,
+                "tags": list(dr.get_tags(plugin))
             }))
 
 

--- a/insights/core/taglang.py
+++ b/insights/core/taglang.py
@@ -1,0 +1,159 @@
+"""
+Simple language for defining predicates against a list or set of strings.
+
+Operator Precedence:
+    - ``!`` high - opposite truth value of its predicate
+    - ``/`` high - starts a regex that continues until whitespace unless quoted
+    - ``&`` medium - "and" of two predicates
+    - ``|`` low - "or" of two predicates
+    - ``,`` low - "or" of two predicates. Synonym for ``|``.
+
+It supports grouping with parentheses and quoted strings/regexes surrounded
+with either single or double quotes.
+
+Examples:
+    >>> pred = parse("a | b & !c")  # means (a or (b and (not c)))
+    >>> pred(["a"])
+    True
+    >>> pred(["b"])
+    True
+    >>> pred(["b", "c"])
+    False
+    >>> pred = parse("/net | apache")
+    >>> pred(["networking"])
+    True
+    >>> pred(["mynetwork"])
+    True
+    >>> pred(["apache"])
+    True
+    >>> pred(["security"])
+    False
+    >>> pred = parse("(a | b) & c")
+    >>> pred(["a", "c"])
+    True
+    >>> pred(["b", "c"])
+    True
+    >>> pred(["a"])
+    False
+    >>> pred(["b"])
+    False
+    >>> pred(["c"])
+    False
+
+Regular expressions start with a forward slash ``/`` and continue until
+whitespace unless they are quoted with either single or double quotes. This
+means that they can consume what would normally be considered an operator or a
+closing parenthesis if you aren't careful.
+
+For example, this is a parse error because the regex consumes the comma:
+    >>> pred = parse("/net, apache")
+    Exception
+
+Instead, do this:
+    >>> pred = parse("/net , apache")
+
+or this:
+    >>> pred = parse("/net | apache")
+
+or this:
+    >>> pred = parse("'/net', apache")
+"""
+import re
+import string
+from insights.parsr import (Char, EOF, Forward, InSet, Many, Opt, String,
+                            QuotedString, WS)
+
+
+class Predicate(object):
+    """
+    Provides __call__ for invoking the Predicate like a function without having
+    to explictly call its test method.
+    """
+
+    def __call__(self, value):
+        return self.test(value)
+
+
+class Eq(Predicate):
+    """ The value must be in the set of values. """
+
+    def __init__(self, value):
+        self.value = value
+
+    def test(self, values):
+        return self.value in values
+
+
+class Regex(Predicate):
+    """ The regex must match at least one of the values. """
+
+    def __init__(self, value):
+        self.regex = re.compile(value)
+
+    def test(self, values):
+        return any(self.regex.search(v) for v in values)
+
+
+class Not(Predicate):
+    """ The values must not satisfy the wrapped condition. """
+
+    def __init__(self, pred):
+        self.pred = pred
+
+    def test(self, value):
+        return not self.pred.test(value)
+
+
+class And(Predicate):
+    """ The values must satisfy both the left and the right condition. """
+
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def test(self, value):
+        return self.left.test(value) and self.right.test(value)
+
+
+class Or(Predicate):
+    """ The values must satisfy either the left or the right condition. """
+
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def test(self, value):
+        return self.left.test(value) or self.right.test(value)
+
+
+def negate(args):
+    op, p = args
+    return Not(p) if op else p
+
+
+def oper(args):
+    left, rest = args
+    for op, right in rest:
+        if op == "&":
+            left = And(left, right)
+        if op in ",|":
+            left = Or(left, right)
+    return left
+
+
+expr = Forward()
+
+bare = String(set(string.printable) - (set(string.whitespace) | set(")&,|")))
+
+tag = (QuotedString | bare).map(Eq)
+
+regex_body = QuotedString | String(set(string.printable) - set(string.whitespace))
+regex = Char("/") >> regex_body.map(Regex)
+
+factor_body = ((Char("(") >> expr << Char(")")) | regex | tag)
+factor = (WS >> Opt(Char("!")) + factor_body << WS).map(negate)
+
+term = (factor + Many(Char("&") + factor)).map(oper)
+expr <= (term + Many(InSet(",|") + term)).map(oper)
+
+parse = expr << EOF

--- a/insights/formats/template.py
+++ b/insights/formats/template.py
@@ -64,7 +64,8 @@ class TemplateFormat(Formatter):
             body: rendered content for the rule as provided in the rule module.
             mod_doc: pydoc of the module containing the rule
             rule_doc: pydoc of the rule
-            rule_path: absolute path to the source file of the rule
+            source_path: absolute path to the source file of the rule
+            tags: the list of tags associated with the rule
             datasources: sorted list of command or files contributing to the rule
         """
         if comp in broker:
@@ -79,6 +80,7 @@ class TemplateFormat(Formatter):
                 "mod_doc": sys.modules[comp.__module__].__doc__ or "",
                 "rule_doc": comp.__doc__ or "",
                 "source_path": inspect.getabsfile(comp),
+                "tags": list(dr.get_tags(comp)),
                 "datasources": sorted(set(self.get_datasources(comp, broker)))
             })
 

--- a/insights/tests/test_taglang.py
+++ b/insights/tests/test_taglang.py
@@ -1,0 +1,102 @@
+from insights.core.taglang import parse
+
+
+def test_simple():
+    pred = parse("security")
+    assert pred(["security"])
+    assert not pred(["logging"])
+
+
+def test_regex():
+    """
+    Regexes start with a forward slash (/). If they must contain spaces,
+    enclose the regex after the forward slash in quotes.
+    """
+    pred = parse("/net")
+    assert pred(["networking"])
+    assert pred(["tenet"])
+    assert not pred(["security"])
+
+    pred = parse("/^net")
+    assert pred(["networking"])
+    assert not pred(["tenet"])
+    assert not pred(["security"])
+
+    pred = parse("/'net work'")
+    assert pred(["net work"])
+    assert not pred(["networking"])
+    assert not pred(["tenet"])
+    assert not pred(["security"])
+
+
+def test_negation():
+    pred = parse("!security")
+    assert not pred(["security", "logging"])
+    assert not pred(["security"])
+    assert pred(["logging"])
+    assert pred(["jboss"])
+    assert pred([])
+
+
+def test_conjunction():
+    pred = parse("security & logging")
+    assert pred(["security", "logging"])
+    assert not pred(["security"])
+    assert not pred(["logging"])
+
+
+def test_disjunction():
+    pred = parse("security | logging")
+    assert pred(["security", "logging"])
+    assert pred(["security"])
+    assert pred(["logging"])
+    assert not pred(["jboss"])
+
+    # , is a synonym for |
+    pred = parse("security, logging")
+    assert pred(["security", "logging"])
+    assert pred(["security"])
+    assert pred(["logging"])
+    assert not pred(["jboss"])
+
+
+def test_precedence():
+    """ ! binds more strongly than &, which binds more strongly than | """
+    pred = parse("security | logging & !jboss")
+    assert pred(["security"])
+    assert pred(["logging"])
+    assert not pred(["logging", "jboss"])
+    assert not pred(["apache", "jboss"])
+
+
+def test_grouping():
+    pred = parse("(security | logging) & jboss")
+    assert pred(["security", "jboss"])
+    assert pred(["logging", "jboss"])
+    assert not pred(["security", "logging"])
+    assert not pred(["security"])
+    assert not pred(["logging"])
+    assert not pred(["jboss"])
+
+
+def test_regex_in_group():
+    """
+    A regex at the end of a group must have a space before the closing paren
+    or the paren will be considered part of the regex.
+    """
+    pred = parse("(security | /logging ) & jboss")
+    assert pred(["security", "jboss"])
+    assert pred(["logging", "jboss"])
+    assert not pred(["security", "logging"])
+    assert not pred(["security"])
+    assert not pred(["logging"])
+    assert not pred(["jboss"])
+
+
+def test_quoted_string():
+    # notice the entire string is quoted, so it's a single tag instead of
+    # multiple tags connected by operators.
+    pred = parse("'(security | /logging ) & jboss'")
+    assert pred(['(security | /logging ) & jboss'])
+    assert not pred(["security", "jboss"])
+    assert not pred(["logging", "jboss"])

--- a/insights/tools/query.py
+++ b/insights/tools/query.py
@@ -23,11 +23,14 @@ import logging
 import pydoc
 import re
 import sys
+import yaml
 
 from six.moves import StringIO
 
-from insights import dr, get_filters
+from insights import (apply_default_enabled, apply_configs, dr, get_filters,
+        load_default_plugins, load_packages, parse_plugins)
 from insights.core.plugins import datasource, is_type
+from insights.core import taglang
 from insights.core import spec_factory as sf
 
 logging.basicConfig(level=logging.ERROR)
@@ -79,34 +82,28 @@ def parse_args():
     p = argparse.ArgumentParser(__doc__.strip())
     p.add_argument("paths", nargs="*", help="Files or commands to use for component activation.")
     p.add_argument("-c", "--components", help="Comma separated list of components that have already executed. Names without '.' are assumed to be in insights.specs.Specs.")
+    p.add_argument("--config", help="Configure components.")
     p.add_argument("-i", "--info", help="Comma separated list of components to get dependency info about.", action="store_true")
     p.add_argument("-p", "--preload", help="Comma separated list of packages or modules to preload.")
     p.add_argument("-d", "--pydoc", help="Show pydoc for the given object. E.g.: insights-info -d insights.rule")
+    p.add_argument("-k", "--pkg-query", help="Expression to select rules by package.")
     p.add_argument("-s", "--source", help="Show source for the given object. E.g.: insights-info -s insights.core.plugins.rule")
     p.add_argument("-S", "--specs", help="Show specs for the given name.  E.g.: insights-info -S uname", action="store_true")
+    p.add_argument("--tags", help="Expression to select rules by tag.")
     p.add_argument("-t", "--types", help="Filter results based on component type; e.g. 'rule,parser'. Names without '.' are assumed to be in insights.core.plugins.")
     p.add_argument("-v", "--verbose", help="Print component dependencies.", action="store_true")
     return p.parse_args()
 
 
 def load_default_components():
-    default_packages = [
-        "insights.specs.default",
-        "insights.specs.insights_archive",
-        "insights.specs.sos_archive",
-        "insights.specs.jdr_archive",
-        "insights.parsers",
-        "insights.combiners",
-    ]
-
-    for p in default_packages:
-        dr.load_components(p, continue_on_error=False)
+    load_default_plugins()
+    dr.load_components("insights.parsers", continue_on_error=False)
+    dr.load_components("insights.combiners", continue_on_error=False)
 
 
 def preload_components(comps):
-    if comps:
-        for c in comps.split(","):
-            dr.load_components(c.strip(), continue_on_error=False)
+    plugins = parse_plugins(comps)
+    load_packages(plugins)
 
 
 def get_components(comps, default_module):
@@ -299,6 +296,11 @@ def print_component(comp, verbose=False, specs=False):
         print(space + "Dependents:")
         for r in sorted(dependents, key=dr.get_name):
             print(dbl_space + dr.get_name(r))
+    tags = dr.get_tags(comp)
+    if tags:
+        print(space + "Tags:")
+        for r in sorted(tags):
+            print(dbl_space + r)
     print()
 
 
@@ -342,6 +344,14 @@ def get_pydoc(spec):
         return output.read()
 
 
+def apply_configuration(path):
+    with open(path) as f:
+        config = yaml.safe_load(f)
+        load_packages(config.get('packages', []))
+        apply_default_enabled(config)
+        apply_configs(config)
+
+
 def main():
     if "" not in sys.path:
         sys.path.insert(0, "")
@@ -358,22 +368,52 @@ def main():
         print(doc or "{} has no pydoc.".format(args.pydoc))
         return
 
-    load_default_components()
-    preload_components(args.preload)
-
     if args.info:
+        if args.config:
+            apply_configuration(args.config)
         dump_info(args.paths)
         return
 
-    types = get_components(args.types, "insights.core.plugins")
+    load_default_components()
+
+    if args.preload:
+        preload_components(args.preload)
+
+    if args.config:
+        apply_configuration(args.config)
+
+    types = tuple(get_components(args.types, "insights.core.plugins"))
+
+    if args.pkg_query:
+        pred = taglang.parse(args.pkg_query)
+
+        def pkg_query(c):
+            return pred([dr.get_module_name(c)])
+    else:
+        def pkg_query(c):
+            return True
+
+    if args.tags:
+        pred = taglang.parse(args.tags)
+
+        def tags_query(c):
+            return pred(dr.get_tags(c))
+    else:
+        def tags_query(c):
+            return True
 
     components = get_components(args.components, "insights.specs.Specs")
+
+    if not args.paths:
+        components = [c for c in list(dr.DELEGATES) if pkg_query(c) and tags_query(c)]
+        print_results(components, types, args.verbose, args.specs)
+        return
+
     ds = get_matching_datasources(args.paths)
 
     broker = create_broker(components + ds)
-    results = dry_run(broker=broker)
-
-    print_results(results, tuple(types), args.verbose, args.specs)
+    results = [r for r in dry_run(broker=broker) if pkg_query(r) and tags_query(r)]
+    print_results(results, types, args.verbose, args.specs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
All components have a `tags` keyword in their decorators, and the values defined there can be overridden in configuration. This PR provides a `--tags` option to `insights run` that allows users to express which rules they want to run based on how they're tagged.

Tag expressions are written in a simple language that allows exact match, regular expression match, quoted strings or regexes, and grouping along with operators for negation, `and`, and `or`.

For example, `insights run -p telemetry --tags 'network & apache & !mod_cluster'` means select rules that have the `network` and `apache` tags but not a `mod_cluster` tag.

`insights-run` also has a `-k` option that applies the same expression language to the full module names of loaded components. If `-k` and `--tags` are used at the same time, the effect is an intersection of their selected rules. In other words, load components with `-p`, filter them by full module name with `-k`, and select from what's left with `--tags`.

For example, `insights run -p telemetry -k '/networking & !/bond'` means load all of the telemetry rules and run only those that have "networking" in the full module name but that don't have "bond" in the full module name.

The same `-k` and `--tags` options are available for `insights info`.

This PR also adds the tags for a rule to any result it contributes to the json or yaml output.

Signed-off-by: Christopher Sams <csams@redhat.com>