### PR TITLE
client: add suppressed --force option

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -206,6 +206,11 @@ def _legacy_handle_unregistration(config, pconn):
     """
         returns (bool): True success, False failure
     """
+    def __cleanup_local_files():
+        write_unregistered_file()
+        get_scheduler(config).remove_scheduling()
+        delete_cache_files()
+
     check = get_registration_status(config, pconn)
 
     for m in check['messages']:
@@ -213,6 +218,8 @@ def _legacy_handle_unregistration(config, pconn):
 
     if check['unreachable']:
         # Run connection test and exit
+        if config.force:
+            __cleanup_local_files()
         return None
 
     if check['status']:
@@ -222,9 +229,7 @@ def _legacy_handle_unregistration(config, pconn):
         logger.info('This system is already unregistered.')
     if unreg:
         # only set if unreg was successful
-        write_unregistered_file()
-        get_scheduler(config).remove_scheduling()
-        delete_cache_files()
+        __cleanup_local_files()
     return unreg
 
 
@@ -239,8 +244,8 @@ def handle_unregistration(config, pconn):
         return _legacy_handle_unregistration(config, pconn)
 
     unreg = pconn.unregister()
-    if unreg:
-        # only set if unreg was successful
+    if unreg or config.force:
+        # only set if unreg was successful or --force was set
         write_unregistered_file()
         delete_cache_files()
     return unreg

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -143,6 +143,12 @@ DEFAULT_OPTS = {
         # non-CLI
         'default': None
     },
+    'force': {
+        'default': False,
+        'opt': ['--force'],
+        'help': argparse.SUPPRESS,
+        'action': 'store_true'
+    },
     'group': {
         'default': None,
         'opt': ['--group'],


### PR DESCRIPTION
During unregister, this allows cleanup of local files even when API unregistration fails. This is to enable unregistration along side RHSM.