### PR TITLE
Parser for  ip neigh show

### DIFF
--- a/insights/parsers/ip.py
+++ b/insights/parsers/ip.py
@@ -534,6 +534,7 @@ class IpNeighParser(CommandParser):
         'STALE': 3,
         'DELAY': 4,
         'FAILED': 5,
+        'INCOMPLETE': 6,
     }
 
     def parse_content(self, content):
@@ -624,6 +625,14 @@ class Ipv4Neigh(IpNeighParser):
 class Ipv6Neigh(IpNeighParser):
     """
     Class to parse ``ip -6 neigh show nud all`` command output.
+    """
+    pass
+
+
+@parser(Specs.ip_neigh_show)
+class IpNeighShow(IpNeighParser):
+    """
+    Class to parse ``ip neigh show`` or ``ip -s -s neigh show`` command output.
     """
     pass
 

--- a/insights/parsers/tests/test_ip.py
+++ b/insights/parsers/tests/test_ip.py
@@ -792,7 +792,7 @@ def test_ip_neigh_show():
     result = ip.IpNeighShow(context_wrap(IP_NEIGH_SHOW))
     assert len(result.data) == 13
     assert result['2a04:9a00:1:1:ec4:7aff:febb:d3ca']['nud'] == 'REACHABLE'
-    assert result['10.101.5.71']['nud'] == 'INCOMPLETE'
     assert len(result['2a04:9a00:1:1:ec4:7aff:febb:d1fe']) == 4
     assert len(result['10.101.5.252']) == 4
     assert result['10.101.5.17']['nud'] == 'INCOMPLETE'
+    assert result['10.101.5.71']['nud'] == 'INCOMPLETE'

--- a/insights/parsers/tests/test_ip.py
+++ b/insights/parsers/tests/test_ip.py
@@ -797,3 +797,4 @@ def test_ip_neigh_show():
     assert result['10.101.5.17']['nud'] == 'INCOMPLETE'
     assert result['10.101.5.71']['nud'] == 'INCOMPLETE'
     assert len(result['10.101.5.71']) == 3
+    assert len(result['10.101.5.17']) == 3

--- a/insights/parsers/tests/test_ip.py
+++ b/insights/parsers/tests/test_ip.py
@@ -769,3 +769,29 @@ def test_ipv6_neigh():
         "dev": "tun0", "nud": "NOARP", "lladdr": "33:33:ff:ea:2c:00",
         'addr': ipaddress.ip_address(u'ff02::1:ffea:2c00')
     }
+
+IP_NEIGH_SHOW = """
+2a04:9a00:1:1:ec4:7aff:febb:d3ca dev bond0.104 lladdr 0c:c4:7a:bb:d3:ca REACHABLE
+fe80::22a:6aff:fe65:c3c2 dev bond0.104 lladdr 00:2a:6a:65:c3:c2 router STALE
+2a04:9a00:1:1:ec4:7aff:febd:50b2 dev bond0.104 lladdr 0c:c4:7a:bd:50:b2 REACHABLE
+2a04:9a00:1:1:ec4:7aff:fe1e:390e dev bond0.104 lladdr 0c:c4:7a:1e:39:0e REACHABLE
+2a04:9a00:1:1:ec4:7aff:fe1f:45a dev bond0.104 lladdr 0c:c4:7a:1f:04:5a REACHABLE
+fe80::ec4:7aff:fe1f:808 dev bond0.104 lladdr 0c:c4:7a:1f:08:08 STALE
+2a04:9a00:1:1:ec4:7aff:febb:d1fe dev bond0.104 lladdr 0c:c4:7a:bb:d1:fe REACHABLE
+10.101.3.27 dev bond0.101 lladdr 00:90:fa:7f:b0:78 STALE
+10.101.5.252 dev bond0.102 lladdr 00:2a:6a:65:c5:42 STALE
+10.101.5.27 dev bond0.102 lladdr 0c:c4:7a:8f:44:02 DELAY
+10.101.3.252 dev bond0.101 lladdr 00:2a:6a:65:c5:42 STALE
+10.101.3.21 dev bond0.101 lladdr 00:90:fa:7f:ad:d8 REACHABLE
+10.101.5.71 dev bond0.102  INCOMPLETE
+10.101.5.17 dev bond0.102  INCOMPLETE
+""".strip()
+
+
+def test_ip_neigh_show():
+    result = ip.IpNeighShow(context_wrap(IP_NEIGH_SHOW))
+    assert len(result.data) == 13
+    assert result['2a04:9a00:1:1:ec4:7aff:febb:d3ca']['nud'] == 'REACHABLE'
+    assert result['10.101.5.71']['nud'] == 'INCOMPLETE'
+    assert len(result["2a04:9a00:1:1:ec4:7aff:febb:d1fe"]) == 4
+    assert len(result["10.101.5.252"]) == 4

--- a/insights/parsers/tests/test_ip.py
+++ b/insights/parsers/tests/test_ip.py
@@ -796,3 +796,4 @@ def test_ip_neigh_show():
     assert len(result['10.101.5.252']) == 4
     assert result['10.101.5.17']['nud'] == 'INCOMPLETE'
     assert result['10.101.5.71']['nud'] == 'INCOMPLETE'
+    assert len(result['10.101.5.71']) == 3

--- a/insights/parsers/tests/test_ip.py
+++ b/insights/parsers/tests/test_ip.py
@@ -793,5 +793,6 @@ def test_ip_neigh_show():
     assert len(result.data) == 13
     assert result['2a04:9a00:1:1:ec4:7aff:febb:d3ca']['nud'] == 'REACHABLE'
     assert result['10.101.5.71']['nud'] == 'INCOMPLETE'
-    assert len(result["2a04:9a00:1:1:ec4:7aff:febb:d1fe"]) == 4
-    assert len(result["10.101.5.252"]) == 4
+    assert len(result['2a04:9a00:1:1:ec4:7aff:febb:d1fe']) == 4
+    assert len(result['10.101.5.252']) == 4
+    assert result['10.101.5.17']['nud'] == 'INCOMPLETE'

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -241,6 +241,7 @@ class Specs(SpecSet):
     iptables = RegistryPoint()
     ipv4_neigh = RegistryPoint()
     ipv6_neigh = RegistryPoint()
+    ip_neigh_show = RegistryPoint()
     ironic_conf = RegistryPoint(filterable=True)
     ironic_inspector_log = RegistryPoint(filterable=True)
     iscsiadm_m_session = RegistryPoint()

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -62,6 +62,7 @@ class SosSpecs(Specs):
     httpd_M = simple_file("sos_commands/apache/apachectl_-M")
     installed_rpms = first_file(["sos_commands/rpm/package-data", "installed-rpms"])
     ip_addr = first_of([simple_file("sos_commands/networking/ip_-d_address"), simple_file("sos_commands/networking/ip_address")])
+    ip_neigh_show = first_file(["sos_commands/networking/ip_-s_-s_neigh_show", "sos_commands/networking/ip_neigh_show"])
     ip_route_show_table_all = simple_file("sos_commands/networking/ip_route_show_table_all")
     ip_s_link = first_of([simple_file("sos_commands/networking/ip_-s_-d_link"), simple_file("sos_commands/networking/ip_-s_link"), simple_file("sos_commands/networking/ip_link")])
     iptables = first_file(["/etc/sysconfig/iptables", "/etc/sysconfig/iptables.save"])


### PR DESCRIPTION
The parser has been added to parser the output of `ip neigh show` or `ip -s -s  neigh show` commands stored in sosreport. 


Signed-off-by: vishawanathjadhav <vjadhav@redhat.com>