### PR TITLE
Add more info to insights-client user agent

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -191,6 +191,8 @@ class InsightsConnection(object):
 
         python_version = "%s %s" % (platform.python_implementation(), platform.python_version())
 
+        os_family = "Unknown"
+        os_release = ""
         for p in ["/etc/os-release", "/etc/redhat-release"]:
             try:
                 with open(p) as f:
@@ -208,6 +210,8 @@ class InsightsConnection(object):
                 break
             except IOError:
                 continue
+            except Exception as e:
+                logger.warning("Failed to detect OS version: %s", e)
         kernel_version = "%s %s" % (platform.system(), platform.release())
 
         ua = "{client_version} ({core_version}; {requests_version}) {os_family} {os_release} ({python_version}; {kernel_version})".format(

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -172,10 +172,10 @@ class InsightsConnection(object):
         Generates and returns a string suitable for use as a request user-agent
         """
         core_version = "Core %s" % package_info["VERSION"]
-        pkg = pkg_resources.working_set.find(pkg_resources.Requirement("insights-client"))
+        pkg = pkg_resources.working_set.find(pkg_resources.Requirement.parse("insights-client"))
         if pkg is not None:
             client_version = "%s/%s" % (pkg.project_name, pkg.version)
-        pkg = pkg_resources.working_set.find(pkg_resources.Requirement("requests"))
+        pkg = pkg_resources.working_set.find(pkg_resources.Requirement.parse("requests"))
         if pkg is not None:
             requests_version = "%s %s" % (pkg.project_name, pkg.version)
         python_version = "Python %s" % platform.python_version()

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -10,7 +10,7 @@ class InsightsConstants(object):
         os.path.dirname(os.path.abspath(__file__)))
     sleep_time = 180
     command_blacklist = ('rm', 'kill', 'reboot', 'shutdown')
-    default_conf_dir = '/etc/insights-client'
+    default_conf_dir = os.getenv('INSIGHTS_CONF_DIR', default='/etc/insights-client')
     default_conf_file = os.path.join(default_conf_dir, 'insights-client.conf')
     user_agent = os.path.join(app_name, package_info["VERSION"])
     log_dir = os.path.join(os.sep, 'var', 'log', app_name)

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -1,7 +1,5 @@
 import os
 
-from insights import package_info
-
 
 class InsightsConstants(object):
     app_name = 'insights-client'
@@ -12,7 +10,6 @@ class InsightsConstants(object):
     command_blacklist = ('rm', 'kill', 'reboot', 'shutdown')
     default_conf_dir = os.getenv('INSIGHTS_CONF_DIR', default='/etc/insights-client')
     default_conf_file = os.path.join(default_conf_dir, 'insights-client.conf')
-    user_agent = os.path.join(app_name, package_info["VERSION"])
     log_dir = os.path.join(os.sep, 'var', 'log', app_name)
     simple_find_replace_dir = '/etc/redhat-access-insights'
     default_log_file = os.path.join(log_dir, app_name + '.log')

--- a/insights/tests/client/connection/test_init_session.py
+++ b/insights/tests/client/connection/test_init_session.py
@@ -13,7 +13,6 @@ def test_proxy_request(init, session):
     # The constructor is bypassed, because it itself runs the _init_session method.
     connection = InsightsConnection(None)
     connection.config = config
-    connection.user_agent = None
     connection.systemid = None
     connection.authmethod = "BASIC"
     connection.username = "some username"


### PR DESCRIPTION
This PR enhances the data included in the insights-client User-Agent. Rather than a (relatively) constant `<app_name>/<app_version>` string, it now includes version information about the platform (both host and Python platform information).