### PR TITLE
Add 'upto' to query API.

### DIFF
--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -153,6 +153,17 @@ class Entry(object):
         """
         return list(chain.from_iterable(c.children for c in self.children))
 
+    def upto(self, query):
+        """
+        Go up from the current node to the first node that matches query.
+        """
+        pred = _desugar(query)
+        parent = self.parent
+        while parent is not None:
+            if pred.test(parent):
+                return parent
+            parent = parent.parent
+
     def select(self, *queries, **kwargs):
         """
         select uses :py:func:`compile_queries` to compile ``queries`` into a
@@ -366,6 +377,19 @@ class Result(Entry):
         Returns the unique values of all the children as a list.
         """
         return sorted(set(c.value for c in self.children))
+
+    def upto(self, query):
+        """
+        Go up from the current results to the first nodes that match query.
+        """
+        roots = []
+        seen = set()
+        for c in self.children:
+            root = c.upto(query)
+            if root is not None and root not in seen:
+                roots.append(root)
+                seen.add(root)
+        return Result(children=roots)
 
     def select(self, *queries, **kwargs):
         query = compile_queries(*queries)


### PR DESCRIPTION
Signed-off-by: Christopher Sams <csams@redhat.com>

This allows you to walk back up a config structure from the leaves to an arbitrary parent that matches a query instead of just immediate parents or furthest ancestor.