### PR TITLE
Fixed the pattern for ssh_config_d

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -598,7 +598,7 @@ class DefaultSpecs(Specs):
     software_collections_list = simple_command('/usr/bin/scl --list')
     ss = simple_command("/usr/sbin/ss -tupna")
     ssh_config = simple_file("/etc/ssh/ssh_config")
-    ssh_config_d = glob_file(r"/etc/ssh/ssh_config.d/*")
+    ssh_config_d = glob_file(r"/etc/ssh/ssh_config.d/*.conf")
     ssh_foreman_proxy_config = simple_file("/usr/share/foreman-proxy/.ssh/ssh_config")
     sshd_config = simple_file("/etc/ssh/sshd_config")
     sshd_config_perms = simple_command("/bin/ls -l /etc/ssh/sshd_config")


### PR DESCRIPTION
Updated the pattern for ssh_config_d
```
insights/specs/default.py
```

Signed-off-by: shlao <shlao@redhat.com>