### PR TITLE
RHCLOUD-9230 Delete pid files on exit

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 class InsightsClient(object):
 
-    def __init__(self, config=None, setup_logging=True, **kwargs):
+    def __init__(self, config=None, from_phase=True, **kwargs):
         """
         The Insights client interface
         """
@@ -50,18 +50,14 @@ class InsightsClient(object):
                     sys.exit(constants.sig_kill_bad)
             # END hack. in the future, just set self.config=config
 
-        # setup_logging is True when called from phase, but not from wrapper.
-        #  use this to do any common init (like auto_config)
-        if setup_logging:
+        if from_phase:
             _init_client_config_dirs()
             self.set_up_logging()
             try_auto_configuration(self.config)
             self.initialize_tags()
-        else:
-            # write PID to file in case we need to ping systemd
-            write_to_disk(constants.pidfile, content=str(os.getpid()))
-            # write PPID to file so that we can grab the client execution method
-            write_to_disk(constants.ppidfile, content=get_parent_process())
+        else:  # from wrapper
+            _write_pid_files()
+
         # setup insights connection placeholder
         # used for requests
         self.session = None
@@ -718,3 +714,12 @@ def _init_client_config_dirs():
                 pass
             else:
                 raise e
+
+
+def _write_pid_files():
+    for file, content in (
+        (constants.pidfile, str(os.getpid())),  # PID in case we need to ping systemd
+        (constants.ppidfile, get_parent_process())  # PPID so that we can grab the client execution method
+    ):
+        write_to_disk(file, content=content)
+        atexit.register(write_to_disk, file, delete=True)

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -4,13 +4,12 @@ import json
 import logging
 import os
 import sys
-import atexit
 
 from insights.client import InsightsClient
 from insights.client.config import InsightsConfig
 from insights.client.constants import InsightsConstants as constants
 from insights.client.support import InsightsSupport
-from insights.client.utilities import validate_remove_file, print_egg_versions, write_to_disk
+from insights.client.utilities import validate_remove_file, print_egg_versions
 from insights.client.schedule import get_scheduler
 from insights.client.apps.compliance import ComplianceClient
 
@@ -262,9 +261,6 @@ def post_update(client, config):
 
 @phase
 def collect_and_output(client, config):
-    # last phase, delete PID file on exit
-    atexit.register(write_to_disk, constants.pidfile, delete=True)
-    atexit.register(write_to_disk, constants.ppidfile, delete=True)
     # --compliance was called
     if config.compliance:
         config.payload, config.content_type = ComplianceClient(config).oscap_scan()

--- a/insights/tests/client/init/test_write_pidfile.py
+++ b/insights/tests/client/init/test_write_pidfile.py
@@ -4,13 +4,14 @@ from mock.mock import call
 from mock.mock import patch
 
 
+@patch("insights.client.atexit.register")
 @patch("insights.client.write_to_disk")
 @patch("insights.client.os.getpid")
 @patch("insights.client.get_parent_process")
-def test_write_pidfile(get_parent_process, getpid, write_to_disk):
+def test_write_pidfile(get_parent_process, getpid, write_to_disk, register):
     '''
     Test writing of the pidfile when InsightsClient
-    is called initially (when setup_logging=False)
+    is called initially (when from_phase=False)
     '''
     InsightsClient(from_phase=False)
     getpid.assert_called_once()
@@ -20,13 +21,39 @@ def test_write_pidfile(get_parent_process, getpid, write_to_disk):
     ))
 
 
+@patch("insights.client.atexit.register")
 @patch("insights.client.write_to_disk")
+def test_atexit_delete_pidfile(write_to_disk, register):
+    '''
+    Test delete of the pidfile is registered when InsightsClient
+    is called initially (when from_phase=False)
+    '''
+    InsightsClient(from_phase=False)
+    register.assert_has_calls((
+        call(write_to_disk, InsightsConstants.pidfile, delete=True),
+        call(write_to_disk, InsightsConstants.ppidfile, delete=True)
+    ))
+
+
+@patch("insights.client.write_to_disk")
+@patch("insights.client.get_parent_process")
 @patch("insights.client.os.getpid")
