### PR TITLE
compliance: Download tailoring file for tailored policies

### DIFF
--- a/insights/client/apps/compliance/__init__.py
+++ b/insights/client/apps/compliance/__init__.py
@@ -30,15 +30,39 @@ class ComplianceClient:
         if not policies:
             logger.error("System is not associated with any profiles. Assign profiles by either uploading a SCAP scan or using the compliance web UI.\n")
             exit(constants.sig_kill_bad)
-        profile_ref_ids = [policy['ref_id'] for policy in policies]
-        for profile_ref_id in profile_ref_ids:
+        for policy in policies:
             self.run_scan(
-                profile_ref_id,
-                self.find_scap_policy(profile_ref_id),
-                '/var/tmp/oscap_results-{0}.xml'.format(profile_ref_id)
+                policy['ref_id'],
+                self.find_scap_policy(policy['ref_id']),
+                '/var/tmp/oscap_results-{0}.xml'.format(policy['ref_id']),
+                tailoring_file_path=self.download_tailoring_file(policy)
             )
 
         return self.archive.create_tar_file(), COMPLIANCE_CONTENT_TYPE
+
+    def download_tailoring_file(self, policy):
+        if policy['tailored'] == 'false':
+            return None
+
+        # Download tailoring file to pass as argument to run_scan
+        logger.debug(
+            "Policy {0} is a tailored policy. Starting tailoring file download...".format(policy['ref_id'])
+        )
+        tailoring_file_path = "/var/tmp/oscap_tailoring_file-{0}.xml".format(policy['ref_id'])
+        content = self.conn.session.get(
+            "https://{0}/compliance/profiles/{1}/tailoring_file".format(self.config.base_url, policy['id'])
+        )
+        if content is None:
+            logger.info("Problem downloading tailoring file for {0} to {1}".format(policy['ref_id'], tailoring_file_path))
+            return None
+
+        with open(tailoring_file_path, mode="w+b") as f:
+            f.write(content)
+            logger.info("Saved tailoring file for {0} to {1}".format(policy['ref_id'], tailoring_file_path))
+
+        logger.debug("Policy {0} tailoring file download finished".format(policy['ref_id']))
+
+        return tailoring_file_path
 
     # TODO: Not a typo! This endpoint gives OSCAP policies, not profiles
     # We need to update compliance-backend to fix this
@@ -67,11 +91,19 @@ class ComplianceClient:
             exit(constants.sig_kill_bad)
         return filenames[0]
 
-    def run_scan(self, profile_ref_id, policy_xml, output_path):
+    def build_oscap_command(self, profile_ref_id, policy_xml, output_path, tailoring_file_path):
+        command = 'oscap xccdf eval --profile ' + profile_ref_id
+        if tailoring_file_path:
+            command += ' --tailoring-file ' + tailoring_file_path
+        command += ' --results ' + output_path + ' ' + policy_xml
+        return command
+
+    def run_scan(self, profile_ref_id, policy_xml, output_path, tailoring_file_path=None):
         logger.info('Running scan for {0}... this may take a while'.format(profile_ref_id))
         env = os.environ.copy()
         env.update({'TZ': 'UTC'})
-        rc, oscap = call('oscap xccdf eval --profile ' + profile_ref_id + ' --results ' + output_path + ' ' + policy_xml, keep_rc=True, env=env)
+        oscap_command = self.build_oscap_command(profile_ref_id, policy_xml, output_path, tailoring_file_path)
+        rc, oscap = call(oscap_command, keep_rc=True, env=env)
         if rc and rc != NONCOMPLIANT_STATUS:
             logger.error('Scan failed')
             logger.error(oscap)

--- a/insights/client/apps/compliance/__init__.py
+++ b/insights/client/apps/compliance/__init__.py
@@ -41,7 +41,7 @@ class ComplianceClient:
         return self.archive.create_tar_file(), COMPLIANCE_CONTENT_TYPE
 
     def download_tailoring_file(self, policy):
-        if policy['attributes']['tailored'] is False:
+        if 'tailored' not in policy['attributes'] or policy['attributes']['tailored'] is False:
             return None
 
         # Download tailoring file to pass as argument to run_scan

--- a/insights/client/auto_config.py
+++ b/insights/client/auto_config.py
@@ -239,5 +239,5 @@ def try_auto_configuration(config):
         if not _try_satellite6_configuration(config):
             _try_satellite5_configuration(config)
     if not config.legacy_upload and 'cloud.redhat.com' not in config.base_url:
-        config.base_url = config.base_url
+        config.base_url = config.base_url + '/platform'
     logger.debug('Updated base_url: %s', config.base_url)

--- a/insights/client/auto_config.py
+++ b/insights/client/auto_config.py
@@ -239,5 +239,5 @@ def try_auto_configuration(config):
         if not _try_satellite6_configuration(config):
             _try_satellite5_configuration(config)
     if not config.legacy_upload and 'cloud.redhat.com' not in config.base_url:
-        config.base_url = config.base_url + '/platform'
+        config.base_url = config.base_url
     logger.debug('Updated base_url: %s', config.base_url)

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -132,6 +132,12 @@ def test_tailored_file_is_not_downloaded_if_not_needed(config):
     assert compliance_client.download_tailoring_file({'attributes': {'tailored': False}}) is None
 
 
