### PR TITLE
Add grep command to blacklist

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -54,7 +54,8 @@ client:
     blacklist:
         files: []
         commands: []
-        patterns: []
+        patterns:
+            - "grep -F"
         keywords: []
 
     # Can be a list of dictionaries with name/enabled fields or a list of strings


### PR DESCRIPTION
* The grep command is used to apply filters for specs but it also shows
  up in the results of the ps command for core collection.  This can
  cause false positives for rules having filters that are too broad.
  Removing this command will help reduce the number of false positives
  from rules.

Signed-off-by: Bob Fahr <bfahr@redhat.com>