### PR TITLE
Parse foreman production log lines

### DIFF
--- a/insights/parsers/foreman_log.py
+++ b/insights/parsers/foreman_log.py
@@ -49,8 +49,24 @@ class SatelliteLog(LogFileOutput):
 
 @parser(Specs.foreman_production_log)
 class ProductionLog(LogFileOutput):
-    """Class for parsing ``foreman/production.log`` file."""
-    pass
+    """Class for parsing ``foreman/production.log`` file.
+
+    Each line is parsed into a dictionary with the following keys:
+
+        * raw_message (str) - complete log line
+        * message (str) - the body of the log
+        * timestamp (datetime) - date and time of log as datetime object
+    """
+    def _parse_line(self, line):
+        msg_info = {'raw_message': line}
+        line_split = line.split(None, 2)
+        if len(line_split) > 2:
+            try:
+                msg_info['timestamp'] = datetime.strptime(' '.join(line_split[:2]), self.time_format)
+                msg_info['message'] = line_split[2]
+            except ValueError:
+                pass
+        return msg_info
 
 
 @parser(Specs.candlepin_log)

--- a/insights/parsers/tests/test_foreman_log.py
+++ b/insights/parsers/tests/test_foreman_log.py
@@ -176,6 +176,10 @@ FOREMAN_SSL_ACCESS_SSL_LOG = """
 def test_production_log():
     fm_log = ProductionLog(context_wrap(PRODUCTION_LOG))
     assert 2 == len(fm_log.get("Rendered text template"))
+    line_dict = fm_log.get("Katello::Api::V2::RepositoriesController#sync_complete")[0]
+    assert line_dict["message"] == \
+        "[I] Processing by Katello::Api::V2::RepositoriesController#sync_complete as JSON"
+    assert line_dict["timestamp"] == datetime(2015, 11, 13, 3, 30, 7)
     assert "Expired 48 Reports" in fm_log
     assert fm_log.get("Completed 200 OK in 93")[0]['raw_message'] == \
         "2015-11-13 09:41:58 [I] Completed 200 OK in 93ms (Views: 2.9ms | ActiveRecord: 0.3ms)"


### PR DESCRIPTION
Fix issue #2729

Parse each log line into raw_message, message, timestamp for ease of use.
