### PR TITLE
Include rhsm_conf module in documentation

### DIFF
--- a/docs/shared_parsers_catalog/rhsm_conf.rst
+++ b/docs/shared_parsers_catalog/rhsm_conf.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.rhsm_conf
+   :members:
+   :show-inheritance:

--- a/insights/parsers/rhsm_conf.py
+++ b/insights/parsers/rhsm_conf.py
@@ -3,6 +3,7 @@ rhsm.conf - File /etc/rhsm/rhsm.conf
 ====================================
 
 Typical content of "/etc/rhsm/rhsm.conf" is::
+
     [rhsm]
     # Content base URL:
     baseurl= https://cdn.redhat.com


### PR DESCRIPTION
* Add rhsm_conf.rst to include parser in doc build
* Fix docstring errors

Signed-off-by: Bob Fahr <bfahr@redhat.com>