### PR TITLE
set_enabled works on components and their fully qualified names.

### DIFF
--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -89,10 +89,11 @@ ENABLED = defaultdict(lambda: True)
 def set_enabled(component, enabled=True):
     """
     Enable a component for evaluation. If set to False, the component is
-    skipped, and all components that require it will not execute. If component
-    is a fully qualified name string of a callable object instead of the
-    callable object itself, the component's module is loaded as a side effect
-    of calling this function.
+    skipped, and all components that require it will not execute.
+
+    If component is a fully qualified name string of a callable object
+    instead of the callable object itself, the component's module is loaded
+    as a side effect of calling this function.
 
     Args:
         component (str or callable): fully qualified name of the component or
@@ -102,7 +103,11 @@ def set_enabled(component, enabled=True):
     Returns:
         None
     """
-    ENABLED[get_component(component) or component] = enabled
+    if isinstance(component, six.string_types):
+        component = get_component(component)
+
+    if component:
+        ENABLED[component] = enabled
 
 
 def is_enabled(component):

--- a/insights/tests/test_dr_enabled.py
+++ b/insights/tests/test_dr_enabled.py
@@ -1,5 +1,5 @@
 from insights import combiner, dr
-
+from insights.core.context import HostContext
 from insights.parsers.uname import Uname
 
 
@@ -21,9 +21,13 @@ def test_enabled_object():
     assert dr.is_enabled(Uname)
 
 
+def test_set_enabled_object():
+    dr.set_enabled(HostContext)
+    assert dr.is_enabled(HostContext)
+
+
 def test_disabled_string():
     dr.set_enabled("insights.core.context.HostContext", False)
-    from insights.core.context import HostContext
     assert not dr.is_enabled(HostContext)
 
 


### PR DESCRIPTION
Only call `get_component` if the argument is a string.

Fixes #2903

Signed-off-by: Christopher Sams <csams@redhat.com>