### PR TITLE
Ability to attach urls in rule decorators

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -217,8 +217,12 @@ def apply_configs(config):
                     if hasattr(c, k):
                         log.debug("Setting %s.%s to %s", cname, k, v)
                         setattr(c, k, v)
+
                 if hasattr(c, "timeout"):
                     c.timeout = comp_cfg.get("timeout", c.timeout)
+
+                if hasattr(delegate, "links"):
+                    delegate.links = comp_cfg.get("links", delegate.links)
             if cname == name:
                 break
 

--- a/insights/core/evaluators.py
+++ b/insights/core/evaluators.py
@@ -111,7 +111,8 @@ class SingleEvaluator(Evaluator):
                 "type": type_,
                 "key": key,
                 "details": r,
-                "tags": list(dr.get_tags(plugin))
+                "tags": list(dr.get_tags(plugin)),
+                "links": dr.get_delegate(plugin).links or {}
             }))
 
 

--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -279,12 +279,17 @@ class rule(PluginType):
             ``CONTENT`` variable is declared in the module, it will be used for
             every rule in the module and also can be a string or list of
             dictionaries
+        links (dict): a dictionary with strings as keys and lists of urls as
+            values. The keys categorize the urls, e.g. "kcs" for kcs urls and
+            "bugzilla" for bugzilla urls.
     """
     content = None
+    links = None
 
     def __init__(self, *args, **kwargs):
         super(rule, self).__init__(*args, **kwargs)
         self.content = kwargs.get("content")
+        self.links = kwargs.get("links")
 
     def process(self, broker):
         """

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -79,6 +79,19 @@ class HtmlFormat(TemplateFormat):
                 {%- endfor %}
                 </ol>
                 <hr />
+                Links:
+                <ul>
+                {% for cat, links in rule.links.items() %}
+                  <li>{{cat}}
+                  <ul>
+                  {% for link in links %}
+                  <li><a href="{{link}}">{{link}}</a></li>
+                  {% endfor %}
+                  </ul>
+                  </li>
+                {%- endfor %}
+                </ul>
+                <hr />
                 Rule source: {{rule.source_path}}
                 <hr />
           Documentation:

--- a/insights/formats/simple_html.py
+++ b/insights/formats/simple_html.py
@@ -101,6 +101,20 @@ Contributing Data:
           </p>
 
           <hr />
+          Links:
+          <ul>
+          {% for cat, links in rule.links.items() %}
+            <li>{{cat}}
+            <ul>
+            {% for link in links %}
+            <li><a class="source" href="{{link}}">{{link}}</a></li>
+            {% endfor %}
+            </ul>
+            </li>
+          {%- endfor %}
+          </ul>
+
+          <hr />
           <p> Rule Source: <a class="source" href="file://{{rule.source_path}}">{{rule.source_path}}</a></p>
 
           <hr />

--- a/insights/formats/template.py
+++ b/insights/formats/template.py
@@ -72,6 +72,7 @@ class TemplateFormat(Formatter):
             name = dr.get_name(comp)
             rule_id = name.replace(".", "_")
             val = broker[comp]
+            links = dr.get_delegate(comp).links or {}
             self.rules.append({
                 "name": name,
                 "id": rule_id,
@@ -81,7 +82,8 @@ class TemplateFormat(Formatter):
                 "rule_doc": comp.__doc__ or "",
                 "source_path": inspect.getabsfile(comp),
                 "tags": list(dr.get_tags(comp)),
-                "datasources": sorted(set(self.get_datasources(comp, broker)))
+                "datasources": sorted(set(self.get_datasources(comp, broker))),
+                "links": links
             })
 
     def preprocess(self):


### PR DESCRIPTION
The value of the links keyword must be a dictionary with strings as keys and lists of urls as values.

Example:
```
LINKS = {
    "kcs": [
        "https://access.redhat.com/solutions/3237861"
    ],
    "bugzilla": [
        "https://bugzilla.redhat.com/show_bug.cgi?id=1508644",
        "https://bugzilla.redhat.com/show_bug.cgi?id=1531456"
    ]
}

@rule(..., links=LINKS)
def report(...):
    ...
```

Links are included in the json and yaml responses. They're also shown in the simple_html and html output formats.

Signed-off-by: Christopher Sams <csams@redhat.com>