### PR TITLE
Add ls_sys_firmware spec in sos_archive

### DIFF
--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -121,6 +121,7 @@ class SosSpecs(Specs):
     locale = simple_file("sos_commands/i18n/locale")
     lsblk = first_file(["sos_commands/block/lsblk", "sos_commands/filesys/lsblk"])
     ls_boot = simple_file("sos_commands/boot/ls_-lanR_.boot")
+    ls_sys_firmware = simple_file("sos_commands/boot/ls_-lanR_.sys.firmware")
     lscpu = simple_file("sos_commands/processor/lscpu")
     lsinitrd = simple_file("sos_commands/boot/lsinitrd")
     lsof = simple_file("sos_commands/process/lsof_-b_M_-n_-l")


### PR DESCRIPTION
Newly added "ls -lanR /sys/firmware" command output in sosreport.[1]
This PR adds ls_sys_firmware spec for sos_archive.

[1] https://github.com/sosreport/sos/commit/959c5a4a78c797dc68206aff21e2eba63e99bb18 