### PR TITLE
Extend insights.core.filters.add_filter() functionality

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,7 +34,7 @@ archives) to better meet Red Hat customers' security and privacy concerns.
 Blacklists
     A list of files or commands to never upload.
 Filters
-    A set of grep-like strings used to filter files before adding them to
+    A set of simple strings used to filter files before adding them to
     the archive.
 Dynamic Uploader Configuration
     The client will download a configuration file from Red Hat (by

--- a/docs/notebooks/Filters Tutorial.ipynb
+++ b/docs/notebooks/Filters Tutorial.ipynb
@@ -2,838 +2,352 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "# Filtering of Data in Insights Parsers and Rules\n",
-    "In this tutorial we will investigate filters in insights-core, what they are, how they affect your components and how you can use them in your code.  Documentation on filters can be found in the [insights-core documentation](https://insights-core.readthedocs.io/en/latest/api_index.html#module-insights.core.filters).\n",
-    "\n",
-    "The primary purposes of filters are:\n",
-    "\n",
-    "1. to prevent the collection of sensitive information while enabling the collection of necessary information for analysis, and;\n",
-    "2. to reduce the amount of information collected.\n",
-    "\n",
-    "Filters are typically added in rule modules since the purpose of a rule is to analyze particular information and identify a problem, potential problem or fact about the system.  A filter may also be added in a parse modules if it is required to enable parsing of the data.  We will discuss this further when we look at the example.  Filters added by rules and parsers are applied when the data is collected from a system.  They are combined so that if they are added from multiple rules and parsers, each rule will receive all information that was collected by all filters for a given source.  An example will help demonstrate this.\n",
-    "\n",
-    "Suppose you write some rules that needs information from `/var/log/messages`.  This file could be very large and contain potentially sensitive information, so it is not desirable to collect the entire file.  Let's say *rule_a* needs messages that indicate `my_special_process` has failed to start.  And another rule, *rule_b* needs messages that indicate that `my_other_process` had the errors `MY_OTHER_PROCESS: process locked` or `MY_OTHER_PROCESS: memory exceeded`.  Then the two rules could add the following filters to ensure that just the information they need is collected:\n",
-    "\n",
-    "*rule_a*:\n",
-    "```python\n",
-    "add_filter(Specs.messages, 'my_special_process')\n",
-    "```\n",
-    "\n",
-    "*rule_b*:\n",
-    "```python\n",
-    "add_filter(Specs.messages, ['MY_OTHER_PROCESS: process locked',\n",
-    "                            'MY_OTHER_PROCESS: memory exceeded'])\n",
-    "```\n",
-    "\n",
-    "The effect of this would be that when `/var/log/messages` is collected, the filters would be applied and only the lines containing the strings `'my_special_process'`, `'MY_OTHER_PROCESS: process locked'`, or `'MY_OTHER_PROCESS: memory exceeded'` would be collected.  This significantly reduces the size of the data and the chance that sensitive information in `/var/log/messages` might be collected.\n",
-    "\n",
-    "While there are significant benefits to filtering, you must be aware that a datasource is being filtered or your rules could fail to identify a condition that may be present on a system.  For instance suppose a rule *rule_c* also needs information from `/var/log/messages` about `process_xyz`.  If *rule_c* runs with other rules like *rule_a* or *rule_b* then it would never see lines containing `\"process_xyz\"` appearing in `/var/log/messages` unless it adds a new filter.  When any rule or parser adds a filter to a datasource, that data will be filtered for all components, not just the component adding the filter.  Because of this it is important to understand when a datasource is being filtered so that your rule will function properly and include its own filters if needed."
-   ]
+   "metadata": {},
+   "source": "# Filtering of Data in Insights Parsers and Rules\nIn this tutorial we will investigate filters in insights-core, what they are, how they affect your components and how you can use them in your code.  Documentation on filters can be found in the [insights-core documentation](https://insights-core.readthedocs.io/en/latest/api_index.html#module-insights.core.filters).\n\nThe primary purposes of filters are:\n\n1. to prevent the collection of sensitive information while enabling the collection of necessary information for analysis, and;\n2. to reduce the amount of information collected.\n\nFilters are typically added in rule modules since the purpose of a rule is to analyze particular information and identify a problem, potential problem or fact about the system.  A filter may also be added in a parse modules if it is required to enable parsing of the data.  We will discuss this further when we look at the example.  Filters added by rules and parsers are applied when the data is collected from a system.  They are combined so that if they are added from multiple rules and parsers, each rule will receive all information that was collected by all filters for a given source.  An example will help demonstrate this.\n\nSuppose you write some rules that needs information from `/var/log/messages`.  This file could be very large and contain potentially sensitive information, so it is not desirable to collect the entire file.  Let's say *rule_a* needs messages that indicate `my_special_process` has failed to start.  And another rule, *rule_b* needs messages that indicate that `my_other_process` had the errors `MY_OTHER_PROCESS: process locked` or `MY_OTHER_PROCESS: memory exceeded`.  Then the two rules could add the following filters to ensure that just the information they need is collected:\n\n*rule_a*:\n```python\nadd_filter(Specs.messages, 'my_special_process')\n```\n\n*rule_b*:\n```python\nadd_filter(Specs.messages, ['MY_OTHER_PROCESS: process locked',\n                            'MY_OTHER_PROCESS: memory exceeded'])\n```\n\nThe effect of this would be that when `/var/log/messages` is collected, the filters would be applied and only the lines containing the strings `'my_special_process'`, `'MY_OTHER_PROCESS: process locked'`, or `'MY_OTHER_PROCESS: memory exceeded'` would be collected.  This significantly reduces the size of the data and the chance that sensitive information in `/var/log/messages` might be collected.\n\nWhile there are significant benefits to filtering, you must be aware that a datasource is being filtered or your rules could fail to identify a condition that may be present on a system.  For instance suppose a rule *rule_c* also needs information from `/var/log/messages` about `process_xyz`.  If *rule_c* runs with other rules like *rule_a* or *rule_b* then it would never see lines containing `\"process_xyz\"` appearing in `/var/log/messages` unless it adds a new filter.  When any rule or parser adds a filter to a datasource, that data will be filtered for all components, not just the component adding the filter.  Because of this it is important to understand when a datasource is being filtered so that your rule will function properly and include its own filters if needed."
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "## Exploring Filters\n",
-    "### Unfiltered Data\n",
-    "Suppose we want to write a rule that will evaluate the contents of the configuration file `death_star.ini` to determine if there are any vulnerabilities.  Since this is a new data source that is not currently collected by insights-core we'll need to add three elements to collect, parse and evaluate the information."
-   ]
+   "metadata": {},
+   "source": "## Exploring Filters\n### Unfiltered Data\nSuppose we want to write a rule that will evaluate the contents of the configuration file `death_star.ini` to determine if there are any vulnerabilities.  Since this is a new data source that is not currently collected by insights-core we'll need to add three elements to collect, parse and evaluate the information."
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "\"\"\" Some imports used by all of the code in this tutorial \"\"\"\n",
-    "import sys\n",
-    "sys.path.insert(0, \"../..\")\n",
-    "from __future__ import print_function\n",
-    "import os\n",
-    "from insights import run\n",
-    "from insights.specs import SpecSet\n",
-    "from insights.core import IniConfigFile\n",
-    "from insights.core.plugins import parser, rule, make_fail\n",
-    "from insights.core.spec_factory import simple_file"
-   ]
+   "source": "\"\"\" Some imports used by all of the code in this tutorial \"\"\"\nimport sys\nsys.path.insert(0, \"../..\")\nfrom __future__ import print_function\nimport os\nfrom insights import run\nfrom insights.specs import SpecSet\nfrom insights.core import IniConfigFile\nfrom insights.core.plugins import parser, rule, make_fail\nfrom insights.core.spec_factory import simple_file"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "First we'll need to add a specification to collect the configuration file.  Note that for purposes of this tutorial we are collecting from a directory where this notebook is located.  Normally the file path would be an absolute path on your system or in an archive."
-   ]
+   "metadata": {},
+   "source": "First we'll need to add a specification to collect the configuration file.  Note that for purposes of this tutorial we are collecting from a directory where this notebook is located.  Normally the file path would be an absolute path on your system or in an archive."
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "class Specs(SpecSet):\n",
-    "    \"\"\"\n",
-    "    Define a new spec to collect the file we need.\n",
-    "    \"\"\"\n",
-    "    death_star_config = simple_file(os.path.join(os.getcwd(), 'death_star.ini'), filterable=True)"
-   ]
+   "source": "class Specs(SpecSet):\n    \"\"\"\n    Define a new spec to collect the file we need.\n    \"\"\"\n    death_star_config = simple_file(os.path.join(os.getcwd(), 'death_star.ini'), filterable=True)"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Next we'll need to add a parser to parse the file being collected by the spec.  Since this file is in INI format and insights-core provides the IniConfigFile parser, we can just use that to parse the file.  See [the parser documentation](https://insights-core.readthedocs.io/en/latest/api_index.html#insights.core.IniConfigFile) to find out what methods that parser provides."
-   ]
+   "metadata": {},
+   "source": "Next we'll need to add a parser to parse the file being collected by the spec.  Since this file is in INI format and insights-core provides the IniConfigFile parser, we can just use that to parse the file.  See [the parser documentation](https://insights-core.readthedocs.io/en/latest/api_index.html#insights.core.IniConfigFile) to find out what methods that parser provides."
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "@parser(Specs.death_star_config)\n",
-    "class DeathStarCfg(IniConfigFile):\n",
-    "    \"\"\"\n",
-    "    Define a new parser to parse the spec. Since the spec is a standard INI format we\n",
-    "    can use the existing IniConfigFile parser that is provided by insights-core.\n",
-    "    \n",
-    "    See documentation here:\n",
-    "    https://insights-core.readthedocs.io/en/latest/api_index.html#insights.core.IniConfigFile\n",
-    "    \"\"\"\n",
-    "    pass"
-   ]
+   "source": "@parser(Specs.death_star_config)\nclass DeathStarCfg(IniConfigFile):\n    \"\"\"\n    Define a new parser to parse the spec. Since the spec is a standard INI format we\n    can use the existing IniConfigFile parser that is provided by insights-core.\n    \n    See documentation here:\n    https://insights-core.readthedocs.io/en/latest/api_index.html#insights.core.IniConfigFile\n    \"\"\"\n    pass"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Finally we can write the rule that will examine the contents of the parsed configuration file to determine if there are any vulnerabilities. In this INI file we can find the vulnerabilities by searching for keywords to find one that contains the string `vulnerability`.  If any vulnerabilities are found the rule should return information in the form of a `response` that documents the vulnerabilities found, and tags them with the key `DS_IS_VULNERABLE`.  If no vulnerabilities are found the rule should just drop out, effectively returning `None`."
-   ]
+   "metadata": {},
+   "source": "Finally we can write the rule that will examine the contents of the parsed configuration file to determine if there are any vulnerabilities. In this INI file we can find the vulnerabilities by searching for keywords to find one that contains the string `vulnerability`.  If any vulnerabilities are found the rule should return information in the form of a `response` that documents the vulnerabilities found, and tags them with the key `DS_IS_VULNERABLE`.  If no vulnerabilities are found the rule should just drop out, effectively returning `None`."
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "@rule(DeathStarCfg)\n",
-    "def ds_vulnerable(ds_cfg):\n",
-    "    \"\"\"\n",
-    "    Define a new rule to look for vulnerable conditions that may be\n",
-    "    included in the INI file.  If found report them.\n",
-    "    \"\"\"\n",
-    "    vulnerabilities = []\n",
-    "    for section in ds_cfg.sections():\n",
-    "        print(\"Section: {}\".format(section))\n",
-    "        for item_key in ds_cfg.items(section):\n",
-    "            print(\"    {}={}\".format(item_key, ds_cfg.get(section, item_key)))\n",
-    "            if 'vulnerability' in item_key:\n",
-    "                vulnerabilities.append((item_key, ds_cfg.get(section, item_key)))\n",
-    "\n",
-    "    if vulnerabilities:\n",
-    "        return make_fail('DS_IS_VULNERABLE', vulnerabilities=vulnerabilities)"
-   ]
+   "source": "@rule(DeathStarCfg)\ndef ds_vulnerable(ds_cfg):\n    \"\"\"\n    Define a new rule to look for vulnerable conditions that may be\n    included in the INI file.  If found report them.\n    \"\"\"\n    vulnerabilities = []\n    for section in ds_cfg.sections():\n        print(\"Section: {}\".format(section))\n        for item_key in ds_cfg.items(section):\n            print(\"    {}={}\".format(item_key, ds_cfg.get(section, item_key)))\n            if 'vulnerability' in item_key:\n                vulnerabilities.append((item_key, ds_cfg.get(section, item_key)))\n\n    if vulnerabilities:\n        return make_fail('DS_IS_VULNERABLE', vulnerabilities=vulnerabilities)"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Before we run the rule, lets look at the contents of the configuration file. It is in the format of a typical INI file and contains some interesting information.  In particular we see that it does contain a keyword that should match the string we are looking for in the rule, *\"major_vulnerability=ray-shielded particle exhaust vent\"*.  So we expect the rule to return results."
-   ]
+   "metadata": {},
+   "source": "Before we run the rule, lets look at the contents of the configuration file. It is in the format of a typical INI file and contains some interesting information.  In particular we see that it does contain a keyword that should match the string we are looking for in the rule, *\"major_vulnerability=ray-shielded particle exhaust vent\"*.  So we expect the rule to return results."
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "[global]\r\n",
-      "logging=debug\r\n",
-      "log=/var/logs/sample.log\r\n",
-      "\r\n",
-      "# Keep this info secret\r\n",
-      "[secret_stuff]\r\n",
-      "username=dvader\r\n",
-      "password=luke_is_my_son\r\n",
-      "\r\n",
-      "[facts]\r\n",
-      "major_vulnerability=ray-shielded particle exhaust vent\r\n",
-      "\r\n",
-      "[settings]\r\n",
-      "music=The Imperial March\r\n",
-      "color=black\r\n"
-     ]
+     "text": "[global]\r\nlogging=debug\r\nlog=/var/logs/sample.log\r\n\r\n# Keep this info secret\r\n[secret_stuff]\r\nusername=dvader\r\npassword=luke_is_my_son\r\n\r\n[facts]\r\nmajor_vulnerability=ray-shielded particle exhaust vent\r\n\r\n[settings]\r\nmusic=The Imperial March\r\ncolor=black\r\n"
     }
    ],
