### PR TITLE
insights-operator and must-gather archive recognition. top level config component for both.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,7 +34,7 @@ archives) to better meet Red Hat customers' security and privacy concerns.
 Blacklists
     A list of files or commands to never upload.
 Filters
-    A set of grep-like strings used to filter files before adding it to
+    A set of grep-like strings used to filter files before adding them to
     the archive.
 Dynamic Uploader Configuration
     The client will download a configuration file from Red Hat (by
@@ -46,6 +46,18 @@ Dynamic Uploader Configuration
 These features allow these archives to be processed quickly and more
 securely in the Insights production environment.  On the other hand, the
 reduced data set narrows the scope of uses to be Insights-specific.
+
+OCP 4 Archives
+--------------
+
+OCP 4 can generate diagnostic archives with a component called the
+``insights-operator``.  They are automatically uploaded to Red Hat for analysis.
+
+The openshift-must-gather CLI tool produces more comprehensive archives than
+the operator. ``insights-core`` recognizes them as well.
+
+.. _openshift-must-gather: https://github.com/openshift/must-gather
+
 
 Execution Model
 ===============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Contents:
     parsers_index
     combiners_index
     components_index
+    ocp
     docs_guidelines
     components
     embedded_content

--- a/docs/ocp.rst
+++ b/docs/ocp.rst
@@ -1,0 +1,22 @@
+Openshift 4 Analysis
+====================
+OpenShift 4 can generate diagnostic archives with a component called the
+``insights-operator``.  They are automatically uploaded to Red Hat for analysis.
+
+The openshift-must-gather_ CLI tool produces more comprehensive archives than
+the operator. ``insights-core`` recognizes them as well.
+
+If you have an insights-operator or must-gather archive, you can write rules
+for it by using the :py:func:`insights.ocp.ocp` component, which gives you a
+top level view of **all** of the collected cluster configuration in a form
+that's easy to `navigate and query`_.
+
+You can access the entire configuration iteractively with ``insights inspect
+insights.ocp.ocp <archive>`` or ``insights ocpshell <archive>``.
+
+.. _openshift-must-gather: https://github.com/openshift/must-gather
+.. _navigate and query: https://insights-core.readthedocs.io/en/latest/notebooks/Parsr%20Query%20Tutorial.html
+
+.. automodule:: insights.ocp
+   :members:
+   :show-inheritance:

--- a/insights/core/context.py
+++ b/insights/core/context.py
@@ -252,6 +252,18 @@ class JDRContext(ExecutionContext):
         return super(JDRContext, self).locate_path(p)
 
 
+@fs_root
+class InsightsOperatorContext(ExecutionContext):
+    """Recognizes insights-operator archives"""
+    marker = "config/featuregate"
+
+
+@fs_root
+class MustGatherContext(ExecutionContext):
+    """Recognizes must-gather archives"""
+    marker = "namespaces"
+
+
 class OpenStackContext(ExecutionContext):
     def __init__(self, hostname):
         super(OpenStackContext, self).__init__()

--- a/insights/ocp.py
+++ b/insights/ocp.py
@@ -1,0 +1,80 @@
+"""
+Top level OpenShift 4 component
+===============================
+The :py:func:`ocp` component recognizes insights-operator and must-gather
+archives.
+"""
+import logging
+import os
+import yaml
+
+from fnmatch import fnmatch
+from insights.core.plugins import component
+from insights.core.context import InsightsOperatorContext, MustGatherContext
+
+from insights.core.archives import extract
+from insights.parsr.query import from_dict, Result
+from insights.util import content_type
+
+
+log = logging.getLogger(__name__)
+
+try:
+    # requires pyyaml installed after libyaml
+    Loader = yaml.CSafeLoader
+except:
+    log.info("Couldn't find libyaml loader. Falling back to python loader.")
+    Loader = yaml.SafeLoader
+
+
+def _get_files(path):
+    for root, dirs, names in os.walk(path):
+        for name in names:
+            yield os.path.join(root, name)
+
+
+def _load(path):
+    with open(path) as f:
+        doc = yaml.load(f, Loader=Loader)
+        return from_dict(doc)
+
+
+def _process(path, excludes=None):
+    excludes = excludes if excludes is not None else []
+    for f in _get_files(path):
+        if excludes and any(fnmatch(f, e) for e in excludes):
+            continue
+        try:
+            yield _load(f)
+        except Exception:
+            log.debug("Failed to load %s; skipping.", f)
+
+
+def analyze(paths, excludes=None):
+    if not isinstance(paths, list):
+        paths = [paths]
+
+    results = []
+    for path in paths:
+        if content_type.from_file(path) == "text/plain":
+            results.append(_load(path))
+        elif os.path.isdir(path):
+            results.extend(_process(path, excludes))
+        else:
+            with extract(path) as ex:
+                results.extend(_process(ex.tmp_dir, excludes))
+
+    return Result(children=results)
+
+
+@component([InsightsOperatorContext, MustGatherContext])
+def ocp(io, mg):
+    """
+    The ``ocp`` component parses all configuration in an insights-operator or
+    must-gather archive and returns an object that is part of the parsr common
+    data model.  It can be navigated and queried in a standard way. See the
+    `tutorial`_ for details.
+
+    .. _tutorial: https://insights-core.readthedocs.io/en/latest/notebooks/Parsr%20Query%20Tutorial.html
+    """
+    return analyze((io or mg).root)

--- a/insights/ocp.py
+++ b/insights/ocp.py
@@ -1,7 +1,7 @@
 """
 Top level OpenShift 4 component
 ===============================
-The :py:func:`ocp` component recognizes insights-operator and must-gather
+The :py:func:`conf` component recognizes insights-operator and must-gather
 archives.
 """
 import logging
@@ -68,9 +68,9 @@ def analyze(paths, excludes=None):
 
 
 @component([InsightsOperatorContext, MustGatherContext])
-def ocp(io, mg):
+def conf(io, mg):
     """
-    The ``ocp`` component parses all configuration in an insights-operator or
+    The ``conf`` component parses all configuration in an insights-operator or
     must-gather archive and returns an object that is part of the parsr common
     data model.  It can be navigated and queried in a standard way. See the
     `tutorial`_ for details.


### PR DESCRIPTION
This PR allows insights-core to recognize OCP 4 insights-operator and must-gather archives. It exposes the entire cluster configuration as a single component that rules can be written against in exactly the same way as queries in an interactive ocpshell session. External contexts may override the ones that are built in.