### PR TITLE
The http_conf Name definition is too strict.

### DIFF
--- a/insights/combiners/httpd_conf.py
+++ b/insights/combiners/httpd_conf.py
@@ -275,7 +275,10 @@ class DocParser(object):
         Complex = Forward()
         Comment = (WS >> OneLineComment("#")).map(lambda x: None)
 
-        Name = String(string.ascii_letters + "_/")
+        First = InSet(string.ascii_letters + "_/")
+        Rest = String(string.ascii_letters + "_/" + string.digits)
+        Name = (First + Rest).map("".join)
+
         Num = Number & (WSChar | LineEnd)
 
         StartName = WS >> PosMarker(StartTagName(Letters)) << WS

--- a/insights/combiners/tests/test_httpd_conf_tree.py
+++ b/insights/combiners/tests/test_httpd_conf_tree.py
@@ -5,6 +5,10 @@ from insights.tests import context_wrap
 from insights.parsers import SkipException
 import pytest
 
+HTTPD_CONF_MIXED_NAME = '''
+H2Push on
+'''
+
 
 HTTPD_CONF_MIXED = '''
 JustFotTest_NoSec "/var/www/cgi"
@@ -785,3 +789,9 @@ def test_recursive_includes():
         httpd1 = _HttpdConf(context_wrap(MULTIPLE_INCLUDES, path='/etc/httpd/conf/httpd.conf'))
         httpd2 = _HttpdConf(context_wrap(MULTIPLE_INCLUDES, path='/etc/httpd/conf.d/05-foreman.d/hello.conf'))
         HttpdConfTree([httpd1, httpd2])
+
+
+def test_mixed_name():
+    httpd1 = _HttpdConf(context_wrap(HTTPD_CONF_MIXED_NAME, path='/etc/httpd/conf/httpd.conf'))
+    result = HttpdConfTree([httpd1])
+    assert len(result.doc["H2Push"]) == 1


### PR DESCRIPTION
Allow digits after the first character in directive names. This allows directives like `H2Push`.

Fixes #2748

Signed-off-by: Christopher Sams <csams@redhat.com>