### PR TITLE
Ensure that args to get_running_commands is a list

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -46,7 +46,7 @@ def get_owner(filename):
     return (name, group)
 
 
-def _get_running_commands(broker, commands=None):
+def _get_running_commands(broker, commands):
     """
     Search for command in ``ps auxcww`` output and determine RPM providing binary
 
@@ -56,8 +56,13 @@ def _get_running_commands(broker, commands=None):
 
     Returns:
         list: List of the full command paths of the ``command``.
+
+    Raises:
+        Exception: Raises an exception if commands object is not a list or is empty
     """
-    commands = [] if commands is None else commands
+    if not commands or not isinstance(commands, list):
+        raise Exception('Commands argument must be a list object and contain at least on item')
+
     ps_list = [broker[Ps].search(COMMAND_NAME__contains=c) for c in commands]
     ps_cmds = [i for sub_l in ps_list for i in sub_l]
     ctx = broker[HostContext]
@@ -364,7 +369,7 @@ class DefaultSpecs(Specs):
         Returns:
             list: List of the binary paths to each running process
         """
-        return _get_running_commands(broker, 'httpd')
+        return _get_running_commands(broker, ['httpd', ])
 
     httpd_pid = simple_command("/usr/bin/pgrep -o httpd")
     httpd_limits = foreach_collect(httpd_pid, "/proc/%s/limits")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -61,7 +61,7 @@ def _get_running_commands(broker, commands):
         Exception: Raises an exception if commands object is not a list or is empty
     """
     if not commands or not isinstance(commands, list):
-        raise Exception('Commands argument must be a list object and contain at least on item')
+        raise Exception('Commands argument must be a list object and contain at least one item')
 
     ps_list = [broker[Ps].search(COMMAND_NAME__contains=c) for c in commands]
     ps_cmds = [i for sub_l in ps_list for i in sub_l]

--- a/insights/tests/test_specs.py
+++ b/insights/tests/test_specs.py
@@ -6,6 +6,7 @@ from insights.core.context import HostContext
 from insights.core.plugins import ContentException
 from insights.core.spec_factory import (DatasourceProvider, simple_file,
                                         simple_command, glob_file, SpecSet)
+import insights.specs.default as default_specs
 import tempfile
 import pytest
 import glob
@@ -102,3 +103,13 @@ def test_datasource_provider():
     p = MyParser(ds)
     assert p.content == data.splitlines()
     assert list(ds.stream()) == data.splitlines()
+
+
+def test_get_running_commands():
+    broker = dr.Broker()
+    broker[HostContext] = HostContext()
+    with pytest.raises(Exception):
+        default_specs._get_running_commands(broker, 'not_a_list')
+
+    with pytest.raises(Exception):
+        default_specs._get_running_commands(broker, [])


### PR DESCRIPTION
* Commands argument could be a type other than a list which caused
  archive collection to fail
* Identified in bugzilla 1915219
* Added tests for exceptions

Signed-off-by: Bob Fahr <bfahr@redhat.com>