### PR TITLE
Add parser for HammerComputeResourceList

### DIFF
--- a/docs/shared_parsers_catalog/hammer_compute_resource_list.rst
+++ b/docs/shared_parsers_catalog/hammer_compute_resource_list.rst
@@ -1,0 +1,3 @@
+. automodule:: insights.parsers.hammer_compute_resource_list
+   :members:
+   :show-inheritance:

--- a/docs/shared_parsers_catalog/hammer_compute_resource_list.rst
+++ b/docs/shared_parsers_catalog/hammer_compute_resource_list.rst
@@ -1,3 +1,3 @@
-. automodule:: insights.parsers.hammer_compute_resource_list
+.. automodule:: insights.parsers.hammer_compute_resource_list
    :members:
    :show-inheritance:

--- a/insights/parsers/hammer_compute_resource_list.py
+++ b/insights/parsers/hammer_compute_resource_list.py
@@ -32,14 +32,14 @@ Examples:
     <class 'insights.parsers.hammer_compute_resource_list.HammerComputeResourceList'>
 """
 
-from insights import parser, CommandParser
-from insights.parsers import SkipException
-from insights.specs import Specs
 import json
+from insights import JSONParser, parser, CommandParser
+from insights.parsers import ParseException, SkipException
+from insights.specs import Specs
 
 
 @parser(Specs.hammer_compute_resource_list)
-class HammerComputeResourceList(CommandParser):
+class HammerComputeResourceList(CommandParser, JSONParser):
     """
     Parse the JSON output from the ``hammer --interactive 0 --output json compute-resource list`` command.
 
@@ -49,8 +49,10 @@ class HammerComputeResourceList(CommandParser):
     Attributes:
         data(list): A list of the parsed output returned by `hammer compute resource list`
     """
-
     def parse_content(self, content):
         if not content:
-            raise SkipException('No content or hammer auth failed.')
-        self.data = json.loads(''.join(content))
+            raise SkipException("No content or hammer auth failed.")
+        try:
+            self.data = json.loads(''.join(content))
+        except:
+            raise ParseException("Could not parse json.", content)

--- a/insights/parsers/hammer_compute_resource_list.py
+++ b/insights/parsers/hammer_compute_resource_list.py
@@ -1,6 +1,6 @@
 """
 HammerComputeResourceList - command ``hammer --interactive 0 --output json compute-resource list``
-===================================================
+==================================================================================================
 
 This parser reads the compute resource list of a Satellite server using hammer in JSON format.
 It relies on the root user running the command and hammer to authenticate based on the hammer configuration file.
@@ -24,7 +24,7 @@ Sample output from the ``hammer --interactive 0 --output json compute-resource l
     "Name": "vmware67",
     "Provider": "VMware"
   }
-]
+    ]
 
 Examples:
 

--- a/insights/parsers/hammer_compute_resource_list.py
+++ b/insights/parsers/hammer_compute_resource_list.py
@@ -1,0 +1,56 @@
+"""
+HammerComputeResourceList - command ``hammer --interactive 0 --output json compute-resource list``
+===================================================
+
+This parser reads the compute resource list of a Satellite server using hammer in JSON format.
+It relies on the root user running the command and hammer to authenticate based on the hammer configuration file.
+If the command is unable to authenticate then no compute resources will be shown and an erro flag will be recorded in the parser
+
+Sample output from the ``hammer --interactive 0 --output json compute-resource list`` command::
+
+    [
+  {
+    "Id": 1,
+    "Name": "kvm-server",
+    "Provider": "Libvirt"
+  },
+  {
+    "Id": 4,
+    "Name": "VMWARE",
+    "Provider": "VMware"
+  },
+  {
+    "Id": 3,
+    "Name": "vmware67",
+    "Provider": "VMware"
+  }
+]
+
+Examples:
+
+    >>> type(hammer_compute_resources_list)
+    <class 'insights.parsers.hammer_compute_resource_list.HammerComputeResourceList'>
+"""
+
+from insights import parser, CommandParser
+from insights.parsers import SkipException
+from insights.specs import Specs
+import json
+
+
+@parser(Specs.hammer_compute_resource_list)
+class HammerComputeResourceList(CommandParser):
+    """
+    Parse the JSON output from the ``hammer --interactive 0 --output json compute-resource list`` command.
+
+    Raises:
+        SkipException: When nothing is parsed or hammer auth fails
+
+    Attributes:
+        data(list): A list of the parsed output returned by `hammer compute resource list`
+    """
+
+    def parse_content(self, content):
+        if not content:
+            raise SkipException('No content or hammer auth failed.')
+        self.data = json.loads(''.join(content))

