### PR TITLE
RHCLOUD-8745 Fix warning when skipping a glob

### DIFF
--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -287,7 +287,7 @@ class DataCollector(object):
                 glob_specs = self._parse_glob_spec(g)
                 for g in glob_specs:
                     if g['file'] in rm_conf.get('files', []):
-                        logger.warn("WARNING: Skipping file %s", g)
+                        logger.warn("WARNING: Skipping file %s", g['file'])
                     else:
                         glob_spec = InsightsFile(g, self.mountpoint)
                         self.archive.add_to_archive(glob_spec)

--- a/insights/tests/client/test_skip_commands_files.py
+++ b/insights/tests/client/test_skip_commands_files.py
@@ -136,7 +136,7 @@ def test_omit_after_parse_command(InsightsCommand, run_pre_command):
 
 @patch("insights.client.data_collector.DataCollector._parse_glob_spec", return_value=[{'glob': '/etc/yum.repos.d/*.repo', 'symbolic_name': 'yum_repos_d', 'pattern': [], 'file': '/etc/yum.repos.d/test.repo'}])
 @patch("insights.client.data_collector.logger.warn")
-def test_run_collection_logs_skipped_files(warn, parse_glob_spec):
+def test_run_collection_logs_skipped_globs(warn, parse_glob_spec):
     c = InsightsConfig()
     data_collector = DataCollector(c)
 
@@ -144,3 +144,71 @@ def test_run_collection_logs_skipped_files(warn, parse_glob_spec):
     rm_conf = {'files': ["/etc/yum.repos.d/test.repo"]}
     data_collector.run_collection(collection_rules, rm_conf, {}, '')
     warn.assert_called_once_with("WARNING: Skipping file %s", "/etc/yum.repos.d/test.repo")
+
+
+@patch("insights.client.data_collector.logger.warn")
+def test_run_collection_logs_skipped_files_by_file(warn):
+    c = InsightsConfig()
+    data_collector = DataCollector(c)
+
+    collection_rules = {'commands': [], 'files': [{'file': '/etc/machine-id', 'pattern': [], 'symbolic_name': 'etc_machine_id'}], 'globs': []}
+    rm_conf = {'files': ["/etc/machine-id"]}
+    data_collector.run_collection(collection_rules, rm_conf, {}, '')
+    warn.assert_called_once_with("WARNING: Skipping file %s", "/etc/machine-id")
+
+
+@patch("insights.client.data_collector.logger.warn")
+def test_run_collection_logs_skipped_files_by_symbolic_name(warn):
+    c = InsightsConfig()
+    data_collector = DataCollector(c)
+
+    collection_rules = {'commands': [], 'files': [{'file': '/etc/machine-id', 'pattern': [], 'symbolic_name': 'etc_machine_id'}], 'globs': []}
+    rm_conf = {'files': ["etc_machine_id"]}
+    data_collector.run_collection(collection_rules, rm_conf, {}, '')
+    warn.assert_called_once_with("WARNING: Skipping file %s", "/etc/machine-id")
+
+
+@patch("insights.client.data_collector.DataCollector._parse_file_spec", return_value=[{'file': '/etc/sysconfig/network-scripts/ifcfg-enp0s3', 'pattern': [], 'symbolic_name': 'ifcfg'}])
+@patch("insights.client.data_collector.logger.warn")
+def test_run_collection_logs_skipped_files_by_wildcard(warn, parse_file_spec):
+    c = InsightsConfig()
+    data_collector = DataCollector(c)
+
+    collection_rules = {'commands': [], 'files': [{'file': '/etc/sysconfig/network-scripts/()*ifcfg-.*', 'pattern': [], 'symbolic_name': 'ifcfg'}], 'globs': []}
+    rm_conf = {'files': ["/etc/sysconfig/network-scripts/ifcfg-enp0s3"]}
+    data_collector.run_collection(collection_rules, rm_conf, {}, '')
+    warn.assert_called_once_with("WARNING: Skipping file %s", "/etc/sysconfig/network-scripts/ifcfg-enp0s3")
+
+
+@patch("insights.client.data_collector.logger.warn")
+def test_run_collection_logs_skipped_commands_by_command(warn):
+    c = InsightsConfig()
+    data_collector = DataCollector(c)
+
+    collection_rules = {'commands': [{'command': '/bin/date', 'pattern': [], 'symbolic_name': 'date'}], 'files': [], 'globs': []}
+    rm_conf = {'commands': ["/bin/date"]}
+    data_collector.run_collection(collection_rules, rm_conf, {}, '')
+    warn.assert_called_once_with("WARNING: Skipping command %s", "/bin/date")
+
+
+@patch("insights.client.data_collector.logger.warn")
+def test_run_collection_logs_skipped_commands_by_symbolic_name(warn):
+    c = InsightsConfig()
+    data_collector = DataCollector(c)
+
+    collection_rules = {'commands': [{'command': '/bin/date', 'pattern': [], 'symbolic_name': 'date'}], 'files': [], 'globs': []}
+    rm_conf = {'commands': ["date"]}
+    data_collector.run_collection(collection_rules, rm_conf, {}, '')
+    warn.assert_called_once_with("WARNING: Skipping command %s", "/bin/date")
+
+
+@patch("insights.client.data_collector.DataCollector._parse_command_spec", return_value=[{'command': '/sbin/ethtool enp0s3', 'pattern': [], 'pre_command': 'iface', 'symbolic_name': 'ethtool'}])
+@patch("insights.client.data_collector.logger.warn")
+def test_run_collection_logs_skipped_commands_by_pre_command(warn, parse_command_spec):
+    c = InsightsConfig()
+    data_collector = DataCollector(c)
+
+    collection_rules = {'commands': [{'command': '/sbin/ethtool', 'pattern': [], 'pre_command': 'iface', 'symbolic_name': 'ethtool'}], 'files': [], 'globs': [], 'pre_commands': {'iface': '/sbin/ip -o link | awk -F \': \' \'/.*link\\/ether/ {print $2}\''}}
+    rm_conf = {'commands': ["/sbin/ethtool enp0s3"]}
+    data_collector.run_collection(collection_rules, rm_conf, {}, '')
+    warn.assert_called_once_with("WARNING: Skipping command %s", "/sbin/ethtool enp0s3")

