### PR TITLE
Fix error with ipython and jedi in inspect

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,9 @@ docs = set([
     'ipython',
     'colorama',
     'jinja2',
-    'Pygments'
+    'Pygments',
+    'jedi<0.18.0'    # Open issue with jedi 0.18.0 and iPython <= 7.19
+                     # https://github.com/davidhalter/jedi/issues/1714
 ])
 
 testing = set([


### PR DESCRIPTION
* There is an open issue with ipython and jedi that causes an exception
  if tab completion is triggered in insights inspect
* Open issue in
  [IPython](https://github.com/ipython/ipython/issues/12740)
* This closes #2878

Signed-off-by: Bob Fahr <bfahr@redhat.com>