### PR TITLE
Enable client to retrieve advisor report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ output/
 share/
 .Python
 .python*
+.pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ share/
 .Python
 .python*
 .pytest_cache
+.vscode

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -516,7 +516,7 @@ class InsightsClient(object):
         Show insights about this machine
         '''
         try:
-            with open("/var/lib/insights/insights-details.v1.json", mode="r+b") as f:
+            with open("/var/lib/insights/insights-details.json", mode="r+b") as f:
                 insights_data = json.load(f)
             print(insights_data)
         except Exception as e:

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -514,7 +514,7 @@ class InsightsClient(object):
             if self.config.legacy_upload:
                 data = self.connection.get_legacy_advisor_report()
             else:
-                data = self.connection.get_advisor_report()
+                data = {"error": "Unable to retrieve advisor report"}
             print(json.dumps(data))
         except Exception as e:
             print("Unknown Error: %s" % e)

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -511,7 +511,7 @@ class InsightsClient(object):
         '''
         try:
             data = self.connection.get_advisor_report()
-            print(data)
+            print(json.dumps(data))
         except Exception as e:
             print("Unknown Error: %s" % e)
 

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -516,10 +516,7 @@ class InsightsClient(object):
         Show insights about this machine
         '''
         try:
-            with open("/var/lib/insights/%s.json" % generate_machine_id(), mode="r+b") as f:
-                inventory_data = json.load(f)
-            host_id = inventory_data["results"][0]["id"]
-            with open("/var/lib/insights/%s.json" % host_id, mode="r+b") as f:
+            with open("/var/lib/insights/insights-details.v1.json", mode="r+b") as f:
                 insights_data = json.load(f)
             print(insights_data)
         except Exception as e:

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -510,11 +510,7 @@ class InsightsClient(object):
         Show insights about this machine
         '''
         try:
-            data = {}
-            if self.config.legacy_upload:
-                data = self.connection.get_legacy_advisor_report()
-            else:
-                data = {"error": "Unable to retrieve advisor report"}
+            data = self.connection.get_advisor_report()
             print(json.dumps(data))
         except Exception as e:
             print("Unknown Error: %s" % e)

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -505,13 +505,23 @@ class InsightsClient(object):
         logger.debug('New machine-id: %s', generate_machine_id(new=True))
 
     @_net
+    def check_results(self):
+        try:
+            self.connection.get_advisor_report()
+        except Exception as e:
+            print("Unknown Error: %s" % e)
+
     def show(self):
         '''
         Show insights about this machine
         '''
         try:
-            data = self.connection.get_advisor_report()
-            print(json.dumps(data))
+            with open("/var/lib/insights/%s.json" % generate_machine_id(), mode="r+b") as f:
+                inventory_data = json.load(f)
+            host_id = inventory_data["results"][0]["id"]
+            with open("/var/lib/insights/%s.json" % host_id, mode="r+b") as f:
+                insights_data = json.load(f)
+            print(insights_data)
         except Exception as e:
             print("Unknown Error: %s" % e)
 

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -504,6 +504,17 @@ class InsightsClient(object):
         logger.debug('Re-register set, forcing registration.')
         logger.debug('New machine-id: %s', generate_machine_id(new=True))
 
