### PR TITLE
Add branch_info into the metadata for payloads

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -862,6 +862,7 @@ class InsightsConnection(object):
             # add display_name to canonical facts
             c_facts['display_name'] = self.config.display_name
         if self.config.branch_info:
+            c_facts["branch_info"] = self.config.branch_info
             c_facts["satellite_id"] = self.config.branch_info["remote_leaf"]
         c_facts = json.dumps(c_facts)
         logger.debug('Canonical facts collected:\n%s', c_facts)

--- a/insights/tests/client/test_platform.py
+++ b/insights/tests/client/test_platform.py
@@ -102,6 +102,7 @@ def test_payload_upload(op, session, c, _legacy_upload_archive):
             'file': ('testp', ANY, 'testct'),  # ANY = return call from mocked open(), acts as filepointer here
             'metadata': json.dumps({
                 'test': 'facts',
+                'branch_info': {'remote_branch': -1, 'remote_leaf': -1},
                 'satellite_id': -1,
             })},
         headers={})


### PR DESCRIPTION
Add full branch_info into the metadata of client uploads when using the
--payload option.

Left the satellite_id key where it is in case other apps continue looking for it in the same place.

JIRA: RHCLOUD-3697

Signed-off-by: Stephen Adams <tsadams@gmail.com>