### PR TITLE
encode() messages to call()

### DIFF
--- a/insights/client/apps/compliance/__init__.py
+++ b/insights/client/apps/compliance/__init__.py
@@ -85,7 +85,7 @@ class ComplianceClient:
         return glob("{0}*rhel{1}*.xml".format(POLICY_FILE_LOCATION, self.os_release()))
 
     def find_scap_policy(self, profile_ref_id):
-        rc, grep = call('grep ' + profile_ref_id + ' ' + ' '.join(self.profile_files()), keep_rc=True)
+        rc, grep = call(('grep ' + profile_ref_id + ' ' + ' '.join(self.profile_files())).encode(), keep_rc=True)
         if rc:
             logger.error('XML profile file not found matching ref_id {0}\n{1}\n'.format(profile_ref_id, grep))
             exit(constants.sig_kill_bad)
@@ -107,7 +107,7 @@ class ComplianceClient:
         env = os.environ.copy()
         env.update({'TZ': 'UTC'})
         oscap_command = self.build_oscap_command(profile_ref_id, policy_xml, output_path, tailoring_file_path)
-        rc, oscap = call(oscap_command, keep_rc=True, env=env)
+        rc, oscap = call(oscap_command.encode(), keep_rc=True, env=env)
         if rc and rc != NONCOMPLIANT_STATUS:
             logger.error('Scan failed')
             logger.error(oscap)

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -110,7 +110,7 @@ def test_run_scan(config, call):
     env = os.environ
     env.update({'TZ': 'UTC'})
     compliance_client.run_scan('ref_id', '/nonexistent', output_path)
-    call.assert_called_with("oscap xccdf eval --profile ref_id --results " + output_path + ' /nonexistent', keep_rc=True, env=env)
+    call.assert_called_with(("oscap xccdf eval --profile ref_id --results " + output_path + ' /nonexistent').encode(), keep_rc=True, env=env)
 
 
 @patch("insights.client.apps.compliance.call", return_value=(1, 'bad things happened'.encode('utf-8')))
@@ -122,7 +122,7 @@ def test_run_scan_fail(config, call):
     env.update({'TZ': 'UTC'})
     with raises(SystemExit):
         compliance_client.run_scan('ref_id', '/nonexistent', output_path)
-    call.assert_called_with("oscap xccdf eval --profile ref_id --results " + output_path + ' /nonexistent', keep_rc=True, env=env)
+    call.assert_called_with(("oscap xccdf eval --profile ref_id --results " + output_path + ' /nonexistent').encode(), keep_rc=True, env=env)
 
 
 @patch("insights.client.config.InsightsConfig")


### PR DESCRIPTION
unicode strings in RHEL 6, Python 2.6.6 that are split with shlex insert
null characters '\x00', which cause Popen to fail. call() may handle
this in the future, but for now, compliance will be sure to encode any strings
passed to call.

I've manually tested this with the `--compliance` option against RHEL 6 and 7.

@gravitypriest I decided to put the `encode` calls directly in the `call` arguments so it's really future proof against people adding more things to the commands in `call`.

Fixes https://projects.engineering.redhat.com/browse/RHICOMPL-670

Signed-off-by: Andrew Kofink <akofink@redhat.com>