### PR TITLE
Add specs for existing parser InstalledProductIDs

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -629,6 +629,7 @@ class DefaultSpecs(Specs):
     sshd_config_perms = simple_command("/bin/ls -l /etc/ssh/sshd_config")
     sssd_config = simple_file("/etc/sssd/sssd.conf")
     subscription_manager_id = simple_command("/usr/sbin/subscription-manager identity")  # use "/usr/sbin" here, BZ#1690529
+    subscription_manager_installed_product_ids = simple_command("/usr/bin/find /etc/pki/product-default/ /etc/pki/product/ -name '*pem' -exec rct cat-cert --no-content '{}' \;")
     swift_object_expirer_conf = first_file(["/var/lib/config-data/puppet-generated/swift/etc/swift/object-expirer.conf", "/etc/swift/object-expirer.conf"])
     swift_proxy_server_conf = first_file(["/var/lib/config-data/puppet-generated/swift/etc/swift/proxy-server.conf", "/etc/swift/proxy-server.conf"])
     sysconfig_kdump = simple_file("etc/sysconfig/kdump")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -205,6 +205,7 @@ class InsightsArchiveSpecs(Specs):
     ss = simple_file("insights_commands/ss_-tupna")
     sshd_config_perms = simple_file("insights_commands/ls_-l_.etc.ssh.sshd_config")
     subscription_manager_id = simple_file("insights_commands/subscription-manager_identity")
+    subscription_manager_installed_product_ids = simple_file("insights_commands/find_.etc.pki.product-default._.etc.pki.product._-name_pem_-exec_rct_cat-cert_--no-content")
     sysctl = simple_file("insights_commands/sysctl_-a")
     systemctl_cat_rpcbind_socket = simple_file("insights_commands/systemctl_cat_rpcbind.socket")
     systemctl_cinder_volume = simple_file("insights_commands/systemctl_show_openstack-cinder-volume")

--- a/insights/tests/client/collection_rules/test_map_components.py
+++ b/insights/tests/client/collection_rules/test_map_components.py
@@ -65,7 +65,6 @@ def test_get_component_by_symbolic_name():
         'rabbitmq_queues',
         'rhev_data_center',
         'root_crontab',
-        'subscription_manager_installed_product_ids',
         'yum_list_installed',
         'zdump_v',
         'cni_podman_bridge_conf',


### PR DESCRIPTION
* Add spec for core collection of
  subscription_manager_installed_product_ids command
* Fixes Bugzilla 1905503
* Already being collected by client for legacy collection

Signed-off-by: Bob Fahr <bfahr@redhat.com>