### PR TITLE
always create archive_tmp_dir for compatibility

### DIFF
--- a/insights/client/archive.py
+++ b/insights/client/archive.py
@@ -30,9 +30,7 @@ class InsightsArchive(object):
         """
         self.config = config
         self.tmp_dir = tempfile.mkdtemp(prefix='/var/tmp/')
-        self.archive_tmp_dir = None
-        if not self.config.obfuscate:
-            self.archive_tmp_dir = tempfile.mkdtemp(prefix='/var/tmp/')
+        self.archive_tmp_dir = tempfile.mkdtemp(prefix='/var/tmp/')
         name = determine_hostname()
         self.archive_name = ("insights-%s-%s" %
                              (name,


### PR DESCRIPTION
We opted not to create `archive_tmp_dir` when `obfuscate=True` because soscleaner does its own tempfile management and archive creation.

Compliance is using the `create_tar_file` function which expects this directory to exist, so we kinda pulled the rug out from under them there if obfuscation happens to be enabled. So let's always create the dir just in case.