### PR TITLE
Enhance satellite_installer_configurations

### DIFF
--- a/insights/parsers/satellite_installer_configurations.py
+++ b/insights/parsers/satellite_installer_configurations.py
@@ -12,7 +12,7 @@ Parsers the file `/etc/foreman-installer/custom-hiera.yaml`
 
 from insights import parser, YAMLParser
 from insights.specs import Specs
-from insights.parsers import ParseException
+from insights.parsers import SkipException
 
 
 @parser(Specs.satellite_custom_hiera)
@@ -29,5 +29,5 @@ class CustomHiera(YAMLParser):
     def parse_content(self, content):
         try:
             super(CustomHiera, self).parse_content(content)
-        except ParseException:
+        except SkipException:
             pass

--- a/insights/parsers/satellite_installer_configurations.py
+++ b/insights/parsers/satellite_installer_configurations.py
@@ -12,6 +12,7 @@ Parsers the file `/etc/foreman-installer/custom-hiera.yaml`
 
 from insights import parser, YAMLParser
 from insights.specs import Specs
+from insights.parsers import ParseException
 
 
 @parser(Specs.satellite_custom_hiera)
@@ -25,5 +26,8 @@ class CustomHiera(YAMLParser):
         >>> custom_hiera['apache::mod::prefork::serverlimit']
         582
     """
-
-    pass
+    def parse_content(self, content):
+        try:
+            super(CustomHiera, self).parse_content(content)
+        except ParseException:
+            pass

--- a/insights/parsers/tests/test_satellite_installer_configurations.py
+++ b/insights/parsers/tests/test_satellite_installer_configurations.py
@@ -10,12 +10,40 @@ apache::mod::prefork::maxclients: 582
 apache::mod::prefork::startservers: 10
 """
 
+CUSTOM_HIERA_CONFIG_2 = """
+---
+# This YAML file lets you set your own custom configuration in Hiera for the
+# installer puppet modules that might not be exposed to users directly through
+# installer arguments.
+#
+# For example, to set 'TraceEnable Off' in Apache, a common requirement for
+# security auditors, add this to this file:
+#
+#   apache::trace_enable: Off
+#
+# Consult the full module documentation on http://forge.puppetlabs.com,
+# or the actual puppet classes themselves, to discover options to configure.
+#
+# Do note, setting some values may have unintended consequences that affect the
+# performance or functionality of the application. Consider the impact of your
+# changes before applying them, and test them in a non-production environment
+# first.
+#
+# Here are some examples of how you tune the Apache options if needed:
+#
+# apache::mod::prefork::startservers: 8
+
+"""
+
 
 def test_custom_hiera():
     result = satellite_installer_configurations.CustomHiera(context_wrap(CUSTOM_HIERA_CONFIG))
     assert result.data['mongodb::server::config_data']['storage.wiredTiger.engineConfig.cacheSizeGB'] == 8
     assert result.data['apache::mod::prefork::startservers'] == 10
     assert result.data['apache::mod::prefork::maxclients'] == 582
+
+    result = satellite_installer_configurations.CustomHiera(context_wrap(CUSTOM_HIERA_CONFIG_2))
+    assert result.data is None
 
 
 def test_doc():


### PR DESCRIPTION
Fixes #2469 
* As default, the file "/etc/foreman-installer/custom-hiera.yaml" is empty with some comment.
  However this is reasonable, it means customers haven't done tuning, and we should remind
  customers to do some tuning.

Signed-off-by: Huanhuan Li <huali@redhat.com>