### PR TITLE
Adding posibility of specifying virtual memory limit usage for archive extraction

### DIFF
--- a/insights/core/archives.py
+++ b/insights/core/archives.py
@@ -26,28 +26,37 @@ class InvalidContentType(InvalidArchive):
         self.content_type = content_type
 
 
-class ZipExtractor(object):
-    def __init__(self, timeout=None):
-        self.content_type = "application/zip"
+class Extractor(object):
+    """Base class for different extractor types."""
+    def __init__(self, timeout=None, memory_limit=None):
+        """Creates an extractor object with a given timeout and memory_limit."""
         self.timeout = timeout
+        self.memory_limit = memory_limit
         self.tmp_dir = None
         self.created_tmp_dir = False
+
+    def from_path(selfself, path, extract_dir=None, content_type=None):
+        """Abstract method for child classes"""
+        raise NotImplementedError()
+
+
+class ZipExtractor(Extractor):
+    """Extractor implementation for ZIP archives."""
+    def __init__(self, timeout=None, memory_limit=None):
+        """Create a ZipExtractor object."""
+        super(ZipExtractor, self).__init__(timeout, memory_limit)
+        self.content_type = "application/zip"
 
     def from_path(self, path, extract_dir=None, content_type=None):
         self.tmp_dir = tempfile.mkdtemp(prefix="insights-", dir=extract_dir)
         self.created_tmp_dir = True
         command = "unzip -n -q -d %s %s" % (self.tmp_dir, path)
-        subproc.call(command, timeout=self.timeout)
+        subproc.call(command, timeout=self.timeout, memory_limit=self.memory_limit)
         return self
 
 
-class TarExtractor(object):
-
-    def __init__(self, timeout=None):
-        self.timeout = timeout
-        self.tmp_dir = None
-        self.created_tmp_dir = False
-
+class TarExtractor(Extractor):
+    """Extractor implementation for TAR archives."""
     TAR_FLAGS = {
         "application/x-xz": "-J",
         "application/x-gzip": "-z",
@@ -56,7 +65,12 @@ class TarExtractor(object):
         "application/x-tar": ""
     }
 
+    def __init__(self, timeout=None, memory_limit=None):
+        super(TarExtractor, self).__init__(timeout, memory_limit)
+        self.content_type = "application/tar"
+
     def _tar_flag_for_content_type(self, content_type):
+        """Return the tar command flag for the given content-type or raise an Exception."""
         flag = self.TAR_FLAGS.get(content_type)
         if flag is None:
             raise InvalidContentType(content_type)
@@ -72,7 +86,7 @@ class TarExtractor(object):
             self.created_tmp_dir = True
             command = "tar --delay-directory-restore %s -x --exclude=*/dev/null -f %s -C %s" % (tar_flag, path, self.tmp_dir)
             logging.debug("Extracting files in '%s'", self.tmp_dir)
-            subproc.call(command, timeout=self.timeout)
+            subproc.call(command, timeout=self.timeout, memory_limit=self.memory_limit)
         return self
 
 
@@ -93,21 +107,22 @@ class Extraction(object):
 
 
 @contextmanager
-def extract(path, timeout=None, extract_dir=None, content_type=None):
+def extract(path, timeout=None, memory_limit=None, extract_dir=None, content_type=None):
     """
     Extract path into a temporary directory in `extract_dir`.
 
     Yields an object containing the temporary path and the content type of the
     original archive.
 
-    If the extraction takes longer than `timeout` seconds, the temporary path
-    is removed, and an exception is raised.
+    If the extraction takes longer than `timeout` seconds or the child process
+    tries to use more than `memory_limit` RAM, the temporary path is removed,
+    and an exception is raised.
     """
     content_type = content_type or content_type_from_file(path)
     if content_type == "application/zip":
-        extractor = ZipExtractor(timeout=timeout)
+        extractor = ZipExtractor(timeout=timeout, memory_limit=memory_limit)
     else:
-        extractor = TarExtractor(timeout=timeout)
+        extractor = TarExtractor(timeout=timeout, memory_limit=memory_limit)
 
     try:
         ctx = extractor.from_path(path, extract_dir=extract_dir, content_type=content_type)


### PR DESCRIPTION
This commit adds the needed code for specifying a virtual memory limit when extracting an archive.
If not specified, it will work with no memory limitation, as it already does
