### PR TITLE
use package_info instead of client method, check systemd env

### DIFF
--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -14,6 +14,7 @@ import sys
 from subprocess import Popen, PIPE, STDOUT
 from six.moves.configparser import RawConfigParser
 
+from .. import package_info
 from .constants import InsightsConstants as constants
 
 logger = logging.getLogger(__name__)
@@ -228,8 +229,6 @@ def get_version_info():
     '''
     Get the insights client and core versions for archival
     '''
-    from insights import package_info
-
     cmd = 'rpm -q --qf "%{VERSION}-%{RELEASE}" insights-client'
     version_info = {}
     version_info['core_version'] = '%s-%s' % (package_info['VERSION'], package_info['RELEASE'])

--- a/insights/tests/client/test_utilities.py
+++ b/insights/tests/client/test_utilities.py
@@ -180,7 +180,7 @@ def test_read_pidfile_failure():
 
 @patch('insights.client.utilities.Popen')
 @patch('insights.client.utilities.os.path.exists')
-def test_systemd_notify(exists, Popen):
+def test_systemd_notify_no_socket(exists, Popen):
     '''
     Test this function when NOTIFY_SOCKET is
     undefined, i.e. when we run the client on demand


### PR DESCRIPTION
RHEL 8 systemd complains pretty loudly if you try to run `systemd-notify` outside the systemd job itself. So, don't try to run `systemd-notify` unless `NOTIFY_SOCKET` is available.

In addition, use `package_info` directly instead of calling `InsightsClient().version()` to get the egg versions. `InsightsClient()` does things in its init function that we don't want to do superfluously, so let's not instantiate it just to get the version info.