### PR TITLE
Keep the timestamp returned by Syslog as it is

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -1271,11 +1271,11 @@ class Syslog(LogFileOutput):
 
     Sample log lines::
 
-        May 18 15:13:34 lxc-rhel68-sat56 jabberd/sm[11057]: session started: jid=rhn-dispatcher-sat@lxc-rhel6-sat56.redhat.com/superclient
-        May 18 15:13:36 lxc-rhel68-sat56 wrapper[11375]: --> Wrapper Started as Daemon
-        May 18 15:13:36 lxc-rhel68-sat56 wrapper[11375]: Launching a JVM...
-        May 18 15:24:28 lxc-rhel68-sat56 yum[11597]: Installed: lynx-2.8.6-27.el6.x86_64
-        May 18 15:36:19 lxc-rhel68-sat56 yum[11954]: Updated: sos-3.2-40.el6.noarch
+        May  9 15:13:34 lxc-rhel68-sat56 jabberd/sm[11057]: session started: jid=rhn-dispatcher-sat@lxc-rhel6-sat56.redhat.com/superclient
+        May  9 15:13:36 lxc-rhel68-sat56 wrapper[11375]: --> Wrapper Started as Daemon
+        May  9 15:13:36 lxc-rhel68-sat56 wrapper[11375]: Launching a JVM...
+        May 10 15:24:28 lxc-rhel68-sat56 yum[11597]: Installed: lynx-2.8.6-27.el6.x86_64
+        May 10 15:36:19 lxc-rhel68-sat56 yum[11954]: Updated: sos-3.2-40.el6.noarch
 
     Examples:
         >>> Syslog.token_scan('daemon_start', 'Wrapper Started as Daemon')
@@ -1283,9 +1283,9 @@ class Syslog(LogFileOutput):
         >>> Syslog.keep_scan('yum_lines', 'yum')
         >>> Syslog.keep_scan('yum_installed_lines', ['yum', 'Installed'])
         >>> syslog.get('wrapper')[0]
