### PR TITLE
New combiner ProcEnvironAll

### DIFF
--- a/docs/shared_combiners_catalog/proc_environ.rst
+++ b/docs/shared_combiners_catalog/proc_environ.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.combiners.proc_environ
+   :members:
+   :show-inheritance:

--- a/insights/combiners/proc_environ.py
+++ b/insights/combiners/proc_environ.py
@@ -1,0 +1,53 @@
+"""
+ProcEnvironAll - Combiner ``/proc/<PID>/environ``
+=================================================
+
+The Combiner combiners and wraps all the
+:class:`insights.parsers.proc_environ.ProcEnviron` in to a list.
+
+"""
+from insights import add_filter
+from insights.core.plugins import combiner
+from insights.combiners.ps import Ps
+from insights.parsers.proc_environ import ProcEnviron as PE
+
+
+add_filter(Ps, 'PID')
+
+
+@combiner(PE, Ps)
+class ProcEnvironAll(list):
+    """
+    Class for parsing the ``/proc/<PID>/environ`` file into a dictionaries
+    with environment variable name as key and containing environment variable
+    value.
+
+    Examples:
+        >>> proc_envs[0]['REGISTRIES']
+        '--add-registry registry.access.redhat.com'
+        >>> proc_envs.get_environ_of_proc('openshift-route').pid
+        131
+    """
+
+    def __init__(self, pe, ps):
+        self.extend(pe)
+        self._ps = ps
+
+    def get_environ_of_proc(self, proc_name):
+        """
+        Returns the :class:`insights.parsers.proc_environ.ProcEnviron` of the
+        specified `proc_name`.
+
+        Args:
+            proc_name (str): Name of the process that want to check.
+
+        Returns:
+            ProcEnviron (str): The parse result of the environ. None when no
+                such `proc_name`.
+        """
+        proc_ps = self._ps.search(COMMAND_NAME__contains=proc_name)
+        pid = proc_ps[-1]['PID'] if proc_ps else None
+        if pid:
+            pe = [env for env in self if env.pid == pid]
+            if pe:
+                return pe[0]

--- a/insights/combiners/tests/test_proc_environ.py
+++ b/insights/combiners/tests/test_proc_environ.py
@@ -1,4 +1,3 @@
-import pytest
 import doctest
 from insights.tests import context_wrap
 from insights.parsers.proc_environ import ProcEnviron

--- a/insights/combiners/tests/test_proc_environ.py
+++ b/insights/combiners/tests/test_proc_environ.py
@@ -1,8 +1,21 @@
-from insights.parsers.proc_environ import ProcEnviron, OpenshiftFluentdEnviron, OpenshiftRouterEnviron
-from insights.tests import context_wrap
-from insights.parsers import proc_environ, ParseException, SkipException
-import doctest
 import pytest
+import doctest
+from insights.tests import context_wrap
+from insights.parsers.proc_environ import ProcEnviron
+from insights.parsers.ps import PsAuxcww
+from insights.combiners.ps import Ps
+from insights.combiners.proc_environ import ProcEnvironAll
+from insights.combiners import proc_environ
+
+PS_AUXCWW = """
+USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root         1  0.1  0.0 195712  7756 ?        Ss    2019 477:10 systemd
+root         2  0.0  0.0      0     0 ?        S     2019   1:04 kthreadd
+root         3  0.0  0.0      0     0 ?        S     2019  36:41 ksoftirqd/0
+root         8  0.0  0.0      0     0 ?        S     2019  31:50 migration/0
+root         9  0.1  0.0      0     0 ?        S     2019   0:00 rcu_bh
+root       131  0.1  0.0      0     0 ?        S     2019  05:00 openshift-route
+"""
 
 PROC_ENVIRON_EMPTY = """
 """.strip()
