### PR TITLE
Create continue_on_error flag for lists of parsers

### DIFF
--- a/insights/combiners/httpd_conf.py
+++ b/insights/combiners/httpd_conf.py
@@ -338,7 +338,7 @@ def parse_doc(content, ctx=None):
     return Entry(children=result, src=ctx)
 
 
-@parser(Specs.httpd_conf)
+@parser(Specs.httpd_conf, continue_on_error=False)
 class _HttpdConf(ConfigParser):
     """ Parser for individual httpd configuration files. """
     def __init__(self, *args, **kwargs):
@@ -370,7 +370,7 @@ class HttpdConfTree(ConfigCombiner):
         return res.value if res else "/etc/httpd"
 
 
-@parser(Specs.httpd_conf_scl_httpd24)
+@parser(Specs.httpd_conf_scl_httpd24, continue_on_error=False)
 class _HttpdConfSclHttpd24(ConfigParser):
     """ Parser for individual httpd configuration files. """
     def parse_doc(self, content):
@@ -395,7 +395,7 @@ class HttpdConfSclHttpd24Tree(ConfigCombiner):
         return res.value if res else "/opt/rh/httpd24/root/etc/httpd"
 
 
-@parser(Specs.httpd_conf_scl_jbcs_httpd24)
+@parser(Specs.httpd_conf_scl_jbcs_httpd24, continue_on_error=False)
 class _HttpdConfSclJbcsHttpd24(ConfigParser):
     """ Parser for individual httpd configuration files. """
     def parse_doc(self, content):

--- a/insights/combiners/logrotate_conf.py
+++ b/insights/combiners/logrotate_conf.py
@@ -198,7 +198,7 @@ def parse_doc(content, ctx=None):
     return Entry(children=result, src=ctx)
 
 
-@parser(Specs.logrotate_conf)
+@parser(Specs.logrotate_conf, continue_on_error=False)
 class _LogRotateConf(ConfigParser):
     def parse_doc(self, content):
         return parse_doc("\n".join(content), ctx=self)

--- a/insights/combiners/nginx_conf.py
+++ b/insights/combiners/nginx_conf.py
@@ -33,7 +33,7 @@ class EmptyQuotedString(Parser):
         return self.children[0].process(pos, data, ctx)
 
 
-@parser(Specs.nginx_conf)
+@parser(Specs.nginx_conf, continue_on_error=False)
 class _NginxConf(ConfigParser):
     def __init__(self, *args, **kwargs):
         def to_entry(name, attrs, body):

--- a/insights/tests/test_parser_continue_on_error.py
+++ b/insights/tests/test_parser_continue_on_error.py
@@ -1,0 +1,39 @@
+from insights import dr, parser
+from insights.core.plugins import component
+
+
+@component()
+def data():
+    return [1, 2, 3, 4, 5]
+
+
+@parser(data)
+class Lax(object):
+    count = 0
+
+    def __init__(self, d):
+        if Lax.count > 3:
+            raise Exception("Lax")
+        Lax.count += 1
+
+
+@parser(data, continue_on_error=False)
+class Boom(object):
+    count = 0
+
+    def __init__(self, d):
+        if Boom.count > 3:
+            raise Exception("Boom")
+        Boom.count += 1
+
+
+def test_dont_continue_on_error():
+    Boom.count = 0
+    broker = dr.run(Boom)
+    assert Boom not in broker
+
+
+def test_continue_on_error():
+    Lax.count = 0
+    broker = dr.run(Lax)
+    assert len(broker[Lax]) == 4


### PR DESCRIPTION
Some parsers that consume multi_output specs like globs, like ethtool,
can succeed or fail independently. However, configuration parsers that
are combined to form one config tree should succeed or fail as a unit.
Otherwise, rules would get an incorrect view of the configuration.

Fixes #2208

Signed-off-by: Christopher Sams <csams@redhat.com>