--- a/insights/tests/client/test_skip_commands_files.py
+++ b/insights/tests/client/test_skip_commands_files.py
@@ -132,3 +132,15 @@ def test_omit_after_parse_command(InsightsCommand, run_pre_command):
     rm_conf = {'commands': ["/sbin/ethtool -i eth0"]}
     data_collector.run_collection(collection_rules, rm_conf, {}, '')
     InsightsCommand.assert_not_called()
+
+
+@patch("insights.client.data_collector.DataCollector._parse_glob_spec", return_value=[{'glob': '/etc/yum.repos.d/*.repo', 'symbolic_name': 'yum_repos_d', 'pattern': [], 'file': '/etc/yum.repos.d/test.repo'}])
+@patch("insights.client.data_collector.logger.warn")
+def test_run_collection_logs_skipped_files(warn, parse_glob_spec):
+    c = InsightsConfig()
+    data_collector = DataCollector(c)
+
+    collection_rules = {'commands': [], 'files': [], 'globs': [{'glob': '/etc/yum.repos.d/*.repo', 'symbolic_name': 'yum_repos_d', 'pattern': []}]}
+    rm_conf = {'files': ["/etc/yum.repos.d/test.repo"]}
+    data_collector.run_collection(collection_rules, rm_conf, {}, '')
+    warn.assert_called_once_with("WARNING: Skipping file %s", "/etc/yum.repos.d/test.repo")


### PR DESCRIPTION
Fixed the bug and added some tests. The affected message is only one of a few more that serve the same purpose. I added tests for the sister warns too, so they are all covered. Used mocks to avoid relying on real files being present and possibly running into permission issues.

To reproduce:
1. Add a rule to _remove.conf_ to remove a file that would be matched by a glob rule. E.g. _/etc/yum.repos.d/redhat.repo_.
   ```ini
   [remove]
   files=/etc/yum.repos.d/redhat.repo
   ```
2. Run the client and see that a warning is emitted. This warning contains a file name and not a full specification dictionary dump.
   ```
   WARNING: Skipping file /etc/yum.repos.d/redhat.repo
   ```