@@ -17,46 +30,34 @@ REGISTRIES=--add-registry registry.access.redhat.com \x00OPTIONS= --selinux-enab
 
 OPENSHIFT_ROUTE_ENVIRON = """
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\x00HOSTNAME=node1\x00ROUTER_EXTERNAL_HOST_HOSTNAME=\x00ROUTER_METRICS_TLS_CERT_FILE=/etc/pki/tls/metrics/tls.crt\x00ROUTER_METRICS_TLS_KEY_FILE=/etc/pki/tls/metrics/tls.key\x00STATS_PASSWORD=9cBJqkmTE6\x00ROUTER_MAX_CONNECTIONS=25000\x00DEFAULT_CERTIFICATE_DIR=/etc/pki/tls/private\x00ROUTER_EXTERNAL_HOST_INSECURE=false\x00ROUTER_EXTERNAL_HOST_PASSWORD=\x00ROUTER_SERVICE_HTTP_PORT=80\x00ROUTER_CIPHERS=\x00ROUTER_EXTERNAL_HOST_INTERNAL_ADDRESS=\x00ROUTER_LISTEN_ADDR=0.0.0.0:1936\x00ROUTER_METRICS_TYPE=haproxy\x00ROUTER_SERVICE_NAME=router\x00ROUTER_EXTERNAL_HOST_USERNAME=\x00DEFAULT_CERTIFICATE_PATH=/etc/pki/tls/private/tls.crt\x00ROUTER_EXTERNAL_HOST_HTTPS_VSERVER=\x00ROUTER_EXTERNAL_HOST_PARTITION_PATH=\x00ROUTER_SERVICE_NAMESPACE=default\x00STATS_USERNAME=admin\x00ROUTER_EXTERNAL_HOST_PRIVKEY=/etc/secret-volume/router.pem\x00RELOAD_INTERVAL=10s\x00ROUTER_EXTERNAL_HOST_HTTP_VSERVER=\x00ROUTER_EXTERNAL_HOST_VXLAN_GW_CIDR=\x00ROUTER_SERVICE_HTTPS_PORT=443\x00ROUTER_SUBDOMAIN=\x00STATS_PORT=1936\x00ROUTER_SERVICE_PORT_443_TCP=443\x00ROUTER_PORT_80_TCP_PORT=80\x00KUBERNETES_PORT_443_TCP_PROTO=tcp\x00KUBERNETES_PORT_443_TCP_ADDR=172.30.0.1\x00KUBERNETES_PORT_53_UDP_PROTO=udp\x00KUBERNETES_PORT_53_UDP_PORT=53\x00REGISTRY_CONSOLE_SERVICE_HOST=172.30.207.124\x00REGISTRY_CONSOLE_PORT=tcp://172.30.207.124:9000\x00ROUTER_PORT_1936_TCP=tcp://172.30.106.114:1936\x00DOCKER_REGISTRY_SERVICE_HOST=172.30.43.64\x00DOCKER_REGISTRY_PORT=tcp://172.30.43.64:5000\x00KUBERNETES_PORT=tcp://172.30.0.1:443\x00ROUTER_PORT_80_TCP_ADDR=172.30.106.114\x00ROUTER_PORT_443_TCP_PORT=443\x00DOCKER_REGISTRY_SERVICE_PORT_5000_TCP=5000\x00DOCKER_REGISTRY_PORT_5000_TCP_ADDR=172.30.43.64\x00KUBERNETES_SERVICE_PORT=443\x00ROUTER_SERVICE_PORT_1936_TCP=1936\x00KUBERNETES_PORT_53_TCP=tcp://172.30.0.1:53\x00KUBERNETES_PORT_53_TCP_ADDR=172.30.0.1\x00KUBERNETES_SERVICE_PORT_HTTPS=443\x00KUBERNETES_SERVICE_PORT_DNS=53\x00REGISTRY_CONSOLE_PORT_9000_TCP_PROTO=tcp\x00REGISTRY_CONSOLE_PORT_9000_TCP_PORT=9000\x00ROUTER_PORT_80_TCP=tcp://172.30.106.114:80\x00ROUTER_PORT_443_TCP=tcp://172.30.106.114:443\x00ROUTER_PORT_443_TCP_PROTO=tcp\x00DOCKER_REGISTRY_PORT_5000_TCP_PROTO=tcp\x00KUBERNETES_SERVICE_PORT_DNS_TCP=53\x00KUBERNETES_PORT_443_TCP_PORT=443\x00KUBERNETES_PORT_53_UDP=udp://172.30.0.1:53\x00KUBERNETES_PORT_53_TCP_PORT=53\x00REGISTRY_CONSOLE_SERVICE_PORT_REGISTRY_CONSOLE=9000\x00REGISTRY_CONSOLE_PORT_9000_TCP_ADDR=172.30.207.124\x00ROUTER_PORT_80_TCP_PROTO=tcp\x00ROUTER_PORT_1936_TCP_PORT=1936\x00DOCKER_REGISTRY_PORT_5000_TCP=tcp://172.30.43.64:5000\x00KUBERNETES_PORT_53_UDP_ADDR=172.30.0.1\x00ROUTER_SERVICE_PORT_80_TCP=80\x00ROUTER_PORT_443_TCP_ADDR=172.30.106.114\x00DOCKER_REGISTRY_PORT_5000_TCP_PORT=5000\x00KUBERNETES_SERVICE_HOST=172.30.0.1\x00ROUTER_PORT_1936_TCP_ADDR=172.30.106.114\x00DOCKER_REGISTRY_SERVICE_PORT=5000\x00REGISTRY_CONSOLE_SERVICE_PORT=9000\x00REGISTRY_CONSOLE_PORT_9000_TCP=tcp://172.30.207.124:9000\x00ROUTER_SERVICE_HOST=172.30.106.114\x00ROUTER_SERVICE_PORT=80\x00ROUTER_PORT=tcp://172.30.106.114:80\x00ROUTER_PORT_1936_TCP_PROTO=tcp\x00KUBERNETES_PORT_443_TCP=tcp://172.30.0.1:443\x00KUBERNETES_PORT_53_TCP_PROTO=tcp\x00container=oci\x00HOME=/root\x00KUBECONFIG=/var/lib/origin/openshift.local.config/master/admin.kubeconfig\x00TEMPLATE_FILE=/var/lib/haproxy/conf/haproxy-config.template\x00RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy\x00
-""".strip()
+"""
 
 OPENSHIFT_FLUENTD_ENVIRON = """
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\x00container=oci\x00LOGGING_FILE_SIZE=1024000\x00LOGGING_FILE_AGE=10\x00LOGGING_FILE_PATH=/var/log/fluentd/fluentd.log\x00
-""".strip()
+"""
 
 
-def test_proc_environ():
-    results = ProcEnviron(context_wrap(PROC_ENVIRON, path='/proc/123/environ'))
-    assert results['REGISTRIES'] == '--add-registry registry.access.redhat.com'
-    assert 'OPTIONS' in results
-
-
-def test_invalid():
-    with pytest.raises(ParseException) as e:
-        ProcEnviron(context_wrap(PROC_ENVIRON_ERR, path='/proc/123/environ'))
-    assert "Incorrect" in str(e)
-
-
-def test_empty():
-    with pytest.raises(SkipException) as e:
-        ProcEnviron(context_wrap(PROC_ENVIRON_EMPTY, path='/proc/123/environ'))
-    assert "Empty output." in str(e)
+def test_proc_environ_all():
+    ret1 = ProcEnviron(context_wrap(PROC_ENVIRON, path='/proc/8/environ'))
+    ret2 = ProcEnviron(context_wrap(OPENSHIFT_ROUTE_ENVIRON, path='/proc/9/environ'))
+    ret3 = ProcEnviron(context_wrap(OPENSHIFT_FLUENTD_ENVIRON, path='/proc/131/environ'))
+    ps = Ps(None, None, None, None, PsAuxcww(context_wrap(PS_AUXCWW)), None)
+    pes = ProcEnvironAll([ret1, ret2, ret3], ps)
+    assert pes[0]['REGISTRIES'] == '--add-registry registry.access.redhat.com'
+    assert 'OPTIONS' in pes[0]
+    assert pes[0].pid == 8
+    assert pes[1]['RELOAD_INTERVAL'] == '10s'
+    assert pes[2]['LOGGING_FILE_SIZE'] == '1024000'
+    assert pes.get_environ_of_proc('openshift-route').pid == 131
 
 
 def test_proc_environ_doc_examples():
