### PR TITLE
Fix test to run with latest pytest version

### DIFF
--- a/insights/parsers/tests/test_pcs_quorum_status.py
+++ b/insights/parsers/tests/test_pcs_quorum_status.py
@@ -73,7 +73,7 @@ def test_pcs_quorum_status():
 def test_invalid():
     with pytest.raises(ParseException) as e:
         PcsQuorumStatus(context_wrap(PCS_QUORUM_STATUS_INVALID))
-    assert "invalid" in str(e)
+    assert "Incorrect content" in str(e)
 
 
 def test_empty():


### PR DESCRIPTION
Change test to look for text in the exception that is added by the parser instead of random text within the test data.  This allows the test to work with the latest version of pytest.

Signed-off-by: Bob Fahr <bfahr@redhat.com>