### PR TITLE
WIP: Replace "Mount" with "ProcMounts"

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -110,9 +110,9 @@ Parser Plugins
 Parser plugins are responsible for analyzing the raw data
 and converting it into usable *facts* that can be evaluated by the
 Combiners and Rules.  Each Parser plugin is typically responsible
-for parsing a specific set of data.  For instance, the **Mount** parser
-plugin (:py:class:`insights.parsers.mount.Mount`)
-parses the output of the `mount` command and the **FSTab**
+for parsing a specific set of data.  For instance, the **ProcMounts** parser
+plugin (:py:class:`insights.parsers.mount.ProcMounts`)
+parses the output of the `/proc/mounts` file and the **FSTab**
 parser plugin (:py:class:`insights.parsers.fstab.FSTab`)
 parses the contents of the `/etc/fstab/` file.
 

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -38,8 +38,23 @@ hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime,seclabel)
 /dev/sda1 on /boot type ext4 (rw,relatime,seclabel,data=ordered)
 """.strip()
 
+MOUNT_DOC = """
+/dev/mapper/rootvg-rootlv on / type ext4 (rw,relatime,barrier=1,data=ordered)
+proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
+/dev/mapper/HostVG-Config on /etc/shadow type ext4 (rw,noatime,seclabel,stripe=256,data=ordered)
+dev/sr0 on /run/media/root/VMware Tools type iso9660 (ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2) [VMware Tools]
+""".strip()
 
-PROC_MOUNT = """
+MOUNT_DATA_WITH_SPECIAL_MNT_POINT = """
+hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime,seclabel)
+/dev/sda1 on /boot type ext4 (rw,relatime,seclabel,data=ordered)
+/dev/mapper/fedora-root on / type ext4 (rw,relatime,seclabel,data=ordered)
+/dev/mapper/HostVG-Config on /etc/shadow type ext4 (rw,noatime,seclabel,stripe=256,data=ordered) [CONFIG]
+/dev/sr0 on /run/media/root/VMware Tools type iso9660 (ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2) [VMware Tools]
+/dev/sr1 on /run/media/Disk on C type NFS type iso9660 (ro,uid=0,gid=0,iocharset=utf8,uhelper=udisks2) [C type Disk]
+""".strip()
+
+PROC_MOUNTS = """
 proc /proc proc rw,relatime 0 0
 sysfs /sys sysfs rw,relatime 0 0
 devtmpfs /dev devtmpfs rw,relatime,size=8155456k,nr_inodes=2038864,mode=755 0 0
@@ -61,7 +76,44 @@ sunrpc /var/lib/nfs/rpc_pipefs rpc_pipefs rw,relatime 0 0
 /etc/auto.misc /misc autofs rw,relatime,fd=7,pgrp=1936,timeout=300,minproto=5,maxproto=5,indirect 0 0
 """.strip()
 
