### PR TITLE
Enhance parser grub_conf

### DIFF
--- a/insights/parsers/grub_conf.py
+++ b/insights/parsers/grub_conf.py
@@ -287,7 +287,7 @@ class Grub1EFIConfig(Grub1Config):
         self._efi = True
 
 
-@parser(Specs.grub2_cfg, [IsRhel6, IsRhel7])
+@parser(Specs.grub2_cfg, [IsRhel6, IsRhel7, IsRhel8])
 class Grub2Config(GrubConfig):
     """
     Parser for configuration for GRUB version 2.


### PR DESCRIPTION
To check RHEL8 grub config, it is necessary to add "IsRhel8" in "Grub2Config".