### PR TITLE
Use builtins.open in python 3.

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -245,8 +245,12 @@ class TextFileProvider(FileProvider):
             rc, out = self.ctx.shell_out(args, keep_rc=True, env=SAFE_ENV)
             self.rc = rc
             return out
-        with codecs.open(self.path, "r", encoding="utf-8", errors="surrogateescape") as f:
-            return [l.rstrip("\n") for l in f]
+        if six.PY3:
+            with open(self.path, "r", encoding="utf-8", errors="surrogateescape") as f:
+                return [l.rstrip("\n") for l in f]
+        else:
+            with codecs.open(self.path, "r", encoding="utf-8", errors="surrogateescape") as f:
+                return [l.rstrip("\n") for l in f]
 
     def _stream(self):
         """
@@ -263,8 +267,12 @@ class TextFileProvider(FileProvider):
                     with streams.connect(*args, env=SAFE_ENV) as s:
                         yield s
                 else:
-                    with codecs.open(self.path, "r", encoding="utf-8", errors="surrogateescape") as f:
-                        yield f
+                    if six.PY3:
+                        with open(self.path, "r", encoding="utf-8", errors="surrogateescape") as f:
+                            yield f
+                    else:
+                        with codecs.open(self.path, "r", encoding="utf-8", errors="surrogateescape") as f:
+                            yield f
         except StopIteration:
             raise
         except Exception as ex:


### PR DESCRIPTION
We used codecs.open for py2 compat, and it's an order of magnitude slower decoding unicode than vanilla open in py3. Use six to be smarter.

Signed-off-by: Christopher Sams <csams@redhat.com>