-PROCMOUNT_ERR_DATA = """
+PROC_MOUNTS_WITH_SPECIAL_MNT_POINT = """
+sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+devtmpfs /dev devtmpfs rw,seclabel,nosuid,size=1920484k,nr_inodes=480121,mode=755 0 0
+securityfs /sys/kernel/security securityfs rw,nosuid,nodev,noexec,relatime 0 0
+tmpfs /dev/shm tmpfs rw,seclabel,nosuid,nodev 0 0
+devpts /dev/pts devpts rw,seclabel,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
+tmpfs /run tmpfs rw,seclabel,nosuid,nodev,mode=755 0 0
+tmpfs /sys/fs/cgroup tmpfs ro,seclabel,nosuid,nodev,noexec,mode=755 0 0
+cgroup /sys/fs/cgroup/systemd cgroup rw,seclabel,nosuid,nodev,noexec,relatime,xattr,release_agent=/usr/lib/systemd/systemd-cgroups-agent,name=systemd 0 0
+pstore /sys/fs/pstore pstore rw,seclabel,nosuid,nodev,noexec,relatime 0 0
+bpf /sys/fs/bpf bpf rw,nosuid,nodev,noexec,relatime,mode=700 0 0
+cgroup /sys/fs/cgroup/devices cgroup rw,seclabel,nosuid,nodev,noexec,relatime,devices 0 0
+cgroup /sys/fs/cgroup/cpu,cpuacct cgroup rw,seclabel,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0
+cgroup /sys/fs/cgroup/net_cls,net_prio cgroup rw,seclabel,nosuid,nodev,noexec,relatime,net_cls,net_prio 0 0
+cgroup /sys/fs/cgroup/freezer cgroup rw,seclabel,nosuid,nodev,noexec,relatime,freezer 0 0
+cgroup /sys/fs/cgroup/rdma cgroup rw,seclabel,nosuid,nodev,noexec,relatime,rdma 0 0
+cgroup /sys/fs/cgroup/blkio cgroup rw,seclabel,nosuid,nodev,noexec,relatime,blkio 0 0
+cgroup /sys/fs/cgroup/pids cgroup rw,seclabel,nosuid,nodev,noexec,relatime,pids 0 0
+cgroup /sys/fs/cgroup/cpuset cgroup rw,seclabel,nosuid,nodev,noexec,relatime,cpuset 0 0
+cgroup /sys/fs/cgroup/perf_event cgroup rw,seclabel,nosuid,nodev,noexec,relatime,perf_event 0 0
+cgroup /sys/fs/cgroup/hugetlb cgroup rw,seclabel,nosuid,nodev,noexec,relatime,hugetlb 0 0
+cgroup /sys/fs/cgroup/memory cgroup rw,seclabel,nosuid,nodev,noexec,relatime,memory 0 0
+configfs /sys/kernel/config configfs rw,relatime 0 0
+/dev/mapper/rhel_vm37--146-root / xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
+selinuxfs /sys/fs/selinux selinuxfs rw,relatime 0 0
+systemd-1 /proc/sys/fs/binfmt_misc autofs rw,relatime,fd=39,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=19590 0 0
+debugfs /sys/kernel/debug debugfs rw,seclabel,relatime 0 0
+hugetlbfs /dev/hugepages hugetlbfs rw,seclabel,relatime,pagesize=2M 0 0
+mqueue /dev/mqueue mqueue rw,seclabel,relatime 0 0
+/dev/sda1 /boot xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
+binfmt_misc /proc/sys/fs/binfmt_misc binfmt_misc rw,relatime 0 0
+tmpfs /run/user/0 tmpfs rw,seclabel,nosuid,nodev,relatime,size=386888k,mode=700 0 0
+/dev/sr0 /run/media/root/VMware\040Tools iso9660 ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2 0 0
+/dev/sr1 /mnt/Disk\040on\040C\040type\040NFS xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
+""".strip()
+
+PROC_MOUNTS_ERR_DATA = """
 rootfs / rootfs rw 0 0
 sysfs /sys sysfs rw,relatime
 """.strip()
@@ -75,27 +127,11 @@ sysfs /sys sysfs rw,relatime 0 0
 devtmpfs /dev devtmpfs rw,relatime,size=8155456k,nr_inodes=2038864,mode=755 0 0
 """.strip()
 
-MOUNT_DOC = """
-/dev/mapper/rootvg-rootlv on / type ext4 (rw,relatime,barrier=1,data=ordered)
-proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
-/dev/mapper/HostVG-Config on /etc/shadow type ext4 (rw,noatime,seclabel,stripe=256,data=ordered)
-dev/sr0 on /run/media/root/VMware Tools type iso9660 (ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2) [VMware Tools]
-""".strip()
-
-PROC_MOUNT_DOC = """
+PROC_MOUNTS_DOC = """
 /dev/mapper/rootvg-rootlv / ext4 rw,relatime,barrier=1,data=ordered 0 0
 proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
 /dev/mapper/HostVG-Config /etc/shadow ext4 rw,noatime,seclabel,stripe=256,data=ordered 0 0
 dev/sr0 /run/media/root/VMware\040Tools iso9660 ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2 0 0
