### PR TITLE
Added parser for testparm data for Samba configuration

### DIFF
--- a/insights/parsers/samba.py
+++ b/insights/parsers/samba.py
@@ -70,6 +70,7 @@ Examples:
 """
 import re
 
+from . import ParseException
 from .. import add_filter, IniConfigFile, parser
 from insights.specs import Specs
 
@@ -120,12 +121,10 @@ class SambaConfigs(SambaConfig):
     """
     This parser reads the Samba configuration from command `testparm -v -c` which is more
     reliable than parsing the config as well as contains server role.
+
+    Attributes:
+    server_role (string): Server role as reported by the command.
     """
-
-    def __init__(self, *args, **kwargs):
-        self.server_role = None
-        super(SambaConfigs, self).__init__(*args, **kwargs)
-
     def parse_content(self, content):
         # Parse server role
         for line in content:
@@ -133,6 +132,8 @@ class SambaConfigs(SambaConfig):
             if r:
                 self.server_role = r.group(1)
                 break
+        else:
+            raise ParseException("Server role not found.")
 
         # Technically, the implicit [global] section handling is not needed as testparm command
         # processes it, but for simplicity the old parser is used so the logic is not duplicated

--- a/insights/parsers/samba.py
+++ b/insights/parsers/samba.py
@@ -2,17 +2,17 @@
 SambaConfig - file ``/etc/samba/smb.conf``
 ==========================================
 
-This parser reads the SaMBa configuration file ``/etc/samba/smb.conf``, which
+This parser reads the Samba configuration file ``/etc/samba/smb.conf``, which
 is in standard .ini format, with a couple of notable features:
 
-* SaMBa ignores spaces at the start of options, which the ConfigParser class
-  normally does not.  This spacing is stripped by this parser.
-* SaMBa likewise ignores spaces in section heading names.
-* SaMBa allows the same section to be defined multiple times, with the
+* Samba ignores spaces at the start of options, which the ConfigParser class
+  normally does not. This spacing is stripped by this parser.
+* Samba likewise ignores spaces in section heading names.
+* Samba allows the same section to be defined multiple times, with the
   options therein being merged as if they were one section.
-* SaMBa allows options to be declared before the first section marker.
+* Samba allows options to be declared before the first section marker.
   This parser puts these options in a `global` section.
-* SaMBa treats ';' as a comment prefix, similar to '#'.
+* Samba treats ';' as a comment prefix, similar to '#'.
 
 Sample configuration file::
 
@@ -76,13 +76,22 @@ from insights.specs import Specs
 
 add_filter(Specs.samba, ["["])
 
+add_filter(Specs.testparm_s, ["["])
+add_filter(Specs.testparm_s, ["Server role:"])
+
+add_filter(Specs.testparm_v_s, ["["])
+add_filter(Specs.testparm_v_s, ["Server role:"])
+
 
 @parser(Specs.samba)
 class SambaConfig(IniConfigFile):
     """
-    This parser reads the SaMBa configuration file ``/etc/samba/smb.conf``.
-    """
+    This parser reads the Samba configuration file ``/etc/samba/smb.conf``.
 
+    Note: It is needed for better resolution descriptions when it is necessary to know what exactly
+    is in the configuration file. For generic tasks use ``SambaConfigs`` or ``SambaConfigsAll``
+    instead.
+    """
     def parse_content(self, content):
         # smb.conf is special from other ini files in the property that
         # whatever is before the first section (before the first section)
@@ -112,18 +121,18 @@ class SambaConfig(IniConfigFile):
         self.data._sections = new_dict
 
 
-add_filter(Specs.testparm_v_s, ["["])
-add_filter(Specs.testparm_v_s, ["Server role:"])
-
-
-@parser(Specs.testparm_v_s)
+@parser(Specs.testparm_s)
 class SambaConfigs(SambaConfig):
     """
-    This parser reads the Samba configuration from command `testparm -v -c` which is more
-    reliable than parsing the config as well as contains server role.
+    This parser reads the Samba configuration from command `testparm -s` which is more reliable
+    than parsing the config file, as it includes configuration in internal registry. It also
+    includes server role.
+
+    Note: This is the most suitable parser when only user changes to the configuration are important
+    for the detection logic, i.e. misconfiguration.
 
     Attributes:
-    server_role (string): Server role as reported by the command.
+        server_role (string): Server role as reported by the command.
     """
     def parse_content(self, content):
         # Parse server role
