### PR TITLE
client: Maintain /v/l/i/results.json and /v/l/i/inventory.json files

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -394,6 +394,10 @@ class InsightsClient(object):
     def get_results(self, upload_response=None):
         client.get_results(self.config, self.connection, upload_response)
 
+    @_net
+    def get_inventory(self):
+        client.get_inventory(self.config, self.connection)
+
     def rotate_eggs(self):
         """
             moves newest.egg to last_stable.egg

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -384,11 +384,15 @@ class InsightsClient(object):
         if not os.path.exists(payload):
             raise IOError('Cannot upload %s: File does not exist.' % payload)
 
-        upload_results = client.upload(
+        upload_response = client.upload(
             self.config, self.connection, payload, content_type)
 
         # return api response
-        return upload_results
+        return upload_response
+
+    @_net
+    def get_results(self, upload_response=None):
+        client.get_results(self.config, self.connection, upload_response)
 
     def rotate_eggs(self):
         """

--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -377,6 +377,9 @@ def get_results(config, pconn, upload_resp):
         logger.error("Failed to retrieve results, code %s", resp.status_code)
         return False
 
+def get_inventory(config, pconn):
+    pconn.get_inventory()
+
 def _delete_archive_internal(config, archive):
     '''
     Only used during built-in collection.

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -183,6 +183,20 @@ DEFAULT_OPTS = {
         'action': 'store_true',
         'group': 'debug'
     },
+    'no_collect': {
+        'default': False,
+        'opt': ['--no-collect'],
+        'help': 'Do not create the archive',
+        'action': 'store_true',
+        'group': 'debug'
+    },
+    'no_results': {
+        'default': False,
+        'opt': ['--no-results'],
+        'help': 'Do not retrieve current analysis results',
+        'action': 'store_true',
+        'group': 'debug'
+    },
     'obfuscate': {
         # non-CLI
         'default': False

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -26,7 +26,8 @@ except ImportError:
 from .utilities import (determine_hostname,
                         generate_machine_id,
                         write_unregistered_file,
-                        write_registered_file)
+                        write_registered_file,
+                        write_atomically)
 from .cert_auth import rhsmCertificate
 from .constants import InsightsConstants as constants
 from insights import package_info
@@ -715,6 +716,11 @@ class InsightsConnection(object):
         logger.debug('Machine ID: %s', results[0]['insights_id'])
         logger.debug('Inventory ID: %s', results[0]['id'])
         return True
+
+    def get_inventory(self):
+        results = self._fetch_system_by_machine_id()
+        write_atomically(constants.insights_core_inventory_file,
+                         lambda f: f.write(json.dumps(results and results[0]) + "\n"))
 
     # -LEGACY-
     def _legacy_unregister(self):

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -37,6 +37,7 @@ class InsightsConstants(object):
     insights_core_last_stable_gpg_sig = os.path.join(insights_core_lib_dir, 'last_stable.egg.asc')
     insights_core_newest = os.path.join(insights_core_lib_dir, 'newest.egg')
     insights_core_gpg_sig_newest = os.path.join(insights_core_lib_dir, 'newest.egg.asc')
+    insights_core_results_file = os.path.join(insights_core_lib_dir, "results.json")
     sig_kill_ok = 100
     sig_kill_bad = 101
     cached_branch_info = os.path.join(default_conf_dir, '.branch_info')

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -38,6 +38,7 @@ class InsightsConstants(object):
     insights_core_newest = os.path.join(insights_core_lib_dir, 'newest.egg')
     insights_core_gpg_sig_newest = os.path.join(insights_core_lib_dir, 'newest.egg.asc')
     insights_core_results_file = os.path.join(insights_core_lib_dir, "results.json")
+    insights_core_inventory_file = os.path.join(insights_core_lib_dir, "inventory.json")
     sig_kill_ok = 100
     sig_kill_bad = 101
     cached_branch_info = os.path.join(default_conf_dir, '.branch_info')

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -241,8 +241,6 @@ def post_update(client, config):
 def collect_and_output(client, config):
     # last phase, delete PID file on exit
     atexit.register(write_to_disk, constants.pidfile, delete=True)
-    # update our local inventory record
-    client.get_inventory()
     # --compliance was called
     if config.compliance:
         config.payload, config.content_type = ComplianceClient(config).oscap_scan()
@@ -284,6 +282,7 @@ def collect_and_output(client, config):
     client.delete_cached_branch_info()
 
     if not config.no_results:
+        client.get_inventory()
         client.get_results(resp)
 
     # rotate eggs once client completes all work successfully

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -241,6 +241,8 @@ def post_update(client, config):
 def collect_and_output(client, config):
     # last phase, delete PID file on exit
     atexit.register(write_to_disk, constants.pidfile, delete=True)
+    # update our local inventory record
+    client.get_inventory()
     # --compliance was called
     if config.compliance:
         config.payload, config.content_type = ComplianceClient(config).oscap_scan()

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -11,6 +11,7 @@ import shlex
 import re
 import stat
 import sys
+import tempfile
 from subprocess import Popen, PIPE, STDOUT
 from six.moves.configparser import RawConfigParser
 
@@ -105,6 +106,11 @@ def write_to_disk(filename, delete=False, content=get_time()):
         with open(filename, 'wb') as f:
             f.write(content.encode('utf-8'))
 
+def write_atomically(path, writer):
+    with tempfile.NamedTemporaryFile(mode="w", dir=os.path.dirname(path), delete=False) as fo:
+            writer(fo)
+            fo.flush()
+            os.rename(fo.name, path)
 
 def generate_machine_id(new=False,
                         destination_file=constants.machine_id_file):

--- a/insights/tests/client/phase/test_collect_and_upload.py
+++ b/insights/tests/client/phase/test_collect_and_upload.py
@@ -16,6 +16,8 @@ def patch_insights_config(old_function):
                        "return_value.load_all.return_value.display_name": False,
                        "return_value.load_all.return_value.to_stdout": False,
                        "return_value.load_all.return_value.no_upload": False,
+                       "return_value.load_all.return_value.no_collect": False,
+                       "return_value.load_all.return_value.no_results": False,
                        "return_value.load_all.return_value.to_json": False,
                        "return_value.load_all.return_value.keep_archive": False,
                        "return_value.load_all.return_value.register": False,


### PR DESCRIPTION
I propose to make these two files (or something like it) part of the stable API of the insights-client.

Open issues:

- The /v/li/results.json is supposed to contain the analysis results corresponding to the most recent upload.  With the legacy API, the upload POST request does not complete until the results are available.  I have heard that the platform API might complete a upload before results are available.

- The two files need to be documented somewhere as stable API.

- Where would the tests for this go?
