### PR TITLE
Remove blank lines for parse_fixed_table

### DIFF
--- a/insights/parsers/__init__.py
+++ b/insights/parsers/__init__.py
@@ -289,8 +289,9 @@ def parse_fixed_table(table_lines,
     data in fixed positions in each remaining row of table data.
     Table columns must not contain spaces within the column name.  Column headings
     are assumed to be left justified and the column data width is the width of the
-    heading label plus all whitespace to the right of the label.  This function
-    will handle blank columns.
+    heading label plus all whitespace to the right of the label. This function will
+    remove all blank rows in data but it will handle blank columns if some of the
+    columns aren't empty.
 
     Arguments:
         table_lines (list): List of strings with the first line containing column
@@ -330,6 +331,7 @@ def parse_fixed_table(table_lines,
         [{'Column1': 'data1', 'Column2': 'data 2', 'Column3': 'data   3'},
          {'Column1': 'data4', 'Column2': 'data5', 'Column3': 'data6'}]
     """
+
     def calc_column_indices(line, headers):
         idx = []
         for h in headers:
@@ -355,13 +357,14 @@ def parse_fixed_table(table_lines,
 
     table_data = []
     for line in table_lines[first_line + 1:last_line]:
-        col_data = {}
-        for i, (s, e) in enumerate(idx_pairs):
-            val = line[s:e].strip()
-            if empty_exception and not val:
-                raise ParseException('Incorrect line: \'{0}\''.format(line))
-            col_data[col_headers[i]] = val
-        table_data.append(col_data)
+        if line.strip():
+            col_data = {}
+            for i, (s, e) in enumerate(idx_pairs):
+                val = line[s:e].strip()
+                if empty_exception and not val:
+                    raise ParseException('Incorrect line: \'{0}\''.format(line))
+                col_data[col_headers[i]] = val
+            table_data.append(col_data)
 
     return table_data
 

--- a/insights/parsers/tests/test_parsers_module.py
+++ b/insights/parsers/tests/test_parsers_module.py
@@ -224,6 +224,16 @@ Trailing non-data line
  Another trailing non-data line
 """.strip()
 
+FIXED_CONTENT_5 = """
+Column1    Column 2    Column 3
+
+data1      data 2      data   3
+
+data       7             data   9
+
+data10
+""".strip()
+
 
 FIXED_CONTENT_DUP_HEADER_PREFIXES = """
 NAMESPACE    NAME    LABELS
@@ -288,6 +298,8 @@ def test_parse_fixed_table():
 
     data = parse_fixed_table(FIXED_CONTENT_DUP_HEADER_PREFIXES.splitlines())
     assert data[0] == {'NAMESPACE': 'default', 'NAME': 'foo', 'LABELS': 'app=superawesome'}
+    data = parse_fixed_table(FIXED_CONTENT_5.splitlines())
+    assert len(data) == 3
 
 
 def test_parse_fixed_table_empty_exception():


### PR DESCRIPTION
* If we keep blank lines, it will generate a dict with empty values,
* which is useless.

Signed-off-by: Huanhuan Li <huali@redhat.com>