-   "source": [
-    "!cat death_star.ini"
-   ]
+   "source": "!cat death_star.ini"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Lets run our rule and find out.  To run the rule we'll use the `insights.run()` function and as the argument pass in our rule object (note this is not a string but the actual object).  The results returned will be an `insights.dr.broker` object that contains all sorts of information about the execution of the rule.  You can explore more details of the `broker` in the [Insights Core Tutorial](https://github.com/RedHatInsights/insights-core/blob/master/docs/notebooks/Insights%20Core%20Tutorial.ipynb) notebook.\n",
-    "\n",
-    "The `print` statements in our rule provide output as it loops through the configuration file."
-   ]
+   "metadata": {},
+   "source": "Lets run our rule and find out.  To run the rule we'll use the `insights.run()` function and as the argument pass in our rule object (note this is not a string but the actual object).  The results returned will be an `insights.dr.broker` object that contains all sorts of information about the execution of the rule.  You can explore more details of the `broker` in the [Insights Core Tutorial](https://github.com/RedHatInsights/insights-core/blob/master/docs/notebooks/Insights%20Core%20Tutorial.ipynb) notebook.\n\nThe `print` statements in our rule provide output as it loops through the configuration file."
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Section: global\n",
-      "    logging=debug\n",
-      "    log=/var/logs/sample.log\n",
-      "Section: secret_stuff\n",
-      "    username=dvader\n",
-      "    password=luke_is_my_son\n",
-      "Section: facts\n",
-      "    major_vulnerability=ray-shielded particle exhaust vent\n",
-      "Section: settings\n",
-      "    color=black\n",
-      "    music=The Imperial March\n"
-     ]
+     "text": "Section: global\n    logging=debug\n    log=/var/logs/sample.log\nSection: secret_stuff\n    username=dvader\n    password=luke_is_my_son\nSection: facts\n    major_vulnerability=ray-shielded particle exhaust vent\nSection: settings\n    color=black\n    music=The Imperial March\n"
     }
    ],
