### PR TITLE
Compliance - only scan internal policies

### DIFF
--- a/insights/client/apps/compliance/__init__.py
+++ b/insights/client/apps/compliance/__init__.py
@@ -69,7 +69,9 @@ class ComplianceClient:
     # We need to update compliance-backend to fix this
     def get_policies(self):
         response = self.conn.session.get("https://{0}/compliance/profiles".format(self.config.base_url),
-                                         params={'search': 'system_names={0}'.format(self.hostname)})
+                                         params={
+                                             'search': 'external=false&system_names={0}'.format(self.hostname)
+                                         })
         logger.debug("Content of the response: {0} - {1}".format(response,
                                                                  response.json()))
         if response.status_code == 200:

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -51,7 +51,7 @@ def test_get_policies(config):
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
     assert compliance_client.get_policies() == [{'attributes': 'data'}]
     compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles',
-                                                          params={'search': 'external=true&system_names=foo'})
+                                                          params={'search': 'external=false&system_names=foo'})
 
 
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
@@ -61,7 +61,7 @@ def test_get_policies_no_policies(config):
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': []})))
     assert compliance_client.get_policies() == []
     compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles',
-                                                          params={'search': 'external=true&system_names=foo'})
+                                                          params={'search': 'external=false&system_names=foo'})
 
 
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
@@ -71,7 +71,7 @@ def test_get_policies_error(config):
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=500))
     assert compliance_client.get_policies() == []
     compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles',
-                                                          params={'search': 'external=true&system_names=foo'})
+                                                          params={'search': 'external=false&system_names=foo'})
 
 
 @patch("insights.client.apps.compliance.linux_distribution", return_value=(None, '6.5', None))

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -50,7 +50,8 @@ def test_get_policies(config):
     compliance_client.hostname = 'foo'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
     assert compliance_client.get_policies() == [{'attributes': 'data'}]
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo'})
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles',
+                                                          params={'search': 'external=true&system_names=foo'})
 
 
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
@@ -59,7 +60,8 @@ def test_get_policies_no_policies(config):
     compliance_client.hostname = 'foo'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': []})))
     assert compliance_client.get_policies() == []
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo'})
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles',
+                                                          params={'search': 'external=true&system_names=foo'})
 
 
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
@@ -68,7 +70,8 @@ def test_get_policies_error(config):
     compliance_client.hostname = 'foo'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=500))
     assert compliance_client.get_policies() == []
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo'})
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles',
+                                                          params={'search': 'external=true&system_names=foo'})
 
 
 @patch("insights.client.apps.compliance.linux_distribution", return_value=(None, '6.5', None))


### PR DESCRIPTION
Without this external=false change, we are scanning external policies on
'insights-client --compliance', but those weren't manually assigned and
should not be scanned. Furthermore, you could have 2 policies, internal
and external with the same ref_id scanned.