+    ret1 = ProcEnviron(context_wrap(PROC_ENVIRON, path='/proc/8/environ'))
+    ret2 = ProcEnviron(context_wrap(OPENSHIFT_ROUTE_ENVIRON, path='/proc/9/environ'))
+    ret3 = ProcEnviron(context_wrap(OPENSHIFT_FLUENTD_ENVIRON, path='/proc/131/environ'))
+    ps = Ps(None, None, None, None, PsAuxcww(context_wrap(PS_AUXCWW)), None)
     env = {
-        'proc_environ': ProcEnviron(
-            context_wrap(PROC_ENVIRON, path='/proc/123/environ')),
+        'proc_envs': ProcEnvironAll([ret1, ret2, ret3], ps)
     }
     failed, total = doctest.testmod(proc_environ, globs=env)
     assert failed == 0
-
-
-def test_openshift_router_proc_environ():
-    results = OpenshiftRouterEnviron(context_wrap(OPENSHIFT_ROUTE_ENVIRON, path='/proc/123/environ'))
-    print(results)
-    assert results['RELOAD_INTERVAL'] == '10s'
-
-
-def test_openshift_fluentd_proc_environ():
-    results = OpenshiftFluentdEnviron(context_wrap(OPENSHIFT_FLUENTD_ENVIRON, path='/proc/123/environ'))
-    assert results['LOGGING_FILE_SIZE'] == '1024000'

