### PR TITLE
Enhance the parsers of saphostexec

### DIFF
--- a/insights/parsers/saphostexec.py
+++ b/insights/parsers/saphostexec.py
@@ -71,8 +71,10 @@ class SAPHostExecStatus(CommandParser, dict):
     def data(self):
         """
         .. warning::
+
             Deprecated, the parser works as a dict please use the built-in
             accesses of `dict`
+
         Returns the parsed data.
         """
         return self
@@ -151,8 +153,10 @@ class SAPHostExecVersion(CommandParser, dict):
     def data(self):
         """
         .. warning::
+
             Deprecated, the parser works as a dict please use the built-in
             accesses of `dict`
+
         Returns the parsed data.
         """
         return self

--- a/insights/parsers/saphostexec.py
+++ b/insights/parsers/saphostexec.py
@@ -4,22 +4,22 @@ saphostexec - Commands
 
 Shared parsers for parsing output of the ``saphostexec [option]`` commands.
 
-SAPHostExecStatus- command ``saphostexec -status``
---------------------------------------------------
+SAPHostExecStatus - command ``saphostexec -status``
+---------------------------------------------------
 
 SAPHostExecVersion - command ``saphostexec -version``
 -----------------------------------------------------
 """
-from .. import parser, CommandParser, LegacyItemAccess
-from insights.parsers import SkipException
+from insights import parser, CommandParser
+from insights.parsers import SkipException, ParseException
 from insights.specs import Specs
 from collections import namedtuple
 
 
 @parser(Specs.saphostexec_status)
-class SAPHostExecStatus(CommandParser, LegacyItemAccess):
+class SAPHostExecStatus(CommandParser, dict):
     """
-    Class for parsing the output of `saphostexec -status` command.
+    Class for parsing the output of ``saphostexec -status`` command.
 
     Typical output of the command is::
 
@@ -27,38 +27,68 @@ class SAPHostExecStatus(CommandParser, LegacyItemAccess):
         sapstartsrv running (pid = 9163)
         saposcol running (pid = 9323)
 
-    Attributes:
-        is_running (bool): The SAP Host Agent is running or not.
-        services (list): List of services.
-
     Examples:
         >>> type(sha_status)
         <class 'insights.parsers.saphostexec.SAPHostExecStatus'>
         >>> sha_status.is_running
         True
-        >>> sha_status.services['saphostexec']
+        >>> sha_status.services['saphostexec'].status
+        'running'
+        >>> sha_status['saphostexec'].status
+        'running'
+        >>> sha_status['saphostexec'].pid
         '9159'
     """
 
-    def parse_content(self, content):
-        self.is_running = False
-        self.services = self.data = {}
-        if 'saphostexec stopped' not in content[0]:
-            for line in content:
-                line_splits = line.split()
-                self.services[line_splits[0]] = ''
-                if len(line_splits) == 5 and line_splits[1] == 'running':
-                    self.services[line_splits[0]] = line_splits[-1][:-1]
-                else:
-                    raise SkipException("Incorrect status: '{0}'".format(line))
+    SAPHostAgentService = namedtuple("SAPHostAgentService", field_names=["status", "pid"])
+    """namedtuple: Type for storing the lines of ``saphostexec -status``"""
 
-            self.is_running = self.services and all(p for p in self.services.values())
+    def parse_content(self, content):
+        data = {}
+        for line in content:
+            line_sp = line.split(None, 1)
+            print(line_sp)
+            if len(line_sp) == 2:
+                value_sp = line_sp[1].replace('(', '').replace(')', '').split()
+                svc, sta, pid = line_sp[0], value_sp[0], value_sp[-1]
+                data[svc] = self.SAPHostAgentService(sta, pid)
+                print(svc, pid)
+            else:
+                raise ParseException("Incorrect line: '{0}'".format(line))
+        if data:
+            self.update(data)
+        else:
+            raise SkipException
+
+    @property
+    def is_running(self):
+        """
+        Returns if the SAPHostAgent is running or not.
+        """
+        return all(p.status == 'running' for p in self.values())
+
+    @property
+    def data(self):
+        """
+        .. warning::
+            Deprecated, the parser works as a dict please use the built-in
+            accesses of `dict`
+        Returns the parsed data.
+        """
+        return self
+
+    @property
+    def services(self):
+        """
+        Returns the parsed lines.
+        """
+        return self
 
 
 @parser(Specs.saphostexec_version)
-class SAPHostExecVersion(CommandParser, LegacyItemAccess):
+class SAPHostExecVersion(CommandParser, dict):
     """
-    Class for parsing the output of `saphostexec -version` command.
+    Class for parsing the output of ``saphostexec -version`` command.
 
     Typical output of the command is::
 
@@ -87,25 +117,23 @@ class SAPHostExecVersion(CommandParser, LegacyItemAccess):
         Linux 3
         Linux
 
-
-    Attributes:
-        components (dict): Dict of :py:class:`SAPComponent` instances.
-
     Examples:
         >>> type(sha_version)
         <class 'insights.parsers.saphostexec.SAPHostExecVersion'>
         >>> sha_version.components['saphostexec'].version
         '721'