+@patch("insights.client.config.InsightsConfig")
+def test_tailored_file_is_not_downloaded_if_tailored_is_missing(config):
+    compliance_client = ComplianceClient(config)
+    assert compliance_client.download_tailoring_file({'id': 'foo', 'attributes': {'ref_id': 'aaaaa'}}) is None
+
+
 @patch("insights.client.apps.compliance.open", new_callable=mock_open)
 @patch("insights.client.config.InsightsConfig")
 def test_tailored_file_is_downloaded_if_needed(config, call):

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -12,9 +12,9 @@ PATH = '/usr/share/xml/scap/ref_id.xml'
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None, compressor='gz')
 def test_oscap_scan(config, assert_rpms):
     compliance_client = ComplianceClient(config)
-    compliance_client.get_policies = lambda: [{'ref_id': 'foo', 'tailored': 'false'}]
+    compliance_client.get_policies = lambda: [{'attributes': {'ref_id': 'foo', 'tailored': False}}]
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
-    compliance_client.run_scan = lambda ref_id, policy_xml, output_path: None, tailoring_file_path: None
+    compliance_client.run_scan = lambda ref_id, policy_xml, output_path, tailoring_file_path: None
     compliance_client.archive.archive_tmp_dir = '/tmp'
     compliance_client.archive.archive_name = 'insights-compliance-test'
     archive, content_type = compliance_client.oscap_scan()
@@ -26,7 +26,7 @@ def test_oscap_scan(config, assert_rpms):
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
 def test_missing_packages(config, call):
     compliance_client = ComplianceClient(config)
-    compliance_client.get_policies = lambda: [{'ref_id': 'foo'}]
+    compliance_client.get_policies = lambda: [{'attributes': {'ref_id': 'foo'}}]
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
     compliance_client.run_scan = lambda ref_id, policy_xml: None
     with raises(SystemExit):
@@ -37,7 +37,7 @@ def test_missing_packages(config, call):
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
 def test_errored_rpm_call(config, call):
     compliance_client = ComplianceClient(config)
-    compliance_client.get_policies = lambda: [{'ref_id': 'foo'}]
+    compliance_client.get_policies = lambda: [{'attributes': {'ref_id': 'foo'}}]
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
     compliance_client.run_scan = lambda ref_id, policy_xml: None
     with raises(SystemExit):

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -1,8 +1,7 @@
 # -*- coding: UTF-8 -*-
 
 from insights.client.apps.compliance import ComplianceClient, COMPLIANCE_CONTENT_TYPE
-from mock.mock import patch, Mock
-from unittest.mock import mock_open
+from mock.mock import patch, Mock, mock_open
 from pytest import raises
 import os
 

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -12,7 +12,7 @@ PATH = '/usr/share/xml/scap/ref_id.xml'
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None, compressor='gz')
 def test_oscap_scan(config, assert_rpms):
     compliance_client = ComplianceClient(config)
-    compliance_client.get_policies = lambda: [{'ref_id': 'foo'}]
+    compliance_client.get_policies = lambda: [{'ref_id': 'foo', 'tailored': 'false'}]
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
     compliance_client.run_scan = lambda ref_id, policy_xml, output_path: None
     compliance_client.archive.archive_tmp_dir = '/tmp'

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -14,7 +14,7 @@ def test_oscap_scan(config, assert_rpms):
     compliance_client = ComplianceClient(config)
     compliance_client.get_policies = lambda: [{'ref_id': 'foo', 'tailored': 'false'}]
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
-    compliance_client.run_scan = lambda ref_id, policy_xml, output_path: None
+    compliance_client.run_scan = lambda ref_id, policy_xml, output_path: None, tailoring_file_path: None
     compliance_client.archive.archive_tmp_dir = '/tmp'
     compliance_client.archive.archive_name = 'insights-compliance-test'
     archive, content_type = compliance_client.oscap_scan()

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -48,8 +48,8 @@ def test_errored_rpm_call(config, call):
 def test_get_policies(config):
     compliance_client = ComplianceClient(config)
     compliance_client.hostname = 'foo'
-    compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': {'profiles': 'data'}}]})))
-    assert compliance_client.get_policies() == 'data'
+    compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
+    assert compliance_client.get_policies() == [{'attributes': 'data'}]
     compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo'})
 
 

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -50,7 +50,7 @@ def test_get_policies(config):
     compliance_client.hostname = 'foo'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': {'profiles': 'data'}}]})))
     assert compliance_client.get_policies() == 'data'
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/systems', params={'search': 'name=foo'})
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo'})
 
 
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
@@ -59,7 +59,7 @@ def test_get_policies_no_policies(config):
     compliance_client.hostname = 'foo'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': []})))
     assert compliance_client.get_policies() == []
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/systems', params={'search': 'name=foo'})
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo'})
 
 
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
@@ -68,7 +68,7 @@ def test_get_policies_error(config):
     compliance_client.hostname = 'foo'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=500))
     assert compliance_client.get_policies() == []
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/systems', params={'search': 'name=foo'})
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo'})
 
 
 @patch("insights.client.apps.compliance.linux_distribution", return_value=(None, '6.5', None))


### PR DESCRIPTION
Notice this is only meant to work on CI for now - it cannot be promoted to production as hitting the endpoint for downloading tailoring policies would not work. I can change the code to handle that situation but it's probably better to hold off releasing this until the production API responds appropriately with a `policy['tailored']` field.  

:warning: To create a tailored policy, you would need:
https://github.com/RedHatInsights/compliance-frontend/pull/423 in the frontend
https://github.com/RedHatInsights/compliance-backend/pull/352 in the backend