### PR TITLE
Separate payload logging

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -38,13 +38,18 @@ def do_log_rotation():
 
 def get_file_handler(config):
     log_file = config.logging_file
+    payload_log = config.logging_file + '-payload'
     log_dir = os.path.dirname(log_file)
     if not log_dir:
         log_dir = os.getcwd()
     elif not os.path.exists(log_dir):
         os.makedirs(log_dir, 0o700)
-    file_handler = logging.handlers.RotatingFileHandler(
-        log_file, backupCount=3)
+    if config.payload:
+        file_handler = logging.handlers.RotatingFileHandler(
+            payload_log, backupCount=3)
+    else:
+        file_handler = logging.handlers.RotatingFileHandler(
+            log_file, backupCount=3)
     file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
     return file_handler
 

--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -38,18 +38,13 @@ def do_log_rotation():
 
 def get_file_handler(config):
     log_file = config.logging_file
-    payload_log = config.logging_file + '-payload'
     log_dir = os.path.dirname(log_file)
     if not log_dir:
         log_dir = os.getcwd()
     elif not os.path.exists(log_dir):
         os.makedirs(log_dir, 0o700)
-    if config.payload:
-        file_handler = logging.handlers.RotatingFileHandler(
-            payload_log, backupCount=3)
-    else:
-        file_handler = logging.handlers.RotatingFileHandler(
-            log_file, backupCount=3)
+    file_handler = logging.handlers.RotatingFileHandler(
+        log_file, backupCount=3)
     file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
     return file_handler
 

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -637,7 +637,7 @@ class InsightsConfig(object):
             self.diagnosis = True
         if self.payload or self.diagnosis or self.compliance:
             self.legacy_upload = False
-        if self.payload and (self.logging_file == constants.logging_file):
+        if self.payload and (self.logging_file == constants.default_log_file):
             self.logging_file = constants.default_payload_log
         if os.path.exists(constants.register_marker_file):
             self.register = True

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -637,6 +637,8 @@ class InsightsConfig(object):
             self.diagnosis = True
         if self.payload or self.diagnosis or self.compliance:
             self.legacy_upload = False
+        if self.payload and (self.logging_file == constants.logging_file):
+            self.logging_file = constants.default_payload_log
         if os.path.exists(constants.register_marker_file):
             self.register = True
 

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -13,6 +13,7 @@ class InsightsConstants(object):
     log_dir = os.path.join(os.sep, 'var', 'log', app_name)
     simple_find_replace_dir = '/etc/redhat-access-insights'
     default_log_file = os.path.join(log_dir, app_name + '.log')
+    default_payload_log = os.path.join(log_dir, app_name + '-payload.log')
     default_sed_file = os.path.join(default_conf_dir, '.exp.sed')
     base_url = 'cert-api.access.redhat.com/r/insights/platform'
     legacy_base_url = 'cert-api.access.redhat.com/r/insights'


### PR DESCRIPTION
This is to create a separate log file when we use the --payload argument. The problem was sending up a payload and a classic upload daily would leave you with only 2 days worth of logs due to our rotation settings. If we split them, we can keep the same rotation, but it will create a different set of files depending on which type of upload you do. 

This also helps identify which type of upload was performed, which is pretty handy. 
RHCLOUD-2141