### PR TITLE
Update the spec of DmsetupInfo

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -228,6 +228,7 @@ class DefaultSpecs(Specs):
     dmesg = simple_command("/bin/dmesg")
     dmesg_log = simple_file("/var/log/dmesg")
     dmidecode = simple_command("/usr/sbin/dmidecode")
+    dmsetup_info = simple_command("/usr/sbin/dmsetup info -C")
     dnf_conf = simple_file("/etc/dnf/dnf.conf")
     docker_info = simple_command("/usr/bin/docker info")
     docker_list_containers = simple_command("/usr/bin/docker ps --all --no-trunc")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -40,6 +40,7 @@ class InsightsArchiveSpecs(Specs):
     display_name = simple_file("display_name")
     dmesg = simple_file("insights_commands/dmesg")
     dmidecode = simple_file("insights_commands/dmidecode")
+    dmsetup_info = simple_file("insights_commands/dmsetup_info_-C")
     docker_info = simple_file("insights_commands/docker_info")
     docker_list_containers = simple_file("insights_commands/docker_ps_--all_--no-trunc")
     docker_list_images = simple_file("insights_commands/docker_images_--all_--no-trunc_--digests")

--- a/insights/tests/client/collection_rules/test_map_components.py
+++ b/insights/tests/client/collection_rules/test_map_components.py
@@ -52,7 +52,6 @@ def test_get_component_by_symbolic_name():
     #   Filter out the (B) specs with this list
     skipped_specs = [
         'ceph_osd_df',
-        'dmsetup_info',
         'du_dirs',
         'gluster_peer_status',
         'gluster_v_status',


### PR DESCRIPTION
There is a rule that needs the info from DmsetupInfo, so I create a new PR for this.

Updated
```
insights/specs/default.py
insights/specs/insights_archive.py
```
Signed-off-by: shlao <shlao@redhat.com>