### PR TITLE
adding a scandir() based option for get_all_files

### DIFF
--- a/insights/core/archives.py
+++ b/insights/core/archives.py
@@ -76,16 +76,6 @@ class TarExtractor(object):
         return self
 
 
-def get_all_files(path):
-    names = []
-    for root, dirs, files in os.walk(path):
-        for dirname in dirs:
-            names.append(os.path.join(root, dirname) + "/")
-        for filename in files:
-            names.append(os.path.join(root, filename))
-    return names
-
-
 class Extraction(object):
     def __init__(self, tmp_dir, content_type):
         self.tmp_dir = tmp_dir

--- a/insights/core/hydration.py
+++ b/insights/core/hydration.py
@@ -20,9 +20,10 @@ if hasattr(os, "scandir"):
 
 else:
     def get_all_files(path):
-        for f in archives.get_all_files(path):
-            if os.path.isfile(f) and not os.path.islink(f):
-                yield f
+        for root, _, files in os.walk(path):
+            for f in files:
+                if os.path.isfile(f) and not os.path.islink(f):
+                    yield os.path.join(root, f)
 
 
 def identify(files):

--- a/insights/core/hydration.py
+++ b/insights/core/hydration.py
@@ -22,8 +22,9 @@ else:
     def get_all_files(path):
         for root, _, files in os.walk(path):
             for f in files:
-                if os.path.isfile(f) and not os.path.islink(f):
-                    yield os.path.join(root, f)
+                full_path = os.path.join(root, f)
+                if os.path.isfile(full_path) and not os.path.islink(full_path):
+                    yield full_path
 
 
 def identify(files):

--- a/insights/tests/test_extractors.py
+++ b/insights/tests/test_extractors.py
@@ -5,7 +5,7 @@ import tempfile
 import zipfile
 from contextlib import closing
 
-from insights.core import archives
+from insights.core.hydration import get_all_files
 from insights.core.archives import extract
 
 
@@ -38,7 +38,7 @@ def test_with_zip():
 
     try:
         with extract("/tmp/test.zip") as ex:
-            assert any(f.endswith("/sys/kernel/kexec_crash_size") for f in archives.get_all_files(ex.tmp_dir))
+            assert any(f.endswith("/sys/kernel/kexec_crash_size") for f in get_all_files(ex.tmp_dir))
 
     finally:
         os.unlink("/tmp/test.zip")


### PR DESCRIPTION
This PR replaces the get_all_files function with an `os.scandir()` based implementation.  `os.scandir()` was added in 3.5 and offers a performance increase over `os.walk` since it reduces the number of system calls to stat files.

Signed-off-by: Jesse Jaggars <jjaggars@redhat.com>