### PR TITLE
fix: collect version_info in core3 archives

### DIFF
--- a/insights/specs/core3_archive.py
+++ b/insights/specs/core3_archive.py
@@ -15,3 +15,4 @@ simple_file = partial(simple_file, context=SerializedArchiveContext)
 class Core3Specs(Specs):
     branch_info = simple_file("/branch_info", kind=RawFileProvider)
     display_name = simple_file("display_name")
+    version_info = simple_file("version_info")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -837,6 +837,7 @@ class DefaultSpecs(Specs):
     uptime = simple_command("/usr/bin/uptime")
     usr_journald_conf_d = glob_file(r"usr/lib/systemd/journald.conf.d/*.conf")  # note that etc_journald.conf.d also exists
     vdo_status = simple_command("/usr/bin/vdo status")
+    version_info = simple_file("/version_info")
     vgdisplay = simple_command("/sbin/vgdisplay")
     vhost_net_zero_copy_tx = simple_file("/sys/module/vhost_net/parameters/experimental_zcopytx")
     vdsm_log = simple_file("var/log/vdsm/vdsm.log")


### PR DESCRIPTION
Looks like we need this spec defined for core3 archives. Ran a test
locally and this is the only reason I can spot that we wouldn't be
populating this field in some cases.

Signed-off-by: Stephen Adams <tsadams@gmail.com>