### PR TITLE
Add parser for abrt status --bare

### DIFF
--- a/docs/shared_parsers_catalog/abrt_status_bare.rst
+++ b/docs/shared_parsers_catalog/abrt_status_bare.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.abrt_status_bare
+   :members:
+   :show-inheritance:

--- a/insights/parsers/abrt_status_bare.py
+++ b/insights/parsers/abrt_status_bare.py
@@ -1,0 +1,28 @@
+# -*- coding: UTF-8 -*-
+
+"""
+AbrtStatusBare - command ``/usr/bin/abrt status --bare=True``
+=============================================================
+
+``/usr/bin/abrt status --bare=True`` returns the number of problems ABRT
+detected in the system.
+
+Examples:
+    >>> abrt_status_bare.problem_count
+    1997
+"""
+
+from insights import CommandParser, parser
+from insights.specs import Specs
+
+
+@parser(Specs.abrt_status_bare)
+class AbrtStatusBare(CommandParser):
+    """
+    Parser for the output of ``abrt status --bare=True``
+
+    Attributes:
+        problem_count (int): the number of problems ABRT detected
+    """
+    def parse_content(self, content):
+        self.problem_count = int(content[0].strip())

--- a/insights/parsers/tests/test_abrt_status_bare.py
+++ b/insights/parsers/tests/test_abrt_status_bare.py
@@ -1,0 +1,33 @@
+# -*- coding: UTF-8 -*-
+
+from insights.parsers import abrt_status_bare
+from insights.parsers.abrt_status_bare import AbrtStatusBare
+from insights.tests import context_wrap
+
+import doctest
+
+OUTPUT = """
+420
+""".strip()
+
+OUTPUT_MULTILINE = """
+1997
+This line will never exist in real output, but it is ignored.
+""".strip()
+
+
+def test():
+    result = AbrtStatusBare(context_wrap(OUTPUT))
+    assert result.problem_count == 420
+
+    result = AbrtStatusBare(context_wrap(OUTPUT_MULTILINE))
+    assert result.problem_count == 1997
+
+
+def test_docs():
+    env = {
+        'abrt_status_bare': AbrtStatusBare(context_wrap(OUTPUT_MULTILINE)),
+        'AbrtStatusBare': AbrtStatusBare,
+    }
+    failed, total = doctest.testmod(abrt_status_bare, globs=env)
+    assert failed == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -16,6 +16,7 @@ class Openshift(SpecSet):
 
 
 class Specs(SpecSet):
+    abrt_status_bare = RegistryPoint()
     amq_broker = RegistryPoint(multi_output=True)
     auditctl_status = RegistryPoint()
     auditd_conf = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -89,6 +89,7 @@ format_rpm = _make_rpm_formatter()
 
 
 class DefaultSpecs(Specs):
+    abrt_status_bare = simple_command("/usr/bin/abrt status --bare=True")
     amq_broker = glob_file("/var/opt/amq-broker/*/etc/broker.xml")
     auditctl_status = simple_command("/sbin/auditctl -s")
     auditd_conf = simple_file("/etc/audit/auditd.conf")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -9,6 +9,7 @@ glob_file = partial(glob_file, context=HostArchiveContext)
 
 class InsightsArchiveSpecs(Specs):
 
+    abrt_status_bare = simple_file("insights_commands/abrt_status_--bare_True")
     all_installed_rpms = glob_file("insights_commands/rpm_-qa*")
     auditctl_status = simple_file("insights_commands/auditctl_-s")
     aws_instance_id_doc = simple_file("insights_commands/python_-m_insights.tools.cat_--no-header_aws_instance_id_doc")


### PR DESCRIPTION
This is a really basic parser for `abrt status` to be used in diagnosing potential problems in tools that interface with ABRT via D-Bus.