### PR TITLE
Enhance the IsRhel# components and add the 'minor' attr

### DIFF
--- a/insights/components/rhel_version.py
+++ b/insights/components/rhel_version.py
@@ -24,12 +24,16 @@ class IsRhel6(object):
     to determine RHEL version. It checks if RHEL6, if not
     RHEL6 it raises ``SkipComponent``.
 
+    Attributes:
+        minor (int): The minor version of RHEL 6.
+
     Raises:
         SkipComponent: When RHEL version is not RHEL6.
     """
     def __init__(self, rhel):
         if rhel.major != 6:
             raise SkipComponent('Not RHEL6')
+        self.minor = rhel.minor
 
 
 @component(RedHatRelease)
@@ -39,12 +43,16 @@ class IsRhel7(object):
     to determine RHEL version. It checks if RHEL7, if not \
     RHEL7 it raises ``SkipComponent``.
 
+    Attributes:
+        minor (int): The minor version of RHEL 7.
+
     Raises:
         SkipComponent: When RHEL version is not RHEL7.
     """
     def __init__(self, rhel):
         if rhel.major != 7:
             raise SkipComponent('Not RHEL7')
+        self.minor = rhel.minor
 
 
 @component(RedHatRelease)
@@ -54,9 +62,13 @@ class IsRhel8(object):
     to determine RHEL version. It checks if RHEL8, if not
     RHEL8 it raises ``SkipComponent``.
 
+    Attributes:
+        minor (int): The minor version of RHEL 8.
+
     Raises:
         SkipComponent: When RHEL version is not RHEL8.
     """
     def __init__(self, rhel):
         if rhel.major != 8:
             raise SkipComponent('Not RHEL8')
+        self.minor = rhel.minor


### PR DESCRIPTION
- Add the minor attribute to the IsRhel* components to make them can be widely used
   E.g. replace the `RedHatRelease` [here](https://github.com/RedHatInsights/insights-core/pull/2910/files#diff-3d5665cd194cc52869c22cc075e78581f83602790b2fb1a695dea1f55576754dR402)

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>