### PR TITLE
Add new parser/combiner for RHSM release version

### DIFF
--- a/docs/shared_combiners_catalog/rhsm_release.rst
+++ b/docs/shared_combiners_catalog/rhsm_release.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.combiners.rhsm_release
+   :members:
+   :show-inheritance:

--- a/docs/shared_parsers_catalog/rhsm_releasever.rst
+++ b/docs/shared_parsers_catalog/rhsm_releasever.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.rhsm_releasever
+   :members:
+   :show-inheritance:

--- a/insights/combiners/rhsm_release.py
+++ b/insights/combiners/rhsm_release.py
@@ -1,0 +1,47 @@
+"""
+Red Hat Subscription Manager Release
+====================================
+
+Combiner provides the Red Hat Subscription Manager release information from
+the parsers :class:`insights.parsers.rhsm_releasever.RhsmReleaseVer`
+and :class:`insights.parsers.subscription_manager_release.SubscriptionManagerReleaseShow`.
+"""
+from insights.core.plugins import combiner
+from insights.parsers.rhsm_releasever import RhsmReleaseVer
+from insights.parsers.subscription_manager_release import SubscriptionManagerReleaseShow
+
+
+@combiner([RhsmReleaseVer, SubscriptionManagerReleaseShow])
+class RhsmRelease(object):
+    """
+    Combiner for parsers RhsmReleaseVer and SubscriptionManagerReleaseShow.
+
+    Examples:
+        >>> type(rhsm_release)
+        <class 'insights.combiners.rhsm_release.RhsmRelease'>
+        >>> rhsm_release.set
+        '7.6'
+        >>> rhsm_release.major
+        7
+        >>> rhsm_release.minor
+        6
+    """
+    def __init__(self, rhsm_release, sm_release):
+        self.set = None
+        """ str: Release version string returned from the parsers """
+
+        self.major = None
+        """ int: Major version of the release """
+
+        self.minor = None
+        """ int: Minor version of the release """
+
+        if rhsm_release is not None:
+            self.set = rhsm_release.set
+            self.major = rhsm_release.major
+            self.minor = rhsm_release.minor
+
+        else:
+            self.set = sm_release.set
+            self.major = sm_release.major
+            self.minor = sm_release.minor

--- a/insights/combiners/rhsm_release.py
+++ b/insights/combiners/rhsm_release.py
@@ -19,8 +19,8 @@ class RhsmRelease(object):
     Examples:
         >>> type(rhsm_release)
         <class 'insights.combiners.rhsm_release.RhsmRelease'>
-        >>> rhsm_release.set
-        '7.6'
+        >>> rhsm_release.set == '7.6'
+        True
         >>> rhsm_release.major
         7
         >>> rhsm_release.minor

--- a/insights/combiners/tests/test_rhsm_release.py
+++ b/insights/combiners/tests/test_rhsm_release.py
@@ -1,0 +1,47 @@
+import doctest
+
+import insights.combiners.rhsm_release as rhsm_release_module
+from insights.combiners.rhsm_release import RhsmRelease
+from insights.parsers.rhsm_releasever import RhsmReleaseVer
+from insights.parsers.subscription_manager_release import SubscriptionManagerReleaseShow
+from insights.tests import context_wrap
+
+RHSM_RELEASE = """
+{"releaseVer": "7.6"}
+""".strip()
+
+SUBSCRIPTION_MANAGER_RELEASE = """
+Release: 7.2
+""".strip()
+
+SM_PARSER = SubscriptionManagerReleaseShow(context_wrap(SUBSCRIPTION_MANAGER_RELEASE))
+RHSM_PARSER = RhsmReleaseVer(context_wrap(RHSM_RELEASE))
+
+
+def test_with_rhsm():
+    rhsm_release = RhsmRelease(RHSM_PARSER, None)
+    assert rhsm_release.set == '7.6'
+    assert rhsm_release.major == 7
+    assert rhsm_release.minor == 6
+
+
+def test_with_sub_mgr():
+    rhsm_release = RhsmRelease(None, SM_PARSER)
+    assert rhsm_release.set == '7.2'
+    assert rhsm_release.major == 7
+    assert rhsm_release.minor == 2
+
+
+def test_with_both():
+    rhsm_release = RhsmRelease(RHSM_PARSER, SM_PARSER)
+    assert rhsm_release.set == '7.6'
+    assert rhsm_release.major == 7
+    assert rhsm_release.minor == 6
+
+
+def test_doc_examples():
+    env = {
+        'rhsm_release': RhsmRelease(RHSM_PARSER, None),
+    }
+    failed, total = doctest.testmod(rhsm_release_module, globs=env)
+    assert failed == 0