-        >>> sha_version.components['saphostexec'].patch
+        >>> sha_version['saphostexec'].version
+        '721'
+        >>> sha_version['saphostexec'].patch
         '1011'
     """
 
-    SAPComponent = namedtuple("SAPComponent",
+    SAPHostAgentComponent = namedtuple("SAPHostAgentComponent",
             field_names=["version", "patch", "changelist"])
-    """namedtuple: Type for storing the SAP components"""
+    """namedtuple: Type for storing the lines of ``saphostexec -version``"""
 
     def parse_content(self, content):
-        self.components = self.data = {}
+        data = {}
         for line in content:
             # Only process component lines for now
             if not line.startswith('/usr/sap/hostctrl/exe/'):
@@ -113,4 +141,25 @@ class SAPHostExecVersion(CommandParser, LegacyItemAccess):
             key, val = line.split(':', 1)
             key = key.split('/')[-1]
             ver, pch, chl, _ = [s.split()[-1].strip() for s in val.split(', ', 3)]
-            self.components[key] = self.SAPComponent(ver, pch, chl)
+            data[key] = self.SAPHostAgentComponent(ver, pch, chl)
+        if data:
+            self.update(data)
+        else:
+            raise SkipException
+
+    @property
+    def data(self):
+        """
+        .. warning::
+            Deprecated, the parser works as a dict please use the built-in
+            accesses of `dict`
+        Returns the parsed data.
+        """
+        return self
+
+    @property
+    def components(self):
+        """
+        Return the dict of :py:class:`SAPHostAgentComponent` instances.
+        """
+        return self

--- a/insights/parsers/saphostexec.py
+++ b/insights/parsers/saphostexec.py
@@ -46,13 +46,13 @@ class SAPHostExecStatus(CommandParser, dict):
     def parse_content(self, content):
         data = {}
         for line in content:
-            line_sp = line.split(None, 1)
-            print(line_sp)
+            if not line.strip():
+                continue
+            line_sp = line.strip().split(None, 1)
             if len(line_sp) == 2:
                 value_sp = line_sp[1].replace('(', '').replace(')', '').split()
                 svc, sta, pid = line_sp[0], value_sp[0], value_sp[-1]
                 data[svc] = self.SAPHostAgentService(sta, pid)
-                print(svc, pid)
             else:
                 raise ParseException("Incorrect line: '{0}'".format(line))
         if data:

--- a/insights/parsers/tests/test_saphostexec.py
+++ b/insights/parsers/tests/test_saphostexec.py
@@ -44,6 +44,8 @@ Linux
 
 SHA_STOP = """
 saphostexec stopped
+
+sapstartsrv running (pid = 9163)
 """.strip()
 
 

--- a/insights/parsers/tests/test_saphostexec.py
+++ b/insights/parsers/tests/test_saphostexec.py
@@ -1,4 +1,4 @@
-from insights.parsers import saphostexec, SkipException
+from insights.parsers import saphostexec, SkipException, ParseException
 from insights.parsers.saphostexec import SAPHostExecStatus, SAPHostExecVersion
 from insights.tests import context_wrap
 import pytest
@@ -12,8 +12,7 @@ saposcol running (pid = 9323)
 
 STATUS_ABNORMAL = """
 saphostexec running (pid = 9159)
-sapstartsrv run (pid = 9163)
-saposcol (pid = 9323)
+sapstartsrv
 """.strip()
 
 VER_DOC = """
@@ -49,22 +48,29 @@ saphostexec stopped
 
 
 def test_saphostexec_status_abnormal():
-    with pytest.raises(SkipException) as s:
+    with pytest.raises(ParseException) as s:
         SAPHostExecStatus(context_wrap(STATUS_ABNORMAL))
-    assert "Incorrect status: 'sapstartsrv run (pid = 9163)'" in str(s)
-    assert "Incorrect status: 'saposcol (pid = 9,23)'" not in str(s)
+    assert "Incorrect line: 'sapstartsrv'" in str(s)
+
+    with pytest.raises(SkipException):
+        SAPHostExecStatus(context_wrap(''))
 
 
 def test_saphostexec_status():
     sha_status = SAPHostExecStatus(context_wrap(STATUS_DOC))
     assert sha_status.is_running is True
-    assert sha_status.services['saphostexec'] == '9159'
+    assert sha_status.services['saphostexec'].status == 'running'
+    assert sha_status.services['saphostexec'].pid == '9159'
     assert 'saposcol' in sha_status
 
     sha_status = SAPHostExecStatus(context_wrap(SHA_STOP))
     assert sha_status.is_running is False
-    assert sha_status.services == {}
     assert 'saposcol' not in sha_status
+
+
+def test_saphostexec_version_abnormal():
+    with pytest.raises(SkipException):
+        SAPHostExecVersion(context_wrap(''))
 
 
 def test_saphostexec_version():


### PR DESCRIPTION
- Use the `dict` as the base class instead of LegacyItemAccess
- Fix the bug that cannot handle empty output correctly.

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>