### PR TITLE
Add parser for command readlink /etc/mtab

### DIFF
--- a/docs/shared_parsers_catalog/readlink_e_mtab.rst
+++ b/docs/shared_parsers_catalog/readlink_e_mtab.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.readlink_e_mtab
+   :members:
+   :show-inheritance:

--- a/insights/parsers/readlink_e_mtab.py
+++ b/insights/parsers/readlink_e_mtab.py
@@ -20,6 +20,7 @@ from insights import parser, CommandParser
 
 @parser(Specs.readlink_e_etc_mtab)
 class ReadLinkEMtab(CommandParser):
+    """Class for command: readlink -e /etc/mtab"""
     def parse_content(self, content):
         if content is None or len(content) == 0:
             raise SkipException("No Data from command: readlink -e /etc/mtab")

--- a/insights/parsers/readlink_e_mtab.py
+++ b/insights/parsers/readlink_e_mtab.py
@@ -1,0 +1,36 @@
+"""
+ReadLinkEMtab - command ``readlink -e /etc/mtab``
+=================================================
+
+The ``readlink -e /etc/mtab`` command provides information about
+the path of ``mtab`` file.
+
+Sample content from command ``readlink -e /etc/mtab`` is::
+    /proc/4578/mounts
+
+Examples:
+    >>> mtab.path
+    '/proc/4578/mounts'
+"""
+
+from insights.specs import Specs
+from insights.parsers import SkipException
+from insights import parser, CommandParser
+
+
+@parser(Specs.readlink_e_etc_mtab)
+class ReadLinkEMtab(CommandParser):
+    def parse_content(self, content):
+        if content is None or len(content) == 0:
+            raise SkipException("No Data from command: readlink -e /etc/mtab")
+
+        for line in content:
+            self._path = line  # use the last line
+
+    @property
+    def path(self):
+        """Returns real file path from command"""
+        return self._path
+
+    def __str__(self):
+        return str("readlink -e /etc/mtab: " + self._path)

--- a/insights/parsers/readlink_e_mtab.py
+++ b/insights/parsers/readlink_e_mtab.py
@@ -31,6 +31,3 @@ class ReadLinkEMtab(CommandParser):
     def path(self):
         """Returns real file path from command"""
         return self._path
-
-    def __str__(self):
-        return str("readlink -e /etc/mtab: " + self._path)

--- a/insights/parsers/tests/test_readlink_mtab.py
+++ b/insights/parsers/tests/test_readlink_mtab.py
@@ -1,0 +1,32 @@
+import pytest
+import doctest
+
+from insights.tests import context_wrap
+from insights.parsers import readlink_e_mtab, SkipException
+
+REAL_FILE_PATH = '''
+/proc/4578/mounts
+'''.strip()
+
+BAD_FILE_PATH = ""
+
+
+def test_doc_examples():
+    env = {
+        'mtab': readlink_e_mtab.ReadLinkEMtab(
+            context_wrap(REAL_FILE_PATH)),
+    }
+    failed, total = doctest.testmod(readlink_e_mtab, globs=env)
+    assert failed == 0
+
+
+def test_readlink_e_mtab():
+    mtab = readlink_e_mtab.ReadLinkEMtab(context_wrap(REAL_FILE_PATH))
+    assert len(mtab.path) > 0
+    assert mtab.path == REAL_FILE_PATH
+
+
+def test_fail():
+    with pytest.raises(SkipException) as e:
+        readlink_e_mtab.ReadLinkEMtab(context_wrap(BAD_FILE_PATH))
+    assert "No Data from command: readlink -e /etc/mtab" in str(e)

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -479,6 +479,7 @@ class Specs(SpecSet):
     rabbitmq_users = RegistryPoint()
     rc_local = RegistryPoint()
     rdma_conf = RegistryPoint()
+    readlink_e_etc_mtab = RegistryPoint()
     redhat_release = RegistryPoint()
     resolv_conf = RegistryPoint()
     rhev_data_center = RegistryPoint()
@@ -639,4 +640,3 @@ class Specs(SpecSet):
     yum_repolist = RegistryPoint()
     yum_repos_d = RegistryPoint(multi_output=True)
     zipl_conf = RegistryPoint()
-    readlink_e_etc_mtab = RegistryPoint()

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -639,3 +639,4 @@ class Specs(SpecSet):
     yum_repolist = RegistryPoint()
     yum_repos_d = RegistryPoint(multi_output=True)
     zipl_conf = RegistryPoint()
+    readlink_e_etc_mtab = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -772,6 +772,7 @@ class DefaultSpecs(Specs):
     rabbitmq_users = simple_command("/usr/sbin/rabbitmqctl list_users")
     rc_local = simple_file("/etc/rc.d/rc.local")
     rdma_conf = simple_file("/etc/rdma/rdma.conf")
+    readlink_e_etc_mtab = simple_command("readlink -e /etc/mtab")
     redhat_release = simple_file("/etc/redhat-release")
     resolv_conf = simple_file("/etc/resolv.conf")
     rhosp_release = simple_file("/etc/rhosp-release")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -286,3 +286,4 @@ class InsightsArchiveSpecs(Specs):
     woopsie = simple_file("insights_commands/find_.var.crash_.var.tmp_-path_.reports-_.whoopsie-report")
     yum_list_installed = simple_file("insights_commands/yum_-C_--noplugins_list_installed")
     yum_repolist = simple_file("insights_commands/yum_-C_repolist")
+    readlink_e_etc_mtab = simple_file("readlink_-e_.etc.mtab")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -226,6 +226,7 @@ class InsightsArchiveSpecs(Specs):
     rabbitmq_queues = simple_file("insights_commands/rabbitmqctl_list_queues_name_messages_consumers_auto_delete")
     rabbitmq_report = simple_file("insights_commands/rabbitmqctl_report")
     rabbitmq_users = simple_file("insights_commands/rabbitmqctl_list_users")
+    readlink_e_etc_mtab = simple_file("readlink_-e_.etc.mtab")
     rhn_charsets = simple_file("insights_commands/rhn-charsets")
     rhn_schema_stats = simple_file("insights_commands/rhn-schema-stats")
     rhn_schema_version = simple_file("insights_commands/rhn-schema-version")
@@ -286,4 +287,3 @@ class InsightsArchiveSpecs(Specs):
     woopsie = simple_file("insights_commands/find_.var.crash_.var.tmp_-path_.reports-_.whoopsie-report")
     yum_list_installed = simple_file("insights_commands/yum_-C_--noplugins_list_installed")
     yum_repolist = simple_file("insights_commands/yum_-C_repolist")
-    readlink_e_etc_mtab = simple_file("readlink_-e_.etc.mtab")


### PR DESCRIPTION
Added
insights/parsers/readlink_e_mtab.py
insights/parsers/tests/test_readlink_mtab.py
docs/shared_parsers_catalog/readlink_e_mtab.rst

Updated
insights/specs/__init__.py
insights/specs/default.py
insights/specs/insights_archive.py

pytest -k readlink_e_mtab
================ test session starts ================
platform linux -- Python 3.6.8, pytest-3.0.6, py-1.8.0, pluggy-0.4.0
rootdir: /root/src/insights/shlao/insights-core, inifile: setup.cfg
plugins: cov-2.4.0
collected 1878 items 

insights/parsers/tests/test_readlink_mtab.py .
================ 1877 tests deselected ================
======== 1 passed, 1877 deselected in 4.11 seconds ========