--- a/insights/parsers/rhsm_releasever.py
+++ b/insights/parsers/rhsm_releasever.py
@@ -28,10 +28,10 @@ class RhsmReleaseVer(JSONParser):
     Examples:
         >>> type(rhsm_releasever)
         <class 'insights.parsers.rhsm_releasever.RhsmReleaseVer'>
-        >>> rhsm_releasever['releaseVer']
-        '6.10'
-        >>> rhsm_releasever.set
-        '6.10'
+        >>> rhsm_releasever['releaseVer'] == '6.10'
+        True
+        >>> rhsm_releasever.set == '6.10'
+        True
         >>> rhsm_releasever.major
         6
         >>> rhsm_releasever.minor

--- a/insights/parsers/rhsm_releasever.py
+++ b/insights/parsers/rhsm_releasever.py
@@ -1,0 +1,62 @@
+"""
+RHSM Release Version - ``file /var/lib/rhsm/cache/releasever.json``
+===================================================================
+Parser Red Hat Subscription manager release info.
+
+"""
+from .. import JSONParser, parser
+from insights.parsers import SkipException
+from insights.specs import Specs
+
+
+@parser(Specs.rhsm_releasever)
+class RhsmReleaseVer(JSONParser):
+    """
+    Class for parsing the file: ``/var/lib/rhsm/cache/releasever.json``.
+
+    This information mirror the information provided by the
+    ``subscription-manager release --show`` command.
+
+    .. note::
+        Please refer to the super-class :class:`insights.core.JSONParser`
+        for additional information on attributes and methods.
+
+    Sample input data::
+
+        {"releaseVer": "6.10"}
+
+    Examples:
+        >>> type(rhsm_releasever)
+        <class 'insights.parsers.rhsm_releasever.RhsmReleaseVer'>
+        >>> rhsm_releasever['releaseVer']
+        '6.10'
+        >>> rhsm_releasever.set
+        '6.10'
+        >>> rhsm_releasever.major
+        6
+        >>> rhsm_releasever.minor
+        10
+    """
+    def parse_content(self, content):
+        """
+        Parse the contents of file ``/var/lib/rhsm/cache/releasever.json``.
+        """
+        super(RhsmReleaseVer, self).parse_content(content)
+        self.set = self.major = self.minor = None
+        if 'releaseVer' not in self.data:
+            raise SkipException('releaseVer is not in data')
+
+        rel = self.data['releaseVer']
+        rel_splits = rel.split('.')
+        # Release: 6.7
+        if len(rel_splits) == 2:
+            if rel_splits[0].isdigit() and rel_splits[-1].isdigit():
+                self.set = rel
+                self.major = int(rel_splits[0])
+                self.minor = int(rel_splits[-1])
+
+        # Release: 7Server or 8
+        elif rel and rel[0].isdigit():
+            self.set = rel
+            self.major = int(rel[0])
+            # leave self.minor as None

--- a/insights/parsers/subscription_manager_release.py
+++ b/insights/parsers/subscription_manager_release.py
@@ -64,5 +64,12 @@ class SubscriptionManagerReleaseShow(CommandParser):
                     self.major = int(rel[0])
                     # leave self.minor as None
                     return
+                # Release: 8
+                elif rel[0].isdigit() and len(rel) == 1:
+                    self.set = rel
+                    self.major = int(rel[0])
+                    # leave self.minor as None
+                    return
+
             raise SkipException("Incorrect content: {0}".format(line))
         # Release not set