--- a/insights/parsers/proc_environ.py
+++ b/insights/parsers/proc_environ.py
@@ -2,25 +2,26 @@
 ProcEnviron - File ``/proc/<PID>/environ``
 ==========================================
 
-Parser for parsing the ``environ`` file under ``/proc/<PID>``
-directory.
+Parser for parsing the ``environ`` file under ``/proc/<PID>`` directory.
 
 """
 
-from insights import Parser, parser, LegacyItemAccess
+from insights import Parser, parser
 from insights.parsers import SkipException, ParseException
 from insights.specs import Specs
+from insights.util import deprecated
 
 
-class ProcEnviron(Parser, LegacyItemAccess):
+@parser(Specs.environ_all)
+class ProcEnviron(Parser, dict):
     """
-    Base class for parsing the ``environ`` file under special ``/proc/<PID>``
-    directory into a dictionaries with environment variable name as key and containing
-    environment variable value.
+    Class for parsing the ``/proc/<PID>/environ`` file into a dictionaries
+    with environment variable name as key and containing environment variable
+    value.
 
     Typical content looks like::
 
-        REGISTRIES=--add-registry registry.access.redhat.com \x00OPTIONS= --selinux-enabled       --signature-verification=False\x00DOCKER_HTTP_HOST_COMPAT=1\x00ADD_REGISTRY=--add-registry registry.access.redhat.com\x00PATH=/usr/libexec/docker:/usr/bin:/usr/sbin\x00PWD=/run/docker/libcontainerd/containerd/135240dbd15a834acb21d68867930917afcc84c5f006ba65004acd88dccab756/init\x00LANG=en_US.UTF-8\x00GOTRACEBACK=crash\x00DOCKER_NETWORK_OPTIONS= --mtu=1450\x00DOCKER_CERT_PATH=/etc/docker\x00SHLVL=0\x00DOCKER_STORAGE_OPTIONS=--storage-driver devicemapper --storage-opt dm.fs=xfs --storage-opt dm.thinpooldev=/dev/mapper/docker--vg-docker--pool --storage-opt dm.use_deferred_removal=true --storage-opt dm.use_deferred_deletion=true \x00
+        REGISTRIES=--add-registry registry.access.redhat.com \x00OPTIONS= --selinux-enabled --signature-verification=False\x00DOCKER_HTTP_HOST_COMPAT=1\x00ADD_REGISTRY=--add-registry registry.access.redhat.com\x00PATH=/usr/libexec/docker:/usr/bin:/usr/sbin\x00PWD=/run/docker/libcontainerd/containerd/135240dbd15a834acb21d68867930917afcc84c5f006ba65004acd88dccab756/init\x00LANG=en_US.UTF-8\x00GOTRACEBACK=crash\x00DOCKER_NETWORK_OPTIONS= --mtu=1450\x00DOCKER_CERT_PATH=/etc/docker\x00SHLVL=0\x00DOCKER_STORAGE_OPTIONS=--storage-driver devicemapper --storage-opt dm.fs=xfs --storage-opt dm.thinpooldev=/dev/mapper/docker--vg-docker--pool --storage-opt dm.use_deferred_removal=true --storage-opt dm.use_deferred_deletion=true \x00
 
     Examples:
         >>> proc_environ['REGISTRIES']
@@ -32,34 +33,73 @@ class ProcEnviron(Parser, LegacyItemAccess):
         insights.parsers.SkipException: if the ``environ`` file is empty or doesn't exist.
         insights.parsers.ParseException: if the ``environ`` file content is incorrect.
 
