### PR TITLE
Enahce readlink

### DIFF
--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -227,7 +227,7 @@ class InsightsArchiveSpecs(Specs):
     rabbitmq_queues = simple_file("insights_commands/rabbitmqctl_list_queues_name_messages_consumers_auto_delete")
     rabbitmq_report = simple_file("insights_commands/rabbitmqctl_report")
     rabbitmq_users = simple_file("insights_commands/rabbitmqctl_list_users")
-    readlink_e_etc_mtab = simple_file("readlink_-e_.etc.mtab")
+    readlink_e_etc_mtab = simple_file("insights_commands/readlink_-e_.etc.mtab")
     rhn_charsets = simple_file("insights_commands/rhn-charsets")
     rhn_schema_stats = simple_file("insights_commands/rhn-schema-stats")
     rhn_schema_version = simple_file("insights_commands/rhn-schema-version")


### PR DESCRIPTION
Fix: https://github.com/RedHatInsights/insights-core/issues/2399

* add the missing "insights_command/" to readlink in insights_archive.py 

Signed-off-by: Xiaonan He <xhe@redhat.com>