### PR TITLE
Fix issues with in ceph version parser.

### DIFF
--- a/insights/parsers/ceph_version.py
+++ b/insights/parsers/ceph_version.py
@@ -58,6 +58,7 @@ community_to_release_map = {
     "12.2.8-52": {'version': "3.2", 'major': '3', 'minor': '2', 'downstream_release': '0'},
     "12.2.8-89": {'version': "3.2.1", 'major': '3', 'minor': '2', 'downstream_release': '1'},
     "12.2.8-128": {'version': "3.2.2", 'major': '3', 'minor': '2', 'downstream_release': '2'},
+    "12.2.12-45": {'version': "3.3", 'major': '3', 'minor': '3', 'downstream_release': '0'},
 }
 
 
@@ -91,7 +92,7 @@ class CephVersion(CommandParser):
 
         ceph_version_line = content[-1]
         # re search pattern
-        pattern_community = r'((\d{1,2})\.(\d{1,2})\.((\d{1,2})|x))((\-(\d{1,2}))?)'
+        pattern_community = r'((\d{1,2})\.(\d{1,2})\.((\d{1,2})|x))((\-(\d+)))'
         community_version_mo = re.search(pattern_community, str(ceph_version_line), 0)
         if not community_version_mo:
             raise CephVersionError("Wrong Format Ceph Version", content)

--- a/insights/parsers/tests/test_ceph_version.py
+++ b/insights/parsers/tests/test_ceph_version.py
@@ -9,10 +9,11 @@ CV3 = "error"
 CV4 = "ceph version 10.2.2-38.el7cp (b83334e01379f267fb2f9ce729d74a0a8fa1e92c)"
 CV5 = "ceph version 1"
 CV6 = "ceph version 1.2.3-5"
-CV_5 = "ceph version 10.2.5 (c461ee19ecbc0c5c330aca20f7392c9a00730367)"
+CV_5 = "ceph version 10.2.5-37.el7cp (c461ee19ecbc0c5c330aca20f7392c9a00730367)"
 CV7 = "ceph version 10.2.5-37.el7cp (033f137cde8573cfc5a4662b4ed6a63b8a8d1464)"
 CV8 = "ceph version 10.2.7-27.el7cp (abcd137cde8573cfc5a4662b4ed6a63b8a8kadf1)"
 CV9 = "ceph version 12.2.5-59.el7cp (d4b9f17b56b3348566926849313084dd6efc2ca2)"
+CV10 = "ceph version 12.2.8-128.el7cp (030358773c5213a14c1444a5147258672b2dc15f)"
 
 
 def test_ceph_version():
@@ -64,3 +65,9 @@ def test_ceph_version():
     assert ceph_version9.major == '3'
     assert ceph_version9.minor == "1"
     assert ceph_version9.downstream_release == "1"
+
+    ceph_version10 = CephVersion(context_wrap(CV10))
+    assert ceph_version10.version == "3.2.2"
+    assert ceph_version10.major == '3'
+    assert ceph_version10.minor == "2"
+    assert ceph_version10.downstream_release == "2"


### PR DESCRIPTION
Fixed the regex issue in the 'ceph_version.py' parser file.
Also updated the community_to_release_map to add new Ceph release.

Signed-off-by: Ashish Singh <assingh@redhat.com>