-   "source": [
-    "results = run(ds_vulnerable)"
-   ]
+   "source": "results = run(ds_vulnerable)"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Now we are ready to look at the results.  The results are stored in `results[ds_vulnerable]` where the rule object `ds_vulnerable` is the key into the dictionary of objects that your rule depended upon to execute, such as the parser `DeathStarCfg` and the spec `Spec.death_star_config`.  You can see this by looking at those objects in results."
-   ]
+   "metadata": {},
+   "source": "Now we are ready to look at the results.  The results are stored in `results[ds_vulnerable]` where the rule object `ds_vulnerable` is the key into the dictionary of objects that your rule depended upon to execute, such as the parser `DeathStarCfg` and the spec `Spec.death_star_config`.  You can see this by looking at those objects in results."
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "insights.core.spec_factory.TextFileProvider"
-      ]
+      "text/plain": "insights.core.spec_factory.TextFileProvider"
      },
      "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "type(results[Specs.death_star_config])"
-   ]
+   "source": "type(results[Specs.death_star_config])"
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "__main__.DeathStarCfg"
-      ]
+      "text/plain": "__main__.DeathStarCfg"
      },
      "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "type(results[DeathStarCfg])"
-   ]
+   "source": "type(results[DeathStarCfg])"
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "insights.core.plugins.make_fail"
-      ]
+      "text/plain": "insights.core.plugins.make_fail"
      },
      "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "type(results[ds_vulnerable])"
