### PR TITLE
do not error out when using --group on platform

### DIFF
--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -631,10 +631,6 @@ class InsightsConfig(object):
         if self.payload and not self.content_type:
             raise ValueError(
                 '--payload requires --content-type')
-        if not self.legacy_upload:
-            if self.group:
-                raise ValueError(
-                    '--group is not supported at this time.')
         if self.offline:
             if self.to_json:
                 raise ValueError('Cannot use --to-json in offline mode.')


### PR DESCRIPTION
Adding tags has restored the ability to use groups in the platform, so remove the error when using it.