-def test_write_pidfile_not_called(getpid, write_to_disk):
+def test_write_pidfile_not_called(getpid, get_parent_process, write_to_disk):
     '''
     Test that the pidfile is not written when
-    called from a phase (setup_logging=True)
+    called from a phase (from-phase=True)
     '''
     InsightsClient(from_phase=True)
+    get_parent_process.assert_not_called()
     getpid.assert_not_called()
     write_to_disk.assert_not_called()
+
+
+@patch("insights.client.atexit.register")
+def test_atexit_delete_pidfile_not_called(register):
+    '''
+    Test that delete of the pidfile is not registered when
+    called from a phase (from_phase=True)
+    '''
+    InsightsClient(from_phase=True)
+    register.assert_not_called()

--- a/insights/tests/client/init/test_write_pidfile.py
+++ b/insights/tests/client/init/test_write_pidfile.py
@@ -1,11 +1,12 @@
 from insights.client import InsightsClient
 from insights.client.constants import InsightsConstants
+from mock.mock import call
 from mock.mock import patch
 
 
 @patch("insights.client.write_to_disk")
 @patch("insights.client.os.getpid")
-@patch("insights.client.utilities.get_parent_process")
+@patch("insights.client.get_parent_process")
 def test_write_pidfile(get_parent_process, getpid, write_to_disk):
     '''
     Test writing of the pidfile when InsightsClient
@@ -13,9 +14,10 @@ def test_write_pidfile(get_parent_process, getpid, write_to_disk):
     '''
     InsightsClient(from_phase=False)
     getpid.assert_called_once()
-    calls = [write_to_disk(InsightsConstants.pidfile, content=str(getpid.return_value)),
-             write_to_disk(InsightsConstants.ppidfile, content=get_parent_process.return_value)]
-    write_to_disk.has_calls(calls)
+    write_to_disk.assert_has_calls((
+        call(InsightsConstants.pidfile, content=str(getpid.return_value)),
+        call(InsightsConstants.ppidfile, content=get_parent_process.return_value)
+    ))
 
 
 @patch("insights.client.write_to_disk")

--- a/insights/tests/client/init/test_write_pidfile.py
+++ b/insights/tests/client/init/test_write_pidfile.py
@@ -11,7 +11,7 @@ def test_write_pidfile(get_parent_process, getpid, write_to_disk):
     Test writing of the pidfile when InsightsClient
     is called initially (when setup_logging=False)
     '''
-    InsightsClient(setup_logging=False)
+    InsightsClient(from_phase=False)
     getpid.assert_called_once()
     calls = [write_to_disk(InsightsConstants.pidfile, content=str(getpid.return_value)),
              write_to_disk(InsightsConstants.ppidfile, content=get_parent_process.return_value)]
@@ -25,6 +25,6 @@ def test_write_pidfile_not_called(getpid, write_to_disk):
     Test that the pidfile is not written when
     called from a phase (setup_logging=True)
     '''
-    InsightsClient(setup_logging=True)
+    InsightsClient(from_phase=True)
     getpid.assert_not_called()
     write_to_disk.assert_not_called()


### PR DESCRIPTION
This is a fix for [RHCLOUD-9230](https://issues.redhat.com/browse/RHCLOUD-9230).

The reported bug was that the _insights-client_ does not delete its (P)PID files if called with the _--version_ argument. The problem is that the files are created whenever the wrapper is used, but deleted only at the end of the _collect and output_ phase. If this phase does not happen, the files are not deleted.

Fixed by registering the delete at the same place where the files are written. Like this, the files are deleted even on failure and regardless of what phases are run or whether even any phase is run. This includes the _--version_ switch that results in no phases being run at all.

Along with this I slipped in these following tiny changes:

- Fixed the tests that got broken by https://github.com/RedHatInsights/insights-core/pull/2675.
- Renamed the _InsightsClient.\_\_init\_\__ _setup_logging_ argument to _from_phase_. I checked both the _insights-core_ and _insights-client_ commit history and the argument is nowhere used by name, the rename should be thus safe.

The tests I added verify only the delete function registration, not the actual delete. The original tests did the same for the writes.