### PR TITLE
Update the check of NetWeaver for Sap combiner

### DIFF
--- a/insights/combiners/sap.py
+++ b/insights/combiners/sap.py
@@ -20,6 +20,23 @@ SAPInstances = namedtuple("SAPInstances",
         field_names=["name", "hostname", "sid", "type", "number", "fqdn", "version"])
 """namedtuple: Type for storing the SAP instance."""
 
+FUNC_TYPES = ('SMDA',)
+"""
+SMDA   :    Solution Manager Diagnostics Agents
+"""
+NETW_TYPES = ('D', 'ASCS', 'DVEBMGS', 'J', 'SCS', 'ERS', 'W', 'G', 'JC')
+"""
+D      :    NetWeaver (ABAP Dialog Instance)
+ASCS   :    NetWeaver (ABAP Central Services)
+DVEBMGS:    NetWeaver (Primary Application server
+J      :    NetWeaver (Java App Server Instance)
+SCS    :    NetWeaver (Java Central Services)
+ERS    :    NetWeaver (Enqueue Replication Server)
+W      :    NetWeaver (WebDispatcher)
+G      :    NetWeaver (Gateway)
+JC     :    NetWeaver (Java App Server Instance)
+"""
+
 
 @combiner(hostname, [SAPHostCtrlInstances, Lssap])
 class Sap(dict):
@@ -59,7 +76,6 @@ class Sap(dict):
                                    E.g. HANA, NetWeaver, ASCS, or others
         local_instances (list): List of all SAP instances running on this host
     """
-    FUNC_INSTS = ('SMDA',)
     """ tuple: Tuple of the prefix string of the functional SAP instances"""
 
     def __init__(self, hostname, insts, lssap):
@@ -71,10 +87,10 @@ class Sap(dict):
         self.all_instances = []
         self._types = set()
         if insts:
+            self._types = insts.types
+            self.all_instances = insts.instances
             for inst in insts.data:
                 k = inst['InstanceName']
-                self.all_instances.append(k)
-                self._types.add(inst['InstanceType'])
                 self.local_instances.append(k) if hn == inst['Hostname'] else None
                 data[k] = SAPInstances(k,
                                        inst['Hostname'],
@@ -103,7 +119,7 @@ class Sap(dict):
         self.update(data)
 
         for i in self.all_instances:
-            (self.function_instances if i.startswith(self.FUNC_INSTS) else self.business_instances).append(i)
+            (self.function_instances if i.startswith(FUNC_TYPES) else self.business_instances).append(i)
 
     def version(self, instance):
         """str: Returns the version of the ``instance``."""
@@ -128,7 +144,7 @@ class Sap(dict):
     @property
     def is_netweaver(self):
         """bool: Is any SAP NetWeaver instance detected?"""
-        return 'D' in self._types
+        return any(_t in self._types for _t in NETW_TYPES)
 
     @property
     def is_hana(self):
@@ -137,7 +153,7 @@ class Sap(dict):
 
     @property
     def is_ascs(self):
-        """bool: Is any SAP System Central Services instance detected?"""
+        """bool: Is any ABAP Central Services instance detected?"""
         return 'ASCS' in self._types
 
     @property

--- a/insights/combiners/tests/test_sap.py
+++ b/insights/combiners/tests/test_sap.py
@@ -257,7 +257,8 @@ def test_lssap_ascs():
     hn = Hostname(HnF(context_wrap(HOSTNAME)), None, None, None, None)
     sap = Sap(hn, None, lssap)
     assert sap['ASCS16'].sid == 'HA2'
-    assert sap.is_netweaver is False
+    # ASCS is also a kind of NetWeaver
+    assert sap.is_netweaver is True
     assert sap.is_hana is False
     assert sap.is_ascs is True
 


### PR DESCRIPTION
All the following instance types indicate that the server is SAP NetWeaver server.
- 'D', 'ASCS', 'DVEBMGS', 'J', 'SCS', 'ERS', 'W', 'G', 'JC'

The old "is_netweaver" only checks 'D', this PR added all the other types.

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>