### PR TITLE
Add method to healthcheck-parser to find failures for a specific check

### DIFF
--- a/insights/parsers/freeipa_healthcheck_log.py
+++ b/insights/parsers/freeipa_healthcheck_log.py
@@ -74,3 +74,12 @@ class FreeIPAHealthCheckLog(JSONParser):
     def issues(self):
         """ list: non-success results in healthcheck log."""
         return [entry for entry in self.data if entry["result"] != "SUCCESS"]
+
+    def get_results(self, source, check):
+        """Given a source and check find and return the result"""
+        results = []
+        for entry in self.data:
+            if (entry.get('source') == source and entry.get('check') == check and entry.get('result') in ['ERROR', 'CRITICAL']):
+                results.append(entry)
+
+        return results

--- a/insights/parsers/tests/test_freeipa_healthcheck_log.py
+++ b/insights/parsers/tests/test_freeipa_healthcheck_log.py
@@ -80,6 +80,22 @@ def test_freeipa_healthcheck_log_not_ok():
         assert issue['source'] == 'ipahealthcheck.system.filesystemspace'
 
 
+def test_freeipa_healthcheck_get_results_ok():
+    log_obj = FreeIPAHealthCheckLog(context_wrap(FREEIPA_HEALTHCHECK_LOG_OK))
+    results = log_obj.get_results('ipahealthcheck.system.filesystemspace', 'FileSystemSpaceCheck')
+    assert len(results) == 0
+
+
+def test_freeipa_healthcheck_get_results_not_ok():
+    log_obj = FreeIPAHealthCheckLog(context_wrap(FREEIPA_HEALTHCHECK_LOG_FAILURES))
+    results = log_obj.get_results('ipahealthcheck.system.filesystemspace', 'FileSystemSpaceCheck')
+    assert len(results) == 1
+    for result in results:
+        assert result['result'] in ['ERROR', 'CRITICAL']
+        assert result['check'] == 'FileSystemSpaceCheck'
+        assert result['source'] == 'ipahealthcheck.system.filesystemspace'
+
+
 def test_freeipa_healthcheck_log__documentation():
     env = {
         'healthcheck': FreeIPAHealthCheckLog(context_wrap(FREEIPA_HEALTHCHECK_LOG_DOCS_EXAMPLE)),


### PR DESCRIPTION
This new parser method makes creating per-check rules easy, like this:
```
freeipa_healthcheck_log.get_results('ipahealthcheck.ipa.certs', 'IPACertTracking')
```

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
Signed-off-by: François Cami <fcami@redhat.com>