### PR TITLE
Deduplicate http response content when upload fails

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -413,14 +413,6 @@ class InsightsConnection(object):
         Bail out if we get a 401 and leave a message
         """
 
-        try:
-            logger.log(NETWORK, "HTTP Status Code: %s", req.status_code)
-            logger.log(NETWORK, "HTTP Response Text: %s", req.text)
-            logger.log(NETWORK, "HTTP Response Reason: %s", req.reason)
-            logger.log(NETWORK, "HTTP Response Content: %s", req.content)
-        except:
-            logger.error("Malformed HTTP Request.")
-
         # attempt to read the HTTP response JSON message
         try:
             logger.log(NETWORK, "HTTP Response Message: %s", req.json()["message"])
@@ -429,9 +421,6 @@ class InsightsConnection(object):
 
         # handle specific status codes
         if req.status_code >= 400:
-            logger.info("Debug Information:\nHTTP Status Code: %s",
-                        req.status_code)
-            logger.info("HTTP Status Text: %s", req.reason)
             if req.status_code == 401:
                 logger.error("Authorization Required.")
                 logger.error("Please ensure correct credentials "

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -421,6 +421,9 @@ class InsightsConnection(object):
 
         # handle specific status codes
         if req.status_code >= 400:
+            logger.debug("Debug Information:\nHTTP Status Code: %s",
+                        req.status_code)
+            logger.debug("HTTP Status Text: %s", req.reason)
             if req.status_code == 401:
                 logger.error("Authorization Required.")
                 logger.error("Please ensure correct credentials "


### PR DESCRIPTION
We are currently logging debug information twice when using --net-debug.
This change makes it so that we only report the failure once in stdout.
The output for the failure message still provides relevant info that's
needed to find out what happened. The --net-debug prints some additional
info rather than printing the same thing twice

Signed-off-by: Stephen Adams <tsadams@gmail.com>