### PR TITLE
Remove the unused SAP specs

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -597,14 +597,6 @@ class DefaultSpecs(Specs):
         sap = broker[Sap]
         return [sap.sid(i).lower() for i in sap.local_instances]
 
-    @datasource(Sap)
-    def sap_sid_name(broker):
-        """(list): Returns the list of (SAP SID, SAP InstanceName) """
-        sap = broker[Sap]
-        return [(sap.sid(i), i) for i in sap.local_instances]
-
-    sap_dev_disp = foreach_collect(sap_sid_name, "/usr/sap/%s/%s/work/dev_disp")
-    sap_dev_rd = foreach_collect(sap_sid_name, "/usr/sap/%s/%s/work/dev_rd")
     sap_hdb_version = foreach_execute(sap_sid, "/usr/bin/sudo -iu %sadm HDB version", keep_rc=True)
     saphostctl_getcimobject_sapinstance = simple_command("/usr/sap/hostctrl/exe/saphostctrl -function GetCIMObject -enuminstances SAPInstance")
     sat5_insights_properties = simple_file("/etc/redhat-access/redhat-access-insights.properties")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -193,8 +193,6 @@ class InsightsArchiveSpecs(Specs):
     rhev_data_center = simple_file("insights_commands/python_-m_insights.tools.cat_--no-header_rhev_data_center")
     rndc_status = simple_file("insights_commands/rndc_status")
     rpm_V_packages = first_file(["insights_commands/rpm_-V_coreutils_procps_procps-ng_shadow-utils_passwd_sudo_chrony", "insights_commands/rpm_-V_coreutils_procps_procps-ng_shadow-utils_passwd_sudo"])
-    sap_dev_disp = glob_file("/usr/sap/*/*/work/dev_disp")
-    sap_dev_rd = glob_file("/usr/sap/*/*/work/dev_rd")
     sap_hdb_version = simple_file("insights_commands/python_-m_insights.tools.cat_--no-header_sap_hdb_version")
     saphostctl_getcimobject_sapinstance = simple_file("insights_commands/usr.sap.hostctrl.exe.saphostctrl_-function_GetCIMObject_-enuminstances_SAPInstance")
     satellite_mongodb_storage_engine = simple_file("insights_commands/mongo_pulp_database_--eval_db.serverStatus_.storageEngine")


### PR DESCRIPTION
- The specs in this PR are not used by any rule, remove them temporary
   They are not added to uploader.json, no need to change the insights-core-assets repo.

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>