### PR TITLE
Include analysis metadata in json and yaml responses.

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -73,12 +73,15 @@ in this instance
 """
 
 
-def add_status(name, nvr, commit):
+def add_status(name, nvr, commit=None):
     """
     Rule repositories should call this method in their package __init__ to
     register their version information.
     """
     RULES_STATUS[name] = {"version": nvr, "commit": commit}
+
+
+add_status(package_info["NAME"], get_nvr(), package_info["COMMIT"])
 
 
 def process_dir(broker, root, graph, context, inventory=None):

--- a/insights/formats/__init__.py
+++ b/insights/formats/__init__.py
@@ -2,7 +2,9 @@ from __future__ import print_function
 import six
 import sys
 
+from datetime import datetime
 from insights import dr, rule
+from insights.util import utc
 
 
 RENDERERS = {}
@@ -57,6 +59,7 @@ class Formatter(object):
     def __init__(self, broker, stream=sys.stdout):
         self.broker = broker
         self.stream = stream
+        self.start_time = datetime.now(utc)
 
     def __enter__(self):
         self.preprocess()

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -124,7 +124,7 @@ class HtmlFormat(TemplateFormat):
     def create_template_context(self):
         ctx = {
             "root": self.find_root() or "Unknown",
-            "start_time": self.start_time,
+            "start_time": self.start_time.strftime("%Y-%m-%d %H:%M:%S")
         }
         sorted_rules = {}
         response_type_getter = itemgetter("response_type")

--- a/insights/formats/template.py
+++ b/insights/formats/template.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import inspect
 import sys
-from datetime import datetime
 
 from jinja2 import Template
 
@@ -91,7 +90,6 @@ class TemplateFormat(Formatter):
         Watches rules go by as they evaluate and collects information about
         them for later display in postprocess.
         """
-        self.start_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
         self.rules = []
         self.broker.add_observer(self.collect_rules, rule)
 

--- a/insights/tests/test_evaluators.py
+++ b/insights/tests/test_evaluators.py
@@ -91,7 +91,10 @@ def test_single_evaluator():
     with SingleEvaluator(broker) as e:
         dr.run(report, broker=broker)
         result2 = e.get_response()
-        assert result1 == result2
+        assert result1["reports"] == result2["reports"]
+        for k in ["start", "finish", "execution_context", "plugin_sets"]:
+            assert k in result1["analysis_metadata"]
+            assert k in result2["analysis_metadata"]
 
 
 def test_insights_evaluator():
@@ -104,7 +107,10 @@ def test_insights_evaluator():
     with InsightsEvaluator(broker) as e:
         dr.run(report, broker=broker)
         result2 = e.get_response()
-        assert result1 == result2
+        assert result1["reports"] == result2["reports"]
+        for k in ["start", "finish", "execution_context", "plugin_sets"]:
+            assert k in result1["analysis_metadata"]
+            assert k in result2["analysis_metadata"]
 
 
 def test_insights_evaluator_attrs_serial():

--- a/insights/util/__init__.py
+++ b/insights/util/__init__.py
@@ -5,6 +5,8 @@ import functools
 import platform
 import os
 import warnings
+import datetime
+
 
 TMP_DIR = os.path.join("/tmp", "insights-web")
 logger = logging.getLogger(__name__)
@@ -27,6 +29,29 @@ def parse_bool(s, default=False):
     if s is None:
         return default
     return TRUTH.get(s.lower(), default)
+
+
+# python2 doesn't have a utc tzinfo by default
+# see https://docs.python.org/2/library/datetime.html#tzinfo-objects
+try:
+    utc = datetime.timezone.utc
+except:
+    class UTC(datetime.tzinfo):
+        """
+        A tzinfo class for UTC.
+        """
+        ZERO = datetime.timedelta(0)
+
+        def utcoffset(self, dt):
+            return self.ZERO
+
+        def tzname(self, dt):
+            return "UTC"
+
+        def dst(self, dt):
+            return self.ZERO
+
+    utc = UTC()
 
 
 def which(cmd, env=None):


### PR DESCRIPTION
The new analysis_metadata section contains:
- analysis start time in UTC
- analysis end time in UTC
- execution context (host, sos report, insights archive, etc.)
- list of loaded plugin sets that registered themselves with `insights.add_status`
```
"analysis_metadata": {
    "start": "2020-04-24T21:52:06.342965+00:00",
    "finish": "2020-04-24T21:52:07.778594+00:00",
    "execution_context": "insights.core.context.SosArchiveContext",
    "plugin_sets": {
      "insights-core": {
        "version": "insights-core-3.0.8-dev",
        "commit": "placeholder"
      },
      "example-plugins": {
        "version": "example-plugins-1.2.3-4",
        "commit": "placeholder"
      }
    }
  }
```

Closes #2560

Signed-off-by: Christopher Sams <csams@redhat.com>