### PR TITLE
[lvm] Remove "unknown device" string from warnings

### DIFF
--- a/insights/parsers/lvm.py
+++ b/insights/parsers/lvm.py
@@ -81,7 +81,6 @@ def find_warnings(content):
             "failed.",
             "Invalid metadata",
             "response failed",
-            "unknown device",
             "duplicate",
             "not found",
             "Missing device",


### PR DESCRIPTION
"unknown device" is not part of warning messages of pvs/lvs/vgs
commanmds but pvs will display unknown device when device is
missing. See example of such output:

```
PV                   VG     Fmt  Attr PSize   PFree DevSize PV UUID
/dev/fedora/home                 ---       0     0  418.75g
unknown device                   ---       0     0   50.00g
/dev/fedora/swap                 ---       0     0    7.69g
```