### PR TITLE
Reverse context definition order. Add core3_archive spec file.

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -137,6 +137,7 @@ def _run(broker, graph=None, root=None, context=None, inventory=None):
 def load_default_plugins():
     dr.load_components("insights.specs.default")
     dr.load_components("insights.specs.insights_archive")
+    dr.load_components("insights.specs.core3_archive")
     dr.load_components("insights.specs.sos_archive")
     dr.load_components("insights.specs.jdr_archive")
 

--- a/insights/core/context.py
+++ b/insights/core/context.py
@@ -136,6 +136,8 @@ class ExecutionContextMeta(type):
             return
         ExecutionContextMeta.registry.append(cls)
 
+    # Remember that contexts are tried *in reverse order* so that they
+    # may be overridden by just loading a plugin.
     @classmethod
     def identify(cls, files):
         for e in reversed(cls.registry):
@@ -214,13 +216,13 @@ class HostContext(ExecutionContext):
 
 
 @fs_root
-class SerializedArchiveContext(ExecutionContext):
-    marker = "insights_archive.txt"
+class HostArchiveContext(ExecutionContext):
+    marker = "insights_commands"
 
 
 @fs_root
-class HostArchiveContext(ExecutionContext):
-    marker = "insights_commands"
+class SerializedArchiveContext(ExecutionContext):
+    marker = "insights_archive.txt"
 
 
 @fs_root

--- a/insights/shell.py
+++ b/insights/shell.py
@@ -17,6 +17,8 @@ import IPython
 from pygments.console import ansiformat
 from traitlets.config.loader import Config
 
+from insights.core.context import SerializedArchiveContext
+from insights.core.serde import Hydration
 from insights.parsr.query import *  # noqa
 from insights.parsr.query import eq, matches, make_child_query as q  # noqa
 from insights.parsr.query.boolean import FALSE, TRUE
@@ -58,6 +60,10 @@ def _create_new_broker(path=None):
     def make_broker(ctx):
         broker = dr.Broker()
         broker[ctx.__class__] = ctx
+
+        if isinstance(ctx, SerializedArchiveContext):
+            h = Hydration(ctx.root)
+            broker = h.hydrate(broker=broker)
 
         dr.run(datasources, broker=broker)
 

--- a/insights/specs/core3_archive.py
+++ b/insights/specs/core3_archive.py
@@ -1,0 +1,16 @@
+"""
+This file holds specs that are in the new core3 archives but that don't have an entry
+in the meta_data directory. This happens when the client itself collects the data
+and puts it into the archive.
+"""
+from functools import partial
+
+from insights.core.context import SerializedArchiveContext
+from insights.specs import Specs
+from insights.core.spec_factory import simple_file
+
+simple_file = partial(simple_file, context=SerializedArchiveContext)
+
+
+class Core3Specs(Specs):
+    branch_info = simple_file("/branch_info")


### PR DESCRIPTION
Core3 archives were being processed as regular archives because the context
detection tested contexts in reverse order of their definition, and
`HostArchiveContext` was defined after `SerializedArchiveContext` (core3 archive).

In other words, `HostArchiveContext` would always win and treat $ROOT/data as
the archive root. This PR reverses the order and fixes that.

Regular specs wouldn't work for core3 archives, but the client puts some
critical files like satellite branch_info directly into the archive root, so
I've allowed regular specs to depend on and fire in the presence of
`SerializedArchiveContext`.

Fixes #2736 

Signed-off-by: Christopher Sams <csams@redhat.com>