### PR TITLE
Remove the semicolon from query statement

### DIFF
--- a/insights/parsers/engine_db_query.py
+++ b/insights/parsers/engine_db_query.py
@@ -5,6 +5,7 @@ EngineDBQuery - command ``engine-db-query --statement "<DB_QUERY>" --json``
 Parses the output of the command `engine-db-query` returned in JSON format.
 """
 from insights.core import CommandParser, JSONParser
+from insights.parsers import SkipException
 from insights.core.plugins import parser
 from insights.specs import Specs
 
@@ -14,7 +15,7 @@ class EngineDBQueryVDSMversion(CommandParser, JSONParser):
     """
     Get the hostname & vdsm package version along with host info.
 
-    Class for parsing the output of the command - ``engine-db-query --statement "SELECT vs.vds_name, rpm_version FROM vds_dynamic vd, vds_static vs WHERE vd.vds_id = vs.vds_id;" --json``.
+    Class for parsing the output of the command - ``engine-db-query --statement "SELECT vs.vds_name, rpm_version FROM vds_dynamic vd, vds_static vs WHERE vd.vds_id = vs.vds_id" --json``.
 
     Attributes:
         data (dict): Host info.
@@ -44,6 +45,12 @@ class EngineDBQueryVDSMversion(CommandParser, JSONParser):
         >>> output.result == [{'vds_name': 'hosto', 'rpm_version': 'vdsm-4.30.40-1.el7ev'}]
         True
     """
+    def parse_content(self, content):
+        if not content:
+            raise SkipException("Empty output.")
+
+        super(EngineDBQueryVDSMversion, self).parse_content(content)
+
     @property
     def result(self):
         """Get the value of 'result'."""

--- a/insights/parsers/tests/test_engine_db_query.py
+++ b/insights/parsers/tests/test_engine_db_query.py
@@ -1,5 +1,6 @@
 import doctest
-from insights.parsers import engine_db_query
+import pytest
+from insights.parsers import engine_db_query, ParseException, SkipException
 from insights.tests import context_wrap
 
 
@@ -53,6 +54,32 @@ OUTPUT_2 = """
 }
 """.strip()
 
+ERROR = """
+
+            SELECT
+                row_to_json(t)
+            FROM
+               (SELECT vs.vds_name, rpm_version FROM vds_dynamic vd, vds_static vs WHERE vd.vds_id = vs.vds_id;) t
+
+Traceback (most recent call last):
+  File "/usr/lib/python2.7/site-packages/engine_db_query/__init__.py", line 337, in query_return_json
+    query
+SyntaxError: syntax error at or near ";"
+LINE 5: ...ds_dynamic vd, vds_static vs WHERE vd.vds_id = vs.vds_id;) t
+                                                                   ^
+
+Traceback (most recent call last):
+  File "/usr/bin/engine-db-query", line 281, in <module>
+    sys.exit(main())
+  File "/usr/bin/engine-db-query", line 273, in main
+    knowledge_base=args.kb_url
+  File "/usr/lib/python2.7/site-packages/engine_db_query/__init__.py", line 213, in execute
+    knowledge_base=knowledge_base
+  File "/usr/lib/python2.7/site-packages/engine_db_query/__init__.py", line 348, in query_return_json
+    ret = cursor.fetchall()
+psycopg2.ProgrammingError: no results to fetch
+""".strip()
+
 
 def test_edbq():
     output = engine_db_query.EngineDBQueryVDSMversion(context_wrap(OUTPUT))
@@ -62,6 +89,16 @@ def test_edbq():
     # for multiple hosts
     output = engine_db_query.EngineDBQueryVDSMversion(context_wrap(OUTPUT_2))
     assert output.result == [{'vds_name': 'hosto', 'rpm_version': 'vdsm-4.40.20-33.git1b7dedcf3.fc30'}, {'vds_name': 'hosto2', 'rpm_version': 'vdsm-4.40.13-38.gite9bae3c68.fc30'}]
+
+    # No content
+    with pytest.raises(SkipException) as e:
+        engine_db_query.EngineDBQueryVDSMversion(context_wrap(""))
+    assert "Empty output." in str(e)
+
+    # Error
+    with pytest.raises(ParseException) as e:
+        engine_db_query.EngineDBQueryVDSMversion(context_wrap(ERROR))
+    assert "couldn't parse json." in str(e)
 
 
 def test_doc_examples():

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -238,7 +238,7 @@ class DefaultSpecs(Specs):
     docker_storage_setup = simple_file("/etc/sysconfig/docker-storage-setup")
     docker_sysconfig = simple_file("/etc/sysconfig/docker")
     dracut_kdump_capture_service = simple_file("/usr/lib/dracut/modules.d/99kdumpbase/kdump-capture.service")
-    engine_db_query_vdsm_version = simple_command('engine-db-query --statement "SELECT vs.vds_name, rpm_version FROM vds_dynamic vd, vds_static vs WHERE vd.vds_id = vs.vds_id;" --json')
+    engine_db_query_vdsm_version = simple_command('engine-db-query --statement "SELECT vs.vds_name, rpm_version FROM vds_dynamic vd, vds_static vs WHERE vd.vds_id = vs.vds_id" --json')
     engine_log = simple_file("/var/log/ovirt-engine/engine.log")
     etc_journald_conf = simple_file(r"etc/systemd/journald.conf")
     etc_journald_conf_d = glob_file(r"etc/systemd/journald.conf.d/*.conf")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -45,7 +45,7 @@ class InsightsArchiveSpecs(Specs):
     docker_info = simple_file("insights_commands/docker_info")
     docker_list_containers = simple_file("insights_commands/docker_ps_--all_--no-trunc")
     docker_list_images = simple_file("insights_commands/docker_images_--all_--no-trunc_--digests")
-    engine_db_query_vdsm_version = simple_file("insights_commands/engine-db-query_-s_SELECT_vs.vds_name_rpm_version_FROM_vds_dynamic_vd_vds_static_vs_WHERE_vd.vds_id_vs.vds_id_--json")
+    engine_db_query_vdsm_version = simple_file("insights_commands/engine-db-query_--statement_SELECT_vs.vds_name_rpm_version_FROM_vds_dynamic_vd_vds_static_vs_WHERE_vd.vds_id_vs.vds_id_--json")
     ethtool = glob_file("insights_commands/ethtool_*", ignore="ethtool_-.*")
     ethtool_S = glob_file("insights_commands/ethtool_-S_*")
     ethtool_T = glob_file("insights_commands/ethtool_-T_*")


### PR DESCRIPTION
Two major changes
-----------------

1. Remove the ";" from DB query statement:

ON RHV Manager the statement ending with ";" failed with below error

```

            SELECT
                row_to_json(t)
            FROM
               (SELECT vs.vds_name, rpm_version FROM vds_dynamic vd, vds_static vs WHERE vd.vds_id = vs.vds_id;) t

Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/engine_db_query/__init__.py", line 337, in query_return_json
    query
SyntaxError: syntax error at or near ";"
LINE 5: ...ds_dynamic vd, vds_static vs WHERE vd.vds_id = vs.vds_id;) t
                                                                   ^

Traceback (most recent call last):
  File "/usr/bin/engine-db-query", line 281, in <module>
    sys.exit(main())
  File "/usr/bin/engine-db-query", line 273, in main
    knowledge_base=args.kb_url
  File "/usr/lib/python2.7/site-packages/engine_db_query/__init__.py", line 213, in execute
    knowledge_base=knowledge_base
  File "/usr/lib/python2.7/site-packages/engine_db_query/__init__.py", line 348, in query_return_json
    ret = cursor.fetchall()
psycopg2.ProgrammingError: no results to fetch
```

After removing the ";", we get the expectec output,

```
{ "id_host": "None","when": "2020-09-07 14:44:21","time": "0.00279307365417", "name": "None", "description": "None", "type": "None", "kb": "None", "bugzilla": "None", "file": "", "path": "None", "id": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "hash": "d41d8cd98f00b204e9800998ecf8427e", "result": [[{"vds_name": "hosto", "rpm_version": "vdsm-4.30.40-1.el7ev"}]]}
```

2. Fixed data collection file name:

The rule failed with below error,

```
insights.core.plugins.ContentException: /home/psachin/insights-vm-9-32.example.com-20200826174644/insights_commands/engine-db-query_-s_SELECT_vs.vds_name_rpm_version_FROM_vds_dynamic_vd_vds_static_vs_WHERE_vd.vds_id_vs.vds_id_--json does not exist.
```

Signed-off-by: Sachin Patil <psachin@redhat.com>