### PR TITLE
Ignore filters.yaml in insights-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ share/
 .python*
 .pytest_cache
 .vscode
+insights/filters.yaml


### PR DESCRIPTION
We don't want the filters to end up in pypi, so this is just a safety
measure to make sure they don't accidentally get committed to the repo

Signed-off-by: Stephen Adams <tsadams@gmail.com>