-   ]
+   "source": "type(results[ds_vulnerable])"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Now lets look at the rule results to see if they match what we expected."
-   ]
+   "metadata": {},
+   "source": "Now lets look at the rule results to see if they match what we expected."
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "{'error_key': 'DS_IS_VULNERABLE',\n",
-       " 'type': 'rule',\n",
-       " 'vulnerabilities': [(u'major_vulnerability',\n",
-       "   u'ray-shielded particle exhaust vent')]}"
-      ]
+      "text/plain": "{'error_key': 'DS_IS_VULNERABLE',\n 'type': 'rule',\n 'vulnerabilities': [(u'major_vulnerability',\n   u'ray-shielded particle exhaust vent')]}"
      },
      "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "results[ds_vulnerable]"
-   ]
+   "source": "results[ds_vulnerable]"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Success, it worked as we expected finding the vulnerability.  Now lets look at how filtering can affect the rule results."
-   ]
+   "metadata": {},
+   "source": "Success, it worked as we expected finding the vulnerability.  Now lets look at how filtering can affect the rule results."
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "### Filtering Data\n",
-    "When we looked at the contents of the file you may have noticed some other interesting information such as this:\n",
-    "```\n",
-    "# Keep this info secret\n",
-    "[secret_stuff]\n",
-    "username=dvader\n",
-    "password=luke_is_my_son\n",
-    "```\n",
-    "As a parser writer, if you know that a file could contain sensitive information, you may choose to filter it in the parser module to avoid collecting it.  Usernames, passwords, hostnames, security keys, and other sensitive information should not be collected.  In this case the `username` and `password` are in the configuration file, so we should add a filter to this parser to prevent them from being collected.\n",
-    "\n",
-    "How do we add a filter and avoid breaking the parser?  Each parser is unique, so the parser writer must determine if a filter is necessary, and how to add a filter that will allow the parser to function with a minimal set of data.  For instance a Yaml or XML parser might have a difficult time parsing a filtered Yaml or XML file.\n",
-    "\n",
-    "For our example, we are using an INI file parser.  INI files are structured with sections which are identified as a section name in square brackets like `[section name]`, followed by items like `name` or `name=value`.  One possible way to filter an INI file is to add the filter `\"[\"` which will collect all lines with sections but no items.  This can be successfully parsed by the INI parser, so that is how we'll filter out this sensitive information in our configuration file.  We'll rewrite the parser adding the `add_filter(Specs.death_star_config, '[')` to filter all lines except those with a `'['` string."
-   ]
+   "metadata": {},
+   "source": "### Filtering Data\nWhen we looked at the contents of the file you may have noticed some other interesting information such as this:\n```\n# Keep this info secret\n[secret_stuff]\nusername=dvader\npassword=luke_is_my_son\n```\nAs a parser writer, if you know that a file could contain sensitive information, you may choose to filter it in the parser module to avoid collecting it.  Usernames, passwords, hostnames, security keys, and other sensitive information should not be collected.  In this case the `username` and `password` are in the configuration file, so we should add a filter to this parser to prevent them from being collected.\n\nHow do we add a filter and avoid breaking the parser?  Each parser is unique, so the parser writer must determine if a filter is necessary, and how to add a filter that will allow the parser to function with a minimal set of data.  For instance a Yaml or XML parser might have a difficult time parsing a filtered Yaml or XML file.\n\nFor our example, we are using an INI file parser.  INI files are structured with sections which are identified as a section name in square brackets like `[section name]`, followed by items like `name` or `name=value`.  One possible way to filter an INI file is to add the filter `\"[\"` which will collect all lines with sections but no items.  This can be successfully parsed by the INI parser, so that is how we'll filter out this sensitive information in our configuration file.  We'll rewrite the parser adding the `add_filter(Specs.death_star_config, '[')` to filter all lines except those with a `'['` string."
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "from insights.core.filters import add_filter\n",
-    "\n",
-    "add_filter(Specs.death_star_config, '[')\n",
-    "\n",
-    "@parser(Specs.death_star_config)\n",
-    "class DeathStarCfg(IniConfigFile):\n",
-    "    \"\"\"\n",
-    "    Define a new parser to parse the spec. Since the spec is a standard INI format we\n",
-    "    can use the existing IniConfigFile parser that is provided by insights-core.\n",
-    "    \n",
-    "    See documentation here:\n",
-    "    https://insights-core.readthedocs.io/en/latest/api_index.html#insights.core.IniConfigFile\n",
-    "    \"\"\"\n",
-    "    pass"
-   ]
+   "source": "from insights.core.filters import add_filter\n\nadd_filter(Specs.death_star_config, '[')\n\n@parser(Specs.death_star_config)\nclass DeathStarCfg(IniConfigFile):\n    \"\"\"\n    Define a new parser to parse the spec. Since the spec is a standard INI format we\n    can use the existing IniConfigFile parser that is provided by insights-core.\n    \n    See documentation here:\n    https://insights-core.readthedocs.io/en/latest/api_index.html#insights.core.IniConfigFile\n    \"\"\"\n    pass"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Now lets run the rule again and see what happens.  Do you expect the same results we got before?"
-   ]
+   "metadata": {},
+   "source": "Now lets run the rule again and see what happens.  Do you expect the same results we got before?"
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Section: global\n",
-      "Section: secret_stuff\n",
-      "Section: facts\n",
-      "Section: settings\n"
-     ]
+     "text": "Section: global\nSection: secret_stuff\nSection: facts\nSection: settings\n"
     },
     {
      "data": {
-      "text/plain": [
-       "'No results'"
-      ]
+      "text/plain": "'No results'"
      },
      "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "results = run(ds_vulnerable)\n",
-    "results.get(ds_vulnerable, \"No results\")        # Use .get method of dict so we can provide default other than None"
-   ]
+   "source": "results = run(ds_vulnerable)\nresults.get(ds_vulnerable, \"No results\")        # Use .get method of dict so we can provide default other than None"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Is that what you expected? Notice the output from the `print` statements in the rule, only the section names are printed.  That is the result of adding the filter, only lines with `'['` (the sections) are collected and provided to the parser.  This means that the lines we were looking for in the rule are no longer there, and that it appears our rule didn't find any vulnerabilities.  Next we'll look at how to fix our rule to work with the filtered data."
-   ]
+   "metadata": {},
+   "source": "Is that what you expected? Notice the output from the `print` statements in the rule, only the section names are printed.  That is the result of adding the filter, only lines with `'['` (the sections) are collected and provided to the parser.  This means that the lines we were looking for in the rule are no longer there, and that it appears our rule didn't find any vulnerabilities.  Next we'll look at how to fix our rule to work with the filtered data."
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "### Adding Filters to Rules\n",
-    "We can add filters to a rule just like we added a filter to the parser, using the `add_filter()` method.  The `add_filter` method requires a spec and a string or list/set of strings.  In this case our rule is looking for the string `'vulnerability'` so we just need to add that to the filter."
-   ]
+   "metadata": {},
+   "source": "### Adding Filters to Rules\nWe can add filters to a rule just like we added a filter to the parser, using the `add_filter()` method.  The `add_filter` method requires a spec and a string or list/set of strings.  In this case our rule is looking for the string `'vulnerability'` so we just need to add that to the filter.\n\nAlternatively, filters can be added by specifying a parser or combiner in the `add_filter()` method instead of a spec. In that scenario, the dependency tree will be traversed to locate underlying datasources that are filterable (`filterable` parameter is equal to `True`). And the specified filters will be added to those datasouces. \nIn our example, we can filter the underlying `Specs.death_star_config` datasource by adding the `add_filter(DeathStarCfg, 'vulnerability')` statement. This is especially useful when you are working with a combiner that consolidates data from multiple parsers, which in turn depend on multiple datasources. Adding a filter to a combiner would allow for consistent filtering of data across all applicable datasources."
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "add_filter(Specs.death_star_config, 'vulnerability')\n",
-    "\n",
-    "@rule(DeathStarCfg)\n",
-    "def ds_vulnerable(ds_cfg):\n",
-    "    \"\"\"\n",
-    "    Define a new rule to look for vulnerable conditions that may be\n",
-    "    included in the INI file.  If found report them.\n",
-    "    \"\"\"\n",
-    "    vulnerabilities = []\n",
-    "    for section in ds_cfg.sections():\n",
-    "        print(\"Section: {}\".format(section))\n",
-    "        for item_key in ds_cfg.items(section):\n",
-    "            print(\"    {}={}\".format(item_key, ds_cfg.get(section, item_key)))\n",
-    "            if 'vulnerability' in item_key:\n",
-    "                vulnerabilities.append((item_key, ds_cfg.get(section, item_key)))\n",
-    "\n",
-    "    if vulnerabilities:\n",
-    "        return make_fail('DS_IS_VULNERABLE', vulnerabilities=vulnerabilities)"
-   ]
+   "source": "add_filter(Specs.death_star_config, 'vulnerability')\n\n@rule(DeathStarCfg)\ndef ds_vulnerable(ds_cfg):\n    \"\"\"\n    Define a new rule to look for vulnerable conditions that may be\n    included in the INI file.  If found report them.\n    \"\"\"\n    vulnerabilities = []\n    for section in ds_cfg.sections():\n        print(\"Section: {}\".format(section))\n        for item_key in ds_cfg.items(section):\n            print(\"    {}={}\".format(item_key, ds_cfg.get(section, item_key)))\n            if 'vulnerability' in item_key:\n                vulnerabilities.append((item_key, ds_cfg.get(section, item_key)))\n\n    if vulnerabilities:\n        return make_fail('DS_IS_VULNERABLE', vulnerabilities=vulnerabilities)"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Now lets run the rule again and see what happens."
-   ]
+   "metadata": {},
+   "source": "Now lets run the rule again and see what happens."
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Section: global\n",
-      "Section: secret_stuff\n",
-      "Section: facts\n",
-      "    major_vulnerability=ray-shielded particle exhaust vent\n",
-      "Section: settings\n"
-     ]
+     "text": "Section: global\nSection: secret_stuff\nSection: facts\n    major_vulnerability=ray-shielded particle exhaust vent\nSection: settings\n"
     },
     {
      "data": {
-      "text/plain": [
-       "{'error_key': 'DS_IS_VULNERABLE',\n",
-       " 'type': 'rule',\n",
-       " 'vulnerabilities': [(u'major_vulnerability',\n",
-       "   u'ray-shielded particle exhaust vent')]}"
-      ]
+      "text/plain": "{'error_key': 'DS_IS_VULNERABLE',\n 'type': 'rule',\n 'vulnerabilities': [(u'major_vulnerability',\n   u'ray-shielded particle exhaust vent')]}"
      },
      "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "results = run(ds_vulnerable)\n",
-    "results.get(ds_vulnerable, \"No results\")        # Use .get method of dict so we can provide default other than None"
-   ]
+   "source": "results = run(ds_vulnerable)\nresults.get(ds_vulnerable, \"No results\")        # Use .get method of dict so we can provide default other than None"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Now look at the output from the `print` statements in the rule, the item that was missing is now included.  By adding the string required by our rule to the spec filters we have successfully included the data needed by our rule to detect the problem.  Also, by adding the filter to the parser we have eliminated the sensitive information from the input."
-   ]
+   "metadata": {},
+   "source": "Now look at the output from the `print` statements in the rule, the item that was missing is now included.  By adding the string required by our rule to the spec filters we have successfully included the data needed by our rule to detect the problem.  Also, by adding the filter to the parser we have eliminated the sensitive information from the input."
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "## Determining if a Spec is Filtered\n",
-    "When you are developing your rule, you may want to add some code, during development, to check if the spec you are using is filtered.  This can be accomplished by looking at the spec in [insights/specs/__init__.py](https://github.com/RedHatInsights/insights-core/blob/master/insights/specs/__init__.py).  Each spec is defined here as a `RegistryPoint()` type.  If the spec is filtered it will have the parameter `filterable=True`, for example the following indicates that the messages log (`/var/log/messages`) will be filtered:\n",
-    "\n",
-    "```\n",
-    "messages = RegistryPoint(filterable=True)\n",
-    "```\n",
-    "\n",
-    "If you need to use a parser that relies on a filtered spec then you need to add your own filter to ensure that your rule will receive the data necessary to evaluate the rule conditions.  If you forget to add a filter to your rule, if you include integration tests for your rule, `pytest` will indicate an exception like the following warning you that the `add_filter` is missing:\n",
-    "\n",
-    "```\n",
-    "telemetry/rules/tests/integration.py:7: \n",
-    " _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _\n",
-    "\n",
-    "component = <function report at 0x7fa843094e60>, input_data = <InputData {name:test4-00000}>, expected = None\n",
-    "\n",
-    "    def run_test(component, input_data, expected=None):\n",
-    "        if filters.ENABLED:\n",
-    "            mod = component.__module__\n",
-    "            sup_mod = '.'.join(mod.split('.')[:-1])\n",
-    "            rps = _get_registry_points(component)\n",
-    "            filterable = set(d for d in rps if dr.get_delegate(d).filterable)\n",
-    "            missing_filters = filterable - ADDED_FILTERS.get(mod, set()) - ADDED_FILTERS.get(sup_mod, set())\n",
-    "            if missing_filters:\n",
-    "                names = [dr.get_name(m) for m in missing_filters]\n",
-    "                msg = \"%s must add filters to %s\"\n",
-    ">               raise Exception(msg % (mod, \", \".join(names)))\n",
-    "E               Exception: telemetry.rules.plugins.kernel.overcommit must add filters to insights.specs.Specs.messages\n",
-    "\n",
-    "../../insights/insights-core/insights/tests/__init__.py:114: Exception\n",
-    "\n",
-    "```\n",
-    "\n",
-    "If you see this exception when you run tests then it means you need to include `add_filter` to your rule."
-   ]
+   "metadata": {},
+   "source": "## Determining if a Spec is Filtered\nWhen you are developing your rule, you may want to add some code, during development, to check if the spec you are using is filtered.  This can be accomplished by looking at the spec in [insights/specs/__init__.py](https://github.com/RedHatInsights/insights-core/blob/master/insights/specs/__init__.py).  Each spec is defined here as a `RegistryPoint()` type.  If the spec is filtered it will have the parameter `filterable=True`, for example the following indicates that the messages log (`/var/log/messages`) will be filtered:\n\n```\nmessages = RegistryPoint(filterable=True)\n```\n\nIf you need to use a parser that relies on a filtered spec then you need to add your own filter to ensure that your rule will receive the data necessary to evaluate the rule conditions.  If you forget to add a filter to your rule, if you include integration tests for your rule, `pytest` will indicate an exception like the following warning you that the `add_filter` is missing:\n\n```\ntelemetry/rules/tests/integration.py:7: \n _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _\n\ncomponent = <function report at 0x7fa843094e60>, input_data = <InputData {name:test4-00000}>, expected = None\n\n    def run_test(component, input_data, expected=None):\n        if filters.ENABLED:\n            mod = component.__module__\n            sup_mod = '.'.join(mod.split('.')[:-1])\n            rps = _get_registry_points(component)\n            filterable = set(d for d in rps if dr.get_delegate(d).filterable)\n            missing_filters = filterable - ADDED_FILTERS.get(mod, set()) - ADDED_FILTERS.get(sup_mod, set())\n            if missing_filters:\n                names = [dr.get_name(m) for m in missing_filters]\n                msg = \"%s must add filters to %s\"\n>               raise Exception(msg % (mod, \", \".join(names)))\nE               Exception: telemetry.rules.plugins.kernel.overcommit must add filters to insights.specs.Specs.messages\n\n../../insights/insights-core/insights/tests/__init__.py:114: Exception\n\n```\n\nIf you see this exception when you run tests then it means you need to include `add_filter` to your rule."
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "## Turning Off Filtering Globally\n",
-    "There are often times that you would want or need to turn off filtering in order to perform testing or to fully analyze some aspects of a system and diagnose problems.  Also if you are running locally on a system you might want to collect all data unfiltered.  You can to this by setting the environment variable `INSIGHTS_FILTERS_ENABLED=False` prior to running insights-core.  This won't work inside this notebook unless you follow the directions below."
-   ]
+   "metadata": {},
+   "source": "## Turning Off Filtering Globally\nThere are often times that you would want or need to turn off filtering in order to perform testing or to fully analyze some aspects of a system and diagnose problems.  Also if you are running locally on a system you might want to collect all data unfiltered.  You can to this by setting the environment variable `INSIGHTS_FILTERS_ENABLED=False` prior to running insights-core.  This won't work inside this notebook unless you follow the directions below."
   },
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "\"\"\"\n",
-    "This code will disable all filtering if it is run as the first cell when the notebook\n",
-    "is opened.  After the notebook has been started you will need to click on the Kernel\n",
-    "menu and then the restart item, and then run this cell first before all others.\n",
-    "You would need to restart the kernel and then not run this cell to prevent disabling\n",
-    "filters.\n",
-    "\"\"\"\n",
-    "import os\n",
-    "os.environ['INSIGHTS_FILTERS_ENABLED'] = 'False'"
-   ]
+   "source": "\"\"\"\nThis code will disable all filtering if it is run as the first cell when the notebook\nis opened.  After the notebook has been started you will need to click on the Kernel\nmenu and then the restart item, and then run this cell first before all others.\nYou would need to restart the kernel and then not run this cell to prevent disabling\nfilters.\n\"\"\"\nimport os\nos.environ['INSIGHTS_FILTERS_ENABLED'] = 'False'"
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Section: global\n",
-      "Section: secret_stuff\n",
-      "Section: facts\n",
-      "    major_vulnerability=ray-shielded particle exhaust vent\n",
-      "Section: settings\n"
-     ]
+     "text": "Section: global\nSection: secret_stuff\nSection: facts\n    major_vulnerability=ray-shielded particle exhaust vent\nSection: settings\n"
     },
     {
      "data": {
-      "text/plain": [
-       "{'error_key': 'DS_IS_VULNERABLE',\n",
-       " 'type': 'rule',\n",
-       " 'vulnerabilities': [(u'major_vulnerability',\n",
-       "   u'ray-shielded particle exhaust vent')]}"
-      ]
+      "text/plain": "{'error_key': 'DS_IS_VULNERABLE',\n 'type': 'rule',\n 'vulnerabilities': [(u'major_vulnerability',\n   u'ray-shielded particle exhaust vent')]}"
      },
      "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "results = run(ds_vulnerable)\n",
-    "results.get(ds_vulnerable, \"No results\")        # Use .get method of dict so we can provide default other than None"
-   ]
+   "source": "results = run(ds_vulnerable)\nresults.get(ds_vulnerable, \"No results\")        # Use .get method of dict so we can provide default other than None"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "## Debugging Components\n",
-    "If you are writing component code you may sometimes not see any results even though you expected them and no errors were displayed.  That is because insights-core is catching the exceptions and saving them.  In order to see the exceptions you can use the following method to display the results of a run and any errors that occurrerd."
-   ]
+   "metadata": {},
+   "source": "## Debugging Components\nIf you are writing component code you may sometimes not see any results even though you expected them and no errors were displayed.  That is because insights-core is catching the exceptions and saving them.  In order to see the exceptions you can use the following method to display the results of a run and any errors that occurrerd."
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "def show_results(results, component):\n",
-    "    \"\"\"\n",
-    "    This function will show the results from run() where:\n",
-    "    \n",
-    "        results = run(component)\n",
-    "        \n",
-    "    run will catch all exceptions so if there are any this\n",
-    "    function will print them out with a stack trace, making\n",
-    "    it easier to develop component code.\n",
-    "    \"\"\"\n",
-    "    if component in results:\n",
-    "        print(results[component])\n",
-    "    else:\n",
-    "        print(\"No results for: {}\".format(component))\n",
-    "\n",
-    "    if results.exceptions:\n",
-    "        for comp in results.exceptions:\n",
-    "            print(\"Component Exception: {}\".format(comp))\n",
-    "            for exp in results.exceptions[comp]:\n",
-    "                print(results.tracebacks[exp])"
-   ]
+   "source": "def show_results(results, component):\n    \"\"\"\n    This function will show the results from run() where:\n    \n        results = run(component)\n        \n    run will catch all exceptions so if there are any this\n    function will print them out with a stack trace, making\n    it easier to develop component code.\n    \"\"\"\n    if component in results:\n        print(results[component])\n    else:\n        print(\"No results for: {}\".format(component))\n\n    if results.exceptions:\n        for comp in results.exceptions:\n            print(\"Component Exception: {}\".format(comp))\n            for exp in results.exceptions[comp]:\n                print(results.tracebacks[exp])"
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Here's an example of this function in use"
-   ]
+   "metadata": {},
+   "source": "Here's an example of this function in use"
   },
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "@rule(DeathStarCfg)\n",
-    "def bad_rule(cfg):\n",
-    "    # Force an error here\n",
-    "    infinity = 1 / 0"
-   ]
+   "source": "@rule(DeathStarCfg)\ndef bad_rule(cfg):\n    # Force an error here\n    infinity = 1 / 0"
   },
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "No handlers could be found for logger \"insights.core.dr\"\n"
-     ]
+     "text": "No handlers could be found for logger \"insights.core.dr\"\n"
     }
    ],
