### PR TITLE
client: return True if unregister with --force

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -218,6 +218,7 @@ def _legacy_handle_unregistration(config, pconn):
         # Run connection test and exit
         if config.force:
             __cleanup_local_files()
+            return True
         return None
 
     if check['status']:


### PR DESCRIPTION
When the `--unregister` option is invoked with `--force`, we circumvent the remote URL checks. This resulted in a `False` being returned by the unregistration operation, but in the case of `--force`, we know the remote URL is unreachable; we want to force the unregistration operation anyway, so we explicitly return `True`.