### PR TITLE
Add HOME env variable while running commands

### DIFF
--- a/insights/client/insights_spec.py
+++ b/insights/client/insights_spec.py
@@ -73,7 +73,8 @@ class InsightsCommand(InsightsSpec):
         # ensure consistent locale for collected command output
         cmd_env = {'LC_ALL': 'C',
                    'PATH': '/sbin:/bin:/usr/sbin:/usr/bin',
-                   'PYTHONPATH': os.getenv('PYTHONPATH')}
+                   'PYTHONPATH': os.getenv('PYTHONPATH'),
+                   'HOME': os.getenv('HOME')}
         args = shlex.split(timeout_command)
 
         # never execute this stuff


### PR DESCRIPTION
There is a  command spec [1] for Red Hat Satellite which fails to execute correctly as HOME environment variable is not set. Setting it globally may help other future commands too.

[1] https://github.com/RedHatInsights/insights-core/blob/519df94d11353ca72ea6fce7e57b09a610d208ae/insights/specs/default.py#L355