### PR TITLE
Enhance parser yum_log to handle erased package with version

### DIFF
--- a/insights/parsers/tests/test_yumlog.py
+++ b/insights/parsers/tests/test_yumlog.py
@@ -15,6 +15,17 @@ May 23 16:09:09 Erased: katello-agent
 Jan 24 00:24:11 Updated: glibc-devel-2.12-1.149.el6_6.4.i686
 """.strip()
 
+OKAY2 = """
+May 19 23:29:12 Installed: cyrus-sasl-md5-2.1.26-23.el7.x86_64
+May 19 23:29:14 Installed: 389-ds-base-1.3.8.4-23.el7_6.x86_64
+Jul 21 09:09:39 Updated: httpd-tools-2.4.6-93.el7.x86_64
+Jul 21 09:09:39 Installed: mailcap-2.1.41-2.el7.noarch
+Jul 26 23:24:36 Erased: systemd-219-46.el7.x86_64
+Jul 28 23:24:36 Erased: systemd-219-67.el7.x86_64
+Jul 21 09:09:40 Installed: httpd-2.4.6-93.el7.x86_64
+Jul 20 09:09:40 Installed: httpd-2.4.6-97.el7.x86_64
+""".strip()
+
 ERROR = """
 May 23 18:06:24 Installed: wget-1.14-10.el7_0.1.x86_64
 Jan 24 00:24:00 Updated: glibc-2.12-1.149.el6_6.4.x86_64
@@ -79,3 +90,6 @@ def test_erased():
     yl = YumLog(context_wrap(OKAY))
     assert any(e.pkg.name == "redhat-access-insights-batch" for e in yl) is True
     assert any(e.pkg.name == "katello-agent" for e in yl) is True
+
+    yl2 = YumLog(context_wrap(OKAY2))
+    assert any(e.pkg.name == "systemd" for e in yl2) is True

--- a/insights/parsers/yumlog.py
+++ b/insights/parsers/yumlog.py
@@ -117,7 +117,7 @@ class YumLog(Parser):
                 timestamp = ' '.join([month, day, time])
                 state = state.rstrip(':')
                 pkg = pkg.split(':')[-1].strip()
-                if state == self.ERASED:
+                if state == self.ERASED and len(pkg.split(".")) == 1:
                     pkg = InstalledRpm({'name': pkg})
                 else:
                     pkg = InstalledRpm.from_package(pkg)

--- a/insights/parsers/yumlog.py
+++ b/insights/parsers/yumlog.py
@@ -117,7 +117,7 @@ class YumLog(Parser):
                 timestamp = ' '.join([month, day, time])
                 state = state.rstrip(':')
                 pkg = pkg.split(':')[-1].strip()
-                if state == self.ERASED and len(pkg.split(".")) == 1:
+                if state == self.ERASED and "." not in pkg:
                     pkg = InstalledRpm({'name': pkg})
                 else:
                     pkg = InstalledRpm.from_package(pkg)


### PR DESCRIPTION
In the former yum_log version, there is no version in erased packages, like:

~~~
May 23 16:09:09 Erased: redhat-access-insights-batch
~~~ 

So the code handle this situation with following code:

~~~
 if state == self.ERASED:
    pkg = InstalledRpm({'name': pkg})
else:
    pkg = InstalledRpm.from_package(pkg)
~~~

However, in new yum.log version, there is version in erased packages, like:

~~~
Jul 28 23:24:36 Erased: systemd-219-67.el7.x86_64
~~~

So it is necessary to handle change like:

~~~
 if state == self.ERASED and "." not in pkg:
    pkg = InstalledRpm({'name': pkg})
else:
    pkg = InstalledRpm.from_package(pkg)
~~~