### PR TITLE
[RHICOMPL-737] Fail gracefully for missing profiles

### DIFF
--- a/insights/client/apps/compliance/__init__.py
+++ b/insights/client/apps/compliance/__init__.py
@@ -92,7 +92,7 @@ class ComplianceClient:
         rc, grep = call(grepcmd, keep_rc=True)
         if rc:
             logger.error('XML profile file not found matching ref_id {0}\n{1}\n'.format(profile_ref_id, grep))
-            exit(constants.sig_kill_bad)
+            return None
         filenames = findall('/usr/share/xml/scap/.+xml', grep)
         if not filenames:
             logger.error('No XML profile files found matching ref_id {0}\n{1}\n'.format(profile_ref_id, ' '.join(filenames)))
@@ -107,6 +107,8 @@ class ComplianceClient:
         return command
 
     def run_scan(self, profile_ref_id, policy_xml, output_path, tailoring_file_path=None):
+        if policy_xml is None:
+            return
         logger.info('Running scan for {0}... this may take a while'.format(profile_ref_id))
         env = os.environ.copy()
         env.update({'TZ': 'UTC'})


### PR DESCRIPTION
Before, if a SCAP profile was missing on the client system, the
--compliance run would halt and inform the user, even if there were more
profiles assigned to the host that did exist. After this change, the
user still gets an error message for a missing profile, but other
existing profiles will still be scanned and uploaded as usual.

Here's what it looks like to the customer:

```
$ sudo insights-client --compliance
XML profile file not found matching ref_id xccdf_org.ssgproject.content_profile_rhelh-vpp-nonexistant


Running scan for xccdf_org.ssgproject.content_profile_hipaa... this may take a while
Uploading Insights data.
Successfully uploaded report for rhel7-insights-client.virbr0.akofink-desktop.
```

https://issues.redhat.com/browse/RHICOMPL-737

CC @gravitypriest @bastilian @vkrizan

Signed-off-by: Andrew Kofink <akofink@redhat.com>