--- a/insights/parsers/tests/test_rhsm_releasever.py
+++ b/insights/parsers/tests/test_rhsm_releasever.py
@@ -1,0 +1,50 @@
+import doctest
+import pytest
+import insights.parsers.rhsm_releasever as rhsm_releasever_module
+from insights.parsers import SkipException
+from insights.parsers.rhsm_releasever import RhsmReleaseVer
+from insights.tests import context_wrap
+
+RHEL_MAJ_MIN = '{"releaseVer": "6.10"}'
+RHEL_MAJ_1 = '{"releaseVer": "7Server"}'
+RHEL_MAJ_2 = '{"releaseVer": "8"}'
+RHEL_NONE = '{"releaseVer": ""}'
+RHEL_EMPTY = '{}'
+
+
+def test_rhsm_releasever():
+    relver = RhsmReleaseVer(context_wrap(RHEL_MAJ_MIN))
+    assert relver['releaseVer'] == '6.10'
+    assert relver.set == '6.10'
+    assert relver.major == 6
+    assert relver.minor == 10
+
+    relver = RhsmReleaseVer(context_wrap(RHEL_MAJ_1))
+    assert relver['releaseVer'] == '7Server'
+    assert relver.set == '7Server'
+    assert relver.major == 7
+    assert relver.minor is None
+
+    relver = RhsmReleaseVer(context_wrap(RHEL_MAJ_2))
+    assert relver['releaseVer'] == '8'
+    assert relver.set == '8'
+    assert relver.major == 8
+    assert relver.minor is None
+
+    relver = RhsmReleaseVer(context_wrap(RHEL_NONE))
+    assert relver['releaseVer'] == ''
+    assert relver.set is None
+    assert relver.major is None
+    assert relver.minor is None
+
+    with pytest.raises(SkipException) as e_info:
+        relver = RhsmReleaseVer(context_wrap(RHEL_EMPTY))
+    assert "releaseVer is not in data" in str(e_info.value)
+
+
+def test_doc_examples():
+    env = {
+        'rhsm_releasever': RhsmReleaseVer(context_wrap(RHEL_MAJ_MIN)),
+    }
+    failed, total = doctest.testmod(rhsm_releasever_module, globs=env)
+    assert failed == 0

--- a/insights/parsers/tests/test_subscription_manager_release.py
+++ b/insights/parsers/tests/test_subscription_manager_release.py
@@ -12,6 +12,10 @@ INPUT_NORMAL_2 = """
 Release: 6Server
 """.strip()
 
+INPUT_NORMAL_3 = """
+Release: 8
+""".strip()
+
 INPUT_NOT_SET = """
 Release not set
 """.strip()
@@ -43,6 +47,11 @@ def test_subscription_manager_release_show_ok():
     ret = SubscriptionManagerReleaseShow(context_wrap(INPUT_NORMAL_2))
     assert ret.set == '6Server'
     assert ret.major == 6
+    assert ret.minor is None
+
+    ret = SubscriptionManagerReleaseShow(context_wrap(INPUT_NORMAL_3))
+    assert ret.set == '8'
+    assert ret.major == 8
     assert ret.minor is None
 
 

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -505,6 +505,7 @@ class Specs(SpecSet):
     rhosp_release = RegistryPoint()
     rhsm_conf = RegistryPoint()
     rhsm_log = RegistryPoint(filterable=True)
+    rhsm_releasever = RegistryPoint()
     rndc_status = RegistryPoint()
     root_crontab = RegistryPoint()
     route = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -829,6 +829,7 @@ class DefaultSpecs(Specs):
                                                "rhn-logs/rhn/rhn_taskomatic_daemon.log"])
     rhsm_conf = simple_file("/etc/rhsm/rhsm.conf")
     rhsm_log = simple_file("/var/log/rhsm/rhsm.log")
+    rhsm_releasever = simple_file('/var/lib/rhsm/cache/releasever.json')
     rndc_status = simple_command("/usr/sbin/rndc status")
     root_crontab = simple_command("/usr/bin/crontab -l -u root")
     route = simple_command("/sbin/route -n")


### PR DESCRIPTION
* Add new parser for rhsm releasever file
* Update subscription manager release show parser to handle RHEL8
* Add new combiner for both release version parsers
* Update tests for both parsers and combiner
* Add new parser and combiner to documentation

Signed-off-by: Bob Fahr <bfahr@redhat.com>