### PR TITLE
Update 'corrupt' and docstring of InstalledRpms for empty packages

### DIFF
--- a/insights/parsers/installed_rpms.py
+++ b/insights/parsers/installed_rpms.py
@@ -153,14 +153,19 @@ class RpmList(object):
         """
         Checks if package name is in list of installed RPMs.
 
+        .. note::
+            The :attr:`packages` could be empty, e.g. when rpm database corrupt.
+            When doing exclusion check, make sure the ``packages`` is NOT
+            empty, e.g.::
+
+                >>> if rpms.packages and "pkg_name" not in rpms:
+                >>>     pass
+
         Args:
             package_name (str): RPM package name such as 'bash'
 
         Returns:
             bool: True if package name is in list of installed packages, otherwise False
-
-        Raises:
-            TypeError: When no packages list and the self.packages is ``None``.
         """
         return package_name in self.packages
 
@@ -220,15 +225,21 @@ class InstalledRpms(CommandParser, RpmList):
     related information.
     """
     def __init__(self, *args, **kwargs):
-        self.errors = []
+        self.errors = list()
         """list: List of input lines that indicate an error acquiring the data on the client."""
-        self.unparsed = []
+        self.unparsed = list()
         """list: List of input lines that raised an exception during parsing."""
-        self.packages = None
+        self.packages = dict()
         """
-        dict (InstalledRpm): Dictionary of RPMs keyed by package name.  None when no packages.
-            ``None`` keeps the behavior consistent when applying ``in`` against
-            the :class:`InstalledRpms` object or against :attr:`InstalledRpms.packages` directly.
+        dict (InstalledRpm): Dictionary of RPMs keyed by package name.
+
+        .. note::
+            The ``packages`` could be empty, e.g. when rpm database corrupt.
+            When doing exclusion check, make sure the ``packages`` is NOT
+            empty, e.g.::
+
+                >>> if rpms.packages and "pkg_name" not in rpms.packages:
+                >>>     pass
         """
         super(InstalledRpms, self).__init__(*args, **kwargs)
 
@@ -251,9 +262,8 @@ class InstalledRpms(CommandParser, RpmList):
                         except Exception:
                             # Both ways failed
                             self.unparsed.append(line)
-        if packages:
-            # Don't want defaultdict's behavior after parsing is complete
-            self.packages = dict(packages)
+        # Don't want defaultdict's behavior after parsing is complete
+        self.packages = dict(packages)
 
     @property
     def corrupt(self):

--- a/insights/parsers/installed_rpms.py
+++ b/insights/parsers/installed_rpms.py
@@ -231,7 +231,6 @@ class InstalledRpms(CommandParser, RpmList):
             ``None`` keeps the behavior consistent when applying ``in`` against
             the :class:`InstalledRpms` object or against :attr:`InstalledRpms.packages` directly.
         """
-
         super(InstalledRpms, self).__init__(*args, **kwargs)
 
     def parse_content(self, content):

--- a/insights/parsers/installed_rpms.py
+++ b/insights/parsers/installed_rpms.py
@@ -78,6 +78,7 @@ import warnings
 from ..util import rsplit
 from .. import parser, get_active_lines, CommandParser
 from .rpm_vercmp import rpm_version_compare
+from insights.parsers import SkipException
 from insights.specs import Specs
 
 # This list of architectures is taken from PDC (Product Definition Center):
@@ -215,6 +216,9 @@ class InstalledRpms(CommandParser, RpmList):
     """
     A parser for working with data containing a list of installed RPM files on the system and
     related information.
+
+    Raises:
+        SkipException: When no packages are found.
     """
     def __init__(self, *args, **kwargs):
         self.errors = []
@@ -244,6 +248,8 @@ class InstalledRpms(CommandParser, RpmList):
                         except Exception:
                             # Both ways failed
                             self.unparsed.append(line)
+        if not self.packages:
+            raise SkipException()
         # Don't want defaultdict's behavior after parsing is complete
         self.packages = dict(self.packages)
 

--- a/insights/parsers/installed_rpms.py
+++ b/insights/parsers/installed_rpms.py
@@ -218,7 +218,6 @@ class InstalledRpms(CommandParser, RpmList):
     """
     A parser for working with data containing a list of installed RPM files on the system and
     related information.
-
     """
     def __init__(self, *args, **kwargs):
         self.errors = []

--- a/insights/parsers/tests/test_installed_rpms.py
+++ b/insights/parsers/tests/test_installed_rpms.py
@@ -1,5 +1,6 @@
 import pytest
 from insights.parsers.installed_rpms import InstalledRpms, InstalledRpm, pad_version
+from insights.parsers import SkipException
 from insights.tests import context_wrap
 
 
@@ -82,6 +83,18 @@ ERROR_DB = '''
 error: rpmdbNextIterator: skipping h#     753 Header V3 DSA signature: BAD, key ID db42a6
 yum-security-1.1.16-21.el5.noarch
 '''.strip()
