### PR TITLE
Add LsMod parser to the pre-loaded component for 'ss' spec

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -139,6 +139,10 @@ plugins:
         - name: insights.combiners.sap
           enabled: true
 
+    # needed for the 'pre-check' of the 'ss' spec
+        - name: insights.parsers.lsmod
+          enabled: true
+
     # needed because some specs aren't given names before they're used in DefaultSpecs
         - name: insights.core.spec_factory
           enabled: true


### PR DESCRIPTION
- fix: #2872 
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>