### PR TITLE
samba: Add parser and spec for 'testparm -s' (/etc/samba/smb.conf)

### DIFF
--- a/docs/shared_parsers_catalog/samba_smb_conf.rst
+++ b/docs/shared_parsers_catalog/samba_smb_conf.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.samba_smb_conf
+   :members:
+   :show-inheritance:

--- a/insights/parsers/samba_smb_conf.py
+++ b/insights/parsers/samba_smb_conf.py
@@ -1,0 +1,121 @@
+"""
+SambaConfig - output of ``testparm -s`` (/etc/samba/smb.conf)
+=============================================================
+
+This parser reads the output of testparm -s which reads the Samba configuration
+file ``/etc/samba/smb.conf``. The output is in standard .ini format, with a
+couple of notable features:
+
+* Samba ignores spaces at the start of options, which the ConfigParser class
+  normally does not.  This spacing is stripped by this parser.
+* Samba likewise ignores spaces in section heading names.
+* Samba allows the same section to be defined multiple times, with the
+  options therein being merged as if they were one section.
+* Samba allows options to be declared before the first section marker.
+  This parser puts these options in a `global` section.
+* Samba treats ';' as a comment prefix, similar to '#'.
+
+Sample configuration file::
+
+    # This is the main Samba configuration file. You should read the
+    # smb.conf(5) manual page in order to understand the options listed
+    #...
+    #======================= Global Settings =====================================
+
+    [global]
+        workgroup = MYGROUP
+        server string = Samba Server Version %v
+        max log size = 50
+
+    [homes]
+        comment = Home Directories
+        browseable = no
+        writable = yes
+    ;   valid users = %S
+    ;   valid users = MYDOMAIN\%S
+
+    [printers]
+        comment = All Printers
+        path = /var/spool/samba
+        browseable = no
+        guest ok = no
+        writable = no
+        printable = yes
+
+    # A publicly accessible directory, but read only, except for people in
+    # the "staff" group
+    [public]
+       comment = Public Stuff
+       path = /home/samba
+       public = yes
+       writable = yes
+       printable = no
+       write list = +staff
+
+Examples:
+
+    >>> type(conf)
+    <class 'insights.parsers.samba_smb_conf.SambaConfig'>
+    >>> sorted(conf.sections()) == [u'global', u'homes', u'printers', u'public']
+    True
+    >>> global_options = conf.items('global')  # get a section as a dictionary
+    >>> type(global_options) == type({})
+    True
+    >>> conf.get('public', 'comment') == u'Public Stuff'  # Accessor for section and option
+    True
+    >>> conf.getboolean('public', 'read only')  # Type conversion, but no default
+    False
+    >>> conf.getint('global', 'max log size')  # Same for integer conversion
+    50
+
+"""
+
+from .. import add_filter, IniConfigFile, parser
+from insights.specs import Specs
+
+filter_list = [
+    '[',
+    'password server',
+    'interfaces',
+    'hosts allow',
+    'remote browse sync',
+    'wins server',
+]
+
+add_filter(Specs.samba_smb_conf, ["["])
+
+
+@parser(Specs.samba_smb_conf)
+class SambaConfig(IniConfigFile):
+    """
+    This parser works on the output of ``testparm -s``` which reads the
+    Samba configuration file ``/etc/samba/smb.conf``.
+    """
+
+    def parse_content(self, content, allow_no_value=True):
+        # smb.conf is special from other ini files in the property that
+        # whatever is before the first section (before the first section)
+        # belongs to the [global] section. Therefore, the [global] section is
+        # appended right at the beginning so that everything that would be
+        # parsed as outside section belongs to [global].
+        # Python 2.7 RawConfigParser automatically merges multiple instances
+        # of the same section.  (And if that ever changes, test_samba.py will
+        # catch it.)
+        lstripped = ["[global]"] + [line.lstrip() for line in content]
+
+        super(SambaConfig, self).parse_content(lstripped)
+
+        # Create a new instance of the same dict type used by the underlying
+        # RawConfigParser.
+        new_dict = self.data._dict()
+        # Transform the section names so that whitespace around is stripped
+        # and they are lowercase. smb.conf is special in the property that
+        # section names and option names are case-insensitive and treated
+        # like lower-case.
+        for old_key, old_section in self.data._sections.items():
+            new_key = old_key.strip().lower()
+            if new_key not in new_dict:
+                new_dict[new_key] = self.data._dict()
+            # Merge same-named sections just as samba's `testparm` does.
+            new_dict[new_key].update(old_section)
+        self.data._sections = new_dict

