### PR TITLE
Correct the check for remove file validation

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -18,7 +18,8 @@ from .utilities import (generate_machine_id,
                         delete_unregistered_file,
                         determine_hostname,
                         read_pidfile,
-                        systemd_notify)
+                        systemd_notify,
+                        validate_remove_file)
 from .collection_rules import InsightsUploadConf
 from .data_collector import DataCollector
 from .connection import InsightsConnection
@@ -278,8 +279,11 @@ def collect(config, pconn):
 
     collection_rules = pc.get_conf_file()
     rm_conf = pc.get_rm_conf()
-    if rm_conf:
+    if rm_conf and validate_remove_file(config.remove_file):
         logger.warn("WARNING: Excluding data from files")
+    else:
+        logger.error("Run chmod 600 on %s to correct", config.remove_file)
+        sys.exit(constants.sig_kill_bad)
 
     # defaults
     mp = None

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -172,10 +172,10 @@ def validate_remove_file(remove_file):
         logger.warn("WARN: Remove file does not exist")
         return False
     # Make sure permissions are 600
-    mode = stat.S_IMODE(os.stat(remove_file).st_mode)
-    if not mode == 0o600:
+    mode = oct(stat.S_IMODE(os.stat(remove_file).st_mode))
+    if not mode == "0600" and not mode == "0o600":
         logger.error("ERROR: Invalid remove file permissions"
-                     "Expected 0600 got %s" % oct(mode))
+                     "Expected 0600 got %s" % mode)
         return False
     else:
         logger.debug("Correct file permissions")


### PR DESCRIPTION
We need to properly check for the two different ways the mode is
represented for the remove.conf file. There is a difference between
python3 and python2, so we'll check for both

Signed-off-by: Stephen Adams <tsadams@gmail.com>