### PR TITLE
suppress help output for --check-results

### DIFF
--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -93,7 +93,7 @@ DEFAULT_OPTS = {
     'check_results': {
         'default': False,
         'opt': ['--check-results'],
-        'help': "Check for insights results",
+        'help': argparse.SUPPRESS,
         'action': "store_true",
         'group': 'actions'
     },


### PR DESCRIPTION
`--check-results` is not intended for general use, so we can suppress it from the `--help` output.