### PR TITLE
Run an insights-client collection and upload as non-root

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -49,10 +49,11 @@ class InsightsClient(object):
                     sys.exit(constants.sig_kill_bad)
             # END hack. in the future, just set self.config=config
 
+        # initialize directories
+        _init_client_config_dirs()
         # setup_logging is True when called from phase, but not from wrapper.
         #  use this to do any common init (like auto_config)
         if setup_logging:
-            _init_client_config_dirs()
             self.set_up_logging()
             try_auto_configuration(self.config)
             self.initialize_tags()
@@ -709,3 +710,9 @@ def _init_client_config_dirs():
                 pass
             else:
                 raise e
+    # copy the default config file to the user's local dir if it doesn't exist
+    if not os.path.isfile(constants.default_conf_file):
+        try:
+            shutil.copyfile(constants._etc_config_file, constants.default_conf_file)
+        except OSError as e:
+            logger.error('Cannot initialize user\'s config file.')

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -699,9 +699,8 @@ def format_config(config):
 def _init_client_config_dirs():
     '''
     Initialize log and lib dirs
-    TODO: init non-root config dirs
     '''
-    for d in (constants.log_dir, constants.insights_core_lib_dir):
+    for d in (constants.log_dir, constants.insights_core_lib_dir, constants.default_conf_dir):
         try:
             os.makedirs(d)
         except OSError as e:

