### PR TITLE
Add tags.conf

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -15,7 +15,9 @@ from .auto_config import try_auto_configuration
 from .utilities import (delete_registered_file,
                         delete_unregistered_file,
                         write_to_disk,
-                        generate_machine_id)
+                        generate_machine_id,
+                        get_tags,
+                        write_tags)
 
 logger = logging.getLogger(__name__)
 net_logger = logging.getLogger("network")
@@ -55,6 +57,11 @@ class InsightsClient(object):
         # used for requests
         self.session = None
         self.connection = None
+
+        if self.config.group:
+            tags = get_tags()
+            tags["group"] = self.config.group
+            write_tags(tags)
 
     def _net(func):
         def _init_connection(self, *args, **kwargs):

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -60,6 +60,8 @@ class InsightsClient(object):
 
         if self.config.group:
             tags = get_tags()
+            if tags is None:
+                tags = {}
             tags["group"] = self.config.group
             write_tags(tags)
 

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -7,7 +7,10 @@ import six
 import sys
 from six.moves import configparser as ConfigParser
 
-from .constants import InsightsConstants as constants
+try:
+    from .constants import InsightsConstants as constants
+except ImportError:
+    from constants import InsightsConstants as constants
 
 logger = logging.getLogger(__name__)
 

--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -64,7 +64,7 @@ class DataCollector(object):
         logger.debug("Writing tags to archive...")
         tags = get_tags()
         if tags is not None:
-            self.archive.add_metadata_to_archive(json.dumps(tags), '/tags.json')
+            self.archive.add_metadata_to_archive(json.dumps({constants.app_name: tags}), '/tags.json')
 
     def _run_pre_command(self, pre_cmd):
         '''

--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -16,7 +16,7 @@ from tempfile import NamedTemporaryFile
 
 from insights.util import mangle
 from ..contrib.soscleaner import SOSCleaner
-from .utilities import _expand_paths, get_version_info, read_pidfile
+from .utilities import _expand_paths, get_version_info, read_pidfile, get_tags
 from .constants import InsightsConstants as constants
 from .insights_spec import InsightsFile, InsightsCommand
 
@@ -59,6 +59,12 @@ class DataCollector(object):
         version_info = get_version_info()
         self.archive.add_metadata_to_archive(
             json.dumps(version_info), '/version_info')
+
+    def _write_tags(self):
+        logger.debug("Writing tags to archive...")
+        tags = get_tags()
+        if tags is not None:
+            self.archive.add_metadata_to_archive(json.dumps(tags), '/tags.json')
 
     def _run_pre_command(self, pre_cmd):
         '''
@@ -218,6 +224,7 @@ class DataCollector(object):
         self._write_branch_info(branch_info)
         self._write_display_name()
         self._write_version_info()
+        self._write_tags()
         logger.debug('Metadata collection finished.')
 
     def done(self, conf, rm_conf):

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -14,6 +14,12 @@ import sys
 from subprocess import Popen, PIPE, STDOUT
 from six.moves.configparser import RawConfigParser
 
+import yaml
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
 from .. import package_info
 from .constants import InsightsConstants as constants
 
@@ -309,3 +315,21 @@ def systemd_notify(pid):
     stdout, stderr = proc.communicate()
     if proc.returncode != 0:
         logger.debug('systemd-notify returned %s', proc.returncode)
+
+
+def get_tags(tags_file_path=os.path.join(constants.default_conf_dir, "tags.conf")):
+    '''
+    Load tag data from the tags file.
+
+    Returns: a dict containing tags defined on the host.
+    '''
+    tags = None
+
+    try:
+        with open(tags_file_path) as f:
+            data = f.read()
+            tags = yaml.load(data, Loader=Loader)
+    except FileNotFoundError as e:
+        logger.debug("tags file does not exist: %s", e)
+
+    return tags

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -16,9 +16,9 @@ from six.moves.configparser import RawConfigParser
 
 import yaml
 try:
-    from yaml import CLoader as Loader
+    from yaml import CLoader as Loader, CDumper as Dumper
 except ImportError:
-    from yaml import Loader
+    from yaml import Loader, Dumper
 
 from .. import package_info
 from .constants import InsightsConstants as constants
