### PR TITLE
Update the 'raw_line_key' of parse_delimited_table

### DIFF
--- a/insights/parsers/__init__.py
+++ b/insights/parsers/__init__.py
@@ -445,15 +445,15 @@ def parse_delimited_table(table_lines,
     content = table_lines[first_line + 1:last_line]
     headings = [c.strip() if strip else c for c in header.split(header_delim)]
     r = []
-    for row in content:
-        row = row.strip()
+    for line in content:
+        row = line.strip()
         if row:
             rowsplit = row.split(delim, max_splits)
             if strip:
                 rowsplit = [i.strip() for i in rowsplit]
             o = dict(zip(headings, rowsplit))
             if raw_line_key:
-                o[raw_line_key] = row
+                o[raw_line_key] = line
             r.append(o)
     return r
 

--- a/insights/parsers/tests/test_parsers_module.py
+++ b/insights/parsers/tests/test_parsers_module.py
@@ -386,6 +386,12 @@ POSTGRESQL_LOG = """
  (402 rows)
 """.strip()  # Normally has a --- separator line, which is ignored using get_active_lines
 
+TABLE1 = """
+THIS   IS   A   HEADER
+ this   is   some   content_with_blank_prefix
+This   is   more   content
+""".strip()
+
 TABLE2 = [
     "SID   Nr   Instance    SAPLOCALHOST                        Version                 DIR_EXECUTABLE",
     "HA2|  16|       D16|         lu0417|749, patch 10, changelist 1698137|          /usr/sap/HA2/D16/exe",
@@ -472,6 +478,15 @@ def test_parse_delimited_table():
                  "Version": "749, patch 10, changelist 1698137",
                  "DIR_EXECUTABLE": "/usr/sap/HA2/D22/exe"}]
     assert expected == result
+
+    # Test raw_line_key
+    TABLE1_SP = TABLE1.splitlines()
+    result = parse_delimited_table(TABLE1_SP, raw_line_key='raw_line')
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert isinstance(result[0], dict)
+    # Get the RAW line
+    assert result[0]['raw_line'] == TABLE1_SP[1]
 
 
 DATA_LIST = [


### PR DESCRIPTION
The RAW line should not be stripped.

- The `raw_line_key` is used to keep the RAW lines in the target table
   But the current code stripped the RAW line before saving it to the specified "RAW key"

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>