### PR TITLE
Add new filter method

### DIFF
--- a/insights/core/filters.py
+++ b/insights/core/filters.py
@@ -198,5 +198,5 @@ def dump(stream=None):
         stream.write(dumps())
     else:
         path = os.path.join(os.path.dirname(insights.__file__), _filename)
-        with open(path, "wu") as f:
+        with open(path, "w") as f:
             f.write(dumps())

--- a/insights/tools/apply_spec_filters.py
+++ b/insights/tools/apply_spec_filters.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 from insights import dr, get_filters
 from insights.core.spec_factory import RegistryPoint
 from insights.specs import Specs
+from insights.core import filters
 
 if len(sys.argv) < 3:
     print("Provide uploader.json location and packages to load")
@@ -28,9 +29,11 @@ dr.load_components("insights.specs.default")
 dr.load_components("insights.parsers")
 dr.load_components("insights.combiners")
 
+
 for package in sys.argv[2:]:
     dr.load_components(package)
 
+filters.dump()
 specs = sorted(vars(Specs))
 filters = {}
 for spec in specs:


### PR DESCRIPTION
We can add the new filters.yaml creation to the current apply_spec_filters script so we don't have to add an extra step to the release process. The default dump() location is where we want it to go.

In addition, there was a typo in filters.dump() that has been fixed.