@@ -333,3 +333,18 @@ def get_tags(tags_file_path=os.path.join(constants.default_conf_dir, "tags.conf"
         logger.debug("tags file does not exist: %s", e)
 
     return tags
+
+
+def write_tags(tags, tags_file_path=os.path.join(constants.default_conf_dir, "tags.conf")):
+    """
+    Writes tags to tags_file_path
+
+    Arguments:
+      - tags (dict): the tags to write
+      - tags_file_path (string): path to which tag data will be written
+
+    Returns: None
+    """
+    with open(tags_file_path, mode="w") as f:
+        data = yaml.dump(tags, Dumper=Dumper)
+        f.write(data)

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -329,8 +329,8 @@ def get_tags(tags_file_path=os.path.join(constants.default_conf_dir, "tags.conf"
         with open(tags_file_path) as f:
             data = f.read()
             tags = yaml.load(data, Loader=Loader)
-    except FileNotFoundError as e:
-        logger.debug("tags file does not exist: %s", e)
+    except EnvironmentError as e:
+        logger.debug("tags file does not exist: %s", os.strerror(e.errno))
 
     return tags
 

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -346,5 +346,5 @@ def write_tags(tags, tags_file_path=os.path.join(constants.default_conf_dir, "ta
     Returns: None
     """
     with open(tags_file_path, mode="w") as f:
-        data = yaml.dump(tags, Dumper=Dumper)
+        data = yaml.dump(tags, Dumper=Dumper, default_flow_style=False)
         f.write(data)

--- a/insights/tests/client/test_utilities.py
+++ b/insights/tests/client/test_utilities.py
@@ -254,3 +254,11 @@ def test_get_tags_empty():
 def test_get_tags_nonexist():
     got = util.get_tags("/file/does/not/exist")
     assert got is None
+
+
+def test_write_tags():
+    tags = {'foo': 'bar'}
+    fp = tempfile.NamedTemporaryFile()
+    util.write_tags(tags, tags_file_path=fp.name)
+    got = util.get_tags(fp.name)
+    assert got == tags

--- a/insights/tests/client/test_utilities.py
+++ b/insights/tests/client/test_utilities.py
@@ -231,3 +231,26 @@ def test_systemd_notify_failure_rhel_6(exists, Popen):
     exists.return_value = False
     util.systemd_notify('420')
     Popen.assert_not_called()
+
+
+def test_get_tags():
+    content = b"foo: bar"
+    fp = tempfile.NamedTemporaryFile(delete=False)
+    fp.write(content)
+    fp.close()
+    got = util.get_tags(fp.name)
+    assert got == {"foo": "bar"}
+
+
+def test_get_tags_empty():
+    content = b""
+    fp = tempfile.NamedTemporaryFile(delete=False)
+    fp.write(content)
+    fp.close()
+    got = util.get_tags(fp.name)
+    assert got is None
+
+
+def test_get_tags_nonexist():
+    got = util.get_tags("/file/does/not/exist")
+    assert got is None


### PR DESCRIPTION
This PR introduces a new config file, `tags.conf`, as well as the mechanisms to include tags in the collected archive.

The file `/etc/insights-client/tags.conf` is a YAML file containing key/value pairs that can be used to tag the node with desired attributes. For example:

```yaml
---
zone: us-east1
owner: zach
exclude: true
```

Upon collection, the file `/etc/insights-client/tags.conf` is parsed and its contents are written to the insights archive for inclusion in the upload.

In addition, if the `--group` argument is passed to `insights-client`, the value of the argument is written to the tags file with the `group` key. For example:

```
# cat /etc/insights-client/tags.conf
---
zone: us-east1
owner: zach
exclude: true
# insights-client --group=app-db-01
...
# cat /etc/insights-client/tags.conf
---
zone: us-east1
owner: zach
exclude: true
group: app-db-01
#
```

If the `--group` tag is then omitted from subsequent calls to `insights-client`, no change is made to the tags file.

Because the tags file is YAML, it is possible to create multi-value tags using a YAML list. Similarly, it is possible to create namespaces or nested tags using a YAML dictionary. When the tags are written to the insights archive, they are wrapped inside a top-level "insights-client" key in order to avoid possible collision with future tagging sources. Tags are written to the archive as JSON.