### PR TITLE
Fix 2863

### DIFF
--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -43,8 +43,8 @@ class Entry(object):
 
     def __init__(self, name=None, attrs=None, children=None, lineno=None, src=None):
         self._name = intern(name) if name is not None else name
-        self.attrs = attrs or []
-        self.children = children or []
+        self.attrs = attrs if isinstance(attrs, (list, tuple)) else tuple()
+        self.children = children if isinstance(children, (list, tuple)) else []
         self.parent = None
         self.lineno = lineno
         self.src = src
@@ -99,7 +99,7 @@ class Entry(object):
         """
         Returns the original first line of text that generated the ``Entry``.
         """
-        if self.src is not None:
+        if self.src is not None and self.lineno is not None:
             return self.src.content[self.lineno - 1]
 
     @property
@@ -729,12 +729,12 @@ def from_dict(orig):
                     if isinstance(res[0], Entry):
                         result.extend(res)
                     else:
-                        result.append(Entry(name=k, attrs=res))
+                        result.append(Entry(name=k, attrs=tuple(res)))
                 else:
-                    result.append(Entry(name=k, attrs=[]))
+                    result.append(Entry(name=k))
             else:
-                result.append(Entry(name=k, attrs=[v]))
-        return result
+                result.append(Entry(name=k, attrs=(v,)))
+        return tuple(result)
     return Entry(children=inner(orig))
 
 

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -504,7 +504,8 @@ class _EntryQuery(object):
         return _NotEntryQuery(self)
 
     def to_pyfunc(self):
-        if sys.version_info <= (2, 6):
+        ver = sys.version_info
+        if ver[0] == 2 and ver[1] == 6:
             return self.test
 
         env = {}

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -43,7 +43,7 @@ class Entry(object):
     __slots__ = ("_name", "attrs", "children", "parent", "lineno", "src")
 
     def __init__(self, name=None, attrs=None, children=None, lineno=None, src=None):
-        self._name = intern(name) if name is not None else name
+        self._name = intern(six.ensure_str(name)) if name is not None else name
         self.attrs = attrs if isinstance(attrs, (list, tuple)) else tuple()
         self.children = children if isinstance(children, (list, tuple)) else []
         self.parent = None

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -22,9 +22,16 @@ instances instead of a simple lookup.
 """
 import operator
 import re
+import sys
 from collections import defaultdict
 from itertools import chain
 from insights.parsr.query.boolean import All, Any, Boolean, Not, pred, pred2, TRUE
+
+# intern was a builtin until it moved to sys in python3
+try:
+    intern = sys.intern
+except:
+    pass
 
 
 class Entry(object):
@@ -35,7 +42,7 @@ class Entry(object):
     __slots__ = ("_name", "attrs", "children", "parent", "lineno", "src")
 
     def __init__(self, name=None, attrs=None, children=None, lineno=None, src=None):
-        self._name = name
+        self._name = intern(name) if name is not None else name
         self.attrs = attrs or []
         self.children = children or []
         self.parent = None

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -523,10 +523,10 @@ class _EntryQuery(object):
         func = """
 def predicate(value):
     try:
-        return {}
+        return {body}
     except Exception as ex:
         return False
-        """.format(expr(self))
+        """.format(body=expr(self))
 
         six.exec_(func, env, env)
         return env["predicate"]

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -22,6 +22,7 @@ instances instead of a simple lookup.
 """
 import operator
 import re
+import six
 import sys
 from collections import defaultdict
 from itertools import chain, count
@@ -527,7 +528,7 @@ def predicate(value):
         return False
         """.format(expr(self))
 
-        exec(func, env, env)
+        six.exec_(func, env, env)
         return env["predicate"]
 
 

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -515,7 +515,7 @@ class _EntryQuery(object):
                 return "(" + "not " + expr(b.query) + ")"
             else:
                 num = next(ids)
-                func = f"func_{num}"
+                func = "func_{num}".format(num=num)
                 env[func] = b.test
                 return func + "(value)"
 

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -504,6 +504,9 @@ class _EntryQuery(object):
         return _NotEntryQuery(self)
 
     def to_pyfunc(self):
+        if sys.version_info <= (2, 6):
+            return self.test
+
         env = {}
         ids = count()
 

