### PR TITLE
Enhance that there are two or more values of the same key in a dictio…

### DIFF
--- a/insights/parsers/__init__.py
+++ b/insights/parsers/__init__.py
@@ -186,10 +186,9 @@ def split_kv_pairs(lines, comment_char="#", filter_string=None, split_on="=",
                 kv_pairs[k] = v
             else:
                 if k not in kv_pairs:
-                    kv_pairs[k] = v
+                    kv_pairs[k] = [v]
                 else:
                     _v = kv_pairs[k]
-                    _v = [_v] if not isinstance(_v, list) else _v
                     if v not in _v:
                         _v.append(v)
                         kv_pairs[k] = _v

--- a/insights/parsers/systemctl_show.py
+++ b/insights/parsers/systemctl_show.py
@@ -21,6 +21,10 @@ class SystemctlShowServiceAll(CommandParser, dict):
     Class for parsing ``systemctl show *.service`` command output.
     Empty properties are suppressed.
 
+    .. note::
+        If there are two or more lines that have the same key, then we store the
+        values in a list.
+
     Sample Input::
 
         Id=postfix.service
@@ -29,6 +33,8 @@ class SystemctlShowServiceAll(CommandParser, dict):
         LimitNOFILE=65536
         LimitMEMLOCK=
         LimitLOCKS=18446744073709551615
+        DummyKey1 = Value1
+        DummyKey1 = Value2
 
         Id=postgresql.service
         Names=postgresql.service
@@ -45,6 +51,7 @@ class SystemctlShowServiceAll(CommandParser, dict):
                 "LimitNOFILE"      : "65536",
                 "TimeoutStartUSec" : "1min 30s",
                 "LimitLOCKS"       : "18446744073709551615",
+                "DummyKey1"        : ["Value1", "Value2"]
             },
             "postgresql.service": {
                 "Id"               : "postgresql.service",
@@ -88,7 +95,7 @@ class SystemctlShowServiceAll(CommandParser, dict):
                 sidx = i + 1
         idx_list.append((sidx, len(content)))
         for s, e in idx_list:
-            data = split_kv_pairs(content[s:e], use_partition=False)
+            data = split_kv_pairs(content[s:e], use_partition=False, allow_duplicates=True)
             name = data.get('Names', data.get('Id'))
             if not name:
                 raise ParseException('"Names" or "Id" not found!')

--- a/insights/parsers/systemctl_show.py
+++ b/insights/parsers/systemctl_show.py
@@ -68,15 +68,15 @@ class SystemctlShowServiceAll(CommandParser, dict):
         >>> 'postfix.service' in systemctl_show_all
         True
         >>> systemctl_show_all['postfix.service']['Id']
-        'postfix.service'
+        ['postfix.service']
         >>> 'LimitMEMLOCK' in systemctl_show_all['postfix.service']
         False
         >>> systemctl_show_all['postfix.service']['LimitLOCKS']
-        '18446744073709551615'
+        ['18446744073709551615']
         >>> 'postgresql.service' in systemctl_show_all
         True
         >>> systemctl_show_all['postgresql.service']['LimitNICE']
-        '0'
+        ['0']
 
     Raises:
         SkipException: When nothing needs to parse
@@ -97,9 +97,10 @@ class SystemctlShowServiceAll(CommandParser, dict):
         for s, e in idx_list:
             data = split_kv_pairs(content[s:e], use_partition=False, allow_duplicates=True)
             name = data.get('Names', data.get('Id'))
-            if not name:
+            if not name or len(name) > 1:
                 raise ParseException('"Names" or "Id" not found!')
-            self[name] = dict((k, v) for k, v in data.items() if v)
+
+            self[name[0]] = dict((k, v) for k, v in data.items() if v[0])
 
         if len(self) == 0:
             raise SkipException
@@ -171,7 +172,7 @@ class SystemctlShowTarget(SystemctlShowServiceAll):
         >>> 'network.target' in systemctl_show_target
         True
         >>> systemctl_show_target.get('network.target').get('WantedBy', None)
-        'NetworkManager.service'
+        ['NetworkManager.service']
         >>> systemctl_show_target.get('network.target').get('RequiredBy', None)
 
     Raises:

--- a/insights/parsers/tests/test_parsers_module.py
+++ b/insights/parsers/tests/test_parsers_module.py
@@ -31,6 +31,16 @@ SPLIT_TEST_2 = """
   keyword3     @ Key with no separator
 """.strip()
 
+SPLIT_TEST_3 = """
+@ Comment line
+  keyword1: value1   @ Inline comments
+  keyword1: value2   @ Other line
+  keyword1: value2   @ Inline comments
+  keyword1: value3   @ Inline comments
+  keyword2 : value2a=True, value2b=100M
+""".strip()
+
+
 OFFSET_CONTENT_1 = """
   data 1 line
 data 2 line
@@ -96,6 +106,14 @@ def test_split_kv_pairs():
         'keyword1': 'value1',
         'keyword2': 'value2a=True, value2b=100M',
         'keyword3': ''
+    }
+
+    kv_pairs = split_kv_pairs(SPLIT_TEST_3.splitlines(), comment_char='@', split_on=':', use_partition=True)
+    assert len(kv_pairs) == 2
+    print(kv_pairs)
+    assert kv_pairs == {
+        'keyword1': ['value1', 'value2', 'value3'],
+        'keyword2': 'value2a=True, value2b=100M'
     }
 
 

--- a/insights/parsers/tests/test_parsers_module.py
+++ b/insights/parsers/tests/test_parsers_module.py
@@ -113,7 +113,7 @@ def test_split_kv_pairs():
     print(kv_pairs)
     assert kv_pairs == {
         'keyword1': ['value1', 'value2', 'value3'],
-        'keyword2': 'value2a=True, value2b=100M'
+        'keyword2': ['value2a=True, value2b=100M']
     }
 
 

--- a/insights/parsers/tests/test_parsers_module.py
+++ b/insights/parsers/tests/test_parsers_module.py
@@ -108,7 +108,7 @@ def test_split_kv_pairs():
         'keyword3': ''
     }
 
-    kv_pairs = split_kv_pairs(SPLIT_TEST_3.splitlines(), comment_char='@', split_on=':', use_partition=True)
+    kv_pairs = split_kv_pairs(SPLIT_TEST_3.splitlines(), comment_char='@', split_on=':', use_partition=True, allow_duplicates=True)
     assert len(kv_pairs) == 2
     print(kv_pairs)
     assert kv_pairs == {

--- a/insights/parsers/tests/test_systemctl_show.py
+++ b/insights/parsers/tests/test_systemctl_show.py
@@ -303,19 +303,19 @@ def test_systemctl_show_service_all():
 
     assert 'postfix.service' in svc_all
     assert 'LimitMEMLOCK' not in svc_all['postfix.service']
-    assert svc_all['postfix.service']["LimitNOFILE"] == "65536"
-    assert svc_all['postfix.service']["KillSignal"] == "15"
-    assert svc_all['postfix.service']["LimitLOCKS"] == "18446744073709551615"
+    assert svc_all['postfix.service']["LimitNOFILE"] == ["65536"]
+    assert svc_all['postfix.service']["KillSignal"] == ["15"]
+    assert svc_all['postfix.service']["LimitLOCKS"] == ["18446744073709551615"]
     assert len(svc_all['postfix.service']) == 10
 
     assert 'postgresql.service' in svc_all
-    assert svc_all['postgresql.service']["User"] == "postgres"
-    assert svc_all['postgresql.service']["ControlGroup"] == "/system.slice/postgresql.service"
+    assert svc_all['postgresql.service']["User"] == ["postgres"]
+    assert svc_all['postgresql.service']["ControlGroup"] == ["/system.slice/postgresql.service"]
     assert len(svc_all['postgresql.service']) == 28
 
     assert 'tuned.service' in svc_all
-    assert svc_all['tuned.service']["Id"] == "tuned.service"
-    assert svc_all['tuned.service']["Transient"] == "no"
+    assert svc_all['tuned.service']["Id"] == ["tuned.service"]
+    assert svc_all['tuned.service']["Transient"] == ["no"]
     assert "ABC" not in svc_all['tuned.service']
     assert len(svc_all['tuned.service']) == 44
 
@@ -323,7 +323,7 @@ def test_systemctl_show_service_all():
 def test_systemctl_show_target():
     data = SystemctlShowTarget(context_wrap(SYSTEMCTL_SHOW_TARGET))
     assert 'network.target' in data
-    assert data.get('network.target').get('WantedBy', None) == 'NetworkManager.service'
+    assert data.get('network.target').get('WantedBy', None) == ['NetworkManager.service']
     assert data.get('network.target').get('RequiredBy', None) is None
 
 


### PR DESCRIPTION
Updated
```
insights/parsers/__init__.py
```

Here are the codes of parser SystemctlShowServiceAll:
```
 19 class SystemctlShowServiceAll(CommandParser, dict):
 79     def parse_content(self, content): 
 90         for s, e in idx_list:
 91             data = split_kv_pairs(content[s:e], use_partition=False)
 92             name = data.get('Names', data.get('Id'))
 93             if not name:
 94                 raise ParseException('"Names" or "Id" not found!')
 95             self[name] = dict((k, v) for k, v in data.items() if v)
```

Here are the testing data (on RHEL8):
```
# systemctl show sshd.service  > /tmp/sshd.txt
# cat /tmp/sshd.txt | grep Env
EnvironmentFiles=/etc/crypto-policies/back-ends/opensshserver.config (ignore_errors=yes)
EnvironmentFiles=/etc/sysconfig/sshd (ignore_errors=yes)
```
the function split_kv_pairs will overwrite the dictionary value of the same key **_EnvironmentFiles_** and only save the last value.


Signed-off-by: shlao <shlao@redhat.com>