### PR TITLE
Add --version flag to the Insights CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,3 @@ output/
 share/
 .Python
 .python*
-pyvenv.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ output/
 share/
 .Python
 .python*
+pyvenv.cfg

--- a/insights/command_parser.py
+++ b/insights/command_parser.py
@@ -11,8 +11,6 @@ from __future__ import print_function
 import argparse
 import sys
 
-from insights import get_nvr
-
 USAGE = """insights <command> [<args>]
 Available commands:
   cat         Execute a spec and show the output
@@ -21,6 +19,7 @@ Available commands:
   info        View info and docs for Insights Core components.
   ocpshell         Interactive evaluation of archives, directories, or individual yaml files.
   run         Run insights-core against host or an archive.
+  version     Show Insights Core version information and exit.
 """
 
 
@@ -37,12 +36,10 @@ class InsightsCli(object):
         parser = argparse.ArgumentParser(
             description="Insights Core command line execution",
             usage=USAGE)
-        parser.add_argument('--version', action='store_true', help='show Insights Core version information and exit')
         parser.add_argument('command', help='Insights Core command to run')
-        # if version argument present, print version info and exit
-        if self.parse_version_arg():
-            print(get_nvr())
-            sys.exit()
+        parser.add_argument('--version', action='store_true', help='show Insights Core version information and exit')
+        if self._parse_version_arg():
+            self.version()
         args = parser.parse_args(sys.argv[1:2])
         if not hasattr(self, args.command):
             print('Unrecognized command')
@@ -53,7 +50,10 @@ class InsightsCli(object):
         # Use dispatch pattern to execute command
         getattr(self, args.command)()
 
-    def parse_version_arg(self):
+    def _parse_version_arg(self):
+        """
+        Manually check for version argument/flag in cases when command is not provided.
+        """
         return '--version' in sys.argv[1:3]
 
     def cat(self):
@@ -81,6 +81,14 @@ class InsightsCli(object):
         if "" not in sys.path:
             sys.path.insert(0, "")
         run(print_summary=True)
+
+    def version(self):
+        """
+        Print version information (NVR) and exit.
+        """
+        from insights import get_nvr
+        print(get_nvr())
+        sys.exit()
 
 
 def fix_arg_dashes():

--- a/insights/command_parser.py
+++ b/insights/command_parser.py
@@ -11,6 +11,8 @@ from __future__ import print_function
 import argparse
 import sys
 
