### PR TITLE
Change to use all_instance for HDB Version

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -733,7 +733,7 @@ class DefaultSpecs(Specs):
     @datasource(Sap, HostContext)
     def sap_sid(broker):
         sap = broker[Sap]
-        return [sap.sid(i).lower() for i in sap.local_instances]
+        return [sap.sid(i).lower() for i in sap.all_instances]
 
     sap_hdb_version = foreach_execute(sap_sid, "/usr/bin/sudo -iu %sadm HDB version", keep_rc=True)
     saphostctl_getcimobject_sapinstance = simple_command("/usr/sap/hostctrl/exe/saphostctrl -function GetCIMObject -enuminstances SAPInstance")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -732,6 +732,9 @@ class DefaultSpecs(Specs):
 
     @datasource(Sap, HostContext)
     def sap_sid(broker):
+        """
+        list: List of the SID of all SAP Instances.
+        """
         sap = broker[Sap]
         return [sap.sid(i).lower() for i in sap.all_instances]
 

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -736,7 +736,7 @@ class DefaultSpecs(Specs):
         list: List of the SID of all SAP Instances.
         """
         sap = broker[Sap]
-        return [sap.sid(i).lower() for i in sap.all_instances]
+        return list(set(sap.sid(i).lower() for i in sap.all_instances))
 
     sap_hdb_version = foreach_execute(sap_sid, "/usr/bin/sudo -iu %sadm HDB version", keep_rc=True)
     saphostctl_getcimobject_sapinstance = simple_command("/usr/sap/hostctrl/exe/saphostctrl -function GetCIMObject -enuminstances SAPInstance")


### PR DESCRIPTION
- It's necessary to get all the instances instead of the local instances
  Since It's possible for SAP HANA instances to use alias hostname

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>