### PR TITLE
Catch when grep produces "Not a directory" on failure.

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -527,6 +527,7 @@ class CommandParser(Parser):
 
     __bad_single_lines = [
             "no such file or directory",
+            "not a directory",
             "command not found",
             "no module named",
             "no files found for",

--- a/insights/tests/test_commandparser.py
+++ b/insights/tests/test_commandparser.py
@@ -6,6 +6,7 @@ import pytest
 CMF = "blah: Command not found"
 NO_FILES_FOUND = "No files found for docker.service"
 NO_SUCH_FILE = "/usr/bin/blah: No such file or directory"
+NOT_A_DIRECTORY = "/etc/mail/spamassassin/channel.d: Not a directory"
 MULTI_LINE = """
 blah: Command not found
 /usr/bin/blah: No such file or directory
@@ -39,6 +40,12 @@ def test_no_such_file_or_directory():
     with pytest.raises(ContentException) as e:
         MockParser(context_wrap(NO_SUCH_FILE))
     assert "No such file or directory" in str(e.value)
+
+
+def test_not_a_directory():
+    with pytest.raises(ContentException) as e:
+        MockParser(context_wrap(NOT_A_DIRECTORY))
+    assert "Not a directory" in str(e.value)
 
 
 def test_multi_line():


### PR DESCRIPTION
The CommandParser now watches for "not a directory" to catchcommand failures.

Fixes #2753

Signed-off-by: Christopher Sams <csams@redhat.com>