-   "source": [
-    "results = run(bad_rule)"
-   ]
+   "source": "results = run(bad_rule)"
   },
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "No results for: <function bad_rule at 0x7f5860599de8>\n",
-      "Component Exception: <function bad_rule at 0x7f5860599de8>\n",
-      "Traceback (most recent call last):\n",
-      "  File \"../../insights/core/dr.py\", line 952, in run\n",
-      "    result = DELEGATES[component].process(broker)\n",
-      "  File \"../../insights/core/plugins.py\", line 272, in process\n",
-      "    r = self.invoke(broker)\n",
-      "  File \"../../insights/core/plugins.py\", line 63, in invoke\n",
-      "    return super(PluginType, self).invoke(broker)\n",
-      "  File \"../../insights/core/dr.py\", line 653, in invoke\n",
-      "    return self.component(*args)\n",
-      "  File \"<ipython-input-18-0450035609f8>\", line 4, in bad_rule\n",
-      "    infinity = 1 / 0\n",
-      "ZeroDivisionError: integer division or modulo by zero\n",
-      "\n"
-     ]
+     "text": "No results for: <function bad_rule at 0x7f8c02e99d50>\nComponent Exception: <function bad_rule at 0x7f8c02e99d50>\nTraceback (most recent call last):\n  File \"../../insights/core/dr.py\", line 962, in run\n    result = DELEGATES[component].process(broker)\n  File \"../../insights/core/plugins.py\", line 303, in process\n    r = self.invoke(broker)\n  File \"../../insights/core/plugins.py\", line 64, in invoke\n    return super(PluginType, self).invoke(broker)\n  File \"../../insights/core/dr.py\", line 661, in invoke\n    return self.component(*args)\n  File \"<ipython-input-18-0450035609f8>\", line 4, in bad_rule\n    infinity = 1 / 0\nZeroDivisionError: integer division or modulo by zero\n\n"
     }
    ],
