### PR TITLE
Try to load CSafeLoader and gracefully degrade

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -689,10 +689,15 @@ class YAMLParser(Parser, LegacyItemAccess):
     """
     def parse_content(self, content):
         try:
+            try:
+                from yaml import CSafeLoader as SafeLoader
+            except ImportError:
+                from yaml import SafeLoader
+            
             if type(content) is list:
-                self.data = yaml.safe_load('\n'.join(content))
+                self.data = yaml.load('\n'.join(content), Loader=SafeLoader)
             else:
-                self.data = yaml.safe_load(content)
+                self.data = yaml.load(content, Loader=SafeLoader)
 
             if not isinstance(self.data, (dict, list)):
                 raise ParseException("YAML didn't produce a dictionary or list.")

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -21,6 +21,11 @@ from insights.core.serde import deserializer, serializer
 from . import ls_parser
 from insights.util import deprecated
 
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader
+
 import sys
 # Since XPath expression is not supported by the ElementTree in Python 2.6,
 # import insights.contrib.ElementTree when running python is prior to 2.6 for compatibility.
@@ -689,11 +694,6 @@ class YAMLParser(Parser, LegacyItemAccess):
     """
     def parse_content(self, content):
         try:
-            try:
-                from yaml import CSafeLoader as SafeLoader
-            except ImportError:
-                from yaml import SafeLoader
-
             if type(content) is list:
                 self.data = yaml.load('\n'.join(content), Loader=SafeLoader)
             else:

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -693,7 +693,7 @@ class YAMLParser(Parser, LegacyItemAccess):
                 from yaml import CSafeLoader as SafeLoader
             except ImportError:
                 from yaml import SafeLoader
-            
+
             if type(content) is list:
                 self.data = yaml.load('\n'.join(content), Loader=SafeLoader)
             else:


### PR DESCRIPTION
Rather than always relying on the pure Python SafeLoader, try importing
the CSafeLoader locally, handling the ImportError by falling back to the
Pure Python SafeLoader.

Fixes #2271