### PR TITLE
Remove unused ulimit spec

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -600,7 +600,6 @@ class Specs(SpecSet):
     tuned_adm = RegistryPoint()
     tuned_conf = RegistryPoint()
     udev_persistent_net_rules = RegistryPoint()
-    ulimit_hard = RegistryPoint()
     uname = RegistryPoint()
     up2date = RegistryPoint()
     up2date_log = RegistryPoint(filterable=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -985,7 +985,6 @@ class DefaultSpecs(Specs):
     tuned_adm = simple_command("/usr/sbin/tuned-adm list")
     tuned_conf = simple_file("/etc/tuned.conf")
     udev_persistent_net_rules = simple_file("/etc/udev/rules.d/70-persistent-net.rules")
-    ulimit_hard = simple_command("/usr/bin/ulimit -a -H")
     uname = simple_command("/usr/bin/uname -a")
     up2date = simple_file("/etc/sysconfig/rhn/up2date")
     up2date_log = simple_file("/var/log/up2date")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -274,7 +274,6 @@ class InsightsArchiveSpecs(Specs):
     teamdctl_state_dump = glob_file("insights_commands/teamdctl_*_state_dump")
     tomcat_vdc_fallback = simple_file("insights_commands/find_.usr.share_-maxdepth_1_-name_tomcat_-exec_.bin.grep_-R_-s_VirtualDirContext_--include_.xml")
     tuned_adm = simple_file("insights_commands/tuned-adm_list")
-    ulimit_hard = simple_file("insights_commands/ulimit_-a_-H")
     uname = simple_file("insights_commands/uname_-a")
     uptime = simple_file("insights_commands/uptime")
     version_info = simple_file("version_info")


### PR DESCRIPTION
Ulimit spec cannot be collected because it is a shell builtin.