-""".strip()
-
-MOUNT_DATA_WITH_SPECIAL_MNT_POINT = """
-hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime,seclabel)
-/dev/sda1 on /boot type ext4 (rw,relatime,seclabel,data=ordered)
-/dev/mapper/fedora-root on / type ext4 (rw,relatime,seclabel,data=ordered)
-/dev/mapper/HostVG-Config on /etc/shadow type ext4 (rw,noatime,seclabel,stripe=256,data=ordered) [CONFIG]
-/dev/sr0 on /run/media/root/VMware Tools type iso9660 (ro,nosuid,nodev,relatime,uid=0,gid=0,iocharset=utf8,mode=0400,dmode=0500,uhelper=udisks2) [VMware Tools]
-/dev/sr1 on /run/media/Disk on C type NFS type iso9660 (ro,uid=0,gid=0,iocharset=utf8,uhelper=udisks2) [C type Disk]
 """.strip()
 
 
@@ -185,7 +221,7 @@ def test_mount_exception2():
 
 
 def test_proc_mount():
-    results = ProcMounts(context_wrap(PROC_MOUNT))
+    results = ProcMounts(context_wrap(PROC_MOUNTS))
     assert results is not None
     assert len(results) == 19
     sda1 = results.search(filesystem='/dev/sda1')[0]
@@ -232,30 +268,40 @@ def test_proc_mount():
     ]
 
 
-def test_proc_mount_exception1():
+def test_proc_mounts_with_special_mnt_point():
+    results = ProcMounts(context_wrap(PROC_MOUNTS_WITH_SPECIAL_MNT_POINT))
+    assert len(results) == 34
+    sr0 = results.search(filesystem='/dev/sr0')[0]
+    sr1 = results.search(filesystem='/dev/sr1')[0]
+    assert sr0['mount_point'] == '/run/media/root/VMware Tools'
+    assert sr0['filesystem_type'] == 'iso9660'
+    assert sr1['mount_point'] == '/mnt/Disk on C type NFS'
+    assert 'seclabel' in sr1['mount_options']
+
+
+def test_proc_mounts_exception1():
     with pytest.raises(SkipException) as e:
         ProcMounts(context_wrap(PROC_EXCEPTION1))
     assert 'Empty content' in str(e)
 
 
-def test_proc_mount_exception2():
+def test_proc_mounts_exception2():
     with pytest.raises(ParseException) as e:
         ProcMounts(context_wrap(PROC_EXCEPTION2))
     assert "Input for mount must contain '/' mount point." in str(e)
 
 
-def test_proc_mount_exception3():
+def test_proc_mounts_exception3():
     with pytest.raises(ParseException) as pe:
-        ProcMounts(context_wrap(PROCMOUNT_ERR_DATA))
+        ProcMounts(context_wrap(PROC_MOUNTS_ERR_DATA))
     assert 'Unable to parse' in str(pe.value)
 
 
 def test_doc_examples():
     env = {
             'mnt_info': Mount(context_wrap(MOUNT_DOC)),
-            'proc_mnt_info': ProcMounts(context_wrap(PROC_MOUNT_DOC)),
-            'mounts': Mount(context_wrap(MOUNT_DOC))
-
+            'proc_mnt_info': ProcMounts(context_wrap(PROC_MOUNTS_DOC)),
+            'mounts': ProcMounts(context_wrap(PROC_MOUNTS_DOC))
           }
     failed, total = doctest.testmod(mount, globs=env)
     assert failed == 0

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -24,7 +24,7 @@ from insights.core.spec_factory import CommandOutputProvider, ContentException, 
 from insights.core.spec_factory import simple_file, simple_command, glob_file, command_with_args
 from insights.core.spec_factory import first_of, foreach_collect, foreach_execute
 from insights.core.spec_factory import first_file, listdir
-from insights.parsers.mount import Mount, ProcMounts
+from insights.parsers.mount import ProcMounts
 from insights.parsers.dnf_module import DnfModuleList
 from insights.combiners.cloud_provider import CloudProvider
 from insights.components.rhel_version import IsRhel8
@@ -405,10 +405,10 @@ class DefaultSpecs(Specs):
         # https://access.redhat.com/solutions/21680
         return list(ps_httpds)
 
-    @datasource(Mount)
+    @datasource(ProcMounts)
     def httpd_on_nfs(broker):
         import json
-        mnt = broker[Mount]
+        mnt = broker[ProcMounts]
         mps = mnt.search(mount_type='nfs4')
         # get nfs 4.0 mount points
         nfs_mounts = [m.mount_point for m in mps if m['mount_options'].get("vers") == "4.0"]
@@ -585,7 +585,6 @@ class DefaultSpecs(Specs):
                             "/etc/mongodb.conf",
                             "/etc/opt/rh/rh-mongodb26/mongod.conf"
                             ])
-    mount = simple_command("/bin/mount")
     mounts = simple_file("/proc/mounts")
     mssql_conf = simple_file("/var/opt/mssql/mssql.conf")
     multicast_querier = simple_command("/usr/bin/find /sys/devices/virtual/net/ -name multicast_querier -print -exec cat {} \;")
@@ -989,9 +988,9 @@ class DefaultSpecs(Specs):
     x86_ibrs_enabled = simple_file("sys/kernel/debug/x86/ibrs_enabled")
     x86_retp_enabled = simple_file("sys/kernel/debug/x86/retp_enabled")
 
-    @datasource(Mount)
+    @datasource(ProcMounts)
     def xfs_mounts(broker):
-        mnt = broker[Mount]
+        mnt = broker[ProcMounts]
         mps = mnt.search(mount_type='xfs')
         return [m.mount_point for m in mps]
 

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -151,7 +151,6 @@ class InsightsArchiveSpecs(Specs):
     lvs_noheadings_all = simple_file("insights_commands/lvs_--nameprefixes_--noheadings_--separator_-a_-o_lv_name_lv_size_lv_attr_mirror_log_vg_name_devices_region_size_data_percent_metadata_percent_segtype_--config_global_locking_type_0_devices_filter_a")
     max_uid = simple_file("insights_commands/awk_-F_if_3_max_max_3_END_print_max_.etc.passwd")
     md5chk_files = glob_file("insights_commands/md5sum_*")
-    mount = simple_file("insights_commands/mount")
     modinfo = glob_file("insights_commands/modinfo_*")
     modinfo_i40e = simple_file("insights_commands/modinfo_i40e")
     modinfo_igb = simple_file("insights_commands/modinfo_igb")

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -78,7 +78,6 @@ class SosSpecs(Specs):
     ls_dev = first_file(["sos_commands/block/ls_-lanR_.dev", "sos_commands/devicemapper/ls_-lanR_.dev"])
     lvs = first_file(["sos_commands/lvm2/lvs_-a_-o_lv_tags_devices_--config_global_locking_type_0", "sos_commands/lvm2/lvs_-a_-o_devices"])
     modinfo_all = glob_file("sos_commands/kernel/modinfo_*")
-    mount = simple_file("sos_commands/filesys/mount_-l")
     multipath__v4__ll = first_file(["sos_commands/multipath/multipath_-v4_-ll", "sos_commands/devicemapper/multipath_-v4_-ll"])
     netstat = first_file(["sos_commands/networking/netstat_-neopa", "sos_commands/networking/netstat_-W_-neopa", "sos_commands/networking/netstat_-T_-neopa"])
     netstat_agn = first_of([simple_file("sos_commands/networking/netstat_-agn"), simple_file("sos_commands/networking/netstat_-W_-agn"), simple_file("sos_commands/networking/netstat_-T_-agn")])


### PR DESCRIPTION
- mark the "Mount" parser as `deprecated`
- remove the `Specs.mount` and keep `Specs.mounts`

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>