### PR TITLE
Add parser for file /etc/cni/net.d/87-podman-bridge.conflist

### DIFF
--- a/docs/shared_parsers_catalog/cni_podman_bridge_conf.rst
+++ b/docs/shared_parsers_catalog/cni_podman_bridge_conf.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.cni_podman_bridge_conf
+   :members:
+   :show-inheritance:

--- a/insights/parsers/cni_podman_bridge_conf.py
+++ b/insights/parsers/cni_podman_bridge_conf.py
@@ -1,0 +1,68 @@
+"""
+CNIPodmanBridgeConf - file ``/etc/cni/net.d/87-podman-bridge.conflist``
+=======================================================================
+
+This parser converts file ``/etc/cni/net.d/87-podman-bridge.conflist``
+into a dictionary that matches the JSON string in the file.
+
+Sample file content::
+
+    {
+        "cniVersion": "0.4.0",
+        "name": "podman",
+        "plugins": [
+            {
+                "type": "bridge",
+                "bridge": "cni-podman0",
+                "isGateway": true,
+                "ipMasq": true,
+                "ipam": {
+                    "type": "host-local",
+                    "routes": [
+                        {
+                            "dst": "0.0.0.0/0"
+                        }
+                    ],
+                    "ranges": [
+                        [
+                            {
+                                "subnet": "10.12.0.0/16",
+                                "gateway": "10.12.0.1"
+                            }
+                        ]
+                    ]
+                }
+            },
+            {
+                "type": "portmap",
+                "capabilities": {
+                    "portMappings": true
+                }
+            },
+            {
+                "type": "firewall",
+                "backend": "iptables"
+            },
+            {
+                "type": "tuning"
+            }
+        ]
+    }
+
+    Examples:
+    >>> len(cni_podman_bridge_conf["plugins"])
+    4
+    >>> cni_podman_bridge_conf["plugins"][0]["ipMasq"]
+    True
+"""
+
+from insights.specs import Specs
+from insights import JSONParser, parser
+
+
+@parser(Specs.cni_podman_bridge_conf)
+class CNIPodmanBridgeConf(JSONParser):
+    """
+    Class for file: /etc/cni/net.d/87-podman-bridge.conflist
+    """
+    pass

--- a/insights/parsers/tests/test_cni_podman_bridge_conf.py
+++ b/insights/parsers/tests/test_cni_podman_bridge_conf.py
@@ -1,0 +1,63 @@
+import doctest
+
+from insights.tests import context_wrap
+from insights.parsers import cni_podman_bridge_conf
+from insights.parsers.cni_podman_bridge_conf import CNIPodmanBridgeConf
+
+PODMAN_CNI_FILE = '''
+{
+    "cniVersion": "0.4.0",
+    "name": "podman",
+    "plugins": [
+        {
+            "type": "bridge",
+            "bridge": "cni-podman0",
+            "isGateway": true,
+            "ipMasq": true,
+            "ipam": {
+                "type": "host-local",
+                "routes": [
+                    {
+                        "dst": "0.0.0.0/0"
+                    }
+                ],
+                "ranges": [
+                    [
+                        {
+                            "subnet": "10.12.0.0/16",
+                            "gateway": "10.12.0.1"
+                        }
+                    ]
+                ]
+            }
+        },
+        {
+            "type": "portmap",
+            "capabilities": {
+                "portMappings": true
+            }
+        },
+        {
+            "type": "firewall",
+            "backend": "iptables"
+        },
+        {
+            "type": "tuning"
+        }
+    ]
+}
+'''.strip()
+
+
+def test_doc_examples():
+    env = {
+        'cni_podman_bridge_conf': CNIPodmanBridgeConf(context_wrap(PODMAN_CNI_FILE)),
+    }
+    failed, total = doctest.testmod(cni_podman_bridge_conf, globs=env)
+    assert failed == 0
+
+
+def test_cni_podman_bridge_conf():
+    conf = CNIPodmanBridgeConf(context_wrap(PODMAN_CNI_FILE))
+    assert len(conf["plugins"]) == 4
+    assert conf["plugins"][3]["type"] == "tuning"

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -75,6 +75,7 @@ class Specs(SpecSet):
     cloud_init_log = RegistryPoint(filterable=True)
     cluster_conf = RegistryPoint(filterable=True)
     cmdline = RegistryPoint()
+    cni_podman_bridge_conf = RegistryPoint()
     cobbler_modules_conf = RegistryPoint()
     cobbler_settings = RegistryPoint()
     corosync = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -193,6 +193,7 @@ class DefaultSpecs(Specs):
     cloud_init_log = simple_file("/var/log/cloud-init.log")
     cluster_conf = simple_file("/etc/cluster/cluster.conf")
     cmdline = simple_file("/proc/cmdline")
+    cni_podman_bridge_conf = simple_file("/etc/cni/net.d/87-podman-bridge.conflist")
     cpe = simple_file("/etc/system-release-cpe")
     # are these locations for different rhel versions?
     cobbler_settings = first_file(["/etc/cobbler/settings", "/conf/cobbler/settings"])


### PR DESCRIPTION
Added
```
insights/parsers/cni_podman_bridge_conf.py
insights/parsers/tests/test_cni_podman_bridge_conf.py
docs/shared_parsers_catalog/cni_podman_bridge_conf.rst
```

Updated
```
insights/specs/__init__.py
insights/specs/default.py
```

Signed-off-by: shlao <shlao@redhat.com>