### PR TITLE
Fix %f regex for get_after

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -1186,7 +1186,7 @@ class LogFileOutput(six.with_metaclass(ScanMeta, Parser)):
             'p': r'\w{2}',  # AM / PM
             'M': r'([012345]\d)',  # Minutes
             'S': r'([012345]\d|60)',  # Seconds, including leap second
-            'f': r'\d{6}',  # Microseconds
+            'f': r'\d{1,6}',  # Microseconds
         }
 
         # Construct the regex from the time string

--- a/insights/tests/test_logfileoutput.py
+++ b/insights/tests/test_logfileoutput.py
@@ -301,3 +301,22 @@ def test_logs_with_two_timestamps():
         logerr = BadClassMariaDBLog(ctx)
         assert list(logerr.get_after(datetime(2017, 3, 27, 3, 39, 46))) is None
     assert 'get_after does not recognise time formats of type ' in str(exc)
+
+
+MILLISECONDS_TOWER_LOG = """
+2020-05-28 19:25:36,892 WARNING  django.request Not Found: /api/v1/me/
+2020-05-28 19:25:46,944 INFO     awx.api.authentication User admin performed a GET to /api/v2/activity_stream/ through the API
+2020-05-28 19:33:03,125 INFO     awx.api.authentication User admin performed a GET to /api/v2/job_templates/7/survey_spec/ through the API
+2020-05-28 19:33:03,413 INFO     awx.api.authentication User admin performed a GET to /api/v2/projects/ through the API
+""".strip()
+
+
+class FakeTowerLog(LogFileOutput):
+    time_format = '%Y-%m-%d %H:%M:%S,%f'
+
+
+def test_logs_with_milliseconds():
+    ctx = context_wrap(MILLISECONDS_TOWER_LOG, path='/var/log/tower/tower.log')
+    log = FakeTowerLog(ctx)
+    assert len(log.lines) == 4
+    assert len(list(log.get_after(datetime(2020, 5, 28, 19, 25, 46, 944)))) == 3


### PR DESCRIPTION
strptime supports Microseconds with %f but not Milliseconds. When logs
have milliseconds, %f still works fine to convert to datetime object as zeros
are padded to right.

When LogFileOutput uses %f in time_format but there are 3 digit milliseconds,
get_after function does not work correctly as it looks for a 6 digit
number. This change adjusts the regex to {1,6} digits for get_after to
work.

Source : Comments for %f in following documentation :
https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior

"%f is an extension to the set of format characters in the C standard (but implemented separately in datetime objects, and therefore always available). When used with the strptime() method, the %f directive accepts from one to six digits and zero pads on the right."