+    Attributes:
+        pid(int): The PID of the ``environ`` got from the file path
     """
 
     def parse_content(self, content):
-        if not content:
-            raise SkipException("Empty output.")
-        if len(content) != 1:
+        print('0000000000000')
+        if len(content) > 1:
             raise ParseException("Incorrect content: '{0}'".format(content[-1]))
 
-        self.data = {}
-        for item in content[0].split('\x00'):
+        print('0000i00000000')
+        data = {}
+        cnt = content[0] if content else ''
+        for item in cnt.split('\x00'):
             if '=' in item:
                 k, v = item.strip().split('=', 1)
-                self.data[k] = v
+                data[k] = v
             elif item:
                 raise ParseException("Incorrect content: '{0}'".format(item))
+
+        if not data:
+            raise SkipException("Empty output.")
+
+        self.pid = int(self.file_path.lstrip('/').split('/')[1])
+        self.update(data)
+
+    @property
+    def data(self):
+        return self
 
 
 @parser(Specs.openshift_fluentd_environ)
 class OpenshiftFluentdEnviron(ProcEnviron):
     """
+    .. warning::
+
+        This Parser is deprecated, please use the
+        :func:`insights.combiners.proc_environ.ProcEnvironAll.get_environ_of_proc`
+        function instead.
+
     Class for parsing the ``environ`` file of the ``fluentd`` process.
     """
-    pass
+    def __init__(self, context):
+        deprecated(
+            OpenshiftFluentdEnviron,
+            'Please use the \
+            :func:`insights.combiners.proc_environ.ProcEnvironAll.get_environ_of_proc` \
+            function instead.'
+        )
+        super(OpenshiftFluentdEnviron, self).__init__(context)
 
 
 @parser(Specs.openshift_router_environ)
 class OpenshiftRouterEnviron(ProcEnviron):
     """
+    .. warning::
+
+        This Parser is deprecated, please use the
+        :func:`insights.combiners.proc_environ.ProcEnvironAll.get_environ_of_proc`
+        function instead.
+
     Class for parsing the ``environ`` file of the ``openshift-route`` process.
     """
-    pass
+    def __init__(self, context):
+        deprecated(
+            OpenshiftRouterEnviron,
+            'Please use the \
+            :func:`insights.combiners.proc_environ.ProcEnvironAll.get_environ_of_proc` \
+            function instead.'
+        )
+        super(OpenshiftRouterEnviron, self).__init__(context)

--- a/insights/parsers/proc_environ.py
+++ b/insights/parsers/proc_environ.py
@@ -38,11 +38,9 @@ class ProcEnviron(Parser, dict):
     """
 
     def parse_content(self, content):
-        print('0000000000000')
         if len(content) > 1:
             raise ParseException("Incorrect content: '{0}'".format(content[-1]))
 
-        print('0000i00000000')
         data = {}
         cnt = content[0] if content else ''
         for item in cnt.split('\x00'):

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -150,6 +150,7 @@ class Specs(SpecSet):
     engine_config_all = RegistryPoint()
     engine_db_query_vdsm_version = RegistryPoint()
     engine_log = RegistryPoint(filterable=True)
+    environ_all = RegistryPoint(multi_output=True)
     etc_journald_conf_d = RegistryPoint(multi_output=True)
     etc_journald_conf = RegistryPoint()
     etc_machine_id = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -294,6 +294,7 @@ class DefaultSpecs(Specs):
     du_dirs = foreach_execute(du_dirs_list, "/bin/du -s -k %s")
     engine_db_query_vdsm_version = simple_command('engine-db-query --statement "SELECT vs.vds_name, rpm_version FROM vds_dynamic vd, vds_static vs WHERE vd.vds_id = vs.vds_id" --json')
     engine_log = simple_file("/var/log/ovirt-engine/engine.log")
+    environ_all = glob_file("/proc/*/environ")
     etc_journald_conf = simple_file(r"etc/systemd/journald.conf")
     etc_journald_conf_d = glob_file(r"etc/systemd/journald.conf.d/*.conf")
     etc_machine_id = simple_file("/etc/machine-id")

--- a/insights/tests/test_filters.py
+++ b/insights/tests/test_filters.py
@@ -46,7 +46,7 @@ def test_filter_dumps_loads():
     filters.loads(r)
 
     assert Specs.ps_aux in filters.FILTERS
-    assert filters.FILTERS[Specs.ps_aux] == set(["COMMAND"])
+    assert filters.FILTERS[Specs.ps_aux] == set(["COMMAND", "PID"])
 
 
 def test_get_filter():


### PR DESCRIPTION
- Change the ProcEnviron parser base on the new spec environ_all
- Deprecate the OpenshiftFluentdEnviron and OpenshiftRouterEnviron

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>