+    @_net
+    def show(self):
+        '''
+        Show insights about this machine
+        '''
+        try:
+            data = self.connection.get_advisor_report()
+            print(data)
+        except Exception as e:
+            print("Unknown Error: %s" % e)
+
 
 def format_config(config):
     # Log config except the password

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -510,7 +510,11 @@ class InsightsClient(object):
         Show insights about this machine
         '''
         try:
-            data = self.connection.get_advisor_report()
+            data = {}
+            if self.config.legacy_upload:
+                data = self.connection.get_legacy_advisor_report()
+            else:
+                data = self.connection.get_advisor_report()
             print(json.dumps(data))
         except Exception as e:
             print("Unknown Error: %s" % e)

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -518,7 +518,7 @@ class InsightsClient(object):
         try:
             with open("/var/lib/insights/insights-details.json", mode="r+b") as f:
                 insights_data = json.load(f)
-            print(json.dumps(insights_data))
+            print(json.dumps(insights_data, indent=1))
         except IOError as e:
             if e.errno == errno.ENOENT:
                 raise Exception("Error: no report found. Run insights-client --check-results to update the report cache.") from e

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -519,6 +519,8 @@ class InsightsClient(object):
             with open("/var/lib/insights/insights-details.json", mode="r+b") as f:
                 insights_data = json.load(f)
             print(json.dumps(insights_data))
+        except FileNotFoundError:
+            print("Error: no report found. Run insights-client --check-results to update the report cache.")
         except Exception as e:
             print("Unknown Error: %s" % e)
 

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -521,7 +521,7 @@ class InsightsClient(object):
             print(json.dumps(insights_data, indent=1))
         except IOError as e:
             if e.errno == errno.ENOENT:
-                raise Exception("Error: no report found. Run insights-client --check-results to update the report cache.") from e
+                raise Exception("Error: no report found. Run insights-client --check-results to update the report cache: %s" % e)
             else:
                 raise e
 

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -507,10 +507,9 @@ class InsightsClient(object):
 
     @_net
     def check_results(self):
-        try:
-            self.connection.get_advisor_report()
-        except Exception as e:
-            print("Unknown Error: %s" % e)
+        content = self.connection.get_advisor_report()
+        if content is None:
+            raise Exception("Error: failed to download advisor report.")
 
     def show_results(self):
         '''

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import os
 import logging
@@ -519,8 +520,11 @@ class InsightsClient(object):
             with open("/var/lib/insights/insights-details.json", mode="r+b") as f:
                 insights_data = json.load(f)
             print(json.dumps(insights_data))
-        except FileNotFoundError:
-            print("Error: no report found. Run insights-client --check-results to update the report cache.")
+        except IOError as e:
+            if e.errno == errno.ENOENT:
+                print("Error: no report found. Run insights-client --check-results to update the report cache.")
+            else:
+                print("Unknown IOError: %s" % e)
         except Exception as e:
             print("Unknown Error: %s" % e)
 

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -522,11 +522,9 @@ class InsightsClient(object):
             print(json.dumps(insights_data))
         except IOError as e:
             if e.errno == errno.ENOENT:
-                print("Error: no report found. Run insights-client --check-results to update the report cache.")
+                raise Exception("Error: no report found. Run insights-client --check-results to update the report cache.") from e
             else:
-                print("Unknown IOError: %s" % e)
-        except Exception as e:
-            print("Unknown Error: %s" % e)
+                raise e
 
 
 def format_config(config):

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -518,7 +518,7 @@ class InsightsClient(object):
         try:
             with open("/var/lib/insights/insights-details.json", mode="r+b") as f:
                 insights_data = json.load(f)
-            print(insights_data)
+            print(json.dumps(insights_data))
         except Exception as e:
             print("Unknown Error: %s" % e)
 

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -511,7 +511,7 @@ class InsightsClient(object):
         except Exception as e:
             print("Unknown Error: %s" % e)
 
-    def show(self):
+    def show_results(self):
         '''
         Show insights about this machine
         '''

--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -14,6 +14,7 @@ from .utilities import (generate_machine_id,
                         write_unregistered_file,
                         delete_registered_file,
                         delete_unregistered_file,
+                        delete_cache_files,
                         determine_hostname,
                         read_pidfile,
                         systemd_notify)
@@ -220,6 +221,7 @@ def _legacy_handle_unregistration(config, pconn):
         # only set if unreg was successful
         write_unregistered_file()
         get_scheduler(config).remove_scheduling()
+        delete_cache_files()
     return unreg
 
 
@@ -237,6 +239,7 @@ def handle_unregistration(config, pconn):
     if unreg:
         # only set if unreg was successful
         write_unregistered_file()
+        delete_cache_files()
     return unreg
 
 

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -241,6 +241,12 @@ DEFAULT_OPTS = {
         'type': int,
         'dest': 'retries'
     },