-   "source": [
-    "show_results(results, bad_rule)"
-   ]
+   "source": "show_results(results, bad_rule)"
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
-   "source": []
+   "source": ""
   }
  ],
  "metadata": {
@@ -852,7 +366,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "version": "2.7.17"
   }
  },
  "nbformat": 4,

--- a/insights/plugins/ps_rule_fakes.py
+++ b/insights/plugins/ps_rule_fakes.py
@@ -1,0 +1,25 @@
+from insights import rule, make_pass
+from insights.core.filters import add_filter
+from insights.parsers.ps import PsAux, PsAuxww, PsAlxwww
+from insights.specs import Specs
+
+
+@rule(PsAux)
+def psaux_no_filter(ps_aux):
+    return make_pass("FAKE RESULT")
+
+
+add_filter(Specs.ps_auxww, "fake-filter")
+
+
+@rule(PsAuxww)
+def psauxww_ds_filter(ps_auxww):
+    return make_pass("FAKE RESULT")
+
+
+add_filter(PsAlxwww, "fake-filter")
+
+
+@rule(PsAlxwww)
+def psalxwww_parser_filter(ps_alxwww):
+    return make_pass("FAKE RESULT")

--- a/insights/tests/test_filters.py
+++ b/insights/tests/test_filters.py
@@ -1,8 +1,11 @@
 from collections import defaultdict
 from insights.core import filters
 
