### PR TITLE
add path to simple_command for readlink

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -783,7 +783,7 @@ class DefaultSpecs(Specs):
     rabbitmq_users = simple_command("/usr/sbin/rabbitmqctl list_users")
     rc_local = simple_file("/etc/rc.d/rc.local")
     rdma_conf = simple_file("/etc/rdma/rdma.conf")
-    readlink_e_etc_mtab = simple_command("readlink -e /etc/mtab")
+    readlink_e_etc_mtab = simple_command("/usr/bin/readlink -e /etc/mtab")
     redhat_release = simple_file("/etc/redhat-release")
     resolv_conf = simple_file("/etc/resolv.conf")
     rhosp_release = simple_file("/etc/rhosp-release")


### PR DESCRIPTION
Add path of "/usr/bin/" to simple_command for readlink

Signed-off-by: Xiaonan He <xhe@redhat.com>