### PR TITLE
Add sap combiner and deps to manifest for core collection

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -103,6 +103,16 @@ plugins:
         - name: insights.combiners.hostname
           enabled: true
 
+    # needed to collect the sap_hdb_version spec that uses the Sap combiner
+        - name: insights.parsers.lssap
+          enabled: true
+
+        - name: insights.parsers.saphostctrl
+          enabled: true
+
+        - name: insights.combiners.sap
+          enabled: true
+
     # needed because some specs aren't given names before they're used in DefaultSpecs
         - name: insights.core.spec_factory
           enabled: true


### PR DESCRIPTION
* This fixes an issue with collection of the sap_hdb_version spec in
  core collection

Signed-off-by: Bob Fahr <bfahr@redhat.com>