### PR TITLE
Move test URL messages to network logger

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -315,7 +315,7 @@ class InsightsConnection(object):
         paths = (url.path + '/', '', '/r', '/r/insights')
         for ext in paths:
             try:
-                logger.debug("Testing: %s", test_url + ext)
+                logger.log(NETWORK, "Testing: %s", test_url + ext)
                 if method is "POST":
                     test_req = self.session.post(
                         test_url + ext, timeout=self.config.http_timeout, data=test_flag)
@@ -347,7 +347,7 @@ class InsightsConnection(object):
         if self.config.legacy_upload:
             return self._legacy_test_urls(url, method)
         try:
-            logger.debug('Testing %s', url)
+            logger.log(NETWORK, 'Testing %s', url)
             if method is 'POST':
                 test_tar = TemporaryFile(mode='rb', suffix='.tar.gz')
                 test_files = {


### PR DESCRIPTION
When using test-conenction we now enable --net-debug. In order to see
the url that is being printed, we need to put the url in the NETWORK log
level

Signed-off-by: Stephen Adams <tsadams@gmail.com>