### PR TITLE
Allow attribute navigation for parsr query results. Add ability to search based on child nodes.

### DIFF
--- a/docs/notebooks/Parsr Query Tutorial.ipynb
+++ b/docs/notebooks/Parsr Query Tutorial.ipynb
@@ -694,13 +694,176 @@
     "editable": true
    },
    "source": [
+    "## Attribute Access\n",
+    "If you don't have any predicates for a node, and its name doesn't conflict with an attribute of the underlying object (which should be rare), you can use attribute access to query for it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Require: all denied\n",
+       "Require: all granted\n",
+       "Require: all granted\n",
+       "Require: all granted\n",
+       "Require: all granted\n",
+       "Require: method GET POST OPTIONS\n",
+       "Require: all granted"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conf.doc.Directory.Require"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "## Query by Children\n",
+    "If you want to query for nodes based on values of their children, you can use a `where` clause. It has a few different modes of use.\n",
+    "\n",
+    "The first is the same name and value queries as before:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Directory /]\n",
+       "    AllowOverride: none\n",
+       "    Require: all denied"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conf.doc.Directory.where(\"Require\", \"denied\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "The second is by using the `make_child_query` helper that lets you combine multiple \"top\" level queries that include name and value queries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Directory /home/*/public_html]\n",
+       "    AllowOverride: FileInfo AuthConfig Limit Indexes\n",
+       "    Options: MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec\n",
+       "    Require: method GET POST OPTIONS\n",
+       "\n",
+       "[Directory /]\n",
+       "    AllowOverride: none\n",
+       "    Require: all denied"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from insights.parsr.query import make_child_query as q\n",
+    "\n",
+    "conf.doc.Directory.where(q(\"Require\", \"denied\") | q(\"AllowOverride\", \"FileInfo\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note you can continue the traversal after a where:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Options: MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "res = conf.doc.Directory.where(q(\"Require\", \"denied\") | q(\"AllowOverride\", \"FileInfo\"))\n",
+    "res.Options"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "The name and value queries inside of `q` can contain all of the predicates we've seen before, and `q` instances can be combined with `&` and `|` and negated with `~`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
     "## Truth and Iteration\n",
     "Nodes are \"truthy\" depending on whether they have children. They're also iterable and indexable."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -759,7 +922,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -796,7 +959,7 @@
        " 'User']"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -818,7 +981,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 22,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -833,7 +996,7 @@
       "Value: /etc/httpd\n",
       "Attributes: ['/etc/httpd']\n",
       "Children: 0\n",
-      "Parent: None\n",
+      "Parent: \n",
       "Root: ServerRoot: /etc/httpd\n",
       "File:  /etc/httpd/conf/httpd.conf\n",
       "Original Line: ServerRoot \"/etc/httpd\"\n",
@@ -856,7 +1019,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -876,6 +1039,38 @@
     "port = conf.find(\"Listen\").value\n",
     "print port\n",
     "print type(port)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There's also a `.values` property that will accumulate all of the attributes of multiple children that match a query. Multiple attributes from a single child are converted to a single string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Indexes FollowSymLinks',\n",
+       " 'None',\n",
+       " 'Indexes MultiViews FollowSymlinks',\n",
+       " 'MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec']"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conf[\"Directory\"][\"Options\"].values"
    ]
   },
   {
@@ -902,7 +1097,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 25,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -915,7 +1110,7 @@
        "ServerRoot: /etc/httpd"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -926,7 +1121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 26,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -940,7 +1135,7 @@
        "Alias: /.noindex.html /usr/share/httpd/noindex/index.html"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -951,9 +1146,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 27,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -964,7 +1161,7 @@
        "LogFormat: %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O combinedio"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -985,7 +1182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 28,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -1008,7 +1205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 29,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -1042,7 +1239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 30,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -1082,7 +1279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 31,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -1095,7 +1292,7 @@
        "LogFormat: %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O combinedio"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1106,7 +1303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 32,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -1119,7 +1316,7 @@
        "LogFormat: %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O combinedio"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1146,7 +1343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 33,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -1197,7 +1394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 34,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -1214,7 +1411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 35,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -1225,8 +1422,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Num IfModules: 9\n",
-      "User mod checks: 10\n",
+      "Num IfModules: 8\n",
+      "User mod checks: 9\n",
       "Div by 10? Listen: 80\n",
       "Div by 3? No matches\n"
      ]
@@ -1256,7 +1453,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "version": "2.7.16"
   }
  },
  "nbformat": 4,

--- a/insights/command_parser.py
+++ b/insights/command_parser.py
@@ -17,6 +17,7 @@ Available commands:
   collect     Collect all specs against the client and create an Insights archive.
   inspect     Execute component and shell out to ipython for evaluation.
   info        View info and docs for Insights Core components.
+  ocp         Interactive evaluation of OCP archives or config files.
   run         Run insights-core against host or an archive.
 """
 
@@ -60,6 +61,10 @@ class InsightsCli(object):
     def inspect(self):
         from .tools.insights_inspect import main as inspect_main
         inspect_main()
+
+    def ocp(self):
+        from .ocp import main as ocp_main
+        ocp_main()
 
     def run(self):
         from insights import run

--- a/insights/ocp.py
+++ b/insights/ocp.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+import argparse
+import logging
+import os
+import yaml
+from insights.core.archives import extract
+from insights.parsr.query import from_dict, Result
+from insights.parsr.query import *  # noqa: F403
+
+q = make_child_query  # noqa: F405
+
+try:
+    # go fast!
+    # requires pyyaml installed with libyaml
+    Loader = yaml.CLoader
+    cloader = True
+except:
+    Loader = yaml.Loader
+    cloader = False
+
+
+log = logging.getLogger(__name__)
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("archives", nargs="+", help="Archive or directory to analyze.")
+    return p.parse_args()
+
+
+def get_ipshell():
+    from IPython import embed
+    from IPython.terminal.embed import InteractiveShellEmbed
+    from IPython.core.completer import Completer
+
+    Completer.use_jedi = False
+
+    banner = """
+    Openshift Configuration Explorer
+
+    Tutorial: https://github.com/RedHatInsights/insights-core/blob/master/docs/notebooks/Parsr%20Query%20Tutorial.ipynb
+
+    conf is the top level configuration. Use conf.get_keys() to see first level
+    keys.
+
+    Available Predicates
+        lt, le, eq, gt, ge
+
+        isin, contains
+
+        startswith, endswith
+
+        ieq, icontains, istartswith, iendswith
+
+    Available Operators
+        ~ (not)
+        | (or)
+        & (and)
+
+    Example
+        api = conf.where("kind", "KubeAPIServer")
+        latest = api.status.latestAvailableRevision.value
+        api.status.nodeStatuses.where("currentRevision", ~eq(latest))
+    """
+    exit_msg = '\nExiting IPython'
+
+    try:
+        return InteractiveShellEmbed(banner1=banner, exit_msg=exit_msg)
+    except:
+        return embed
+
+
+def get_files(path):
+    paths = []
+    for root, dirs, names in os.walk(path):
+        for name in names:
+            p = os.path.join(root, name)
+            if p.endswith(".yaml"):
+                paths.append(p)
+    return paths
+
+
+def load(path):
+    with open(path) as f:
+        doc = yaml.load(f, Loader=Loader) if cloader else yaml.safe_load(f)
+        return from_dict(doc)
+
+
+def process(path):
+    # cpu bound in yaml.load. threads don't help.
+    return [load(p) for p in get_files(path)]
+
+
+def analyze(paths):
+    if not isinstance(paths, list):
+        paths = [paths]
+
+    results = []
+    for path in paths:
+        if os.path.isfile(path) and path.endswith((".yaml", ".yml")):
+            results.append(load(path))
+        elif os.path.isdir(path):
+            results.extend(process(path))
+        else:
+            with extract(path) as ex:
+                results.extend(process(ex.tmp_dir))
+
+    return Result(children=results)
+
+
+def main():
+    args = parse_args()
+    archives = args.archives
+    conf = analyze(archives)  # noqa F841 / unused var
+
+    shell = get_ipshell()
+    shell()
+
+
+if __name__ == "__main__":
+    main()

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -131,9 +131,16 @@ class Entry(object):
         Returns the furthest ancestor ``Entry``.
         """
         p = self
-        while p.parent is not None and p.parent.parent is not None:
+        while p.parent is not None:
             p = p.parent
         return p
+
+    @property
+    def roots(self):
+        """
+        Returns the furthest ancestor ``Entry``.
+        """
+        return Result(children=[c.root for c in self.children])
 
     @property
     def grandchildren(self):
@@ -317,6 +324,13 @@ class Result(Entry):
         Returns the values of all the children as a list.
         """
         return [c.value for c in self.children]
+
+    @property
+    def unique_values(self):
+        """
+        Returns the values of all the children as a list.
+        """
+        return list(set(c.value for c in self.children))
 
     def select(self, *queries, **kwargs):
         query = compile_queries(*queries)

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -140,7 +140,7 @@ class Entry(object):
         """
         Returns the furthest ancestor ``Entry``.
         """
-        return Result(children=[c.root for c in self.children])
+        return Result(children=list(set(c.root for c in self.children)))
 
     @property
     def grandchildren(self):

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -305,6 +305,13 @@ class Result(Entry):
         raise Exception("More than one value to return.")
 
     @property
+    def parents(self):
+        """
+        Returns the values of all the children as a list.
+        """
+        return Result(children=[c.parent for c in self.children])
+
+    @property
     def values(self):
         """
         Returns the values of all the children as a list.

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -143,21 +143,24 @@ class Entry(object):
     def find(self, *queries, **kwargs):
         """
         Finds matching results anywhere in the configuration. The arguments are
-        the same as those accepted by :py:func:`compile_queries`, and the
-        kwargs are the same as those accepted by :py:func:`select`.
+        the same as those accepted by :py:func:`compile_queries`, and it
+        accepts a keyword called ``roots`` that will return the ultimate root
+        nodes of any results.
         """
         roots = kwargs.get("roots", False)
         return self.select(*queries, deep=True, roots=roots)
 
-    def where(self, *queries, **kwargs):
+    def where(self, name, value=None, **kwargs):
         """
-        Finds matching results anywhere in the configuration. The arguments are
-        the same as those accepted by :py:func:`compile_queries`, and the
-        kwargs are the same as those accepted by :py:func:`select`.
+        Selects current nodes based on name and value queries of child nodes.
+        If any immediate children match the queries, the parent is included in
+        the results. Accepts the ``deep`` keyword that will cause where to
+        search the entire config tree.
         """
         deep = kwargs.get("deep", False)
-        res = self.select(*queries, deep=deep)
-        return Result(children=list(set([c.parent for c in res])))
+        q = (name, value) if value is not None else name
+        res = self.select(q, deep=deep)
+        return Result(children=list(set(c.parent for c in res)))
 
     @property
     def section(self):

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -73,6 +73,7 @@ class Entry(object):
         self.src = src
         for c in self.children:
             c.parent = self
+        super(Entry, self).__init__()
 
     def __getattr__(self, name):
         """
@@ -97,6 +98,9 @@ class Entry(object):
         Returns the unique names of all the children as a list.
         """
         return sorted(set(c.name for c in self.children))
+
+    def __dir__(self):
+        return self.get_keys() + object.__dir__(self)
 
     @property
     def line(self):
@@ -148,6 +152,13 @@ class Entry(object):
         Returns a flattened list of all grandchildren.
         """
         return list(chain.from_iterable(c.children for c in self.children))
+
+    def pluck(self, *names):
+        """
+        Select just the children with requested names.
+        """
+        names = set(names)
+        return Result(children=[c for c in self.children if c.name in names])
 
     def select(self, *queries, **kwargs):
         """
@@ -331,6 +342,13 @@ class Result(Entry):
         Returns the values of all the children as a list.
         """
         return list(set(c.value for c in self.children))
+
+    def pluck(self, *names):
+        """
+        Select just the grandchildren with requested names.
+        """
+        names = set(names)
+        return Result(children=[c for c in self.grandchildren if c.name in names])
 
     def select(self, *queries, **kwargs):
         query = compile_queries(*queries)

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -65,7 +65,7 @@ class Entry(object):
     instances. Each instance has a name, attributes, a parent, and children.
     """
     def __init__(self, name=None, attrs=None, children=None, lineno=None, src=None):
-        self.name = name
+        self._name = name
         self.attrs = attrs or []
         self.children = children or []
         self.parent = None
@@ -75,6 +75,9 @@ class Entry(object):
             c.parent = self
 
     def __getattr__(self, name):
+        if name == "name" and self._name is not None:
+            return self._name
+
         res = self[name]
         if res:
             return res
@@ -193,7 +196,7 @@ class Entry(object):
         return Result(children=[c for c in self.children if query.test(c)])
 
     def __bool__(self):
-        return bool(self.name or self.attrs or self.children)
+        return bool(self._name or self.attrs or self.children)
 
     def __repr__(self):
         return "\n".join(pretty_format(self))

--- a/insights/parsr/query/boolean.py
+++ b/insights/parsr/query/boolean.py
@@ -71,10 +71,6 @@ class Any(Boolean):
     def __init__(self, *exprs):
         self.exprs = list(exprs)
 
-    def __or__(self, other):
-        self.exprs.append(other)
-        return self
-
     def test(self, value):
         return any(q.test(value) for q in self.exprs)
 
@@ -82,10 +78,6 @@ class Any(Boolean):
 class All(Boolean):
     def __init__(self, *exprs):
         self.exprs = list(exprs)
-
-    def __and__(self, other):
-        self.exprs.append(other)
-        return self
 
     def test(self, value):
         return all(q.test(value) for q in self.exprs)

--- a/insights/parsr/query/tests/test_boolean.py
+++ b/insights/parsr/query/tests/test_boolean.py
@@ -1,0 +1,36 @@
+from insights.parsr.query.boolean import TRUE, FALSE
+
+
+def test_and():
+    q = TRUE & TRUE
+    assert q(None)
+
+    q = TRUE & FALSE
+    assert not q(None)
+
+    q = FALSE & TRUE
+    assert not q(None)
+
+    q = FALSE & FALSE
+    assert not q(None)
+
+
+def test_or():
+    q = TRUE | TRUE
+    assert q(None)
+
+    q = TRUE | FALSE
+    assert q(None)
+
+    q = FALSE | TRUE
+    assert q(None)
+
+    q = FALSE | FALSE
+    assert not q(None)
+
+
+def test_not():
+    q = ~FALSE
+    assert q(None)
+    q = ~TRUE
+    assert not q(None)

--- a/insights/parsr/query/tests/test_find.py
+++ b/insights/parsr/query/tests/test_find.py
@@ -25,7 +25,7 @@ def test_select_leaves():
 def test_select_roots():
     res = complex_tree.select("puppy", deep=True, roots=True)
     assert len(res) == 1
-    assert res[0].name == "dog"
+    assert res[0].name == "root"
 
 
 def test_select_chain():

--- a/insights/parsr/query/tests/test_where.py
+++ b/insights/parsr/query/tests/test_where.py
@@ -1,0 +1,89 @@
+import json
+
+from insights.parsr.query import from_dict, make_child_query as q
+
+
+DATA = json.loads('''
+{
+  "kind": "ClusterVersion",
+  "apiVersion": "config.openshift.io/v1",
+  "metadata": {
+    "name": "version",
+    "selfLink": "/apis/config.openshift.io/v1/clusterversions/version",
+    "uid": "11111111-2222-3333-4444-555555555555",
+    "resourceVersion": "1",
+    "generation": 1,
+    "creationTimestamp": "2019-08-04T23:16:46Z"
+  },
+  "spec": {
+    "clusterID": "55555555-4444-3333-2222-111111111111",
+    "upstream": "xxxxx://xxx.xxxxxxxxx.xxx/xxx/xxxxxxxxxxxxx/xx/xxxxx",
+    "channel": "stable-4.2"
+  },
+  "status": {
+    "desired": {
+      "version": "4.2.0-0.ci-2019-08-04-183142",
+      "image": "registry.svc.ci.openshift.org/ocp/release@sha256:63b65452005d6e9e45bb92a7505524db0e406c3281d91bdc1a4f5c5cf71b01c5",
+      "force": false
+    },
+    "history": [
+      {
+        "state": "Completed",
+        "startedTime": "2019-08-04T23:17:08Z",
+        "completionTime": "2019-08-04T23:32:14Z",
+        "version": "4.2.0-0.ci-2019-08-04-183142",
+        "image": "registry.svc.ci.openshift.org/ocp/release@sha256:63b65452005d6e9e45bb92a7505524db0e406c3281d91bdc1a4f5c5cf71b01c5",
+        "verified": false
+      }
+    ],
+    "observedGeneration": 1,
+    "versionHash": "############",
+    "conditions": [
+      {
+        "type": "Available",
+        "status": "True",
+        "lastTransitionTime": "2019-08-04T23:32:14Z",
+        "message": "Done applying 4.2.0-0.ci-2019-08-04-183142"
+      },
+      {
+        "type": "Failing",
+        "status": "True",
+        "lastTransitionTime": "2019-08-05T15:04:39Z",
+        "reason": "ClusterOperatorNotAvailable",
+        "message": "Cluster operator console is still updating"
+      },
+      {
+        "type": "Progressing",
+        "status": "False",
+        "lastTransitionTime": "2019-08-04T23:32:14Z",
+        "reason": "ClusterOperatorNotAvailable",
+        "message": "Error while reconciling 4.2.0-0.ci-2019-08-04-183142: the cluster operator console has not yet successfully rolled out"
+      },
+      {
+        "type": "RetrievedUpdates",
+        "status": "False",
+        "lastTransitionTime": "2019-08-04T23:17:08Z",
+        "reason": "RemoteFailed",
+        "message": "Unable to retrieve available updates: currently installed version 4.2.0-0.ci-2019-08-04-183142 not found in the stable-4.2 channel"
+      }
+    ],
+    "availableUpdates": null
+  }
+}
+''')
+
+d = from_dict(DATA)
+
+
+def test_values():
+    assert d.status.conditions.status.values == ["True", "True", "False", "False"]
+
+
+def test_where():
+    assert len(d.status.conditions.where("type", "Progressing")) == 1
+
+    res = d.status.conditions.where(q("type", "Progressing") | q("status", "True"))
+    assert len(res) == 3
+
+    # because only two of the resulting conditions have children named reason.
+    assert res.reason.values == ["ClusterOperatorNotAvailable", "ClusterOperatorNotAvailable"]

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ entry_points = {
         'insights-dupkeycheck = insights.tools.dupkeycheck:main',
         'insights-inspect = insights.tools.insights_inspect:main',
         'insights-info = insights.tools.query:main',
+        'insights-ocp = insights.ocp:main',
         'gen_api = insights.tools.generate_api_config:main',
         'insights-perf = insights.tools.perf:main',
         'client = insights.client:run',

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ optional = set([
     'python-logstash',
     'python-statsd',
     'watchdog',
+    'libyaml',
 ])
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR lets you navigate insights parsr query results with attribute access in addition to dictionary access. It also introduces a `where` clause you can use to select nodes based on names and values in their immediate children. Include queries for multiple names and values in the `where` by using the `make_child_query` helper.

```
In [1]: from insights.parsr.query import contains, from_dict, make_child_query as q
In [2]: import json
In [3]: doc = json.load(open("/Downloads/config/version"))
In [4]: d = from_dict(doc)

In [5]: d.status.conditions.where("status", "False")
Out[5]: 
[conditions]
    type: RetrievedUpdates
    status: False
    lastTransitionTime: 2019-08-04T23:17:08Z
    reason: RemoteFailed
    message: Unable to retrieve available updates: currently installed version 4.2.0-0.ci-2019-08-04-183142 not found in the "stable-4.2" channel

[conditions]
    type: Progressing
    status: False
    lastTransitionTime: 2019-08-04T23:32:14Z
    reason: ClusterOperatorNotAvailable
    message: Error while reconciling 4.2.0-0.ci-2019-08-04-183142: the cluster operator console has not yet successfully rolled out

In [6]: d.status.conditions.where("status", "False").message.values
Out[6]: 
['Unable to retrieve available updates: currently installed version 4.2.0-0.ci-2019-08-04-183142 not found in the "stable-4.2" channel',
 'Error while reconciling 4.2.0-0.ci-2019-08-04-183142: the cluster operator console has not yet successfully rolled out']

In [7]: d.status.conditions.where(q("status", "False") & q("type", "Progressing")).message.values
Out[7]: ['Error while reconciling 4.2.0-0.ci-2019-08-04-183142: the cluster operator console has not yet successfully rolled out']

In [8]: d.status.conditions.where(q("status", "False") & q("reason", contains("Fail"))).message.values
Out[8]: ['Unable to retrieve available updates: currently installed version 4.2.0-0.ci-2019-08-04-183142 not found in the "stable-4.2" channel']
```