### PR TITLE
fix(specs): add spec for display_name to core3_archive

### DIFF
--- a/insights/specs/core3_archive.py
+++ b/insights/specs/core3_archive.py
@@ -14,3 +14,4 @@ simple_file = partial(simple_file, context=SerializedArchiveContext)
 
 class Core3Specs(Specs):
     branch_info = simple_file("/branch_info", kind=RawFileProvider)
+    display_name = simple_file("display_name")


### PR DESCRIPTION
There are issues with display_name in core3 archives
RHCLOUD-10799

Signed-off-by: Stephen Adams <tsadams@gmail.com>