### PR TITLE
Skip empty result in chkconfig and unitfiles

### DIFF
--- a/insights/parsers/chkconfig.py
+++ b/insights/parsers/chkconfig.py
@@ -4,8 +4,9 @@ ChkConfig - command ``chkconfig``
 """
 from collections import namedtuple
 from .. import parser, CommandParser
-import re
 from insights.specs import Specs
+from insights.parsers import SkipException
+import re
 
 
 @parser(Specs.chkconfig)
@@ -14,6 +15,9 @@ class ChkConfig(CommandParser):
     A parser for working with data gathered from `chkconfig` utility.
 
     Sample input data is shown as `content` in the examples below.
+
+    Raises:
+        SkipException: When nothing is parsed.
 
     Examples:
         >>> content = '''
@@ -118,6 +122,9 @@ class ChkConfig(CommandParser):
                     num, state = level.split(':')
                     states.append(self.LevelState(num.strip(), state.strip()))
                 self.level_states[service] = states
+
+        if not self.services:
+            raise SkipException
 
     def is_on(self, service_name):
         """

--- a/insights/parsers/systemd/unitfiles.py
+++ b/insights/parsers/systemd/unitfiles.py
@@ -14,6 +14,7 @@ UnitFiles - command ``/bin/systemctl list-unit-files``
 from .. import get_active_lines
 from ... import Parser, parser
 from insights.specs import Specs
+from insights.parsers import SkipException
 
 
 @parser(Specs.systemctl_list_unit_files)
@@ -31,6 +32,9 @@ class UnitFiles(Parser):
         runlevel0.target                              disabled
         runlevel1.target                              disabled
         runlevel2.target                              enabled
+
+    Raises:
+        SkipException: When nothing is parsed.
 
     Example:
 
@@ -93,6 +97,9 @@ class UnitFiles(Parser):
                 self.parsed_lines[service] = line
                 self.service_list.append(service)
 
+        if not self.services:
+            raise SkipException
+
     def is_on(self, service_name):
         """
         Checks if the service is enabled in systemctl.
@@ -143,6 +150,9 @@ class ListUnits(Parser):
 
         161 loaded units listed. Pass --all to see loaded but inactive units, too.
         To show all installed unit files use 'systemctl list-unit-files'.
+
+    Raises:
+        SkipException: When nothing is parsed.
 
     Example:
 
@@ -207,6 +217,9 @@ class ListUnits(Parser):
             service_details = self.parse_service_details(parts[first_part:])
             if service_details:
                 self.unit_list[parts[first_part]] = service_details
+
+        if not self.unit_list:
+            raise SkipException
 
     def get_service_details(self, service_name):
         """

--- a/insights/parsers/tests/test_chkconfig.py
+++ b/insights/parsers/tests/test_chkconfig.py
@@ -1,6 +1,7 @@
 import pytest
 from ...tests import context_wrap
 from ..chkconfig import ChkConfig
+from insights.parsers import SkipException
 
 SERVICES = """
 auditd         	0:off	1:off	2:on	3:on	4:on	5:on	6:off
@@ -42,6 +43,17 @@ xinetd based services:
         tcpmux-server:  off
         time-dgram:     off
         time-stream:    off
+"""
+
+SERVICES_NG = """
+Note: This output shows SysV services only and does not include native
+      systemd services. SysV configuration data might be overridden by native
+      systemd configuration.
+
+      If you want to list systemd services use 'systemctl list-unit-files'.
+      To see services enabled on particular target use
+      'systemctl list-dependencies [target]'.
+
 """
 
 
@@ -87,3 +99,8 @@ def test_rhel_73():
     assert chkconfig.levels_off('netconsole') == set(['0', '1', '2', '3', '4', '5', '6'])
     assert chkconfig.levels_on('network') == set(['2', '3', '4', '5'])
     assert chkconfig.levels_on('rsync') == set(['0', '1', '2', '3', '4', '5', '6'])
+
+
+def test_chkconfig_ng():
+    with pytest.raises(SkipException):
+        ChkConfig(context_wrap(SERVICES_NG))

--- a/insights/parsers/tests/test_unitfiles.py
+++ b/insights/parsers/tests/test_unitfiles.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Per PEP 263
 import doctest
+import pytest
 from insights.tests import context_wrap
+from insights.parsers import SkipException
 from insights.parsers.systemd import unitfiles
 from insights.parsers.systemd.unitfiles import UnitFiles, ListUnits
 
@@ -414,3 +416,20 @@ def test_unitfiles_doc_examples():
     }
     failed, total = doctest.testmod(unitfiles, globs=env)
     assert failed == 0
+
+
+UNITFILES_NG = """
+Failed to list unit files: Connection timed out
+""".strip()
+
+LISTUNITS_NG = """
+Failed to list units
+""".strip()
+
+
+def test_unitfile_NG():
+    with pytest.raises(SkipException):
+        UnitFiles(context_wrap(UNITFILES_NG))
+
+    with pytest.raises(SkipException):
+        ListUnits(context_wrap(LISTUNITS_NG))


### PR DESCRIPTION
- fix: #2882
- When nothing is parsable in the collected file, skip it. 

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>