### PR TITLE
client: write lastupload during platform upload

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -363,6 +363,7 @@ def upload(config, pconn, tar_file, content_type, collection_duration=None):
         upload = pconn.upload_archive(tar_file, content_type, collection_duration)
 
         if upload.status_code in (200, 202):
+            write_to_disk(constants.lastupload_file)
             msg_name = determine_hostname(config.display_name)
             logger.info("Successfully uploaded report for %s.", msg_name)
             if config.register:


### PR DESCRIPTION
Write the `/etc/insights-client/.lastupload` file during platform upload too.

Fixes: RHCLOUD-8339