### PR TITLE
Fix cmdline utils for core archives

### DIFF
--- a/insights/tools/cat.py
+++ b/insights/tools/cat.py
@@ -28,8 +28,9 @@ import yaml
 
 from contextlib import contextmanager
 
-from insights import (apply_configs, create_context, dr, extract, HostContext,
+from insights import (apply_configs, dr, extract, HostContext,
         load_default_plugins)
+from insights.core.hydration import initialize_broker
 from insights.core.spec_factory import ContentProvider
 
 try:
@@ -97,9 +98,8 @@ def create_broker(root=None):
         yield broker
     else:
         def from_dir(d):
-            broker = dr.Broker()
-            ctx = create_context(d, None)
-            broker[ctx.__class__] = ctx
+            # ctx is returned here, but its already in the broker so not needed
+            _, broker = initialize_broker(d)
             return broker
 
         if os.path.isdir(root):

--- a/insights/tools/insights_inspect.py
+++ b/insights/tools/insights_inspect.py
@@ -98,9 +98,10 @@ import yaml
 
 from contextlib import contextmanager
 
-from insights import (apply_configs, create_context, dr, extract, HostContext,
+from insights import (apply_configs, dr, extract, HostContext,
                       load_default_plugins)
 from insights.core import filters
+from insights.core.hydration import initialize_broker
 from IPython import embed
 from IPython.terminal.embed import InteractiveShellEmbed
 
@@ -162,9 +163,8 @@ def create_broker(root=None):
         yield broker
     else:
         def from_dir(d):
-            broker = dr.Broker()
-            ctx = create_context(d, None)
-            broker[ctx.__class__] = ctx
+            # ctx is returned here, but its already in the broker so not needed
+            _, broker = initialize_broker(d)
             return broker
 
         if os.path.isdir(root):


### PR DESCRIPTION
* To properly hydrate core for core collected archives we need to use
  new hydration function to identify context and hydrate broker

Signed-off-by: Bob Fahr <bfahr@redhat.com>