### PR TITLE
Silence user warning when importing pkg_resources

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -8,7 +8,6 @@ import os
 import six
 import json
 import logging
-import pkg_resources
 import platform
 import xml.etree.ElementTree as ET
 import warnings
@@ -24,6 +23,9 @@ except ImportError:
     # python 3
     from urllib.parse import urlparse
     from urllib.parse import quote
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=UserWarning)
+    import pkg_resources
 from .utilities import (determine_hostname,
                         generate_machine_id,
                         write_unregistered_file,

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -23,9 +23,6 @@ except ImportError:
     # python 3
     from urllib.parse import urlparse
     from urllib.parse import quote
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=UserWarning)
-    import pkg_resources
 from .utilities import (determine_hostname,
                         generate_machine_id,
                         write_unregistered_file,
@@ -176,6 +173,7 @@ class InsightsConnection(object):
         """
         Generates and returns a string suitable for use as a request user-agent
         """
+        import pkg_resources
         core_version = "insights-core"
         pkg = pkg_resources.working_set.find(pkg_resources.Requirement.parse(core_version))
         if pkg is not None:


### PR DESCRIPTION
When importing this package, sys.path warnings are recorded on RHEL6.
These are noise and can be safely ignored. They are currently causing
cron emails to be sent every time insights runs on a RHEL6 box.

RHCLOUD-7066
BZ 1847104

Signed-off-by: Stephen Adams <tsadams@gmail.com>