### PR TITLE
Add markers to syslog format tests

### DIFF
--- a/insights/tests/test_formats.py
+++ b/insights/tests/test_formats.py
@@ -1,3 +1,4 @@
+import pytest
 from six import StringIO
 from insights import dr, make_fail, rule
 from insights.formats.text import HumanReadableFormat
@@ -41,6 +42,7 @@ def test_json_format():
     assert "bar" in data
 
 
+@pytest.mark.syslog_format
 def test_syslog_format_no_archive():
     broker = dr.Broker()
     output = StringIO()
@@ -52,6 +54,7 @@ def test_syslog_format_no_archive():
     assert SL_CMD in data
 
 
+@pytest.mark.syslog_format
 def test_syslog_format_archive():
     broker = dr.Broker()
     output = StringIO()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
 [tool:pytest]
+markers =
+    syslog_format: marks tests for syslog format (deselect with '-m "not syslog_format"')
 # Look for tests only in tests directories.
 python_files = "insights/tests/*" "insights/parsers/tests/*" "insights/combiners/tests/*" "insights/parsr/tests/*" "insights/parsr/examples/tests/*" "insights/parsr/query/tests/*" "insights/archive/test.py" "insights/components/tests/*" "insights/parsr/tests/*"
 # Display summary info for (s)skipped, (X)xpassed, (x)xfailed, (f)failed and (e)errored tests


### PR DESCRIPTION
* Add new marker syslog_format to syslog formatter tests to allow
  turning them off when testing in a container that doesn't allow calls
  to ``getuser``
* Turn off tests with the `-m 'not syslog_format'` switch to pytest

Signed-off-by: Bob Fahr <bfahr@redhat.com>