### PR TITLE
Change AnyChar to mean any character instead of only ascii printables

### DIFF
--- a/insights/combiners/tests/test_httpd_conf_tree.py
+++ b/insights/combiners/tests/test_httpd_conf_tree.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from insights.combiners.httpd_conf import (_HttpdConf, HttpdConfTree, _HttpdConfSclHttpd24,
     HttpdConfSclHttpd24Tree, _HttpdConfSclJbcsHttpd24, HttpdConfSclJbcsHttpd24Tree)
 from insights.tests import context_wrap
@@ -466,6 +467,14 @@ DNSSDEnable on
 """.strip()  # noqa W293
 
 
+UNICODE_COMMENTS = """
+#Alterações realizadas por issue no Insights
+DNSSDEnable on
+#DNSSDAutoRegisterVHosts on
+#DNSSDAutoRegisterUserDir on
+"""
+
+
 def test_mixed_case_tags():
     httpd = _HttpdConf(context_wrap(HTTPD_CONF_MIXED, path='/etc/httpd/conf/httpd.conf'))
     assert httpd.find("ServerLimit").value == 256
@@ -744,3 +753,11 @@ def test_regex_and_op_attrs():
 
     if_version = result["IfVersion"]
     assert len(if_version) == 1
+
+
+def test_unicode_comments():
+    httpd = _HttpdConf(context_wrap(UNICODE_COMMENTS, path='/etc/httpd/conf/httpd.conf'))
+    result = HttpdConfTree([httpd])
+
+    rewrite_cond = result["DNSSDEnable"]
+    assert len(rewrite_cond) == 1

--- a/insights/combiners/tests/test_logrotate_conf_tree.py
+++ b/insights/combiners/tests/test_logrotate_conf_tree.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from insights.parsr.query import first
 from insights.combiners.logrotate_conf import _LogRotateConf, LogRotateConfTree
 from insights.tests import context_wrap
@@ -49,6 +50,22 @@ include /etc/logrotate.d
 """.strip()
 
 
+JUNK_SPACE = """
+#SEG_15.06.01 
+/var/log/spooler
+{
+    compress
+    missingok
+    rotate 30
+    size 1M
+    sharedscripts
+    postrotate
+        /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+    endscript
+}
+""".strip()
+
+
 def test_logrotate_tree():
     p = _LogRotateConf(context_wrap(CONF, path="/etc/logrotate.conf"))
     conf = LogRotateConfTree([p])
@@ -59,3 +76,9 @@ def test_logrotate_tree():
     assert len(conf["/var/log/btmp"]["rotate"]) == 1
     assert len(conf["/var/log/btmp"]["postrotate"]) == 1
     assert conf["/var/log/btmp"]["postrotate"][first].value == "do some stuff to btmp"
+
+
+def test_junk_space():
+    p = _LogRotateConf(context_wrap(JUNK_SPACE, path="/etc/logrotate.conf"))
+    conf = LogRotateConfTree([p])
+    assert "compress" in conf["/var/log/spooler"]

--- a/insights/parsr/__init__.py
+++ b/insights/parsr/__init__.py
@@ -335,6 +335,16 @@ class Parser(with_metaclass(_ParserMeta, Node)):
         return self.name or self.__class__.__name__
 
 
+class AnyChar(Parser):
+    def process(self, pos, data, ctx):
+        c = data[pos]
+        if c is not None:
+            return (pos + 1, c)
+        msg = "Expected any character."
+        ctx.set(pos, msg)
+        raise Exception(msg)
+
+
 class Char(Parser):
     """
     Char matches a single character.
@@ -1040,7 +1050,7 @@ class OneLineComment(Parser):
     """
     def __init__(self, s):
         super(OneLineComment, self).__init__()
-        p = Literal(s) >> Opt(String(set(string.printable) - set("\r\n")), "")
+        p = Literal(s) >> Opt(AnyChar.until(InSet("\r\n")), "")
         self.add_child(p)
 
     def process(self, pos, data, ctx):
@@ -1179,7 +1189,7 @@ RightParen = Char(")")
 Colon = Char(":")
 SemiColon = Char(";")
 Comma = Char(",")
-AnyChar = InSet(string.printable) % "Any Char"
+AnyChar = AnyChar()
 NonZeroDigit = InSet(set(string.digits) - set("0"))
 Digit = InSet(string.digits) % "Digit"
 Digits = String(string.digits) % "Digits"


### PR DESCRIPTION
We've had a couple instances of comments containing unicode characters. I patched logrotate with #2218 but realized there's a more general solution after seeing #2219.

This PR fixes #2219 and should also fix the issue I hacked around in #2218 

Signed-off-by: Christopher Sams <csams@redhat.com>