--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -74,7 +74,7 @@ class Entry(object):
         """
         Returns the unique names of all the children as a list.
         """
-        return sorted(set(c.name for c in self.children))
+        return sorted(set(c._name for c in self.children if c._name))
 
     def __dir__(self):
         """

--- a/insights/parsr/query/boolean.py
+++ b/insights/parsr/query/boolean.py
@@ -40,6 +40,7 @@ when it's fully applied.
 
 """
 from itertools import count
+import six
 
 
 class Boolean(object):
@@ -96,7 +97,7 @@ def predicate(value):
         return False
         """.format(expr(self))
 
-        exec(func, env, env)
+        six.exec_(func, env, env)
         return env["predicate"]
 
 

--- a/insights/parsr/query/boolean.py
+++ b/insights/parsr/query/boolean.py
@@ -39,6 +39,7 @@ when it's fully applied.
         gt_five_and_lt_10 = gt(5) & lt(10)
 
 """
+from itertools import count
 
 
 class Boolean(object):
@@ -56,6 +57,47 @@ class Boolean(object):
 
     def __call__(self, value):
         return self.test(value)
+
+    def to_pyfunc(self):
+        env = {}
+        ids = count()
+
+        def expr(b):
+            if b is TRUE:
+                return " True "
+            elif b is FALSE:
+                return " False "
+            elif isinstance(b, All):
+                return "(" + " and ".join(expr(p) for p in b.exprs) + ")"
+            elif isinstance(b, Any):
+                return "(" + " or ".join(expr(p) for p in b.exprs) + ")"
+            elif isinstance(b, Not):
+                return "(" + "not " + expr(b.query) + ")"
+            elif isinstance(b, Predicate):
+                num = next(ids)
+
+                func = f"func_{num}"
+                args = f"args_{num}"
+
+                env[func] = b.func
+                env[args] = b.args
+
+                if isinstance(b, CaselessPredicate):
+                    return func + "(value.lower(), " + "*" + args + ")"
+                return func + "(value, " + "*" + args + ")"
+            else:
+                raise Exception(b)
+
+        func = """
+def predicate(value):
+    try:
+        return {}
+    except Exception as ex:
+        return False
+        """.format(expr(self))
+
+        exec(func, env, env)
+        return env["predicate"]
 
 
 class TRUE(Boolean):

--- a/insights/parsr/query/boolean.py
+++ b/insights/parsr/query/boolean.py
@@ -61,7 +61,8 @@ class Boolean(object):
         return self.test(value)
 
     def to_pyfunc(self):
-        if sys.version_info <= (2, 6):
+        ver = sys.version_info
+        if ver[0] == 2 and ver[1] == 6:
             return self.test
 
         env = {}

--- a/insights/parsr/query/boolean.py
+++ b/insights/parsr/query/boolean.py
@@ -41,6 +41,7 @@ when it's fully applied.
 """
 from itertools import count
 import six
+import sys
 
 
 class Boolean(object):
@@ -60,6 +61,9 @@ class Boolean(object):
         return self.test(value)
 
     def to_pyfunc(self):
+        if sys.version_info <= (2, 6):
+            return self.test
+
         env = {}
         ids = count()
 

--- a/insights/parsr/query/boolean.py
+++ b/insights/parsr/query/boolean.py
@@ -92,10 +92,10 @@ class Boolean(object):
         func = """
 def predicate(value):
     try:
-        return {}
+        return {body}
     except Exception as ex:
         return False
-        """.format(expr(self))
+        """.format(body=expr(self))
 
         six.exec_(func, env, env)
         return env["predicate"]

--- a/insights/parsr/query/boolean.py
+++ b/insights/parsr/query/boolean.py
@@ -76,8 +76,8 @@ class Boolean(object):
             elif isinstance(b, Predicate):
                 num = next(ids)
 
-                func = f"func_{num}"
-                args = f"args_{num}"
+                func = "func_{num}".format(num=num)
+                args = "args_{num}".format(num=num)
 
                 env[func] = b.func
                 env[args] = b.args


### PR DESCRIPTION
Fix #2863 about memory and performance issues with parsr.query.

- Intern node names
- convert predicates to regular python functions on the fly instead of calling through the "AST."
- simplify the desugaring process
- convert attributes to tuples instead of lists