### PR TITLE
Ensure evaluators are populated with system_id and branch_info.

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -34,13 +34,12 @@ from .core.archives import COMPRESSION_TYPES, extract, InvalidArchive, InvalidCo
 from .core import dr  # noqa: F401
 from .core.context import ClusterArchiveContext, HostContext, HostArchiveContext, SerializedArchiveContext, ExecutionContext  # noqa: F401
 from .core.dr import SkipComponent  # noqa: F401
-from .core.hydration import create_context
+from .core.hydration import create_context, initialize_broker  # noqa: F401
 from .core.plugins import combiner, fact, metadata, parser, rule  # noqa: F401
 from .core.plugins import datasource, condition, incident  # noqa: F401
 from .core.plugins import make_response, make_metadata, make_fingerprint  # noqa: F401
 from .core.plugins import make_pass, make_fail, make_info  # noqa: F401
 from .core.filters import add_filter, apply_filters, get_filters  # noqa: F401
-from .core.serde import Hydration
 from .formats import get_formatter
 from .parsers import get_active_lines  # noqa: F401
 from .util import defaults  # noqa: F401
@@ -85,7 +84,7 @@ add_status(package_info["NAME"], get_nvr(), package_info["COMMIT"])
 
 
 def process_dir(broker, root, graph, context, inventory=None):
-    ctx = create_context(root, context)
+    ctx, broker = initialize_broker(root, context=context, broker=broker)
     log.debug("Processing %s with %s" % (root, ctx))
 
     if isinstance(ctx, ClusterArchiveContext):
@@ -93,10 +92,6 @@ def process_dir(broker, root, graph, context, inventory=None):
         archives = [f for f in ctx.all_files if f.endswith(COMPRESSION_TYPES)]
         return process_cluster(graph, archives, broker=broker, inventory=inventory)
 
-    broker[ctx.__class__] = ctx
-    if isinstance(ctx, SerializedArchiveContext):
-        h = Hydration(ctx.root)
-        broker = h.hydrate(broker=broker)
     graph = dict((k, v) for k, v in graph.items() if k in dr.COMPONENTS[dr.GROUPS.single])
     broker = dr.run(graph, broker=broker)
     return broker

--- a/insights/core/evaluators.py
+++ b/insights/core/evaluators.py
@@ -151,14 +151,14 @@ class InsightsEvaluator(SingleEvaluator):
 
     def observer(self, comp, broker):
         super(InsightsEvaluator, self).observer(comp, broker)
-        if comp is Specs.machine_id and comp in broker:
+        if self.system_id is None and Specs.machine_id in broker:
             self.system_id = broker[Specs.machine_id].content[0].strip()
 
-        if comp is Specs.redhat_release and comp in broker:
-            self.release = broker[comp].content[0].strip()
+        if self.release is None and Specs.redhat_release in broker:
+            self.release = broker[Specs.redhat_release].content[0].strip()
 
-        if comp is BranchInfo and BranchInfo in broker:
-            self.branch_info = broker[comp].data
+        if not self.branch_info and BranchInfo in broker:
+            self.branch_info = broker[BranchInfo].data
 
         if comp is Specs.metadata_json and comp in broker:
             md = broker[comp]

--- a/insights/formats/__init__.py
+++ b/insights/formats/__init__.py
@@ -89,7 +89,7 @@ class EvaluatorFormatterAdapter(FormatterAdapter):
 
     def __init__(self, args=None):
         if args:
-            hn = "insights.combiners.hostname"
+            hn = "insights.combiners.hostname, insights.parsers.branch_info"
             args.plugins = ",".join([args.plugins, hn]) if args.plugins else hn
             if args.fail_only:
                 print('Options conflict: -f and -F, drops -F', file=sys.stderr)

--- a/insights/formats/_json.py
+++ b/insights/formats/_json.py
@@ -1,10 +1,10 @@
 import json
 
-from insights.core.evaluators import SingleEvaluator
+from insights.core.evaluators import SingleEvaluator as Evaluator
 from insights.formats import EvaluatorFormatterAdapter
 
 
-class JsonFormat(SingleEvaluator):
+class JsonFormat(Evaluator):
     def postprocess(self):
         json.dump(self.get_response(), self.stream)
 


### PR DESCRIPTION
This PR also adds a procedure for initializing brokers from an archive whose type is automatically detected. This new API should be used by service wrappers.

Fixes #2756

Signed-off-by: Christopher Sams <csams@redhat.com>