### PR TITLE
Validate tags

### DIFF
--- a/insights/client/collection_rules.py
+++ b/insights/client/collection_rules.py
@@ -13,11 +13,6 @@ import yaml
 import stat
 from six.moves import configparser as ConfigParser
 
-try:
-    from yaml import CLoader as Loader
-except ImportError:
-    from yaml import Loader
-
 from subprocess import Popen, PIPE, STDOUT
 from tempfile import NamedTemporaryFile
 from .constants import InsightsConstants as constants

--- a/insights/client/collection_rules.py
+++ b/insights/client/collection_rules.py
@@ -419,8 +419,9 @@ class InsightsUploadConf(object):
         else:
             try:
                 load_yaml(self.tags_file)
+                logger.info("%s loaded successfully", self.tags_file)
             except RuntimeError:
-                logger.warning("Unable to load %s\nInvalid YAML", self.tags_file)
+                logger.warning("Invalid YAML. Unable to load %s", self.tags_file)
                 return None
 
     def validate(self):

--- a/insights/client/collection_rules.py
+++ b/insights/client/collection_rules.py
@@ -13,6 +13,11 @@ import yaml
 import stat
 from six.moves import configparser as ConfigParser
 
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
 from subprocess import Popen, PIPE, STDOUT
 from tempfile import NamedTemporaryFile
 from .constants import InsightsConstants as constants
@@ -108,6 +113,7 @@ class InsightsUploadConf(object):
         self.remove_file = config.remove_file
         self.redaction_file = config.redaction_file
         self.content_redaction_file = config.content_redaction_file
+        self.tags_file = config.tags_file
         self.collection_rules_file = constants.collection_rules_file
         self.collection_rules_url = self.config.collection_rules_url
         self.gpg = self.config.gpg
@@ -408,10 +414,21 @@ class InsightsUploadConf(object):
         self.rm_conf = filtered_rm_conf
         return filtered_rm_conf
 
+    def get_tags_conf(self):
+        '''
+        Try to load the tags.conf file
+        '''
+        if not os.path.isfile(self.tags_file):
+            logger.info(f"No {self.tags_file} exists")
+            return None
+        else:
+            load_yaml(self.tags_file)
+            
     def validate(self):
         '''
-        Validate remove.conf
+        Validate remove.conf and tags.conf
         '''
+        self.get_tags_conf()
         success = self.get_rm_conf()
         if not success:
             logger.info('No contents in the blacklist configuration to validate.')

--- a/insights/client/collection_rules.py
+++ b/insights/client/collection_rules.py
@@ -422,8 +422,11 @@ class InsightsUploadConf(object):
             logger.info(f"No {self.tags_file} exists")
             return None
         else:
-            load_yaml(self.tags_file)
-            
+            try:
+                load_yaml(self.tags_file)
+            except RuntimeError as e:
+                logger.info(e)
+
     def validate(self):
         '''
         Validate remove.conf and tags.conf

--- a/insights/client/collection_rules.py
+++ b/insights/client/collection_rules.py
@@ -420,7 +420,7 @@ class InsightsUploadConf(object):
             try:
                 load_yaml(self.tags_file)
             except RuntimeError as e:
-                logger.info(e)
+                logger.warning(e)
                 return None
 
     def validate(self):

--- a/insights/client/collection_rules.py
+++ b/insights/client/collection_rules.py
@@ -419,13 +419,14 @@ class InsightsUploadConf(object):
         Try to load the tags.conf file
         '''
         if not os.path.isfile(self.tags_file):
-            logger.info(f"No {self.tags_file} exists")
+            logger.info("%s does not exist", self.tags_file)
             return None
         else:
             try:
                 load_yaml(self.tags_file)
             except RuntimeError as e:
                 logger.info(e)
