### PR TITLE
Return the common path of marker which is close to root

### DIFF
--- a/insights/core/context.py
+++ b/insights/core/context.py
@@ -162,12 +162,22 @@ class ExecutionContext(six.with_metaclass(ExecutionContextMeta)):
 
         sep = os.path.sep
         m = sep + cls.marker.lstrip(sep)
+        marker_root = set()
         for f in files:
             if m in f:
                 i = f.find(m)
                 if f.endswith(m) or f[i + len(m)] == sep:
                     root = os.path.dirname(f[:i + 1])
-                    return root, cls
+                    marker_root.add(root)
+        if len(marker_root) == 1:
+            return (marker_root.pop(), cls)
+        if len(marker_root) > 1:
+            # when more marker found, return the one which is closest to root
+            closest_root = marker_root.pop()
+            for left_one in marker_root:
+                if len(left_one) < len(closest_root):
+                    closest_root = left_one
+            return (closest_root, cls)
         return (None, None)
 
     def check_output(self, cmd, timeout=None, keep_rc=False, env=None):


### PR DESCRIPTION
* Sometimes, the dir named "sos_commands" appears more than once in
  sosreport. In this case, the common path should be the one which is
  the closest to the root.

Signed-off-by: Huanhuan Li <huali@redhat.com>