+from insights import get_nvr
+
 USAGE = """insights <command> [<args>]
 Available commands:
   cat         Execute a spec and show the output
@@ -35,7 +37,11 @@ class InsightsCli(object):
         parser = argparse.ArgumentParser(
             description="Insights Core command line execution",
             usage=USAGE)
+        parser.add_argument('--version', action='version', version=get_nvr(), help='display Insights Core version')
         parser.add_argument('command', help='Insights Core command to run')
+        # if present parse version argument only, will print version info and exit
+        if '--version' in sys.argv[1:3]:
+            parser.parse_args(['--version'])
         args = parser.parse_args(sys.argv[1:2])
         if not hasattr(self, args.command):
             print('Unrecognized command')

--- a/insights/command_parser.py
+++ b/insights/command_parser.py
@@ -37,7 +37,7 @@ class InsightsCli(object):
         parser = argparse.ArgumentParser(
             description="Insights Core command line execution",
             usage=USAGE)
-        parser.add_argument('--version', action='store_true', help='display Insights Core version')
+        parser.add_argument('--version', action='store_true', help='show insights-core version information and exit')
         parser.add_argument('command', help='Insights Core command to run')
         # if version argument present, print version info and exit
         if '--version' in sys.argv[1:3]:

--- a/insights/command_parser.py
+++ b/insights/command_parser.py
@@ -37,11 +37,12 @@ class InsightsCli(object):
         parser = argparse.ArgumentParser(
             description="Insights Core command line execution",
             usage=USAGE)
-        parser.add_argument('--version', action='version', version=get_nvr(), help='display Insights Core version')
+        parser.add_argument('--version', action='store_true', help='display Insights Core version')
         parser.add_argument('command', help='Insights Core command to run')
-        # if present parse version argument only, will print version info and exit
+        # if version argument present, print version info and exit
         if '--version' in sys.argv[1:3]:
-            parser.parse_args(['--version'])
+            print(get_nvr())
+            sys.exit()
         args = parser.parse_args(sys.argv[1:2])
         if not hasattr(self, args.command):
             print('Unrecognized command')

--- a/insights/command_parser.py
+++ b/insights/command_parser.py
@@ -37,10 +37,10 @@ class InsightsCli(object):
         parser = argparse.ArgumentParser(
             description="Insights Core command line execution",
             usage=USAGE)
-        parser.add_argument('--version', action='store_true', help='show insights-core version information and exit')
+        parser.add_argument('--version', action='store_true', help='show Insights Core version information and exit')
         parser.add_argument('command', help='Insights Core command to run')
         # if version argument present, print version info and exit
-        if '--version' in sys.argv[1:3]:
+        if self.parse_version_arg():
             print(get_nvr())
             sys.exit()
         args = parser.parse_args(sys.argv[1:2])
@@ -52,6 +52,9 @@ class InsightsCli(object):
         sys.argv.pop(1)
         # Use dispatch pattern to execute command
         getattr(self, args.command)()
+
+    def parse_version_arg(self):
+        return '--version' in sys.argv[1:3]
 
     def cat(self):
         from .tools.cat import main as cat_main

--- a/insights/tests/test_command_parser.py
+++ b/insights/tests/test_command_parser.py
@@ -1,0 +1,35 @@
+import sys
+from insights import get_nvr
+from insights.command_parser import InsightsCli
+import pytest
+from mock import patch
+
+VERSION_OUT = get_nvr() + '\n'
+
+
+def test_insights_cli_version(capsys):
+    test_args_list = [
+        ["insights", "--version"],
+        ["insights", "cat", "--version"],
+        ["insights", "collect", "--version"],
+        ["insights", "inspect", "--version"],
+        ["insights", "info", "--version"],
+        ["insights", "ocpshell", "--version"],
+        ["insights", "run", "--version"],
+        ["insights", "--version", "run"]
+    ]
+    for args in test_args_list:
+        with patch.object(sys, 'argv', args):
+            with pytest.raises(SystemExit):
+                InsightsCli()
+            out, err = capsys.readouterr()
+            assert err == ''
+            assert out == VERSION_OUT
+
+    test_args = ["insights", "-v"]
+    with patch.object(sys, 'argv', test_args):
+        with pytest.raises(SystemExit):
+            InsightsCli()
+        out, err = capsys.readouterr()
+        assert len(err) > 0
+        assert out == ''

--- a/insights/tests/test_command_parser.py
+++ b/insights/tests/test_command_parser.py
@@ -9,14 +9,14 @@ VERSION_OUT = get_nvr() + '\n'
 
 def test_insights_cli_version(capsys):
     test_args_list = [
+        ["insights", "version"],
         ["insights", "--version"],
         ["insights", "cat", "--version"],
         ["insights", "collect", "--version"],
         ["insights", "inspect", "--version"],
         ["insights", "info", "--version"],
         ["insights", "ocpshell", "--version"],
-        ["insights", "run", "--version"],
-        ["insights", "--version", "run"]
+        ["insights", "run", "--version"]
     ]
     for args in test_args_list:
         with patch.object(sys, 'argv', args):

--- a/insights/tests/test_command_parser.py
+++ b/insights/tests/test_command_parser.py
@@ -26,6 +26,8 @@ def test_insights_cli_version(capsys):
             assert err == ''
             assert out == VERSION_OUT
 
+
+def test_insights_cli_version_bad_arg(capsys):
     test_args = ["insights", "-v"]
     with patch.object(sys, 'argv', test_args):
         with pytest.raises(SystemExit):


### PR DESCRIPTION
* Added `version` command and `--version` argument, `ArgumentParser.add_argument` `version` action was not used because of a bug in earlier versions of python.
* The version info can be retrieved using `insights version`, `insights --version` or `insights <command> --version`.
* Added `insights/tests/test_command_parser.py` with couple basic unit tests.

Resolves #2408

Signed-off-by: Vitaliy Dymna <vdymna@redhat.com>