--- a/insights/parsers/tests/test_samba_smb_conf.py
+++ b/insights/parsers/tests/test_samba_smb_conf.py
@@ -1,0 +1,253 @@
+from insights.parsers import samba_smb_conf
+from insights.tests import context_wrap
+from doctest import testmod
+
+SAMBA_CONFIG_DOCUMENTATION = '''
+# This is the main Samba configuration file. You should read the
+# smb.conf(5) manual page in order to understand the options listed
+#...
+#======================= Global Settings =====================================
+
+[global]
+    workgroup = MYGROUP
+    server string = Samba Server Version %v
+    max log size = 50
+
+[homes]
+    comment = Home Directories
+    browseable = no
+    writable = yes
+;   valid users = %S
+;   valid users = MYDOMAIN\%S
+
+[printers]
+    comment = All Printers
+    path = /var/spool/samba
+    browseable = no
+    guest ok = no
+    writable = no
+    printable = yes
+
+# A publicly accessible directory, but read only, except for people in
+# the "staff" group
+[public]
+   comment = Public Stuff
+   path = /home/samba
+   public = yes
+   read only = no
+   printable = no
+   write list = +staff
+'''
+
+
+SAMBA_CONFIG = """
+# This is the main Samba configuration file. You should read the
+# smb.conf(5) manual page in order to understand the options listed
+#...
+#======================= Global Settings =====================================
+
+# By running `testparm`, it is apparent that options outside the [global]
+# section before the [global] section are treated as if they were in the
+# [global] section.
+# `testparm` is a program from the samba package.
+
+this option should be in global = yes
+
+[global]
+
+#...
+# Hosts Allow/Hosts Deny lets you restrict who can connect, and you can
+# specifiy it as a per share option as well
+#
+    workgroup = MYGROUP
+    server string = Samba Server Version %v
+
+;   netbios name = MYSERVER
+
+;   interfaces = lo eth0 192.168.12.2/24 192.168.13.2/24
+;   hosts allow = 127. 192.168.12. 192.168.13.
+
+# --------------------------- Logging Options -----------------------------
+#
+# Log File let you specify where to put logs and how to split them up.
+#
+# Max Log Size let you specify the max size log files should reach
+
+    # logs split per machine
+    log file = /var/log/samba/log.%m
+    # max 50KB per log file, then rotate
+    max log size = 50
+
+# ----------------------- Standalone Server Options ------------------------
+#
+# Scurity can be set to user, share(deprecated) or server(deprecated)
+#
+# Backend to store user information in. New installations should
+# use either tdbsam or ldapsam. smbpasswd is available for backwards
+# compatibility. tdbsam requires no further configuration.
+
+    security = user
+    passdb backend = tdbsam
+
+#...
+# --------------------------- Printing Options -----------------------------
+#
+# Load Printers let you load automatically the list of printers rather
+# than setting them up individually
+#
+# Cups Options let you pass the cups libs custom options, setting it to raw
+# for example will let you use drivers on your Windows clients
+#
+# Printcap Name let you specify an alternative printcap file
+#
+# You can choose a non default printing system using the Printing option
+
+    load printers = yes
+    cups options = raw
+
+;   printcap name = /etc/printcap
+    #obtain list of printers automatically on SystemV
+;   printcap name = lpstat
+;   printing = cups
+
+# --------------------------- Filesystem Options ---------------------------
+#
+# The following options can be uncommented if the filesystem supports
+# Extended Attributes and they are enabled (usually by the mount option
+# user_xattr). Thess options will let the admin store the DOS attributes
+# in an EA and make samba not mess with the permission bits.
+#
+# Note: these options can also be set just per share, setting them in global
+# makes them the default for all shares
+
+;   map archive = no
+;   map hidden = no
+;   map read only = no
+;   map system = no
+;   store dos attributes = yes
+
+
+#============================ Share Definitions ==============================
+
+[homes]
+    comment = Home Directories
+    browseable = no
+    writable = yes
+    password server = 192.168.178.1
+    binddns dir =
+;   valid users = %S
+;   valid users = MYDOMAIN\%S
+
+[printers]
+    comment = All Printers
+    path = /var/spool/samba
+    browseable = no
+    guest ok = no
+    writable = no
+    printable = yes
+
+# Un-comment the following and create the netlogon directory for Domain Logons
+;   [netlogon]
+;   comment = Network Logon Service
+;   path = /var/lib/samba/netlogon
+;   guest ok = yes
+;   writable = no
+;   share modes = no
+
+
+# Un-comment the following to provide a specific roving profile share
+# the default is to use the user's home directory
+;   [Profiles]
+;   path = /var/lib/samba/profiles
+;   browseable = no
+;   guest ok = yes
+
+
+# A publicly accessible directory, but read only, except for people in
+# the "staff" group
+;   [public]
+;   comment = Public Stuff
+;   path = /home/samba
+;   public = yes
+;   writable = yes
+;   printable = no
+;   write list = +staff
+
+[ GlObAl  ]
+
+# Samba also automatically treats non-lowercase section names as lowercase and strips whitespace.
+# This behavior can be checked with `testparm` again.
+this option should also be in global = true
+
+[ GlObAl  ]
+
+# This tests specifically that two same-named sections are automatically merged in case the
+# RawConfigParser's behavior ever changes.
+this another option should also be in global = 1
+"""
+
+# This is the output of testparm -s parsing the above SAMBA_CONFIG
+SAMBA_TESTPARM_OUTPUT = '''
+# Global parameters
+[global]
+        binddns dir =
+        log file = /var/log/samba/log.%m
+        max log size = 50
+        security = USER
+        server string = Samba Server Version %v
+        workgroup = MYGROUP
+        idmap config * : backend = tdb
+        cups options = raw
+
+
+[homes]
+        browseable = No
+        comment = Home Directories
+        read only = No
+
+
+[printers]
+        browseable = No
+        comment = All Printers
+        path = /var/spool/samba
+        printable = Yes
+'''
+
+
+def test_match():
+    config = samba_smb_conf.SambaConfig(context_wrap(SAMBA_TESTPARM_OUTPUT))
+
+    assert config.get('global', 'workgroup') == 'MYGROUP'
+    assert config.get('global', 'server string') == 'Samba Server Version %v'
+    assert not config.has_option('global', 'netbios name')
+    assert config.get('global', 'log file') == '/var/log/samba/log.%m'
+    assert config.get('global', 'max log size') == '50'
+
+    assert config.get('global', 'security') == 'USER'
+
+    assert config.get('global', 'cups options') == 'raw'
+
+    # Test for parse_content(allow_no_values=True)
+    assert config.get('global', 'binddns dir') == ''
+    # Test for filtering PII
+    assert not config.has_option('global', 'password server')
+
+    assert config.get('homes', 'comment') == 'Home Directories'
+    assert config.get('homes', 'browseable') == 'No'
+    assert config.get('homes', 'read only') == 'No'
+    assert not config.has_option('homes', 'valid users')
+
+    assert config.get('printers', 'comment') == 'All Printers'
+    assert config.get('printers', 'path') == '/var/spool/samba'
+    assert config.get('printers', 'browseable') == 'No'
+    assert config.get('printers', 'printable') == 'Yes'
+
+    assert 'netlogin' not in config
+    assert 'Profiles' not in config
+    assert 'public' not in config
+
+
+def test_doc_example():
+    failed, total = testmod(samba_smb_conf,
+                            globs={'conf': samba_smb_conf.SambaConfig(context_wrap(SAMBA_CONFIG_DOCUMENTATION))})
+    assert failed == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -562,6 +562,7 @@ class Specs(SpecSet):
     selinux_config = RegistryPoint()
     sestatus = RegistryPoint()
     setup_named_chroot = RegistryPoint(filterable=True)
