### PR TITLE
Add warnings property for LvmHeadings parsers

### DIFF
--- a/insights/parsers/lvm.py
+++ b/insights/parsers/lvm.py
@@ -286,6 +286,8 @@ class PvsHeadings(LvmHeadings):
     Attributes:
         data (list): List of dicts, each dict containing one row of the table
             with column headings as keys.
+        warnings (set): Set of lines from input data containing
+            warning strings.
 
     Examples:
         >>> pvs_data = shared[PvsHeadings]
@@ -301,6 +303,8 @@ class PvsHeadings(LvmHeadings):
     PRIMARY_KEY = Pvs.PRIMARY_KEY
 
     def parse_content(self, content):
+        self.warnings = set(find_warnings(content))
+        content = [l for l in content if l not in self.warnings]
         self.data = parse_fixed_table(
             content,
             heading_ignore=["PV "],
@@ -419,6 +423,8 @@ class VgsHeadings(LvmHeadings):
     Attributes:
         data (list): List of dicts, each dict containing one row of the table
             with column headings as keys.
+        warnings (set): Set of lines from input data containing
+            warning strings.
 
     Examples:
         >>> vgs_info = shared[VgsHeadings]
@@ -431,6 +437,8 @@ class VgsHeadings(LvmHeadings):
     PRIMARY_KEY = Vgs.PRIMARY_KEY
 
     def parse_content(self, content):
+        self.warnings = set(find_warnings(content))
+        content = [l for l in content if l not in self.warnings]
         self.data = parse_fixed_table(
             content,
             heading_ignore=["VG "],
@@ -608,6 +616,8 @@ class LvsHeadings(LvmHeadings):
     Attributes:
         data (list): List of dicts, each dict containing one row of the table
             with column headings as keys.
+        warnings (set): Set of lines from input data containing
+            warning strings.
 
     Examples:
         >>> lvs_info = shared[LvsHeadings]
@@ -622,6 +632,8 @@ class LvsHeadings(LvmHeadings):
     PRIMARY_KEY = Lvs.PRIMARY_KEY
 
     def parse_content(self, content):
+        self.warnings = set(find_warnings(content))
+        content = [l for l in content if l not in self.warnings]
         self.data = parse_fixed_table(
             content, heading_ignore=["LV "], header_substitute=[("LV Tags", "LV_Tags")]
         )

--- a/insights/parsers/tests/test_lvm.py
+++ b/insights/parsers/tests/test_lvm.py
@@ -20,6 +20,30 @@ Checksum Error
   Attempt To Close Device
 """.strip()
 
+VGSHEADING_CONTENT = """
+Configuration setting "activation/thin_check_executable" unknown.
+Configuration setting "activation/thin_check_options" unknown.
+Configuration setting "activation/thin_check_executable" unknown.
+Configuration setting "activation/thin_check_options" unknown.
+WARNING: Locking disabled. Be careful! This could corrupt your metadata.
+  Using volume group(s) on command line.
+Found duplicate PV qJMs5CEKY89qzq56E2vVeBvxzJGw2sA1: using /dev/mapper/mpathbp2 not /dev/cciss/c0d1p2
+Using duplicate PV /dev/mapper/mpathbp2 from subsystem DM, ignoring /dev/cciss/c0d1p2
+WARNING: Inconsistent metadata found for VG vgshared - updating to use version 26x
+  Archiving volume group "vgshared" metadata (seqno 26).
+  Archiving volume group "vgshared" metadata (seqno 27).
+  Creating volume group backup "/etc/lvm/backup/vgshared" (seqno 27).
+VG       Attr   Ext     #PV #LV #SN VSize   VFree   VG UUID                                VProfile #VMda VMdaFree  VMdaSize  #VMdaUse VG Tags
+vg00     wz--n- 128.00m   1   7   0 279.00g   5.00g MiuKdK-ruw4-UG1i-0uLE-4dfB-bk2v-uxte2W              1   506.00k  1020.00k        1
+vg00alt  wz--n-   4.00m   1   5   0 279.11g 265.11g LNzjbn-HU4C-WFCM-cRZ6-81ns-4rke-X8N0DA              1   507.00k  1020.00k        1
+vg01     wz--n-   4.00m   2   1   0 199.99g 100.99g 7O9ePI-M1Kp-H9VH-Lxt3-pS1Z-nLQB-P1IIO3              2   508.00k  1020.00k        2
+vgshared wz--nc   4.00m   6   1   0   1.76t 899.98g fFYYw3-Ns8Q-akPI-rrFU-YYn5-nKkk-UW67qO              6   507.00k  1020.00k        6
+  Reloading config files
+  Wiping internal VG cache
+Configuration setting "activation/thin_check_executable" unknown.
+Configuration setting "activation/thin_check_options" unknown.
+""".strip()
+
 
 def test_find_warnings():
     data = [l for l in lvm.find_warnings(WARNINGS_CONTENT.splitlines())]
@@ -48,3 +72,10 @@ def test_lvmconfig():
     p = lvm.LvmConfig(context_wrap(LVMCONFIG))
     assert p.data["dmeventd"]["raid_library"] == "libdevmapper-event-lvm2raid.so"
     assert p.data["global"]["thin_check_options"] == ["-q", "--clear-needs-check-flag"]
+
+
+def test_vgsheading_warnings():
+    result = lvm.VgsHeadings(context_wrap(VGSHEADING_CONTENT))
+    assert len(result.warnings) == 6
+    assert 'Configuration setting "activation/thin_check_executable" unknown.' in result.warnings
+    assert 'WARNING: Locking disabled. Be careful! This could corrupt your metadata.' in result.warnings


### PR DESCRIPTION
Added ``raw_lines`` property to the parsers extended by ``LvmHeadings``
class. The content may contains warning or debug information which can
be access using this property.