### PR TITLE
Remove debug call that prints unhelpful tracebacks during component loading

### DIFF
--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -156,9 +156,7 @@ def _import_component(name):
     for f in (_get_from_module, _get_from_class):
         try:
             return f(name)
-        except Exception as e:
-            log.debug("Couldn't load %s" % name)
-            log.debug(e, exc_info=True)
+        except:
             pass
 
 


### PR DESCRIPTION
When dr is asked for a component, it will first ensure that relevant module is
loaded. Since the component can be a module attribute or a class attribute, the
loader tries to get it as each, and this can cause harmless ImportErrors. A
debug statement was added to log them for visibility, but in practice they're
causing confusion in the logs.

Fixes #2912

Signed-off-by: Christopher Sams <csams@redhat.com>