### PR TITLE
Remove debug log messages generated when commands fail during serialization

### DIFF
--- a/insights/core/serde.py
+++ b/insights/core/serde.py
@@ -191,7 +191,6 @@ class Hydration(object):
                 doc["results"] = marshal(value, root=self.data, pool=self.pool)
             except Exception:
                 errors.append(traceback.format_exc())
-                log.debug(traceback.format_exc())
                 doc["results"] = None
             finally:
                 doc["ser_time"] = time.time() - start


### PR DESCRIPTION
Sometimes commands fail during archive creation. core logs the failures at
debug level, but they're generally harmless and causing confusion when people
inspect the collection log. Since we also capture the failures in the metadata
for each component, we can remove the debug statement and not lose the info.

Fixes #2913

Signed-off-by: Christopher Sams <csams@redhat.com>