### PR TITLE
Add parser to report local kpatch patches

### DIFF
--- a/docs/shared_parsers_catalog/kpatch_patches.rst
+++ b/docs/shared_parsers_catalog/kpatch_patches.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.kpatch_patches
+   :members:
+   :show-inheritance:

--- a/insights/parsers/kpatch_patches.py
+++ b/insights/parsers/kpatch_patches.py
@@ -1,0 +1,23 @@
+"""
+KpatchPatches - report locally stored kpatch patches
+====================================================
+
+This parser creates a list of the module names of locally
+stored kpatch modules. If no modules are installed, a
+ContentException will be raised.
+
+"""
+
+from .. import parser, CommandParser
+from insights.specs import Specs
+
+
+@parser(Specs.kpatch_patch_files)
+class KpatchPatches(CommandParser):
+    """
+    A parser for getting modules names of locally stored kpatch-patch files.
+    """
+
+    def parse_content(self, content):
+        # convert dashes to underscores, remove file suffixes, remove duplicates
+        self.patches = list(set([p.split('.')[0].replace("-", "_") for p in content]))

--- a/insights/parsers/tests/test_kpatch_patches.py
+++ b/insights/parsers/tests/test_kpatch_patches.py
@@ -1,0 +1,38 @@
+from insights.parsers import kpatch_patches
+from insights.tests import context_wrap
+from insights.core.plugins import ContentException
+import pytest
+
+
+ASSORTED_KPATCHES = """
+asdfasdfasdf_asdfasdfasdf-asdfasdfasdf_asdfasdfasdf.ko
+asdfasdfasdf_asdfasdfasdf-asdfasdfasdf_asdfasdfasdf.ko.xz
+foo-bar.ko
+foo-bar.ko.xz
+foo.ko
+foo.ko.xz
+test_klp_callbacks_demo.ko
+test_klp_callbacks_demo.ko.xz
+""".strip()
+
+NO_KPATCH = """
+/bin/ls: cannot access '/var/lib/kpatch/4.18.0-147.8.el8.x86_64': No such file or directory
+""".strip()
+
+
+# Try a bunch of random potential patch names
+# Compare to expected module names
+def test_assorted():
+    kp = kpatch_patches.KpatchPatches(context_wrap(ASSORTED_KPATCHES))
+    for patch in [
+            'asdfasdfasdf_asdfasdfasdf_asdfasdfasdf_asdfasdfasdf',
+            'foo_bar',
+            'foo',
+            'test_klp_callbacks_demo']:
+        assert patch in kp.patches
+
+
+# Try the case of no patches installed
+def test_no_kpatch():
+    with pytest.raises(ContentException):
+        kpatch_patches.KpatchPatches(context_wrap(NO_KPATCH))

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -258,6 +258,7 @@ class Specs(SpecSet):
     keystone_crontab = RegistryPoint()
     keystone_crontab_container = RegistryPoint()
     keystone_log = RegistryPoint(filterable=True)
+    kpatch_patch_files = RegistryPoint()
     krb5 = RegistryPoint(multi_output=True)
     ksmstate = RegistryPoint()
     kubepods_cpu_quota = RegistryPoint(multi_output=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -26,6 +26,7 @@ from insights.core.spec_factory import first_of, foreach_collect, foreach_execut
 from insights.core.spec_factory import first_file, listdir
 from insights.parsers.mount import Mount, ProcMounts
 from insights.parsers.dnf_module import DnfModuleList
+from insights.parsers.uname import Uname
 from insights.combiners.cloud_provider import CloudProvider
 from insights.combiners.satellite_version import SatelliteVersion
 from insights.components.rhel_version import IsRhel8
@@ -494,6 +495,13 @@ class DefaultSpecs(Specs):
     keystone_crontab = simple_command("/usr/bin/crontab -l -u keystone")
     keystone_crontab_container = simple_command("docker exec keystone_cron /usr/bin/crontab -l -u keystone")
     keystone_log = first_file(["/var/log/containers/keystone/keystone.log", "/var/log/keystone/keystone.log"])
+
+    @datasource(Uname, context=HostContext)
+    def kpatch_patches_running_kernel_dir(broker):
+        un = broker[Uname]
+        return r"/var/lib/kpatch/" + un.kernel
+
+    kpatch_patch_files = command_with_args("ls %s", kpatch_patches_running_kernel_dir)
     krb5 = glob_file([r"etc/krb5.conf", r"etc/krb5.conf.d/*"])
     ksmstate = simple_file("/sys/kernel/mm/ksm/run")
     kubepods_cpu_quota = glob_file("/sys/fs/cgroup/cpu/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod[a-f0-9_]*.slice/cpu.cfs_quota_us")


### PR DESCRIPTION
This patch creates a parser to report on the possible module names of kpatch patches that are installed on a machine.

Also add a supporting spec 'kpatch_patch_files'

Signed-off-by: Joel Savitz <jsavitz@redhat.com>