+                return None
 
     def validate(self):
         '''

--- a/insights/client/collection_rules.py
+++ b/insights/client/collection_rules.py
@@ -419,8 +419,8 @@ class InsightsUploadConf(object):
         else:
             try:
                 load_yaml(self.tags_file)
-            except RuntimeError as e:
-                logger.warning(e)
+            except RuntimeError:
+                logger.warning("Unable to load %s\nInvalid YAML", self.tags_file)
                 return None
 
     def validate(self):

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -343,7 +343,7 @@ DEFAULT_OPTS = {
     'validate': {
         'default': False,
         'opt': ['--validate'],
-        'help': 'Validate remove.conf',
+        'help': 'Validate remove.conf and tags.yaml',
         'action': 'store_true'
     },
     'verbose': {

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -244,7 +244,7 @@ DEFAULT_OPTS = {
     },
     'tags_file': {
         # non-CLI
-        'default': os.path.join(constants.default_conf_dir, 'tags.conf')
+        'default': os.path.join(constants.default_conf_dir, 'tags.yaml')
     },
     'redaction_file': {
         # non-CLI

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -244,7 +244,7 @@ DEFAULT_OPTS = {
     },
     'tags_file': {
         # non-CLI
-        'default': os.path.join(constants.default_tags_file, 'tags.conf')
+        'default': os.path.join(constants.default_conf_dir, 'tags.conf')
     },
     'redaction_file': {
         # non-CLI

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -242,6 +242,10 @@ DEFAULT_OPTS = {
         # non-CLI
         'default': os.path.join(constants.default_conf_dir, 'remove.conf')
     },
+    'tags_file': {
+        # non-CLI
+        'default': os.path.join(constants.default_tags_file, 'tags.conf')
+    },
     'redaction_file': {
         # non-CLI
         'default': os.path.join(constants.default_conf_dir, 'file-redaction.yaml')

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -10,7 +10,7 @@ class InsightsConstants(object):
     command_blacklist = ('rm', 'kill', 'reboot', 'shutdown')
     default_conf_dir = os.getenv('INSIGHTS_CONF_DIR', default='/etc/insights-client')
     default_conf_file = os.path.join(default_conf_dir, 'insights-client.conf')
-    default_tags_file = os.path.join(default_conf_dir, 'tags.conf')
+    default_tags_file = os.path.join(default_conf_dir, 'tags.yaml')
     log_dir = os.path.join(os.sep, 'var', 'log', app_name)
     simple_find_replace_dir = '/etc/redhat-access-insights'
     default_log_file = os.path.join(log_dir, app_name + '.log')

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -10,6 +10,7 @@ class InsightsConstants(object):
     command_blacklist = ('rm', 'kill', 'reboot', 'shutdown')
     default_conf_dir = os.getenv('INSIGHTS_CONF_DIR', default='/etc/insights-client')
     default_conf_file = os.path.join(default_conf_dir, 'insights-client.conf')
+    default_tags_file = os.path.join(default_conf_dir, 'tags.conf')
     log_dir = os.path.join(os.sep, 'var', 'log', app_name)
     simple_find_replace_dir = '/etc/redhat-access-insights'
     default_log_file = os.path.join(log_dir, app_name + '.log')

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -330,7 +330,7 @@ def get_tags(tags_file_path=constants.default_tags_file):
         try:
             tags = load_yaml(tags_file_path)
         except RuntimeError:
-            logger.error("Unable to load tags.conf\nInvalid YAML")
+            logger.error("Unable to load %s\nInvalid YAML", tags_file_path)
             return None
     else:
         logger.debug("%s does not exist", tags_file_path)

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -15,13 +15,13 @@ from subprocess import Popen, PIPE, STDOUT
 
 import yaml
 try:
-    from yaml import CLoader as Loader, CDumper as Dumper
+    from yaml import CDumper as Dumper
 except ImportError:
-    from yaml import Loader, Dumper
+    from yaml import Dumper
 
 from .. import package_info
 from .constants import InsightsConstants as constants
-from .collection_rules import InsightsUploadConf
+from .collection_rules import InsightsUploadConf, load_yaml
 
 try:
     from insights_client.constants import InsightsConstants as wrapper_constants
@@ -176,7 +176,7 @@ def _expand_paths(path):
 
 def validate_remove_file(config):
     """
-    Validate the remove file
+    Validate the remove file and tags file
     """
     return InsightsUploadConf(config).validate()
 
@@ -318,7 +318,7 @@ def systemd_notify(pid):
         logger.debug('systemd-notify returned %s', proc.returncode)
 
 
-def get_tags(tags_file_path=os.path.join(constants.default_conf_dir, "tags.yaml")):
+def get_tags(tags_file_path=constants.default_tags_file):
     '''
     Load tag data from the tags file.
 
@@ -326,17 +326,18 @@ def get_tags(tags_file_path=os.path.join(constants.default_conf_dir, "tags.yaml"
     '''
     tags = None
 
-    try:
-        with open(tags_file_path) as f:
-            data = f.read()
-            tags = yaml.load(data, Loader=Loader)
-    except EnvironmentError as e:
-        logger.debug("tags file does not exist: %s", os.strerror(e.errno))
+    if os.path.isfile(tags_file_path):
+        try:
+            tags = load_yaml(tags_file_path)
+        except RuntimeError:
+            return None
+    else:
+        logger.debug(f"{tags_file_path} does not exist")
 
     return tags
 
 
-def write_tags(tags, tags_file_path=os.path.join(constants.default_conf_dir, "tags.yaml")):
+def write_tags(tags, tags_file_path=constants.default_tags_file):
     """
     Writes tags to tags_file_path
 

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -330,7 +330,7 @@ def get_tags(tags_file_path=constants.default_tags_file):
         try:
             tags = load_yaml(tags_file_path)
         except RuntimeError:
-            logger.error("Unable to load %s\nInvalid YAML", tags_file_path)
+            logger.error("Invalid YAML. Unable to load %s", tags_file_path)
             return None
     else:
         logger.debug("%s does not exist", tags_file_path)

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -330,6 +330,7 @@ def get_tags(tags_file_path=constants.default_tags_file):
         try:
             tags = load_yaml(tags_file_path)
         except RuntimeError:
+            logger.error("Unable to load tags.conf\nInvalid YAML")
             return None
     else:
         logger.debug("%s does not exist", tags_file_path)

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -332,7 +332,7 @@ def get_tags(tags_file_path=constants.default_tags_file):
         except RuntimeError:
             return None
     else:
-        logger.debug(f"{tags_file_path} does not exist")
+        logger.debug("%s does not exist", tags_file_path)
 
     return tags
 

--- a/insights/tests/client/test_utilities.py
+++ b/insights/tests/client/test_utilities.py
@@ -294,7 +294,7 @@ def test_get_tags_empty():
     fp.write(content)
     fp.close()
     got = util.get_tags(fp.name)
-    assert got is None
+    assert got == {}
 
 
 def test_get_tags_nonexist():


### PR DESCRIPTION
Catch invalid YAML issues related to tags.conf

We don't die if this fails, but we do throw in a warning for it.
Validate will now check that `tags.conf` is v alid as well