+
+ERROR_DB_NO_PKG = """
+error: rpmdb: BDB0113 Thread/process 20263/140251984590912 failed: BDB1507 Thread died in Berkeley DB library
+error: db5 error(-30973) from dbenv->failchk: BDB0087 DB_RUNRECOVERY: Fatal
+error, run database recovery
+error: cannot open Packages index using db5 -  (-30973)
+error: cannot open Packages database in /var/lib/rpm
+error: rpmdb: BDB0113 Thread/process 20263/140251984590912 failed: BDB1507 Thread died in Berkeley DB library
+error: db5 error(-30973) from dbenv->failchk: BDB0087 DB_RUNRECOVERY: Fatal
+error, run database recovery
+error: cannot open Packages database in /var/lib/rpm
+""".strip()
 
 ORACLEASM_RPMS = '''
 oracleasm-2.6.18-164.el5-2.0.5-1.el5.x86_64
@@ -207,6 +220,9 @@ def test_corrupt_db():
     rpms = InstalledRpms(context_wrap(ERROR_DB))
     assert "yum-security" in rpms.packages
     assert rpms.corrupt is True
+
+    with pytest.raises(SkipException):
+        InstalledRpms(context_wrap(ERROR_DB_NO_PKG))
 
 
 def test_rpm_manifest():

--- a/insights/parsers/tests/test_installed_rpms.py
+++ b/insights/parsers/tests/test_installed_rpms.py
@@ -215,20 +215,17 @@ def test_garbage():
 
 def test_corrupt_db():
     rpms = InstalledRpms(context_wrap(ERROR_DB))
+    assert rpms.corrupt is True
     assert "yum-security" in rpms.packages
     assert "yum-security" in rpms
-    assert rpms.corrupt is True
 
     rpms = InstalledRpms(context_wrap(ERROR_DB_NO_PKG))
     assert rpms.corrupt is True
-    with pytest.raises(TypeError):
-        assert "kernel" not in rpms
-    with pytest.raises(TypeError):
-        assert "kernel" not in rpms.packages
-    with pytest.raises(TypeError):
-        rpms.newest("kernel")
-    with pytest.raises(TypeError):
-        rpms.oldest("kernel")
+    assert not rpms.packages
+    assert "kernel" not in rpms
+    assert "kernel" not in rpms.packages
+    assert rpms.newest("kernel") is None
+    assert rpms.oldest("kernel") is None
 
 
 def test_rpm_manifest():

--- a/insights/parsers/tests/test_installed_rpms.py
+++ b/insights/parsers/tests/test_installed_rpms.py
@@ -1,6 +1,5 @@
 import pytest
 from insights.parsers.installed_rpms import InstalledRpms, InstalledRpm, pad_version
-from insights.parsers import SkipException
 from insights.tests import context_wrap
 
 

--- a/insights/parsers/tests/test_installed_rpms.py
+++ b/insights/parsers/tests/test_installed_rpms.py
@@ -86,13 +86,11 @@ yum-security-1.1.16-21.el5.noarch
 
 ERROR_DB_NO_PKG = """
 error: rpmdb: BDB0113 Thread/process 20263/140251984590912 failed: BDB1507 Thread died in Berkeley DB library
-error: db5 error(-30973) from dbenv->failchk: BDB0087 DB_RUNRECOVERY: Fatal
-error, run database recovery
+error: db5 error(-30973) from dbenv->failchk: BDB0087 DB_RUNRECOVERY: Fatal error, run database recovery
 error: cannot open Packages index using db5 -  (-30973)
 error: cannot open Packages database in /var/lib/rpm
 error: rpmdb: BDB0113 Thread/process 20263/140251984590912 failed: BDB1507 Thread died in Berkeley DB library
-error: db5 error(-30973) from dbenv->failchk: BDB0087 DB_RUNRECOVERY: Fatal
-error, run database recovery
+error: db5 error(-30973) from dbenv->failchk: BDB0087 DB_RUNRECOVERY: Fatal error, run database recovery
 error: cannot open Packages database in /var/lib/rpm
 """.strip()
 
@@ -219,10 +217,19 @@ def test_garbage():
 def test_corrupt_db():
     rpms = InstalledRpms(context_wrap(ERROR_DB))
     assert "yum-security" in rpms.packages
+    assert "yum-security" in rpms
     assert rpms.corrupt is True
 
-    with pytest.raises(SkipException):
-        InstalledRpms(context_wrap(ERROR_DB_NO_PKG))
+    rpms = InstalledRpms(context_wrap(ERROR_DB_NO_PKG))
+    assert rpms.corrupt is True
+    with pytest.raises(TypeError):
+        assert "kernel" not in rpms
+    with pytest.raises(TypeError):
+        assert "kernel" not in rpms.packages
+    with pytest.raises(TypeError):
+        rpms.newest("kernel")
+    with pytest.raises(TypeError):
+        rpms.oldest("kernel")
 
 
 def test_rpm_manifest():


### PR DESCRIPTION
- This MR is trying to fix #2651 
- The spec "installed_rpms" sometimes collects nothing but the following
  kind of error messages only:
    error: db5 error(-30973) from dbenv->failchk: BDB0087 DB_RUNRECOVERY: Fatal error, run database recovery
    error: cannot open Packages database in /var/lib/rpm
- Add docstring to remind the user when doing exclusion checking, check if the `packages` is empty at first.

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>