### PR TITLE
Execution contexts register themselves and decide if they handle an archive.

### DIFF
--- a/insights/core/context.py
+++ b/insights/core/context.py
@@ -157,12 +157,14 @@ class ExecutionContext(six.with_metaclass(ExecutionContextMeta)):
         if cls.marker is None or not files:
             return (None, None)
 
-        m = cls.marker
+        sep = os.path.sep
+        m = sep + cls.marker.lstrip(sep)
         for f in files:
             if m in f:
                 i = f.find(m)
-                root = os.path.dirname(f[:i])
-                return root, cls
+                if f.endswith(m) or f[i + len(m)] == sep:
+                    root = os.path.dirname(f[:i + 1])
+                    return root, cls
         return (None, None)
 
     def check_output(self, cmd, timeout=None, keep_rc=False, env=None):

--- a/insights/core/hydration.py
+++ b/insights/core/hydration.py
@@ -1,13 +1,10 @@
 import logging
 import os
-from itertools import product
 
 from insights.core import archives
 from insights.core.context import (ClusterArchiveContext,
-                                   JDRContext,
-                                   HostArchiveContext,
-                                   SosArchiveContext,
-                                   SerializedArchiveContext)
+                                   ExecutionContextMeta,
+                                   HostArchiveContext)
 
 log = logging.getLogger(__name__)
 
@@ -21,17 +18,9 @@ def get_all_files(path):
 
 
 def identify(files):
-    markers = {"insights_archive.txt": SerializedArchiveContext,
-               "insights_commands": HostArchiveContext,
-               "sos_commands": SosArchiveContext,
-               "JBOSS_HOME": JDRContext}
-
-    for f, m in product(files, markers):
-        if m in f:
-            i = f.find(m)
-            common_path = os.path.dirname(f[:i])
-            ctx = markers[m]
-            return common_path, ctx
+    common_path, ctx = ExecutionContextMeta.identify(files)
+    if ctx:
+        return common_path, ctx
 
     common_path = os.path.dirname(os.path.commonprefix(files))
     if not common_path:

--- a/insights/tests/test_context.py
+++ b/insights/tests/test_context.py
@@ -1,0 +1,18 @@
+from insights.core.context import HostArchiveContext, SosArchiveContext, SerializedArchiveContext
+
+def test_host_archive_context():
+    files = [
+            "/foo/junk",
+            "/insights_commands",
+            ]
+    actual = HostArchiveContext.handles(files)
+    assert actual == ("/", HostArchiveContext), actual
+
+
+def test_host_archive_context_unsupported():
+    files = [
+            "/foo/junk",
+            "/not_insights_commands",
+            ]
+    actual = HostArchiveContext.handles(files)
+    assert actual == (None, None), actual

--- a/insights/tests/test_context.py
+++ b/insights/tests/test_context.py
@@ -1,18 +1,65 @@
 from insights.core.context import HostArchiveContext, SosArchiveContext, SerializedArchiveContext
 
+
 def test_host_archive_context():
-    files = [
-            "/foo/junk",
-            "/insights_commands",
-            ]
+    files = ["/foo/junk", "/insights_commands"]
     actual = HostArchiveContext.handles(files)
     assert actual == ("/", HostArchiveContext), actual
 
+    files = ["/foo/junk", "/insights_commands/things"]
+    actual = HostArchiveContext.handles(files)
+    assert actual == ("/", HostArchiveContext), actual
+
+    files = ["/foo/junk", "/foo/junk/insights_commands/foobar.txt"]
+    actual = HostArchiveContext.handles(files)
+    assert actual == ("/foo/junk", HostArchiveContext), actual
+
 
 def test_host_archive_context_unsupported():
-    files = [
-            "/foo/junk",
-            "/not_insights_commands",
-            ]
+    files = ["/foo/junk", "/not_insights_commands"]
     actual = HostArchiveContext.handles(files)
+    assert actual == (None, None), actual
+
+    files = ["/foo/junk", "/insights_commands_not"]
+    actual = HostArchiveContext.handles(files)
+    assert actual == (None, None), actual
+
+
+def test_sos_archive_context_supported():
+    files = ["/foo/junk", "/sos_commands"]
+    actual = SosArchiveContext.handles(files)
+    assert actual == ("/", SosArchiveContext), actual
+
+    files = ["/foo/junk", "/sos_commands/things"]
+    actual = SosArchiveContext.handles(files)
+    assert actual == ("/", SosArchiveContext), actual
+
+    files = ["/foo/junk", "/foo/junk/sos_commands/foobar.txt"]
+    actual = SosArchiveContext.handles(files)
+    assert actual == ("/foo/junk", SosArchiveContext), actual
+
+
+def test_sos_archive_context_unsupported():
+    files = ["/foo/junk", "/sos_commands_not"]
+    actual = SosArchiveContext.handles(files)
+    assert actual == (None, None), actual
+
+    files = ["/foo/junk", "/not_sos_commands"]
+    actual = SosArchiveContext.handles(files)
+    assert actual == (None, None), actual
+
+
+def test_serialize_archive_context_supported():
+    files = ["/foo/junk", "/insights_archive.txt"]
+    actual = SerializedArchiveContext.handles(files)
+    assert actual == ("/", SerializedArchiveContext), actual
+
+
+def test_serialized_archive_context_unsupported():
+    files = ["/foo/junk", "/sos_commands_not"]
+    actual = SerializedArchiveContext.handles(files)
+    assert actual == (None, None), actual
+
+    files = ["/foo/junk", "/insights_archive"]
+    actual = SerializedArchiveContext.handles(files)
     assert actual == (None, None), actual


### PR DESCRIPTION
A context gets registered automatically when subclassing ExecutionContext.

Each subclass should specify a marker file relative to the archive root that is unique to the archive type the context handles.

Execution context classes are consulted in reverse of the order in which they are loaded, so it's possible to load your own context in place of one provided by core.

```python
class MyContext(ExecutionContext):
	marker = "mycontext.txt"
```

Signed-off-by: Christopher Sams <csams@redhat.com>