### PR TITLE
new spec ls_edac_mc

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -381,10 +381,10 @@ class DefaultSpecs(Specs):
     ls_boot = simple_command("/bin/ls -lanR /boot")
     ls_dev = simple_command("/bin/ls -lanR /dev")
     ls_disk = simple_command("/bin/ls -lanR /dev/disk")
+    ls_edac_mc = simple_command("/bin/ls -lan /sys/devices/system/edac/mc")
     etc_and_sub_dirs = sorted(["/etc", "/etc/pki/tls/private", "/etc/pki/tls/certs",
         "/etc/pki/ovirt-vmconsole", "/etc/nova/migration", "/etc/sysconfig",
         "/etc/cloud/cloud.cfg.d", "/etc/rc.d/init.d"])
-    ls_edac_mc = simple_command("/bin/ls -lan /sys/devices/system/edac/mc")
     ls_etc = simple_command("/bin/ls -lan {0}".format(' '.join(etc_and_sub_dirs)))
     ls_lib_firmware = simple_command("/bin/ls -lanR /lib/firmware")
     ls_ocp_cni_openshift_sdn = simple_command("/bin/ls -l /var/lib/cni/networks/openshift-sdn")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -384,6 +384,7 @@ class DefaultSpecs(Specs):
     etc_and_sub_dirs = sorted(["/etc", "/etc/pki/tls/private", "/etc/pki/tls/certs",
         "/etc/pki/ovirt-vmconsole", "/etc/nova/migration", "/etc/sysconfig",
         "/etc/cloud/cloud.cfg.d", "/etc/rc.d/init.d"])
+    ls_edac_mc = simple_command("/bin/ls -lan /sys/devices/system/edac/mc")
     ls_etc = simple_command("/bin/ls -lan {0}".format(' '.join(etc_and_sub_dirs)))
     ls_lib_firmware = simple_command("/bin/ls -lanR /lib/firmware")
     ls_ocp_cni_openshift_sdn = simple_command("/bin/ls -l /var/lib/cni/networks/openshift-sdn")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -96,6 +96,7 @@ class InsightsArchiveSpecs(Specs):
     ls_boot = simple_file("insights_commands/ls_-lanR_.boot")
     ls_dev = simple_file("insights_commands/ls_-lanR_.dev")
     ls_disk = simple_file("insights_commands/ls_-lanR_.dev.disk")
+    ls_edac_mc = simple_file("insights_commands/ls_-lan_.sys.devices.system.edac.mc")
     ls_etc = simple_file("insights_commands/ls_-lan_.etc_.etc.cloud.cloud.cfg.d_.etc.nova.migration_.etc.pki.ovirt-vmconsole_.etc.pki.tls.certs_.etc.pki.tls.private_.etc.rc.d.init.d_.etc.sysconfig")
     ls_lib_firmware = simple_file("insights_commands/ls_-lanR_.lib.firmware")
     ls_ocp_cni_openshift_sdn = simple_file("insights_commands/ls_-l_.var.lib.cni.networks.openshift-sdn")

--- a/insights/tests/client/collection_rules/test_map_components.py
+++ b/insights/tests/client/collection_rules/test_map_components.py
@@ -57,7 +57,6 @@ def test_get_component_by_symbolic_name():
         'gluster_v_status',
         'heat_crontab',
         'httpd_on_nfs',
-        'ls_edac_mc',
         'ls_usr_sbin',
         'lvmconfig',
         'saphostexec_status',


### PR DESCRIPTION
This spec is needed for rule development which is used by ls_edac_mc parser, this spec was removed sometime back as no rule was using this spec.

Signed-off-by: rasrivas <rasrivas@redhat.com>
