### PR TITLE
New filter for dmesg combiner

### DIFF
--- a/insights/combiners/dmesg.py
+++ b/insights/combiners/dmesg.py
@@ -43,9 +43,13 @@ Examples:
     False
 """
 
+from insights.core.filters import add_filter
 from insights.core.plugins import combiner
 from insights.parsers.dmesg import DmesgLineList
 from insights.parsers.dmesg_log import DmesgLog
+from insights.specs import Specs
+
+add_filter(Specs.dmesg, 'Linux version')
 
 
 @combiner([DmesgLineList, DmesgLog])


### PR DESCRIPTION
For using this combiner is necessary to have a filter for 'Linux version' string (so we don't have to rely on its presence in the rules).