### PR TITLE
systemd: use --now to only run systemctl once

### DIFF
--- a/insights/client/schedule.py
+++ b/insights/client/schedule.py
@@ -65,8 +65,7 @@ class InsightsSchedulerSystemd(object):
         logger.debug('Starting systemd timer')
         try:
             # Start timers in the case of rhel 7 running systemd
-            systemctl_timer = run_command_get_output('systemctl start insights-client.timer')
-            systemctl_timer = run_command_get_output('systemctl enable insights-client.timer')
+            systemctl_timer = run_command_get_output('systemctl enable --now insights-client.timer')
             logger.debug("Starting Insights Client systemd timer.")
             logger.debug("Status: %s", systemctl_timer['status'])
             logger.debug("Output: %s", systemctl_timer['output'])
@@ -79,8 +78,7 @@ class InsightsSchedulerSystemd(object):
         logger.debug('Stopping all systemd timers')
         try:
             # Stop timers in the case of rhel 7 running systemd
-            systemctl_timer = run_command_get_output('systemctl disable insights-client.timer')
-            systemctl_timer = run_command_get_output('systemctl stop insights-client.timer')
+            systemctl_timer = run_command_get_output('systemctl disable --now insights-client.timer')
             logger.debug("Stopping Insights Client systemd timer.")
             logger.debug("Status: %s", systemctl_timer['status'])
             logger.debug("Output: %s", systemctl_timer['output'])


### PR DESCRIPTION
Fixes a bug where calling "systemctl start" before "systemctl enable" creates a situate where units that depend on insights-client.timer will not be enabled, therefore they will not start along with insights-client.

Fixes: RHCLOUD-5320