### PR TITLE
Add sos archive path for FreeIPA Healthcheck log

### DIFF
--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -51,6 +51,7 @@ class SosSpecs(Specs):
     foreman_proxy_log = first_of([simple_file("/var/log/foreman-proxy/proxy.log"), simple_file("sos_commands/foreman/foreman-debug/var/log/foreman-proxy/proxy.log")])
     foreman_satellite_log = first_of([simple_file("/var/log/foreman-installer/satellite.log"), simple_file("sos_commands/foreman/foreman-debug/var/log/foreman-installer/satellite.log")])
     foreman_ssl_access_ssl_log = first_file(["var/log/httpd/foreman-ssl_access_ssl.log", r"sos_commands/foreman/foreman-debug/var/log/httpd/foreman-ssl_access_ssl.log"])
+    freeipa_healthcheck_log = simple_file("var/log/ipa/healthcheck/healthcheck.log")
     hammer_ping = first_file(["sos_commands/foreman/hammer_ping", "sos_commands/foreman/foreman-debug/hammer-ping"])
     getcert_list = first_file(["sos_commands/ipa/ipa-getcert_list", "sos_commands/ipa/getcert_list"])
     gluster_v_info = simple_file("sos_commands/gluster/gluster_volume_info")


### PR DESCRIPTION
sos archives now collect the FreeIPA Healthcheck log.
Add it as a data source.

Signed-off-by: François Cami <fcami@redhat.com>