### PR TITLE
Fix context checking in create_context_fix

### DIFF
--- a/insights/core/hydration.py
+++ b/insights/core/hydration.py
@@ -41,7 +41,9 @@ def identify(files):
 
 def create_context(path, context=None):
     top = os.listdir(path)
-    arc = [os.path.join(path, f) for f in top if f.endswith(archives.COMPRESSION_TYPES)]
+    arc = [os.path.join(path, f) for f in top
+           if f.endswith(archives.COMPRESSION_TYPES) and
+           os.path.isfile(os.path.join(path, f))]
     if arc:
         return ClusterArchiveContext(path, all_files=arc)
 


### PR DESCRIPTION
After archive is extracted, if top level dirs end with string which is
a valid compression type, current logic determines context as
ClusterArchiveContext. This change double checks if path is a file
along with ending with a compression extension.

Example : 
When a sosreport named `sosreport-system-2020-04-14-asmmxgz.tar.xz` is extracted, top level dir is `sosreport-system-2020-04-14-asmmxgz` which ends with `gz` and sosreport is wrongly identified as a Cluster Archive.

The probability of archive names ending with one of ('zip', 'tar', 'gz', 'bz2', 'xz') strings might be rare but I accidentally hit this bug on a customer sosreport. 