-        {'timestamp': 'May 18 15:13:36', 'hostname': 'lxc-rhel68-sat56',
+        {'timestamp': 'May  9 15:13:36', 'hostname': 'lxc-rhel68-sat56',
          'procname': wrapper[11375]', 'message': '--> Wrapper Started as Daemon',
-         'raw_message': 'May 18 15:13:36 lxc-rhel68-sat56 wrapper[11375]: --> Wrapper Started as Daemon'
+         'raw_message': 'May  9 15:13:36 lxc-rhel68-sat56 wrapper[11375]: --> Wrapper Started as Daemon'
         }
         >>> syslog.daemon_start
         True
@@ -1307,7 +1307,7 @@ class Syslog(LogFileOutput):
         """
         Parsed result::
 
-            {'timestamp':'May 18 14:24:14',
+            {'timestamp':'May  9 15:13:34',
              'procname': 'kernel',
              'hostname':'lxc-rhel68-sat56',
              'message': '...',
@@ -1319,16 +1319,16 @@ class Syslog(LogFileOutput):
             info, msg = [i.strip() for i in line.split(': ', 1)]
             msg_info['message'] = msg
 
-            info_splits = info.split()
-            if len(info_splits) == 5:
-                logstamp = ' '.join(info_splits[:3])
+            info_splits = info.rsplit(None, 2)
+            if len(info_splits) == 3:
+                logstamp = info_splits[0]
                 try:
                     datetime.datetime.strptime(logstamp, self.time_format)
                 except ValueError:
                     return msg_info
                 msg_info['timestamp'] = logstamp
-                msg_info['hostname'] = info_splits[3]
-                msg_info['procname'] = info_splits[4]
+                msg_info['hostname'] = info_splits[1]
+                msg_info['procname'] = info_splits[2]
         return msg_info
 
     def get_logs_by_procname(self, proc):

--- a/insights/parsers/tests/test_swift_log.py
+++ b/insights/parsers/tests/test_swift_log.py
@@ -37,7 +37,7 @@ def test_swift_log():
     obj_expirer_lines = log.get("object-expirer")
     assert len(obj_expirer_lines) == 1
     assert obj_expirer_lines[0].get("procname") == "object-expirer"
-    assert obj_expirer_lines[0].get("timestamp") == "Oct 2 09:10:43"
+    assert obj_expirer_lines[0].get("timestamp") == "Oct  2 09:10:43"
     assert obj_expirer_lines[0].get("message") == "STDERR: ERROR:root:Error talking to memcached: [Errno 32] Broken pipe (txn: tx015dd5a60bfa491d8eb09-005bb36e53)"
 
     log_line = 'Sep 29 23:50:55 pbnec2-l-rh-ocld-2 object-server: Begin object audit "forever" mode (ALL)'

--- a/insights/tests/test_syslog.py
+++ b/insights/tests/test_syslog.py
@@ -2,11 +2,6 @@ from insights.core import Syslog
 from insights.tests import context_wrap
 
 MSGINFO = """
-May 18 15:13:34 lxc-rhel68-sat56 jabberd/sm[11057]: session started: jid=rhn-dispatcher-sat@lxc-rhel6-sat56.redhat.com/superclient
-May 18 15:13:36 lxc-rhel68-sat56 wrapper[11375]: --> Wrapper Started as Daemon
-May 18 15:13:36 lxc-rhel68-sat56 wrapper[11375]: Launching a JVM...
-May 18 15:24:28 lxc-rhel68-sat56 yum[11597]: Installed: lynx-2.8.6-27.el6.x86_64
-May 18 15:36:19 lxc-rhel68-sat56 yum[11954]: Updated: sos-3.2-40.el6.noarch
 Apr 22 10:35:01 boy-bona CROND[27921]: (root) CMD (/usr/lib64/sa/sa1 -S DISK 1 1)
 Apr 22 10:37:32 boy-bona crontab[28951]: (root) LIST (root)
 Apr 22 10:40:01 boy-bona CROND[30677]: (root) CMD (/usr/lib64/sa/sa1 -S DISK 1 1)
@@ -14,6 +9,11 @@ Apr 22 10:41:13 boy-bona crontab[32515]: (root) LIST (root)
 Apr 29 11:33:36 kvmr7u5 ehtest: crontab[12345]: {
 April 29 11:33:36 kvmr7u5 ehtest: crontab[12345]: { # this line will be skipped by `_parse_line`
 May  5 03:50:01 kvmr7u5 systemd: Removed slice user-0.slice.
+May  9 15:13:34 lxc-rhel68-sat56 jabberd/sm[11057]: session started: jid=rhn-dispatcher-sat@lxc-rhel6-sat56.redhat.com/superclient
+May  9 15:13:36 lxc-rhel68-sat56 wrapper[11375]: --> Wrapper Started as Daemon
+May  9 15:13:36 lxc-rhel68-sat56 wrapper[11375]: Launching a JVM...
+May 10 15:24:28 lxc-rhel68-sat56 yum[11597]: Installed: lynx-2.8.6-27.el6.x86_64
+May 10 15:36:19 lxc-rhel68-sat56 yum[11954]: Updated: sos-3.2-40.el6.noarch
 """.strip()
 
 
@@ -28,10 +28,11 @@ def test_syslog():
     assert crond[0].get('procname') == "CROND[27921]"
     assert msg_info.get('jabberd/sm[11057]')[0].get('hostname') == "lxc-rhel68-sat56"
     assert msg_info.get('Wrapper')[0].get('message') == "--> Wrapper Started as Daemon"
-    assert msg_info.get('Launching')[0].get('raw_message') == "May 18 15:13:36 lxc-rhel68-sat56 wrapper[11375]: Launching a JVM..."
+    assert msg_info.get('Launching')[0].get('raw_message') == "May  9 15:13:36 lxc-rhel68-sat56 wrapper[11375]: Launching a JVM..."
     assert 2 == len(msg_info.get('yum'))
     crontab_logs = list(msg_info.get_logs_by_procname('crontab'))
     assert len(crontab_logs) == 2
     assert crontab_logs[1]['raw_message'] == "Apr 22 10:41:13 boy-bona crontab[32515]: (root) LIST (root)"
-    systemd_logs = msg_info.get_logs_by_procname('systemd')
-    assert len(list(systemd_logs)) == 1
+    systemd_logs = list(msg_info.get_logs_by_procname('systemd'))
+    assert len(systemd_logs) == 1
+    assert systemd_logs[0]['timestamp'] == 'May  5 03:50:01'


### PR DESCRIPTION
- Fix: #2454 
- Adjust the order of the log lines in test_syslog.py
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>