### PR TITLE
collect missing DNF modules data

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -233,6 +233,7 @@ class DefaultSpecs(Specs):
     dmidecode = simple_command("/usr/sbin/dmidecode")
     dmsetup_info = simple_command("/usr/sbin/dmsetup info -C")
     dnf_conf = simple_file("/etc/dnf/dnf.conf")
+    dnf_modules = glob_file("/etc/dnf/modules.d/*.module")
     docker_info = simple_command("/usr/bin/docker info")
     docker_list_containers = simple_command("/usr/bin/docker ps --all --no-trunc")
     docker_list_images = simple_command("/usr/bin/docker images --all --no-trunc --digests")

--- a/insights/tests/client/collection_rules/test_map_components.py
+++ b/insights/tests/client/collection_rules/test_map_components.py
@@ -74,7 +74,6 @@ def test_get_component_by_symbolic_name():
         'cpu_vulns_spectre_v1',
         'cpu_vulns_spectre_v2',
         'cpu_vulns_spec_store_bypass',
-        'dnf_modules',
         'docker_storage',
         'freeipa_healthcheck_log',
         'vmware_tools_conf',


### PR DESCRIPTION
* initially added by #1656 and removed by #2663
* it's still needed for insights.parsers.dnf_modules used by RedHatInsights/insights-puptoo project