+    samba_smb_conf = RegistryPoint(multi_output=True, filterable=True)
     smartctl = RegistryPoint(multi_output=True)
     smartpdc_settings = RegistryPoint(filterable=True)
     smbstatus_p = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -577,6 +577,7 @@ class DefaultSpecs(Specs):
     rpm_V_packages = simple_command("/bin/rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony", keep_rc=True)
     rsyslog_conf = simple_file("/etc/rsyslog.conf")
     samba = simple_file("/etc/samba/smb.conf")
+    samba_smb_conf = simple_command("/usr/bin/testparm -s")
 
     @datasource(Sap)
     def sap_sid_name(broker):

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -197,6 +197,7 @@ class InsightsArchiveSpecs(Specs):
     sealert = simple_file('insights_commands/sealert_-l')
     sestatus = simple_file("insights_commands/sestatus_-b")
     smbstatus_p = simple_file("insights_commands/smbstatus_-p")
+    samba_smb_conf = simple_file("insights_commands/testparm_-s")
     software_collections_list = simple_file('insights_commands/scl_--list')
     spamassassin_channels = simple_file('insights_commands/grep_-r_s_CHANNELURL_.etc.mail.spamassassin.channel.d')
     ss = simple_file("insights_commands/ss_-tupna")

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -221,6 +221,7 @@ class SosSpecs(Specs):
     secure = simple_file("/var/log/secure")
     sestatus = simple_file("sos_commands/selinux/sestatus_-b")
     sssd_logs = glob_file("var/log/sssd/*.log")
+    samba_smb_conf = simple_file("sos_commands/samba/testparm_s")
     samba_logs = glob_file("var/log/samba/log.*")
     ssh_foreman_config = simple_file("/usr/share/foreman/.ssh/ssh_config")
     subscription_manager_id = simple_file("/sos_commands/subscription_manager/subscription-manager_identity")


### PR DESCRIPTION
This should replace the smb.conf parser as testparm sanitizes the output.