### PR TITLE
Added spec for subscription_manager_id sos_archive.py

### DIFF
--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -220,6 +220,7 @@ class SosSpecs(Specs):
     sssd_logs = glob_file("var/log/sssd/*.log")
     samba_logs = glob_file("var/log/samba/log.*")
     ssh_foreman_config = simple_file("/usr/share/foreman/.ssh/ssh_config")
+    subscription_manager_id = simple_file("/sos_commands/subscription_manager/subscription-manager_identity")
     subscription_manager_list_consumed = first_file([
         'sos_commands/yum/subscription-manager_list_--consumed',
         'sos_commands/subscription_manager/subscription-manager_list_--consumed',


### PR DESCRIPTION
The Spec for subscription_manager_id added in sos_archive.py to parse the associated file:
- sos_commands/subscription_manager/subscription-manager_identity.

Signed-off-by: Akshay Ghodake <aghodake@redhat.com>