### PR TITLE
Enhance bond Parser to parser ARP lines

### DIFF
--- a/insights/parsers/bond.py
+++ b/insights/parsers/bond.py
@@ -94,6 +94,8 @@ class Bond(Parser):
         self._partner_mac_address = None
         self._active_slave = None
         self.xmit_hash_policy = None
+        self._arp_polling_interval = None
+        self._arp_ip_target = None
         self._slave_interface = []
         self._aggregator_id = []
         self._mii_status = []
@@ -129,6 +131,10 @@ class Bond(Parser):
                 self._slave_speed.append(line.strip().split(':', 1)[1].strip())
             elif line.strip().startswith("Duplex: "):
                 self._slave_duplex.append(line.strip().split(':', 1)[1].strip())
+            elif line.strip().startswith("ARP Polling Interval (ms):"):
+                self._arp_polling_interval = line.strip().split(':', 1)[1].strip()
+            elif line.strip().startswith("ARP IP target/s (n.n.n.n form):"):
+                self._arp_ip_target = line.strip().split(':', 1)[1].strip()
 
     @property
     def bond_mode(self):
@@ -201,3 +207,17 @@ class Bond(Parser):
         bond file, ``[]`` is returned.
         """
         return self._slave_duplex
+
+    @property
+    def arp_polling_interval(self):
+        """Returns the arp polling interval as a string. ``None`` is returned
+        if no "ARP Polling Interval (ms)" key is found.
+        """
+        return self._arp_polling_interval
+
+    @property
+    def arp_ip_target(self):
+        """Returns the arp ip target as a string. ``None`` is returned
+        if no "ARP IP target/s (n.n.n.n form)" key is found.
+        """
+        return self._arp_ip_target

--- a/insights/parsers/tests/test_bond.py
+++ b/insights/parsers/tests/test_bond.py
@@ -140,6 +140,36 @@ Slave queue ID: 0
 
 BONDINFO_MODE_6 = BONDINFO_MODE_5.replace("Currently Active Slave: enp17s0f0", "")
 
+BONDINFO_MODE_7 = """
+Ethernet Channel Bonding Driver: v3.7.1 (April 27, 2011)
+
+Bonding Mode: fault-tolerance (active-backup)
+Primary Slave: em3 (primary_reselect failure)
+Currently Active Slave: em3
+MII Status: up
+MII Polling Interval (ms): 0
+Up Delay (ms): 0
+Down Delay (ms): 0
+ARP Polling Interval (ms): 1000
+ARP IP target/s (n.n.n.n form): 10.152.1.1
+
+Slave Interface: em3
+MII Status: up
+Speed: 1000 Mbps
+Duplex: full
+Link Failure Count: 92028
+Permanent HW addr: 00:1f:f3:af:d3:f1
+Slave queue ID: 0
+
+Slave Interface: p2p3
+MII Status: up
+Speed: 1000 Mbps
+Duplex: full
+Link Failure Count: 71524
+Permanent HW addr: 00:1f:f3:af:d3:f1
+Slave queue ID: 0
+""".strip()
+
 
 def test_netstat_doc_examples():
     env = {
@@ -186,6 +216,13 @@ def test_bond_class():
     assert bond_obj_3.slave_speed == ['1000 Mbps', '1000 Mbps']
     assert bond_obj_3.slave_link_failure_count == ['0', '0']
     assert bond_obj_3.mii_status == ['up', 'up', 'up']
+    assert bond_obj_3.arp_polling_interval is None
+    assert bond_obj_3.arp_ip_target is None
+
+    bond_obj_4 = Bond(context_wrap(BONDINFO_MODE_7, CONTEXT_PATH))
+    assert bond_obj_4.file_name == 'bond0'
+    assert bond_obj_4.arp_polling_interval == "1000"
+    assert bond_obj_4.arp_ip_target == "10.152.1.1"
 
     with pytest.raises(ParseException) as exc:
         bond_obj = Bond(context_wrap(BONDINFO_UNKNOWN_BOND_MODE, CONTEXT_PATH))


### PR DESCRIPTION
Enhance `bond.py` parser to read "ARP Polling Interval" and "ARP IP target" lines.