### PR TITLE
Add more path to postgresql_log and postgresql_conf

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -676,15 +676,19 @@ class DefaultSpecs(Specs):
     postconf_builtin = simple_command("/usr/sbin/postconf -C builtin")
     postconf = simple_command("/usr/sbin/postconf")
     postgresql_conf = first_file([
-                                 "/var/lib/pgsql/data/postgresql.conf",
-                                 "/opt/rh/postgresql92/root/var/lib/pgsql/data/postgresql.conf",
-                                 "database/postgresql.conf"
-                                 ])
-    postgresql_log = first_of([
-                              glob_file("/var/lib/pgsql/data/pg_log/postgresql-*.log"),
-                              glob_file("/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_log/postgresql-*.log"),
-                              glob_file("/database/postgresql-*.log")
-                              ])
+        "/var/opt/rh/rh-postgresql12/lib/pgsql/data/postgresql.conf",
+        "/var/lib/pgsql/data/postgresql.conf",
+        "/opt/rh/postgresql92/root/var/lib/pgsql/data/postgresql.conf",
+        "database/postgresql.conf"
+    ])
+    postgresql_log = first_of(
+        [
+            glob_file("/var/opt/rh/rh-postgresql12/lib/pgsql/data/log/postgresql-*.log"),
+            glob_file("/var/lib/pgsql/data/pg_log/postgresql-*.log"),
+            glob_file("/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_log/postgresql-*.log"),
+            glob_file("/database/postgresql-*.log")
+        ]
+    )
     puppetserver_config = simple_file("/etc/sysconfig/puppetserver")
     proc_netstat = simple_file("proc/net/netstat")
     proc_slabinfo = simple_file("proc/slabinfo")


### PR DESCRIPTION
* For satellite 6.8, it uses rh-postgresql12-postgresql-server,
  the location of configuration file and error logs changes too.

Signed-off-by: Huanhuan Li <huali@redhat.com>