### PR TITLE
Create the tags file if it does not exist

### DIFF
--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -345,6 +345,6 @@ def write_tags(tags, tags_file_path=os.path.join(constants.default_conf_dir, "ta
 
     Returns: None
     """
-    with open(tags_file_path, mode="w") as f:
+    with open(tags_file_path, mode="w+") as f:
         data = yaml.dump(tags, Dumper=Dumper, default_flow_style=False)
         f.write(data)


### PR DESCRIPTION
The tags file is not opened with mode="w+", so it was not being created if it did not yet already exist.