### PR TITLE
Fix first_file usage for lvmconfig spec

### DIFF
--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -155,8 +155,8 @@ class InsightsArchiveSpecs(Specs):
     lsscsi = simple_file("insights_commands/lsscsi")
     lvdisplay = simple_file("insights_commands/lvdisplay")
     lvmconfig = first_file([
-        simple_file("insights_commands/lvmconfig_--type_full"),
-        simple_file("insights_commands/lvm_dumpconfig_--type_full"),
+        "insights_commands/lvmconfig_--type_full",
+        "insights_commands/lvm_dumpconfig_--type_full"
     ])
     lvs_noheadings = simple_file("insights_commands/lvs_--nameprefixes_--noheadings_--separator_-a_-o_lv_name_lv_size_lv_attr_mirror_log_vg_name_devices_region_size_data_percent_metadata_percent_segtype_seg_monitor_--config_global_locking_type_0")
     lvs_noheadings_all = simple_file("insights_commands/lvs_--nameprefixes_--noheadings_--separator_-a_-o_lv_name_lv_size_lv_attr_mirror_log_vg_name_devices_region_size_data_percent_metadata_percent_segtype_--config_global_locking_type_0_devices_filter_a")


### PR DESCRIPTION
Found insights-info usage and `insights.parsers.lvm.LvmConfig`  broken due to this.