--- a/insights/parsers/tests/test_hammer_compute_resource_list.py
+++ b/insights/parsers/tests/test_hammer_compute_resource_list.py
@@ -1,6 +1,5 @@
 from insights.parsers import hammer_compute_resource_list
 from insights.tests import context_wrap
-import doctest
 import pytest
 from insights.parsers import SkipException
 
@@ -8,11 +7,12 @@ hammer_compute_resource_list_json_data = '''
 [{"Id": 1, "Name": "kvm-server", "Provider": "Libvirt"}, {"Id": 4, "Name": "VMWARE", "Provider": "VMware"}, {"Id": 3, "Name": "vmware67", "Provider": "VMware"}]
 '''
 
+
 def test_hammer_compute_resource_list():
-    resource_list = hammer_compute_resource_list.HammerComputeResourceList(context_wrap(hammer_compute_resource_list_json_data))
+    hammer_compute_resource_list.HammerComputeResourceList(context_wrap(hammer_compute_resource_list_json_data))
+
 
 def test_no_data():
     with pytest.raises(SkipException) as ex:
         hammer_compute_resource_list.HammerComputeResourceList(context_wrap(''))
     assert 'No content or hammer auth failed.' in str(ex)
-

--- a/insights/parsers/tests/test_hammer_compute_resource_list.py
+++ b/insights/parsers/tests/test_hammer_compute_resource_list.py
@@ -1,0 +1,18 @@
+from insights.parsers import hammer_compute_resource_list
+from insights.tests import context_wrap
+import doctest
+import pytest
+from insights.parsers import SkipException
+
+hammer_compute_resource_list_json_data = '''
+[{"Id": 1, "Name": "kvm-server", "Provider": "Libvirt"}, {"Id": 4, "Name": "VMWARE", "Provider": "VMware"}, {"Id": 3, "Name": "vmware67", "Provider": "VMware"}]
+'''
+
+def test_hammer_compute_resource_list():
+    resource_list = hammer_compute_resource_list.HammerComputeResourceList(context_wrap(hammer_compute_resource_list_json_data))
+
+def test_no_data():
+    with pytest.raises(SkipException) as ex:
+        hammer_compute_resource_list.HammerComputeResourceList(context_wrap(''))
+    assert 'No content or hammer auth failed.' in str(ex)
+

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -191,6 +191,7 @@ class Specs(SpecSet):
     grubby_default_kernel = RegistryPoint()
     hammer_ping = RegistryPoint()
     hammer_task_list = RegistryPoint()