+from insights.parsers.ps import PsAux, PsAuxcww
 from insights.specs import Specs
 from insights.specs.default import DefaultSpecs
+
+import pytest
 
 
 def setup_function(func):
@@ -26,6 +29,12 @@ def teardown_function(func):
         del filters.FILTERS[DefaultSpecs.ps_aux]
 
     if func is test_filter_dumps_loads:
+        del filters.FILTERS[Specs.ps_aux]
+
+    if func is test_add_filter_to_parser:
+        del filters.FILTERS[Specs.ps_aux]
+
+    if func is test_add_filter_to_parser_patterns_list:
         del filters.FILTERS[Specs.ps_aux]
 
 
@@ -56,3 +65,46 @@ def test_get_filter_registry_point():
     f = filters.get_filters(Specs.ps_aux)
     assert "COMMAND" in f
     assert "MEM" not in f
+
+
+def test_add_filter_to_parser():
+    filter_string = "bash"
+    filters.add_filter(PsAux, filter_string)
+
+    spec_filters = filters.get_filters(Specs.ps_aux)
+    assert filter_string in spec_filters
+
+    parser_filters = filters.get_filters(PsAux)
+    assert not parser_filters
+
+
+def test_add_filter_to_parser_patterns_list():
+    filters_list = ["bash", "systemd", "Network"]
+    filters.add_filter(PsAux, filters_list)
+
+    spec_filters = filters.get_filters(Specs.ps_aux)
+    assert all(f in spec_filters for f in filters_list)
+
+    parser_filters = filters.get_filters(PsAux)
+    assert not parser_filters
+
+
+def test_add_filter_to_parser_non_filterable():
+    filter_string = "bash"
+    filters.add_filter(PsAuxcww, filter_string)
+
+    spec_filters = filters.get_filters(Specs.ps_auxcww)
+    assert not spec_filters
+
+    parser_filters = filters.get_filters(PsAuxcww)
+    assert not parser_filters
+
+
+def test_add_filter_exception_not_filterable():
+    with pytest.raises(Exception):
+        filters.add_filter(Specs.ps_auxcww, "bash")
+
+
+def test_add_filter_exception_raw():
+    with pytest.raises(Exception):
+        filters.add_filter(Specs.metadata_json, "[]")

