### PR TITLE
Use utf8 in glob

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -4,6 +4,7 @@ import os
 import re
 import six
 import traceback
+import codecs
 
 from collections import defaultdict
 from glob import glob
@@ -243,12 +244,8 @@ class TextFileProvider(FileProvider):
             rc, out = self.ctx.shell_out(args, keep_rc=True, env=SAFE_ENV)
             self.rc = rc
             return out
-        if six.PY3:
-            with open(self.path, "r", encoding="utf-8", errors="surrogateescape") as f:
-                return [l.rstrip("\n") for l in f]
-        else:
-            with open(self.path, "rU") as f:  # universal newlines
-                return [l.rstrip("\n") for l in f]
+        with codecs.open(self.path, "r", encoding="utf-8", errors="surrogateescape") as f:
+            return [l.rstrip("\n") for l in f]
 
     def _stream(self):
         """

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -244,7 +244,7 @@ class TextFileProvider(FileProvider):
             self.rc = rc
             return out
         if six.PY3:
-            with open(self.path, "r", encoding="ascii", errors="surrogateescape") as f:
+            with open(self.path, "r", encoding="utf-8", errors="surrogateescape") as f:
                 return [l.rstrip("\n") for l in f]
         else:
             with open(self.path, "rU") as f:  # universal newlines


### PR DESCRIPTION
Use `codes.open()` for files in glob_file to ensure the proper encoding of files. This is to fix a problem encountered when unicode characters were included in a yum repo file. 

https://projects.engineering.redhat.com/browse/RHCLOUD-3610