### PR TITLE
Adapt FreeIPAHealthCheckLog parser for Healthcheck 0.3 (#2369)

### DIFF
--- a/insights/parsers/freeipa_healthcheck_log.py
+++ b/insights/parsers/freeipa_healthcheck_log.py
@@ -11,84 +11,52 @@ Typical content of file ``/var/log/ipa/healthcheck/healthcheck.log`` is::
 
     [
       {
-        "source": "ipahealthcheck.dogtag.ca",
-        "check": "DogtagCertsConfigCheck",
-        "severity": 0,
-        "uuid": "57f7d2c9-f71f-4c2f-b831-9e30250b18b2",
-        "when": "20190726213428Z",
-        "duration": "0.150333",
+        "source": "ipahealthcheck.ipa.roles",
+        "check": "IPACRLManagerCheck",
+        "result": "SUCCESS",
+        "uuid": "1f4177a4-0ddb-4e4d-8258-a5cd5f4638fc",
+        "when": "20191203122317Z",
+        "duration": "0.002254",
         "kw": {
-          "key": "subsystemCert cert-pki-ca",
-          "configfile": "/var/lib/pki/pki-tomcat/conf/ca/CS.cfg"
+          "key": "crl_manager",
+          "crlgen_enabled": true
         }
       },
       {
-        "source": "ipahealthcheck.ipa.certs",
-        "check": "IPACertmongerExpirationCheck",
-        "severity": 0,
-        "uuid": "afd047c2-d78b-4c5c-b3a4-f68578ee1595",
-        "when": "20190726213429Z",
-        "duration": "0.007105",
+        "source": "ipahealthcheck.ipa.roles",
+        "check": "IPARenewalMasterCheck",
+        "result": "SUCCESS",
+        "uuid": "1feb7f99-2e98-4e37-bb52-686896972022",
+        "when": "20191203122317Z",
+        "duration": "0.018330",
         "kw": {
-          "key": "20190620165230"
-        }
-      },
-      {
-        "source": "ipahealthcheck.ds.replication",
-        "check": "ReplicationConflictCheck",
-        "severity": 0,
-        "uuid": "99c0a513-447c-46f1-95ea-058fc0db6075",
-        "when": "20190726213429Z",
-        "duration": "0.001409",
-        "kw": {}
-      },
-      {
-        "source": "ipahealthcheck.ipa.files",
-        "check": "IPAFileNSSDBCheck",
-        "severity": 0,
-        "uuid": "7e8a7739-c4d6-4b97-b602-9f9e981f793c",
-        "when": "20190726213432Z",
-        "duration": "0.000765",
-        "kw": {
-          "key": "_etc_pki_pki-tomcat_alias_cert9.db_owner",
-          "type": "owner",
-          "path": "/etc/pki/pki-tomcat/alias/cert9.db"
-        }
-      },
-      {
-        "source": "ipahealthcheck.ipa.topology",
-        "check": "IPATopologyDomainCheck",
-        "severity": 0,
-        "uuid": "c5ee8ee1-98d1-4696-bbf1-8243677b8918",
-        "when": "20190726213432Z",
-        "duration": "0.019070",
-        "kw": {
-          "suffix": "ca"
+          "key": "renewal_master",
+          "master": true
         }
       },
       {
         "source": "ipahealthcheck.system.filesystemspace",
         "check": "FileSystemSpaceCheck",
-        "severity": 2,
-        "uuid": "4d1c71c5-cc37-4ebf-b53c-34f4e4534437",
-        "when": "20190726213432Z",
-        "duration": null,
+        "result": "ERROR",
+        "uuid": "90ed8765-6ad7-425c-abbd-b07a652649cb",
+        "when": "20191203122221Z",
+        "duration": "0.000474",
         "kw": {
-          "msg": "/var/lib/dirsrv/: free space percentage under threshold: 1% < 20%",
-          "store": "/var/lib/dirsrv/",
-          "percent_free": 1,
-          "threshold": 20
+          "msg": "/var/log/audit/: free space under threshold: 14 MiB < 512 MiB",
+          "store": "/var/log/audit/",
+          "free_space": 14,
+          "threshold": 512
         }
       }
     ]
 
-The list of errors can be accessed via the errors property.
+The list of errors can be accessed via the issues property.
 
 Examples:
 
-    >>> len(healthcheck.errors)
+    >>> len(healthcheck.issues)
     1
-    >>> healthcheck.errors[0]['check'] == 'FileSystemSpaceCheck'
+    >>> healthcheck.issues[0]['check'] == 'FileSystemSpaceCheck'
     True
 
 """
@@ -103,6 +71,6 @@ class FreeIPAHealthCheckLog(JSONParser):
     """Parses the content of file ``/var/log/ipa/healthcheck/healthcheck.log``."""
 
     @property
-    def errors(self):
-        """ list: errors in healthcheck log."""
-        return [entry for entry in self.data if entry['severity'] > 0]
+    def issues(self):
+        """ list: non-success results in healthcheck log."""
+        return [entry for entry in self.data if entry["result"] != "SUCCESS"]

--- a/insights/parsers/tests/test_freeipa_healthcheck_log.py
+++ b/insights/parsers/tests/test_freeipa_healthcheck_log.py
@@ -4,90 +4,61 @@ from insights.parsers.freeipa_healthcheck_log import FreeIPAHealthCheckLog
 from insights.tests import context_wrap
 
 LONG_FREEIPA_HEALTHCHECK_LOG_OK = """
-[{"source": "ipahealthcheck.meta.services", "check": "certmonger",
-"severity": 0, "uuid": "693c526c-2261-44fe-98e0-94c6b76bf79b",
-"when": "20190711141703Z", "duration": "0.012848", "kw": {"status": true}}]
+[{"source": "ipahealthcheck.ipa.roles", "check": "IPACRLManagerCheck",
+"result": "SUCCESS", "uuid": "1f4177a4-0ddb-4e4d-8258-a5cd5f4638fc",
+"when": "20191203122317Z", "duration": "0.002254",
+"kw": {"key": "crl_manager", "crlgen_enabled": true}}]
 """.strip()
 
 LONG_FREEIPA_HEALTHCHECK_LOG_FAILURES = """
-[{"source": "ipahealthcheck.system.filesystemspace", "check": "FileSystemSpaceCheck",
-"severity": 2, "uuid": "ceadd564-f42f-4640-a3ae-b67f1aa29dc4", "when": "20190711141807Z",
-"duration": null, "kw": {"msg": "/var/log/: free space under threshold: 400 MiB < 1024 MiB",
-"store": "/var/log/", "free_space": 400, "threshold": 1024}}]
+[{"source": "ipahealthcheck.system.filesystemspace",
+"check": "FileSystemSpaceCheck",
+"result": "ERROR", "uuid": "90ed8765-6ad7-425c-abbd-b07a652649cb",
+"when": "20191203122221Z", "duration": "0.000474", "kw": {
+"msg": "/var/log/audit/: free space under threshold: 14 MiB < 512 MiB",
+"store": "/var/log/audit/", "free_space": 14, "threshold": 512}}]
 """.strip()
 
 FREEIPA_HEALTHCHECK_LOG_DOCS_EXAMPLE = '''
     [
       {
-        "source": "ipahealthcheck.dogtag.ca",
-        "check": "DogtagCertsConfigCheck",
-        "severity": 0,
-        "uuid": "57f7d2c9-f71f-4c2f-b831-9e30250b18b2",
-        "when": "20190726213428Z",
-        "duration": "0.150333",
+        "source": "ipahealthcheck.ipa.roles",
+        "check": "IPACRLManagerCheck",
+        "result": "SUCCESS",
+        "uuid": "1f4177a4-0ddb-4e4d-8258-a5cd5f4638fc",
+        "when": "20191203122317Z",
+        "duration": "0.002254",
         "kw": {
-          "key": "subsystemCert cert-pki-ca",
-          "configfile": "/var/lib/pki/pki-tomcat/conf/ca/CS.cfg"
+          "key": "crl_manager",
+          "crlgen_enabled": true
         }
       },
       {
-        "source": "ipahealthcheck.ipa.certs",
-        "check": "IPACertmongerExpirationCheck",
-        "severity": 0,
-        "uuid": "afd047c2-d78b-4c5c-b3a4-f68578ee1595",
-        "when": "20190726213429Z",
-        "duration": "0.007105",
+        "source": "ipahealthcheck.ipa.roles",
+        "check": "IPARenewalMasterCheck",
+        "result": "SUCCESS",
+        "uuid": "1feb7f99-2e98-4e37-bb52-686896972022",
+        "when": "20191203122317Z",
+        "duration": "0.018330",
         "kw": {
-          "key": "20190620165230"
-        }
-      },
-      {
-        "source": "ipahealthcheck.ds.replication",
-        "check": "ReplicationConflictCheck",
-        "severity": 0,
-        "uuid": "99c0a513-447c-46f1-95ea-058fc0db6075",
-        "when": "20190726213429Z",
-        "duration": "0.001409",
-        "kw": {}
-      },
-      {
-        "source": "ipahealthcheck.ipa.files",
-        "check": "IPAFileNSSDBCheck",
-        "severity": 0,
-        "uuid": "7e8a7739-c4d6-4b97-b602-9f9e981f793c",
-        "when": "20190726213432Z",
-        "duration": "0.000765",
-        "kw": {
-          "key": "_etc_pki_pki-tomcat_alias_cert9.db_owner",
-          "type": "owner",
-          "path": "/etc/pki/pki-tomcat/alias/cert9.db"
-        }
-      },
-      {
-        "source": "ipahealthcheck.ipa.topology",
-        "check": "IPATopologyDomainCheck",
-        "severity": 0,
-        "uuid": "c5ee8ee1-98d1-4696-bbf1-8243677b8918",
-        "when": "20190726213432Z",
-        "duration": "0.019070",
-        "kw": {
-          "suffix": "ca"
+          "key": "renewal_master",
+          "master": true
         }
       },
       {
         "source": "ipahealthcheck.system.filesystemspace",
         "check": "FileSystemSpaceCheck",
-        "severity": 2,
-        "uuid": "4d1c71c5-cc37-4ebf-b53c-34f4e4534437",
-        "when": "20190726213432Z",
-        "duration": null,
+        "result": "ERROR",
+        "uuid": "90ed8765-6ad7-425c-abbd-b07a652649cb",
+        "when": "20191203122221Z",
+        "duration": "0.000474",
         "kw": {
-          "msg": "/var/lib/dirsrv/: free space percentage under threshold: 1% < 20%",
-          "store": "/var/lib/dirsrv/",
-          "percent_free": 1,
-          "threshold": 20
-        }
-      }
+          "msg": "/var/log/audit/: free space under threshold: 14 MiB < 512 MiB",
+          "store": "/var/log/audit/",
+          "free_space": 14,
+          "threshold": 512
+         }
+       }
     ]
 '''.strip()
 
@@ -98,15 +69,15 @@ FREEIPA_HEALTHCHECK_LOG_FAILURES = "".join(LONG_FREEIPA_HEALTHCHECK_LOG_FAILURES
 
 def test_freeipa_healthcheck_log_ok():
     log_obj = FreeIPAHealthCheckLog(context_wrap(FREEIPA_HEALTHCHECK_LOG_OK))
-    assert len(log_obj.errors) == 0
+    assert len(log_obj.issues) == 0
 
 
 def test_freeipa_healthcheck_log_not_ok():
     log_obj = FreeIPAHealthCheckLog(context_wrap(FREEIPA_HEALTHCHECK_LOG_FAILURES))
-    assert len(log_obj.errors) > 0
-    for error in log_obj.errors:
-        assert error['check'] == 'FileSystemSpaceCheck'
-        assert error['source'] == 'ipahealthcheck.system.filesystemspace'
+    assert len(log_obj.issues) > 0
+    for issue in log_obj.issues:
+        assert issue['check'] == 'FileSystemSpaceCheck'
+        assert issue['source'] == 'ipahealthcheck.system.filesystemspace'
 
 
 def test_freeipa_healthcheck_log__documentation():


### PR DESCRIPTION
FreeIPA Healthcheck JSON schema changed from 0.2 to 0.3:
the 'severity' key was replaced by 'result'.

Signed-off-by: François Cami <fcami@redhat.com>