+    'show': {
+        'default': False,
+        'opt': ['--show'],
+        'help': "Show insights about this host",
+        'action': "store_true"
+    },
     'silent': {
         'default': False,
         'opt': ['--silent'],

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -647,7 +647,7 @@ class InsightsConfig(object):
         self.keep_archive = self.keep_archive or self.no_upload
         if self.to_json and self.quiet:
             self.diagnosis = True
-        if self.payload or self.diagnosis or self.compliance:
+        if self.payload or self.diagnosis or self.compliance or self.show or self.check_results:
             self.legacy_upload = False
         if self.payload and (self.logging_file == constants.default_log_file):
             self.logging_file = constants.default_payload_log

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -9,7 +9,7 @@ from six.moves import configparser as ConfigParser
 
 try:
     from .constants import InsightsConstants as constants
-except ImportError:
+except:
     from constants import InsightsConstants as constants
 
 logger = logging.getLogger(__name__)

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -70,6 +70,12 @@ DEFAULT_OPTS = {
         # non-CLI
         'default': None,
     },
+    'check_results': {
+        'default': False,
+        'opt': ['--check-results'],
+        'help': "Check for insights results",
+        'action': "store_true"
+    },
     'cmd_timeout': {
         # non-CLI
         'default': constants.default_cmd_timeout

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -247,9 +247,9 @@ DEFAULT_OPTS = {
         'type': int,
         'dest': 'retries'
     },
-    'show': {
+    'show_results': {
         'default': False,
-        'opt': ['--show'],
+        'opt': ['--show-results'],
         'help': "Show insights about this host",
         'action': "store_true"
     },
@@ -647,7 +647,7 @@ class InsightsConfig(object):
         self.keep_archive = self.keep_archive or self.no_upload
         if self.to_json and self.quiet:
             self.diagnosis = True
-        if self.payload or self.diagnosis or self.compliance or self.show or self.check_results:
+        if self.payload or self.diagnosis or self.compliance or self.show_results or self.check_results:
             self.legacy_upload = False
         if self.payload and (self.logging_file == constants.default_log_file):
             self.logging_file = constants.default_payload_log

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -1023,11 +1023,19 @@ class InsightsConnection(object):
         if content is None:
             return None
 
+        os.makedirs("/var/lib/insights", mode=0o755, exist_ok=True)
+
+        with open("/var/lib/insights/%s.json" % generate_machine_id(), mode="w") as f:
+            f.write(content)
+
         host_id = json.loads(content)["results"][0]["id"]
         url = self.base_url + "/insights/v1/system/%s/reports/" % host_id
         content = self._get(url)
         if content is None:
             return None
+
+        with open("/var/lib/insights/%s.json" % host_id, mode="w+b") as f:
+            f.write(content)
 
         return json.loads(content)
 

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -1026,7 +1026,7 @@ class InsightsConnection(object):
 
         host_details = json.loads(content)
         if host_details["total"] < 1:
-            raise Exception("Error: no host detected (insights_id = %s): Run insights-client --status to check registration status" % generate_machine_id())
+            raise Exception("Error: failed to find host with matching machine-id. Run insights-client --status to check registration status")
         if host_details["total"] > 1:
             raise Exception("Error: multiple hosts detected (insights_id = %s)" % generate_machine_id())
 

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -1025,7 +1025,7 @@ class InsightsConnection(object):
 
         os.makedirs("/var/lib/insights", mode=0o755, exist_ok=True)
 
-        with open("/var/lib/insights/%s.json" % generate_machine_id(), mode="w") as f:
+        with open("/var/lib/insights/%s.json" % generate_machine_id(), mode="w+b") as f:
             f.write(content)
 
         host_id = json.loads(content)["results"][0]["id"]

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -1023,7 +1023,8 @@ class InsightsConnection(object):
         if content is None:
             return None
 
-        os.makedirs("/var/lib/insights", mode=0o755, exist_ok=True)
+        if not os.path.exists("/var/lib/insights"):
+            os.makedirs("/var/lib/insights", mode=0o755)
 
         with open("/var/lib/insights/host-details.json", mode="w+b") as f:
             f.write(content)

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -992,7 +992,7 @@ class InsightsConnection(object):
 
             Returns: bytes
         '''
-        cache = URLCache("/var/cache/insights-client/cache.dat")
+        cache = URLCache("/var/cache/insights/cache.dat")
 
         headers = {}
         item = cache.get(url)

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -1024,6 +1024,12 @@ class InsightsConnection(object):
         if content is None:
             return None
 
+        host_details = json.loads(content)
+        if host_details["total"] < 1:
+            raise Exception("Error: no host detected (insights_id = %s): Run insights-client --status to check registration status" % generate_machine_id())
+        if host_details["total"] > 1:
+            raise Exception("Error: multiple hosts detected (insights_id = %s)" % generate_machine_id())
+
         if not os.path.exists("/var/lib/insights"):
             os.makedirs("/var/lib/insights", mode=0o755)
 
@@ -1031,7 +1037,7 @@ class InsightsConnection(object):
             f.write(content)
             logger.debug("Wrote \"/var/lib/insights/host-details.json\"")
 
-        host_id = json.loads(content)["results"][0]["id"]
+        host_id = host_details["results"][0]["id"]
         url = self.base_url + "/insights/v1/system/%s/reports/" % host_id
         content = self._get(url)
         if content is None:

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -1018,6 +1018,10 @@ class InsightsConnection(object):
         '''
             Retrieve advisor report
         '''
+        if 'platform' not in self.base_url:
+            self.base_url = "https://cert.cloud.redhat.com/api"
+            self.cert_verify = True  # Unsure why cert_verify is an instance variable on InsightsConnection
+            self.session.verify = self.cert_verify  # When it appears to ultimately get assigned to the instance variable "verify" on the session object.
         url = self.base_url + "/inventory/v1/hosts?insights_id=%s" % generate_machine_id()
         content = self._get(url)
         if content is None:
@@ -1025,7 +1029,7 @@ class InsightsConnection(object):
 
         os.makedirs("/var/lib/insights", mode=0o755, exist_ok=True)
 
-        with open("/var/lib/insights/host-details.v1.json", mode="w+b") as f:
+        with open("/var/lib/insights/host-details.json", mode="w+b") as f:
             f.write(content)
 
         host_id = json.loads(content)["results"][0]["id"]
@@ -1034,7 +1038,7 @@ class InsightsConnection(object):
         if content is None:
             return None
 
-        with open("/var/lib/insights/insights-details.v1.json", mode="w+b") as f:
+        with open("/var/lib/insights/insights-details.json", mode="w+b") as f:
             f.write(content)
 
         return json.loads(content)

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -1038,14 +1038,3 @@ class InsightsConnection(object):
             f.write(content)
 
         return json.loads(content)
-
-    def get_legacy_advisor_report(self):
-        '''
-            Retrieve advisor report through the legacy API
-        '''
-        url = self.base_url + "/v1/systems/" + generate_machine_id() + "/reports"
-        content = self._get(url)
-        if content is None:
-            return None
-
-        return json.loads(content)

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -1018,10 +1018,6 @@ class InsightsConnection(object):
         '''
             Retrieve advisor report
         '''
-        if 'platform' not in self.base_url:
-            self.base_url = "https://cert.cloud.redhat.com/api"
-            self.cert_verify = True  # Unsure why cert_verify is an instance variable on InsightsConnection
-            self.session.verify = self.cert_verify  # When it appears to ultimately get assigned to the instance variable "verify" on the session object.
         url = self.base_url + "/inventory/v1/hosts?insights_id=%s" % generate_machine_id()
         content = self._get(url)
         if content is None:

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -1024,7 +1024,7 @@ class InsightsConnection(object):
             return None
 
         host_id = json.loads(content)["results"][0]["id"]
-        url = self.base_url + "/insights/v1/systems/%s/reports/" % host_id
+        url = self.base_url + "/insights/v1/system/%s/reports/" % host_id
         content = self._get(url)
         if content is None:
             return None

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -999,6 +999,7 @@ class InsightsConnection(object):
         if item is not None:
             headers["If-None-Match"] = item.etag
 
+        net_logger.info("GET %s", url)
         res = self.session.get(url, headers=headers)
 
         if res.status_code in [requests.codes.OK, requests.codes.NOT_MODIFIED]:
@@ -1028,6 +1029,7 @@ class InsightsConnection(object):
 
         with open("/var/lib/insights/host-details.json", mode="w+b") as f:
             f.write(content)
+            logger.debug("Wrote \"/var/lib/insights/host-details.json\"")
 
         host_id = json.loads(content)["results"][0]["id"]
         url = self.base_url + "/insights/v1/system/%s/reports/" % host_id
@@ -1037,5 +1039,6 @@ class InsightsConnection(object):
 
         with open("/var/lib/insights/insights-details.json", mode="w+b") as f:
             f.write(content)
+            logger.debug("Wrote \"/var/lib/insights/insights-details.json\"")
 
         return json.loads(content)

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -1025,7 +1025,7 @@ class InsightsConnection(object):
 
         os.makedirs("/var/lib/insights", mode=0o755, exist_ok=True)
 
-        with open("/var/lib/insights/%s.json" % generate_machine_id(), mode="w+b") as f:
+        with open("/var/lib/insights/host-details.v1.json", mode="w+b") as f:
             f.write(content)
 
         host_id = json.loads(content)["results"][0]["id"]
@@ -1034,7 +1034,7 @@ class InsightsConnection(object):
         if content is None:
             return None
 
-        with open("/var/lib/insights/%s.json" % host_id, mode="w+b") as f:
+        with open("/var/lib/insights/insights-details.v1.json", mode="w+b") as f:
             f.write(content)
 
         return json.loads(content)

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -135,6 +135,14 @@ def post_update(client, config):
         logger.debug('Entitling an AWS host. Bypassing registration check.')
         return
 
+    if config.show:
+        try:
+            client.show()
+            sys.exit(constants.sig_kill_ok)
+        except Exception as e:
+            print(e)
+            sys.exit(constants.sig_kill_bad)
+
     # -------delete everything below this line-------
     if config.legacy_upload:
         if config.status:
@@ -178,14 +186,6 @@ def post_update(client, config):
             if (not config.disable_schedule and
                get_scheduler(config).set_daily()):
                 logger.info('Automatic scheduling for Insights has been enabled.')
-
-        if config.show:
-            try:
-                client.show()
-                sys.exit(constants.sig_kill_ok)
-            except Exception as e:
-                print(e)
-                sys.exit(constants.sig_kill_bad)
 
         return
     # -------delete everything above this line-------

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -178,6 +178,15 @@ def post_update(client, config):
             if (not config.disable_schedule and
                get_scheduler(config).set_daily()):
                 logger.info('Automatic scheduling for Insights has been enabled.')
+
+        if config.show:
+            try:
+                client.show()
+                sys.exit(constants.sig_kill_ok)
+            except Exception as e:
+                print(e)
+                sys.exit(constants.sig_kill_bad)
+
         return
     # -------delete everything above this line-------
 

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -145,6 +145,7 @@ def post_update(client, config):
 
     if config.check_results:
         try:
+            client.config.base_url += "/platform"
             client.check_results()
             sys.exit(constants.sig_kill_ok)
         except Exception as e:

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -145,7 +145,6 @@ def post_update(client, config):
 
     if config.check_results:
         try:
-            client.config.base_url += "/platform"
             client.check_results()
             sys.exit(constants.sig_kill_ok)
         except Exception as e:

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -195,7 +195,6 @@ def post_update(client, config):
             if (not config.disable_schedule and
                get_scheduler(config).set_daily()):
                 logger.info('Automatic scheduling for Insights has been enabled.')
-
         return
     # -------delete everything above this line-------
 

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -143,6 +143,14 @@ def post_update(client, config):
             print(e)
             sys.exit(constants.sig_kill_bad)
 
+    if config.check_results:
+        try:
+            client.check_results()
+            sys.exit(constants.sig_kill_ok)
+        except Exception as e:
+            print(e)
+            sys.exit(constants.sig_kill_bad)
+
     # -------delete everything below this line-------
     if config.legacy_upload:
         if config.status:

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -135,9 +135,9 @@ def post_update(client, config):
         logger.debug('Entitling an AWS host. Bypassing registration check.')
         return
 
-    if config.show:
+    if config.show_results:
         try:
-            client.show()
+            client.show_results()
             sys.exit(constants.sig_kill_ok)
         except Exception as e:
             print(e)

--- a/insights/client/url_cache.py
+++ b/insights/client/url_cache.py
@@ -1,35 +1,49 @@
-
-import pickle
 import os
+import pickle
+import time
+
+_KEEPTIME = 300  # 5 minutes
 
 
 class CacheItem(object):
-    def __init__(self, etag, content):
+    def __init__(self, etag, content, cached_at):
         self.etag = etag
         self.content = content
+        self.cached_at = cached_at
 
 
 class URLCache(object):
+    """
+        URLCache is a simple pickle cache, intended to be used as an HTTP
+        response cache.
+    """
     def __init__(self, path=None):
-        '''
+        """
             Initialize a URLCache, loading entries from @path, if provided.
-        '''
+        """
         self._path = path
         self._cache = {}
         if os.path.isfile(self._path):
             with open(self._path, "r+b") as f:
-                self._cache = pickle.load(f)
+                try:
+                    self._cache = pickle.load(f)
+                except EOFError:
+                    self._cache = {}
         if not os.path.exists(os.path.dirname(self._path)):
             os.makedirs(os.path.dirname(self._path))
 
     def get(self, url):
         try:
+            item = self._cache[url]
+            if item.cached_at + _KEEPTIME <= time.time():
+                del (self._cache, url)
+                return None
             return self._cache[url]
         except KeyError:
             return None
 
     def set(self, url, etag, content):
-        self._cache[url] = CacheItem(etag, content)
+        self._cache[url] = CacheItem(etag, content, time.time())
 
     def save(self):
         with open(self._path, "w+b") as f:

--- a/insights/client/url_cache.py
+++ b/insights/client/url_cache.py
@@ -19,7 +19,8 @@ class URLCache(object):
         if os.path.isfile(self._path):
             with open(self._path, "r+b") as f:
                 self._cache = pickle.load(f)
-        os.makedirs(os.path.dirname(self._path), exist_ok=True)
+        if not os.path.exists(os.path.dirname(self._path)):
+            os.makedirs(os.path.dirname(self._path))
 
     def get(self, url):
         try:

--- a/insights/client/url_cache.py
+++ b/insights/client/url_cache.py
@@ -1,0 +1,35 @@
+
+import pickle
+import os
+
+
+class CacheItem(object):
+    def __init__(self, etag, content):
+        self.etag = etag
+        self.content = content
+
+
+class URLCache(object):
+    def __init__(self, path=None):
+        '''
+            Initialize a URLCache, loading entries from @path, if provided.
+        '''
+        self._path = path
+        self._cache = {}
+        if os.path.isfile(self._path):
+            with open(self._path, "r+b") as f:
+                self._cache = pickle.load(f)
+        os.makedirs(os.path.dirname(self._path), exist_ok=True)
+
+    def get(self, url):
+        try:
+            return self._cache[url]
+        except KeyError:
+            return None
+
+    def set(self, url, etag, content):
+        self._cache[url] = CacheItem(etag, content)
+
+    def save(self):
+        with open(self._path, "w+b") as f:
+            pickle.dump(self._cache, f)

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -2,6 +2,7 @@
 Utility functions
 """
 from __future__ import absolute_import
+import glob
 import socket
 import os
 import logging
@@ -99,6 +100,11 @@ def delete_unregistered_file():
     #  so while registering, delete this file too. we only
     #  need it around until we're registered
     write_to_disk(constants.register_marker_file, delete=True)
+
+
+def delete_cache_files():
+    for f in glob.glob(os.path.join(constants.insights_core_lib_dir, "*.json")):
+        os.remove(f)
 
 
 def write_to_disk(filename, delete=False, content=get_time()):

--- a/insights/tests/client/phase/test_LEGACY_post_update.py
+++ b/insights/tests/client/phase/test_LEGACY_post_update.py
@@ -16,6 +16,7 @@ def patch_insights_config(old_function):
                        "return_value.load_all.return_value.display_name": False,
                        "return_value.load_all.return_value.register": False,
                        "return_value.load_all.return_value.diagnosis": None,
+                       "return_value.load_all.return_value.show": False,
                        "return_value.load_all.return_value.portal_access": False,
                        "return_value.load_all.return_value.portal_access_no_insights": False})
     return patcher(old_function)

--- a/insights/tests/client/phase/test_LEGACY_post_update.py
+++ b/insights/tests/client/phase/test_LEGACY_post_update.py
@@ -17,6 +17,7 @@ def patch_insights_config(old_function):
                        "return_value.load_all.return_value.register": False,
                        "return_value.load_all.return_value.diagnosis": None,
                        "return_value.load_all.return_value.show": False,
+                       "return_value.load_all.return_value.check_results": False,
                        "return_value.load_all.return_value.portal_access": False,
                        "return_value.load_all.return_value.portal_access_no_insights": False})
     return patcher(old_function)

--- a/insights/tests/client/phase/test_LEGACY_post_update.py
+++ b/insights/tests/client/phase/test_LEGACY_post_update.py
@@ -16,7 +16,7 @@ def patch_insights_config(old_function):
                        "return_value.load_all.return_value.display_name": False,
                        "return_value.load_all.return_value.register": False,
                        "return_value.load_all.return_value.diagnosis": None,
-                       "return_value.load_all.return_value.show": False,
+                       "return_value.load_all.return_value.show_results": False,
                        "return_value.load_all.return_value.check_results": False,
                        "return_value.load_all.return_value.portal_access": False,
                        "return_value.load_all.return_value.portal_access_no_insights": False})

--- a/insights/tests/client/phase/test_post_update.py
+++ b/insights/tests/client/phase/test_post_update.py
@@ -20,6 +20,7 @@ def patch_insights_config(old_function):
                        "return_value.load_all.return_value.reregister": False,
                        "return_value.load_all.return_value.payload": None,
                        "return_value.load_all.return_value.show": False,
+                       "return_value.load_all.return_value.check_results": False,
                        "return_value.load_all.return_value.portal_access": False,
                        "return_value.load_all.return_value.portal_access_no_insights": False})
     return patcher(old_function)

--- a/insights/tests/client/phase/test_post_update.py
+++ b/insights/tests/client/phase/test_post_update.py
@@ -19,6 +19,7 @@ def patch_insights_config(old_function):
                        "return_value.load_all.return_value.diagnosis": None,
                        "return_value.load_all.return_value.reregister": False,
                        "return_value.load_all.return_value.payload": None,
+                       "return_value.load_all.return_value.show": False,
                        "return_value.load_all.return_value.portal_access": False,
                        "return_value.load_all.return_value.portal_access_no_insights": False})
     return patcher(old_function)

--- a/insights/tests/client/phase/test_post_update.py
+++ b/insights/tests/client/phase/test_post_update.py
@@ -19,7 +19,7 @@ def patch_insights_config(old_function):
                        "return_value.load_all.return_value.diagnosis": None,
                        "return_value.load_all.return_value.reregister": False,
                        "return_value.load_all.return_value.payload": None,
-                       "return_value.load_all.return_value.show": False,
+                       "return_value.load_all.return_value.show_results": False,
                        "return_value.load_all.return_value.check_results": False,
                        "return_value.load_all.return_value.portal_access": False,
                        "return_value.load_all.return_value.portal_access_no_insights": False})

--- a/insights/tests/client/test_url_cache.py
+++ b/insights/tests/client/test_url_cache.py
@@ -1,0 +1,21 @@
+import tempfile
+
+from insights.client import url_cache
+from mock.mock import patch
+
+
+def test_url_cache_hit():
+    f = tempfile.NamedTemporaryFile()
+    c = url_cache.URLCache(path=f.name)
+    c.set("http://foo", "abcd", "OK")
+    c.save()
+    assert c.get("http://foo").content == "OK"
+
+
+@patch("insights.client.url_cache._KEEPTIME", new=0)
+def test_url_cache_miss():
+    f = tempfile.NamedTemporaryFile()
+    c = url_cache.URLCache(path=f.name)
+    c.set("http://foo", "abcd", "OK")
+    c.save()
+    assert c.get("http://foo") is None


### PR DESCRIPTION
Part of an effort to integrate Insights into Cockpit involves Cockpit knowing more details about the latest Advisor report. To that end, this PR is added a new command line flag `--show` that does not run through the collection and upload process; instead it gets the latest report as compiled by Advisor and returns the JSON. Responses are cached by ETag (however the certificate-based authentication does not appear to respond with `304` status codes).

There are two well-known files that can be monitored for changes. Both files contain unmodified responses from their respective backend API calls. Both files are updated within a few seconds of each other (both files get updated within the same function call, so realistically, they should be updated at "the same time").

#### /var/lib/insights/host-details.json
`GET /inventory/v1/hosts?insights_id=$(cat /etc/insights-client/machine-
id)`

This file contains a host ID at the `jq` path ".results[0].id". This host ID is used in the subsequent API call below, as well as being the ID to build a permalink to the host's record in inventory at cloud.redhat.com.

#### /var/lib/insights/insights-details.json
`GET /insights/v1/systems/$HOST_ID/reports`

The file contents can either be read directly or can be read by calling `insights-client --show` (this command simply dumps the file contents to stdout).

There is a second flag (and related functions within the insights-client package) that triggers an update (`--check-results`). My plan is to make that opaque to external callers (probably by putting it on a systemd timer or unit that is called a few minutes after the collection unit); we will update the files internally. So there should be no need for external programs to call `--check-results` explicitly.