@@ -135,6 +144,21 @@ class SambaConfigs(SambaConfig):
         else:
             raise ParseException("Server role not found.")
 
-        # Technically, the implicit [global] section handling is not needed as testparm command
-        # processes it, but for simplicity the old parser is used so the logic is not duplicated
         super(SambaConfigs, self).parse_content(content)
+
+
+@parser(Specs.testparm_v_s)
+class SambaConfigsAll(SambaConfigs):
+    """
+    This parser reads the Samba configuration from command `testparm -v -s` which is more reliable
+    than parsing the config file, as it includes configuration in internal registry. It also
+    includes all default values and server role.
+
+    Note: This parser is needed for cases when active value of specific option is needed for the
+    detection logic, irrespective of its origin from user changes or defaults, i.e. security
+    vulnerabilities.
+
+    Attributes:
+        server_role (string): Server role as reported by the command.
+    """
+    pass

--- a/insights/parsers/tests/test_samba.py
+++ b/insights/parsers/tests/test_samba.py
@@ -191,40 +191,71 @@ this option should also be in global = true
 this another option should also be in global = 1
 """
 
+# This is going to be filtered, so removing following lines:
+#
+# Load smb config files from /etc/samba/smb.conf
+# Loaded services file OK.
+
+TESTPARM = """
+Server role: ROLE_STANDALONE
+
+# Global parameters
+[global]
+	add user to group script = 
+	afs token lifetime = 604800
+	afs username map = 
+	aio max threads = 100
+	server schannel = Yes
+
+[homes]
+	browseable = No
+
+"""
+
 
 def test_match():
-    config = samba.SambaConfig(context_wrap(SAMBA_CONFIG))
+    for config in [samba.SambaConfig(context_wrap(SAMBA_CONFIG)),
+                   samba.SambaConfigs(context_wrap(SAMBA_CONFIG))]:
+        assert config.get('global', 'this option should be in global') == 'yes'
+        assert config.get('global', 'this option should also be in global') == 'true'
+        assert config.get('global', 'this another option should also be in global') == '1'
+        assert config.get('global', 'workgroup') == 'MYGROUP'
+        assert config.get('global', 'workgroup') == 'MYGROUP'
+        assert config.get('global', 'server string') == 'Samba Server Version %v'
+        assert not config.has_option('global', 'netbios name')
+        assert config.get('global', 'log file') == '/var/log/samba/log.%m'
+        assert config.get('global', 'max log size') == '50'
 
-    assert config.get('global', 'this option should be in global') == 'yes'
-    assert config.get('global', 'this option should also be in global') == 'true'
-    assert config.get('global', 'this another option should also be in global') == '1'
-    assert config.get('global', 'workgroup') == 'MYGROUP'
-    assert config.get('global', 'workgroup') == 'MYGROUP'
-    assert config.get('global', 'server string') == 'Samba Server Version %v'
-    assert not config.has_option('global', 'netbios name')
-    assert config.get('global', 'log file') == '/var/log/samba/log.%m'
-    assert config.get('global', 'max log size') == '50'
+        assert config.get('global', 'security') == 'user'
+        assert config.get('global', 'passdb backend') == 'tdbsam'
 
-    assert config.get('global', 'security') == 'user'
-    assert config.get('global', 'passdb backend') == 'tdbsam'
+        assert config.get('global', 'load printers') == 'yes'
+        assert config.get('global', 'cups options') == 'raw'
 
-    assert config.get('global', 'load printers') == 'yes'
-    assert config.get('global', 'cups options') == 'raw'
+        assert not config.has_option('global', 'printcap name')
 
-    assert not config.has_option('global', 'printcap name')
+        assert config.get('homes', 'comment') == 'Home Directories'
+        assert config.get('homes', 'browseable') == 'no'
+        assert config.get('homes', 'writable') == 'yes'
+        assert not config.has_option('homes', 'valid users')
 
-    assert config.get('homes', 'comment') == 'Home Directories'
-    assert config.get('homes', 'browseable') == 'no'
-    assert config.get('homes', 'writable') == 'yes'
-    assert not config.has_option('homes', 'valid users')
+        assert config.get('printers', 'comment') == 'All Printers'
+        assert config.get('printers', 'path') == '/var/spool/samba'
+        assert config.get('printers', 'browseable') == 'no'
+        assert config.get('printers', 'guest ok') == 'no'
+        assert config.get('printers', 'writable') == 'no'
+        assert config.get('printers', 'printable') == 'yes'
 
-    assert config.get('printers', 'comment') == 'All Printers'
-    assert config.get('printers', 'path') == '/var/spool/samba'
-    assert config.get('printers', 'browseable') == 'no'
-    assert config.get('printers', 'guest ok') == 'no'
-    assert config.get('printers', 'writable') == 'no'
-    assert config.get('printers', 'printable') == 'yes'
+        assert 'netlogin' not in config
+        assert 'Profiles' not in config
+        assert 'public' not in config
 
-    assert 'netlogin' not in config
-    assert 'Profiles' not in config
-    assert 'public' not in config
+
+def test_server_role():
+    config = samba.SambaConfigs(context_wrap(TESTPARM))
+
+    assert config.get('global', 'server schannel') == 'Yes'
+    assert config.get('homes', 'browseable') == 'No'
+    assert config.get('global', 'afs username map') == ''
+    assert config.server_role == "ROLE_STANDALONE"
+

--- a/insights/parsers/tests/test_samba.py
+++ b/insights/parsers/tests/test_samba.py
@@ -212,13 +212,13 @@ Server role: ROLE_STANDALONE
 [homes]
 	browseable = No
 
-"""
+"""  # noqa: E101,W191,W291
 
 
 def test_match():
-    for config in [samba.SambaConfig(context_wrap(SAMBA_CONFIG)),
+    for config in [samba.SambaConfig(context_wrap(SAMBA_CONFIG)),  # noqa: E101
                    samba.SambaConfigs(context_wrap("Server role: ROLE_STANDALONE\n\n" +
-                                                   SAMBA_CONFIG))]:
+                                      SAMBA_CONFIG))]:
         assert config.get('global', 'this option should be in global') == 'yes'
         assert config.get('global', 'this option should also be in global') == 'true'
         assert config.get('global', 'this another option should also be in global') == '1'
@@ -267,4 +267,3 @@ def test_server_role_missing():
     with pytest.raises(ParseException) as e:
         samba.SambaConfigs(context_wrap(SAMBA_CONFIG))
         assert e.value == "Server role not found."
-

--- a/insights/parsers/tests/test_samba.py
+++ b/insights/parsers/tests/test_samba.py
@@ -218,7 +218,10 @@ Server role: ROLE_STANDALONE
 def test_match():
     for config in [samba.SambaConfig(context_wrap(SAMBA_CONFIG)),  # noqa: E101
                    samba.SambaConfigs(context_wrap("Server role: ROLE_STANDALONE\n\n" +
-                                      SAMBA_CONFIG))]:
+                                      SAMBA_CONFIG)),
+                   samba.SambaConfigsAll(context_wrap("Server role: ROLE_STANDALONE\n\n" +
+                                      SAMBA_CONFIG)),
+                   ]:
         assert config.get('global', 'this option should be in global') == 'yes'
         assert config.get('global', 'this option should also be in global') == 'true'
         assert config.get('global', 'this another option should also be in global') == '1'

--- a/insights/parsers/tests/test_samba.py
+++ b/insights/parsers/tests/test_samba.py
@@ -1,4 +1,6 @@
-from insights.parsers import samba
+import pytest
+
+from insights.parsers import samba, ParseException
 from insights.tests import context_wrap
 from doctest import testmod
 
@@ -215,7 +217,8 @@ Server role: ROLE_STANDALONE
 
 def test_match():
     for config in [samba.SambaConfig(context_wrap(SAMBA_CONFIG)),
-                   samba.SambaConfigs(context_wrap(SAMBA_CONFIG))]:
+                   samba.SambaConfigs(context_wrap("Server role: ROLE_STANDALONE\n\n" +
+                                                   SAMBA_CONFIG))]:
         assert config.get('global', 'this option should be in global') == 'yes'
         assert config.get('global', 'this option should also be in global') == 'true'
         assert config.get('global', 'this another option should also be in global') == '1'
@@ -258,4 +261,10 @@ def test_server_role():
     assert config.get('homes', 'browseable') == 'No'
     assert config.get('global', 'afs username map') == ''
     assert config.server_role == "ROLE_STANDALONE"
+
+
+def test_server_role_missing():
+    with pytest.raises(ParseException) as e:
+        samba.SambaConfigs(context_wrap(SAMBA_CONFIG))
+        assert e.value == "Server role not found."
 

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -627,6 +627,7 @@ class Specs(SpecSet):
     systemd_system_origin_accounting = RegistryPoint()
     systemid = RegistryPoint()
     systool_b_scsi_v = RegistryPoint()
+    testparm_v_s = RegistryPoint(filterable=True)
     tags = RegistryPoint()
     teamdctl_config_dump = RegistryPoint(multi_output=True)
     teamdctl_state_dump = RegistryPoint(multi_output=True)

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -627,6 +627,7 @@ class Specs(SpecSet):
     systemd_system_origin_accounting = RegistryPoint()
     systemid = RegistryPoint()
     systool_b_scsi_v = RegistryPoint()
+    testparm_s = RegistryPoint(filterable=True)
     testparm_v_s = RegistryPoint(filterable=True)
     tags = RegistryPoint()
     teamdctl_config_dump = RegistryPoint(multi_output=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -646,6 +646,7 @@ class DefaultSpecs(Specs):
         simple_file("/conf/rhn/sysconfig/rhn/systemid")
     ])
     systool_b_scsi_v = simple_command("/bin/systool -b scsi -v")
+    testparm_v_s = simple_command("/usr/bin/testparm -v -s")
     tags = simple_file("/tags.json", kind=RawFileProvider)
     thp_use_zero_page = simple_file("/sys/kernel/mm/transparent_hugepage/use_zero_page")
     thp_enabled = simple_file("/sys/kernel/mm/transparent_hugepage/enabled")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -646,6 +646,7 @@ class DefaultSpecs(Specs):
         simple_file("/conf/rhn/sysconfig/rhn/systemid")
     ])
     systool_b_scsi_v = simple_command("/bin/systool -b scsi -v")
+    testparm_s = simple_command("/usr/bin/testparm -s")
     testparm_v_s = simple_command("/usr/bin/testparm -v -s")
     tags = simple_file("/tags.json", kind=RawFileProvider)
     thp_use_zero_page = simple_file("/sys/kernel/mm/transparent_hugepage/use_zero_page")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -218,6 +218,7 @@ class InsightsArchiveSpecs(Specs):
     systemd_docker = first_file(["insights_commands/systemctl_cat_docker.service", "/usr/lib/systemd/system/docker.service"])
     systemd_openshift_node = first_file(["insights_commands/systemctl_cat_atomic-openshift-node.service", "/usr/lib/systemd/system/atomic-openshift-node.service"])
     systool_b_scsi_v = simple_file("insights_commands/systool_-b_scsi_-v")
+    testparm_s = simple_file("insights_commands/testparm_-s")
     testparm_v_s = simple_file("insights_commands/testparm_-v_-s")
     tomcat_vdc_fallback = simple_file("insights_commands/find_.usr.share_-maxdepth_1_-name_tomcat_-exec_.bin.grep_-R_-s_VirtualDirContext_--include_.xml")
     tuned_adm = simple_file("insights_commands/tuned-adm_list")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -218,6 +218,7 @@ class InsightsArchiveSpecs(Specs):
     systemd_docker = first_file(["insights_commands/systemctl_cat_docker.service", "/usr/lib/systemd/system/docker.service"])
     systemd_openshift_node = first_file(["insights_commands/systemctl_cat_atomic-openshift-node.service", "/usr/lib/systemd/system/atomic-openshift-node.service"])
     systool_b_scsi_v = simple_file("insights_commands/systool_-b_scsi_-v")
+    testparm_v_s = simple_file("insights_commands/testparm_-v_-s")
     tomcat_vdc_fallback = simple_file("insights_commands/find_.usr.share_-maxdepth_1_-name_tomcat_-exec_.bin.grep_-R_-s_VirtualDirContext_--include_.xml")
     tuned_adm = simple_file("insights_commands/tuned-adm_list")
     uname = simple_file("insights_commands/uname_-a")

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -248,6 +248,7 @@ class SosSpecs(Specs):
     systemd_system_origin_accounting = simple_file("/etc/systemd/system.conf.d/origin-accounting.conf")
     teamdctl_config_dump = glob_file("sos_commands/teamd/teamdctl_*_config_dump")
     teamdctl_state_dump = glob_file("sos_commands/teamd/teamdctl_*_state_dump")
+    testparm_s = simple_file("sos_commands/samba/testparm_s")
     tomcat_web_xml = first_of([glob_file("/etc/tomcat*/web.xml"),
                                   glob_file("/conf/tomcat/tomcat*/web.xml")])
     tuned_conf = simple_file("/etc/tuned.conf")


### PR DESCRIPTION
testparm command parsing is the better way for handling Samba configuration. Especially it allows getting server role.

The code in the review is not considered to be final but rather draft. I would like to start a conversation about how to handle this.