### PR TITLE
Adding a decompressor option to from_file

### DIFF
--- a/insights/core/archives.py
+++ b/insights/core/archives.py
@@ -62,12 +62,15 @@ class TarExtractor(object):
             raise InvalidContentType(content_type)
         return flag
 
-    def from_path(self, path, extract_dir=None, content_type=None):
+    def from_path(self, path, extract_dir=None, content_type=None, decompressor=None):
         if os.path.isdir(path):
             self.tmp_dir = path
         else:
-            self.content_type = content_type or content_type_from_file(path)
-            tar_flag = self._tar_flag_for_content_type(self.content_type)
+            if decompressor:
+                tar_flag = "-I %s" % decompressor
+            else:
+                self.content_type = content_type or content_type_from_file(path)
+                tar_flag = self._tar_flag_for_content_type(self.content_type)
             self.tmp_dir = tempfile.mkdtemp(prefix="insights-", dir=extract_dir)
             self.created_tmp_dir = True
             command = "tar --delay-directory-restore %s -x --exclude=*/dev/null -f %s -C %s" % (tar_flag, path, self.tmp_dir)


### PR DESCRIPTION
This allows callers to specify exactly which decompression binary to
use, skipping the content-type check and allowing for use of novel
programs such as igzip.