+    hammer_compute_resource_list = RegistryPoint()
     satellite_enabled_features = RegistryPoint()
     haproxy_cfg = RegistryPoint()
     heat_api_log = RegistryPoint(filterable=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -351,7 +351,7 @@ class DefaultSpecs(Specs):
     grubby_default_kernel = simple_command("/usr/sbin/grubby --default-kernel")  # RHEL6 and updwards
     hammer_ping = simple_command("/usr/bin/hammer ping")
     hammer_task_list = simple_command("/usr/bin/hammer --config /root/.hammer/cli.modules.d/foreman.yml --output csv task list --search 'state=running AND ( label=Actions::Candlepin::ListenOnCandlepinEvents OR label=Actions::Katello::EventQueue::Monitor )'")
-    hammer_compute_resource_list = simple_command("hammer --interactive 0 --output json compute-resource list")
+    hammer_compute_resource_list = simple_command("/usr/bin/hammer --interactive 0 --output json compute-resource list")
     haproxy_cfg = first_file(["/var/lib/config-data/puppet-generated/haproxy/etc/haproxy/haproxy.cfg", "/etc/haproxy/haproxy.cfg"])
     heat_api_log = first_file(["/var/log/containers/heat/heat_api.log", "/var/log/heat/heat-api.log", "/var/log/heat/heat_api.log"])
     heat_conf = first_file(["/var/lib/config-data/puppet-generated/heat/etc/heat/heat.conf", "/etc/heat/heat.conf"])

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -351,6 +351,7 @@ class DefaultSpecs(Specs):
     grubby_default_kernel = simple_command("/usr/sbin/grubby --default-kernel")  # RHEL6 and updwards
     hammer_ping = simple_command("/usr/bin/hammer ping")
     hammer_task_list = simple_command("/usr/bin/hammer --config /root/.hammer/cli.modules.d/foreman.yml --output csv task list --search 'state=running AND ( label=Actions::Candlepin::ListenOnCandlepinEvents OR label=Actions::Katello::EventQueue::Monitor )'")
+    hammer_compute_resource_list = simple_command("hammer --interactive 0 --output json compute-resource list")
     haproxy_cfg = first_file(["/var/lib/config-data/puppet-generated/haproxy/etc/haproxy/haproxy.cfg", "/etc/haproxy/haproxy.cfg"])
     heat_api_log = first_file(["/var/log/containers/heat/heat_api.log", "/var/log/heat/heat-api.log", "/var/log/heat/heat_api.log"])
     heat_conf = first_file(["/var/lib/config-data/puppet-generated/heat/etc/heat/heat.conf", "/etc/heat/heat.conf"])

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -83,7 +83,7 @@ class InsightsArchiveSpecs(Specs):
     gluster_peer_status = simple_file("insights_commands/gluster_peer_status")
     hammer_ping = simple_file("insights_commands/hammer_ping")
     hammer_task_list = simple_file("insights_commands/hammer_--config_.root..hammer.cli.modules.d.foreman.yml_--output_csv_task_list_--search_state_running_AND_label_Actions_Candlepin_ListenOnCandlepinEvents_OR_label_Actions_Katello_EventQueue_Monitor")
-    hammer_compute_resource_list = simple_file("hammer --interactive 0 --output json compute-resource list")
+    hammer_compute_resource_list = simple_file("insights_commands/hammer_--interactive_0_--output_json_compute-resource_list")
     heat_crontab = simple_file("insights_commands/crontab_-l_-u_heat")
     heat_crontab_container = simple_file("insights_commands/docker_exec_heat_api_cron_.usr.bin.crontab_-l_-u_heat")
     installed_rpms = head(all_installed_rpms)

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -83,6 +83,7 @@ class InsightsArchiveSpecs(Specs):
     gluster_peer_status = simple_file("insights_commands/gluster_peer_status")
     hammer_ping = simple_file("insights_commands/hammer_ping")
     hammer_task_list = simple_file("insights_commands/hammer_--config_.root..hammer.cli.modules.d.foreman.yml_--output_csv_task_list_--search_state_running_AND_label_Actions_Candlepin_ListenOnCandlepinEvents_OR_label_Actions_Katello_EventQueue_Monitor")
+    hammer_compute_resource_list = simple_file("hammer --interactive 0 --output json compute-resource list")
     heat_crontab = simple_file("insights_commands/crontab_-l_-u_heat")
     heat_crontab_container = simple_file("insights_commands/docker_exec_heat_api_cron_.usr.bin.crontab_-l_-u_heat")
     installed_rpms = head(all_installed_rpms)


### PR DESCRIPTION
Attempt to create a parser for HammerComputeResourceList


```
# py.test -svk hammer_compute_resource_list | grep hammer_compute_resource_list

/tmp/git/insights-core/insights/combiners/nfs_exports.py:73: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
  if isinstance(nfsexportsd, collections.Iterable):
insights/parsers/tests/test_hammer_compute_resource_list.py::test_hammer_compute_resource_list PASSED
insights/parsers/tests/test_hammer_compute_resource_list.py::test_no_data PASSED

```