--- a/insights/client/auto_config.py
+++ b/insights/client/auto_config.py
@@ -245,6 +245,10 @@ def try_auto_configuration(config):
     Try to auto-configure if we are attached to a sat5/6
     """
     if config.auto_config and not config.offline:
+        # non-root can only use basic auth
+        if os.getuid() != 0:
+            logger.debug('Auto configuration is only possible as root.')
+            return
         if not _try_satellite6_configuration(config):
             _try_satellite5_configuration(config)
     if not config.legacy_upload and not re.match(r'(\w+\.)?cloud\.(\w+\.)?redhat\.com', config.base_url):

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -88,7 +88,7 @@ DEFAULT_OPTS = {
     },
     'cert_verify': {
         # non-CLI
-        'default': None,
+        'default': constants.legacy_ca_cert,
     },
     'check_results': {
         'default': False,

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -75,9 +75,7 @@ class InsightsConnection(object):
         self.cert_verify = self.config.cert_verify
         if self.cert_verify is None:
             # if self.config.legacy_upload:
-            self.cert_verify = os.path.join(
-                constants.default_conf_dir,
-                'cert-api.access.redhat.com.pem')
+            self.cert_verify = constants.legacy_ca_cert
             # else:
             # self.cert_verify = True
         else:

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -865,6 +865,7 @@ class InsightsConnection(object):
             c_facts = get_canonical_facts()
         except Exception as e:
             logger.debug('Error getting canonical facts: %s', e)
+        c_facts['insights_id'] = generate_machine_id()
         if self.config.display_name:
             # add display_name to canonical facts
             c_facts['display_name'] = self.config.display_name

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -672,6 +672,9 @@ class InsightsConnection(object):
             None    error connection or parsing response
         '''
         machine_id = generate_machine_id()
+        if not machine_id:
+            # nothing to find
+            return False
         try:
             # [circus music]
             if self.config.legacy_upload:
@@ -865,7 +868,13 @@ class InsightsConnection(object):
             c_facts = get_canonical_facts()
         except Exception as e:
             logger.debug('Error getting canonical facts: %s', e)
-        c_facts['insights_id'] = generate_machine_id()
+        insights_id = generate_machine_id()
+        if insights_id:
+            c_facts['insights_id'] = insights_id
+        else:
+            logger.warning('No machine-id was found.')
+            logger.warning('If an Advisor upload is performed without the machine-id file, this host will not be registered in the inventory.')
+            logger.warning('Run Insights Client as a superuser to generate a machine-id.')
         if self.config.display_name:
             # add display_name to canonical facts
             c_facts['display_name'] = self.config.display_name

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -3,6 +3,7 @@ import os
 # TODO: no bare excepts here
 # TODO: maybe call os.makedirs elsewhere
 # TODO: copy config file to local config dir if it doesn't exist and --conf is not specified
+# TODO: copy an existing machine-id file to local config dir
 
 _user_home = os.path.expanduser('~')
 _app_name = 'insights-client'

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -87,6 +87,7 @@ class InsightsConstants(object):
     default_egg_gpg_key = os.path.join(_etc_insights_client_dir, 'insights-core.gpg')
     legacy_ca_cert = os.path.join(_etc_insights_client_dir, 'cert-api.access.redhat.com.pem')
     machine_id_file = os.path.join(_etc_insights_client_dir, 'machine-id')
+    _etc_config_file = os.path.join(_etc_insights_client_dir, 'insights-client.conf')
 
     # read/write etc files
     default_conf_dir = _conf_dir()

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -1,9 +1,14 @@
 import os
 
+# TODO: no bare excepts here
+# TODO: maybe call os.makedirs elsewhere
+# TODO: copy config file to local config dir if it doesn't exist and --conf is not specified
+
 _user_home = os.path.expanduser('~')
 _app_name = 'insights-client'
 _uid = os.getuid()
 _user_cache = os.getenv('XDG_CACHE_HOME', default=os.path.join(_user_home, '.cache'))
+_etc_insights_client_dir = os.path.join(os.sep, 'etc', 'insights-client')
 
 
 def _log_dir():
@@ -34,6 +39,35 @@ def _lib_dir():
     return insights_lib_dir
 
 
+def _conf_dir():
+    if _uid == 0:
+        return os.getenv('INSIGHTS_CONF_DIR', default=_etc_insights_client_dir)
+    else:
+        local_conf_dir = os.getenv('XDG_CONFIG_HOME', default=os.path.join(_user_home, '.config'))
+        local_insights_conf_dir = os.path.join(local_conf_dir, _app_name)
+        try:
+            os.makedirs(local_insights_conf_dir)
+        except:
+            pass
+        return local_insights_conf_dir
+
+
+def _bc_conf_dir():
+    # only needed for .registered files, if run locally just use the
+    #   same dir as the default conf dir. It's okay if we write these files twice.
+    if _uid == 0:
+        return os.path.join(os.sep, 'etc', 'redhat-access-insights')
+    else:
+        return _conf_dir()
+
+
+def _var_run_dir():
+    if _uid == 0:
+        return os.path.join(os.sep, 'var', 'run')
+    else:
+        return os.path.join(os.sep, 'var', 'run', 'user', str(_uid))
+
+
 class InsightsConstants(object):
     app_name = _app_name
     auth_method = 'BASIC'
@@ -41,45 +75,63 @@ class InsightsConstants(object):
         os.path.dirname(os.path.abspath(__file__)))
     sleep_time = 180
     command_blacklist = ('rm', 'kill', 'reboot', 'shutdown')
-    default_conf_dir = os.getenv('INSIGHTS_CONF_DIR', default='/etc/insights-client')
+    custom_network_log_level = 11
+
+    # read only files - no local backup needed
+    collection_fallback_file = os.path.join(_etc_insights_client_dir, '.fallback.json')
+    default_sed_file = os.path.join(_etc_insights_client_dir, '.exp.sed')
+    pub_gpg_path = os.path.join(_etc_insights_client_dir, 'redhattools.pub.gpg')
+    insights_core_rpm = os.path.join(_etc_insights_client_dir, 'rpm.egg')
+    default_egg_gpg_key = os.path.join(_etc_insights_client_dir, 'insights-core.gpg')
+    legacy_ca_cert = os.path.join(_etc_insights_client_dir, 'cert-api.access.redhat.com.pem')
+
+    # read/write etc files
+    default_conf_dir = _conf_dir()
+    simple_find_replace_dir = _bc_conf_dir()
     default_conf_file = os.path.join(default_conf_dir, 'insights-client.conf')
     default_tags_file = os.path.join(default_conf_dir, 'tags.yaml')
-    log_dir = _log_dir()
     simple_find_replace_dir = '/etc/redhat-access-insights'
     default_log_file = os.path.join(log_dir, app_name + '.log')
     default_payload_log = os.path.join(log_dir, app_name + '-payload.log')
     custom_network_log_level = 11
     default_sed_file = os.path.join(default_conf_dir, '.exp.sed')
-    base_url = 'cert-api.access.redhat.com/r/insights/platform'
-    legacy_base_url = 'cert-api.access.redhat.com/r/insights'
     collection_rules_file = os.path.join(default_conf_dir, '.cache.json')
-    collection_fallback_file = os.path.join(default_conf_dir, '.fallback.json')
     unregistered_files = [os.path.join(default_conf_dir, '.unregistered'),
                           os.path.join(simple_find_replace_dir, '.unregistered')]
     registered_files = [os.path.join(default_conf_dir, '.registered'),
                         os.path.join(simple_find_replace_dir, '.registered')]
     lastupload_file = os.path.join(default_conf_dir, '.lastupload')
-    pub_gpg_path = os.path.join(default_conf_dir, 'redhattools.pub.gpg')
     machine_id_file = os.path.join(default_conf_dir, 'machine-id')
-    default_branch_info = {'remote_branch': -1, 'remote_leaf': -1}
-    default_cmd_timeout = 120  # default command execution to two minutes, prevents long running commands that will hang
-    default_egg_gpg_key = os.path.join(default_conf_dir, 'insights-core.gpg')
     core_etag_file = os.path.join(default_conf_dir, '.insights-core.etag')
     core_gpg_sig_etag_file = os.path.join(default_conf_dir, '.insights-core-gpg-sig.etag')
     last_upload_results_file = os.path.join(default_conf_dir, '.last-upload.results')
-    insights_core_lib_dir = _lib_dir()
     insights_core_rpm = os.path.join(default_conf_dir, 'rpm.egg')
+    cached_branch_info = os.path.join(default_conf_dir, '.branch_info')
+
+    # read/write lib files
+    insights_core_lib_dir = _lib_dir()
     insights_core_last_stable = os.path.join(insights_core_lib_dir, 'last_stable.egg')
     insights_core_last_stable_gpg_sig = os.path.join(insights_core_lib_dir, 'last_stable.egg.asc')
     insights_core_newest = os.path.join(insights_core_lib_dir, 'newest.egg')
     insights_core_gpg_sig_newest = os.path.join(insights_core_lib_dir, 'newest.egg.asc')
+
+    # log files
+    log_dir = _log_dir()
+    default_log_file = os.path.join(log_dir, app_name + '.log')
+    default_payload_log = os.path.join(log_dir, app_name + '-payload.log')
+
+    # other
+    pidfile = os.path.join(_var_run_dir(), 'insights-client.pid')
+    ppidfile = os.path.join(os.sep, 'tmp', 'insights-client.ppid')
+
+    base_url = 'cert-api.access.redhat.com/r/insights/platform'
+    legacy_base_url = 'cert-api.access.redhat.com/r/insights'
+    default_branch_info = {'remote_branch': -1, 'remote_leaf': -1}
+    default_cmd_timeout = 120  # default command execution to two minutes, prevents long running commands that will hang
     module_router_path = "/module-update-router/v1/channel?module=insights-core"
     sig_kill_ok = 100
     sig_kill_bad = 101
-    cached_branch_info = os.path.join(default_conf_dir, '.branch_info')
-    pidfile = os.path.join(os.sep, 'var', 'run', 'insights-client.pid')
     egg_release_file = os.path.join(os.sep, 'tmp', 'insights-client-egg-release')
-    ppidfile = os.path.join(os.sep, 'tmp', 'insights-client.ppid')
     valid_compressors = ("gz", "xz", "bz2", "none")
     # RPM version in which core collection was released
     core_collect_rpm_version = '3.1.0'

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -2,8 +2,9 @@ import os
 
 # TODO: no bare excepts here
 # TODO: maybe call os.makedirs elsewhere
-# TODO: copy config file to local config dir if it doesn't exist and --conf is not specified
-# TODO: copy an existing machine-id file to local config dir
+# TODO: copy config file to local config dir if it doesn't exist and --conf is not specified?
+# TODO: copy an existing machine-id file to local config dir?
+# TODO: set perms on log/lib dirs
 
 _user_home = os.path.expanduser('~')
 _app_name = 'insights-client'
@@ -132,6 +133,10 @@ class InsightsConstants(object):
     module_router_path = "/module-update-router/v1/channel?module=insights-core"
     sig_kill_ok = 100
     sig_kill_bad = 101
+<<<<<<< HEAD
+=======
+    cached_branch_info = os.path.join(default_conf_dir, '.branch_info')
+>>>>>>> skip autoconfig for non-root, create log and lib dirs from egg
     egg_release_file = os.path.join(os.sep, 'tmp', 'insights-client-egg-release')
     valid_compressors = ("gz", "xz", "bz2", "none")
     # RPM version in which core collection was released

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -18,7 +18,7 @@ def _log_dir():
     Get the insights-client log dir
 
     Default: /var/log/insights-client
-    Non-root user: $XDG_CACHE_HOME/insights-client || $HOME/.cache/insights-client/log
+    Non-root user: $XDG_CACHE_HOME/insights-client/log || $HOME/.cache/insights-client/log
     '''
     if _uid == 0:
         insights_log_dir = os.path.join(os.sep, 'var', 'log', _app_name)
@@ -32,7 +32,7 @@ def _lib_dir():
     Get the insights-client egg cache dir
 
     Default: /var/lib/insights
-    Non-root user: $XDG_CACHE_HOME/insights-client || $HOME/.cache/insights-client/lib
+    Non-root user: $XDG_CACHE_HOME/insights-client/lib || $HOME/.cache/insights-client/lib
     '''
     if _uid == 0:
         insights_lib_dir = os.path.join(os.sep, 'var', 'lib', 'insights')
@@ -86,28 +86,24 @@ class InsightsConstants(object):
     insights_core_rpm = os.path.join(_etc_insights_client_dir, 'rpm.egg')
     default_egg_gpg_key = os.path.join(_etc_insights_client_dir, 'insights-core.gpg')
     legacy_ca_cert = os.path.join(_etc_insights_client_dir, 'cert-api.access.redhat.com.pem')
+    machine_id_file = os.path.join(_etc_insights_client_dir, 'machine-id')
 
     # read/write etc files
     default_conf_dir = _conf_dir()
     simple_find_replace_dir = _bc_conf_dir()
     default_conf_file = os.path.join(default_conf_dir, 'insights-client.conf')
     default_tags_file = os.path.join(default_conf_dir, 'tags.yaml')
-    simple_find_replace_dir = '/etc/redhat-access-insights'
-    default_log_file = os.path.join(log_dir, app_name + '.log')
-    default_payload_log = os.path.join(log_dir, app_name + '-payload.log')
+    simple_find_replace_dir = _bc_conf_dir()
     custom_network_log_level = 11
-    default_sed_file = os.path.join(default_conf_dir, '.exp.sed')
     collection_rules_file = os.path.join(default_conf_dir, '.cache.json')
     unregistered_files = [os.path.join(default_conf_dir, '.unregistered'),
                           os.path.join(simple_find_replace_dir, '.unregistered')]
     registered_files = [os.path.join(default_conf_dir, '.registered'),
                         os.path.join(simple_find_replace_dir, '.registered')]
     lastupload_file = os.path.join(default_conf_dir, '.lastupload')
-    machine_id_file = os.path.join(default_conf_dir, 'machine-id')
     core_etag_file = os.path.join(default_conf_dir, '.insights-core.etag')
     core_gpg_sig_etag_file = os.path.join(default_conf_dir, '.insights-core-gpg-sig.etag')
     last_upload_results_file = os.path.join(default_conf_dir, '.last-upload.results')
-    insights_core_rpm = os.path.join(default_conf_dir, 'rpm.egg')
     cached_branch_info = os.path.join(default_conf_dir, '.branch_info')
 
     # read/write lib files
@@ -133,10 +129,6 @@ class InsightsConstants(object):
     module_router_path = "/module-update-router/v1/channel?module=insights-core"
     sig_kill_ok = 100
     sig_kill_bad = 101
-<<<<<<< HEAD
-=======
-    cached_branch_info = os.path.join(default_conf_dir, '.branch_info')
->>>>>>> skip autoconfig for non-root, create log and lib dirs from egg
     egg_release_file = os.path.join(os.sep, 'tmp', 'insights-client-egg-release')
     valid_compressors = ("gz", "xz", "bz2", "none")
     # RPM version in which core collection was released

--- a/insights/client/core_collector.py
+++ b/insights/client/core_collector.py
@@ -49,6 +49,9 @@ class CoreCollector(DataCollector):
             'components': rm_conf.get('components', [])
         }
 
+        # skip the insights-client machine-id spec
+        core_blacklist['components'].append('insights.specs.default.DefaultSpecs.machine_id')
+
         collected_data_path = collect.collect(tmp_path=self.archive.tmp_dir, rm_conf=core_blacklist, client_timeout=self.config.cmd_timeout)
         # update the archive dir with the reported data location from Insights Core
         if not collected_data_path:
@@ -75,6 +78,7 @@ class CoreCollector(DataCollector):
 
         # collect metadata
         logger.debug('Collecting metadata...')
+        self._write_insights_id()
         self._write_branch_info(branch_info)
         self._write_display_name()
         self._write_version_info()

--- a/insights/client/core_collector.py
+++ b/insights/client/core_collector.py
@@ -49,9 +49,6 @@ class CoreCollector(DataCollector):
             'components': rm_conf.get('components', [])
         }
 
-        # skip the insights-client machine-id spec
-        core_blacklist['components'].append('insights.specs.default.DefaultSpecs.machine_id')
-
         collected_data_path = collect.collect(tmp_path=self.archive.tmp_dir, rm_conf=core_blacklist, client_timeout=self.config.cmd_timeout)
         # update the archive dir with the reported data location from Insights Core
         if not collected_data_path:
@@ -78,7 +75,6 @@ class CoreCollector(DataCollector):
 
         # collect metadata
         logger.debug('Collecting metadata...')
-        self._write_insights_id()
         self._write_branch_info(branch_info)
         self._write_display_name()
         self._write_version_info()

--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -147,11 +147,6 @@ class DataCollector(object):
         self.archive.add_metadata_to_archive(
             json.dumps(collection_stats), '/collection_stats')
 
-    def _write_insights_id(self):
-        logger.debug("Writing Insights ID to archive...")
-        self.archive.add_metadata_to_archive(
-            generate_machine_id(), '/etc/insights-client/machine-id')
-
     def _run_pre_command(self, pre_cmd):
         '''
         Run a pre command to get external args for a command
@@ -322,7 +317,6 @@ class DataCollector(object):
 
         # collect metadata
         logger.debug('Collecting metadata...')
-        self._write_insights_id()
         self._write_branch_info(branch_info)
         self._write_display_name()
         self._write_version_info()

--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -17,7 +17,7 @@ from tempfile import NamedTemporaryFile
 
 from insights.util import mangle
 from ..contrib.soscleaner import SOSCleaner
-from .utilities import _expand_paths, get_version_info, systemd_notify_init_thread, get_tags
+from .utilities import _expand_paths, get_version_info, systemd_notify_init_thread, get_tags, generate_machine_id
 from .constants import InsightsConstants as constants
 from .insights_spec import InsightsFile, InsightsCommand
 from .archive import InsightsArchive
@@ -146,6 +146,11 @@ class DataCollector(object):
         logger.debug("Writing collection stats to archive...")
         self.archive.add_metadata_to_archive(
             json.dumps(collection_stats), '/collection_stats')
+
+    def _write_insights_id(self):
+        logger.debug("Writing Insights ID to archive...")
+        self.archive.add_metadata_to_archive(
+            generate_machine_id(), '/etc/insights-client/machine-id')
 
     def _run_pre_command(self, pre_cmd):
         '''
@@ -317,6 +322,7 @@ class DataCollector(object):
 
         # collect metadata
         logger.debug('Collecting metadata...')
+        self._write_insights_id()
         self._write_branch_info(branch_info)
         self._write_display_name()
         self._write_version_info()

--- a/insights/client/insights_spec.py
+++ b/insights/client/insights_spec.py
@@ -140,10 +140,6 @@ class InsightsFile(InsightsSpec):
 
         exec_start = time.time()
 
-        if 'machine-id' in self.real_path and 'insights' in self.real_path:
-            # add this in archive metadata instead
-            return
-
         sedcmd = Popen(['sed', '', self.real_path], stdout=PIPE)
 
         if self.pattern is None:

--- a/insights/client/insights_spec.py
+++ b/insights/client/insights_spec.py
@@ -11,7 +11,7 @@ from tempfile import NamedTemporaryFile
 from insights.util import mangle
 
 from .constants import InsightsConstants as constants
-from .utilities import determine_hostname
+from .utilities import determine_hostname, generate_machine_id
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +139,11 @@ class InsightsFile(InsightsSpec):
             return
 
         exec_start = time.time()
+
+        if 'machine-id' in self.real_path and 'insights' in self.real_path:
+            # add this in archive metadata instead
+            return
+
         sedcmd = Popen(['sed', '', self.real_path], stdout=PIPE)
 
         if self.pattern is None:

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -138,10 +138,14 @@ def generate_machine_id(new=False,
         with open(destination_file, 'r') as machine_id_file:
             machine_id = machine_id_file.read()
     else:
-        logger.debug('Could not find %s file, creating', logging_name)
-        machine_id = str(uuid.uuid4())
-        logger.debug("Creating %s", destination_file)
-        write_to_disk(destination_file, content=machine_id)
+        if os.getuid() == 0:
+            logger.debug('Could not find %s file, creating', logging_name)
+            machine_id = str(uuid.uuid4())
+            logger.debug("Creating %s", destination_file)
+            write_to_disk(destination_file, content=machine_id)
+        else:
+            logger.debug('The %s file must be created by a superuser.', logging_name)
+            return
 
     machine_id = str(machine_id).strip()
 

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -287,6 +287,7 @@ class TextFileProvider(FileProvider):
             p.write(dst)
         else:
             call([which("cp", env=SAFE_ENV), self.path, dst], env=SAFE_ENV)
+            call([which("chmod", env=SAFE_ENV), '+w', dst], env=SAFE_ENV)
 
 
 class SerializedOutputProvider(TextFileProvider):


### PR DESCRIPTION
Fixes: RHCLOUD-8485

Summary of changes:
- Create local config dir in user's home directory
- Create local log dir in user's home directory
- Create local lib dir in user's home directory
- Use local paths for machine-id, eggs, config files, uploader.json files, etc.
- Dynamically choose whether to use system dirs or local dirs depending on whether the user is root
- Write machine-id separately from the collection because it might be in the user's home directory
- Add write permissions for files copied without filters during core collection to allow post-collection data redaction

TODO: 
- generate a blank config in a user's home directory (or copy the system config)
- copy machine-id or generate a different one per user?
- fix bare excepts
