### PR TITLE
Remove duplicated apicid in mappings of CpuInfo

### DIFF
--- a/insights/parsers/cpuinfo.py
+++ b/insights/parsers/cpuinfo.py
@@ -141,7 +141,6 @@ class CpuInfo(LegacyItemAccess, Parser):
             "revision": "revision",
             "address sizes": "address_sizes",
             "bugs": "bugs",
-            "apicid": "apicid"
         }
 
         for line in get_active_lines(content, comment_char="COMMAND>"):


### PR DESCRIPTION
- fix: #2582

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>