--- a/insights/tests/test_integration_support.py
+++ b/insights/tests/test_integration_support.py
@@ -1,0 +1,39 @@
+from insights.plugins.ps_rule_fakes import psaux_no_filter, psauxww_ds_filter, psalxwww_parser_filter
+from insights.specs import Specs
+from . import InputData, run_test
+
+import pytest
+
+
+def test_run_test_missing_filters_exception():
+    """
+    The rule underlying datasource requires a filter,
+    an exception should be raised because filter was not
+    added in the rule module.
+    """
+    input_data = InputData("fake_input")
+    input_data.add(Specs.ps_aux, "FAKE_CONTENT")
+    with pytest.raises(Exception):
+        run_test(psaux_no_filter, input_data, None)
+
+
+def test_run_test_no_missing_filters_using_datasource():
+    """
+    Required filter was added directly to the datasouce,
+    ``run_test`` should complete without any exceptions.
+    """
+    input_data = InputData("fake_input")
+    input_data.add(Specs.ps_auxww, "FAKE_CONTENT")
+    result = run_test(psauxww_ds_filter, input_data, None)
+    assert result
+
+
+def test_run_test_no_missing_filters_using_parser():
+    """
+    Required filter was added to using the parser,
+    ``run_test`` should complete without any exceptions.
+    """
+    input_data = InputData("fake_input")
+    input_data.add(Specs.ps_alxwww, "FAKE_CONTENT")
+    result = run_test(psalxwww_parser_filter, input_data, None)
+    assert result


### PR DESCRIPTION
* Modified `add_filter` so non-datasouce component can be passed into the function.
* Added relevant unit tests to `test_filters.py`.
* Modified `_intercept_add_filter` function to correctly test for missing filters
  during integration tests, based on changed to `add_filter`.
* Added `test_integration_support.py` with unit tests for integation testing
  support functions.
* Added `plugins/ps_rule_fakes.py` with dummy rules that areused in `test_integration_support.py`
  unit tests.
* Modified `Insights API` docs page and `Filtering of Data in Insights Parsers and Rules`
  notebook (added new paragraph under **Adding Filters to Rules** section) to include information about the non-datasource component level filtering.

Resolves #2429

Signed-off-by: Vitaliy Dymna <vdymna@redhat.com>