### PR TITLE
Add links to render data for content formatters

### DIFF
--- a/insights/formats/__init__.py
+++ b/insights/formats/__init__.py
@@ -142,8 +142,11 @@ try:
 
     def format_rule(comp, val):
         content = get_content(comp, val)
+        links = {}
+        if 'links' not in val and dr.get_delegate(comp).links:
+            links = dr.get_delegate(comp).links
         if content and val.get("type") != "skip":
-            return Template(content).render(val)
+            return Template(content).render(val, links=links)
         return str(val)
 
     RENDERERS[rule] = format_rule


### PR DESCRIPTION
This makes links attribute available for use in jinja CONTENT.

If the rule writer wants to show links in the content explicitly, the links dict will be available to use rather than passing extraneous data to make_ funcs.