### PR TITLE
Fix checkin URL with legacy upload

### DIFF
--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -743,7 +743,7 @@ class InsightsConfig(object):
             self.diagnosis = True
         if self.test_connection:
             self.net_debug = True
-        if self.payload or self.diagnosis or self.compliance or self.show_results or self.check_results:
+        if self.payload or self.diagnosis or self.compliance or self.check_results or self.checkin:
             self.legacy_upload = False
         if self.payload and (self.logging_file == constants.default_log_file):
             self.logging_file = constants.default_payload_log

--- a/insights/tests/client/connection/test_init.py
+++ b/insights/tests/client/connection/test_init.py
@@ -1,14 +1,41 @@
+from insights.client.auto_config import try_auto_configuration
+from insights.client.config import InsightsConfig
+from insights.client.connection import InsightsConnection
 from mock.mock import Mock
 from mock.mock import patch
-from insights.client.connection import InsightsConnection
+from pytest import mark
+from sys import argv
 
 
 @patch("insights.client.connection.InsightsConnection._init_session")
 @patch("insights.client.connection.InsightsConnection.get_proxies")
-def test_inventory_url(get_proxies, init_session):
+def test_inventory_url_from_base_url(get_proxies, init_session):
     """
-    Inventory URL is composed correctly.
+    Inventory URL is composed correctly from the given base URL.
     """
     config = Mock(base_url="www.example.com", insecure_connection=False)
     connection = InsightsConnection(config)
     assert connection.inventory_url == "https://www.example.com/inventory/v1"
+
+
+@mark.parametrize(("config_kwargs",), (({"check_results": True},), ({"checkin": True},)))
+@patch("insights.client.connection.InsightsConnection._init_session")
+@patch("insights.client.connection.InsightsConnection.get_proxies")
+@patch("insights.client.auto_config._try_satellite5_configuration")
+@patch("insights.client.auto_config._try_satellite6_configuration")
+@patch('insights.client.config.sys.argv', [argv[0]])
+def test_inventory_url_from_phase(
+    try_satellite6_configuration,
+    try_satellite5_configuration,
+    get_proxies,
+    init_session,
+    config_kwargs
+):
+    """
+    Inventory URL is composed correctly from the default configuration.
+    """
+    config = InsightsConfig(**config_kwargs)
+    config.load_all()  # Disables legacy upload.
+    try_auto_configuration(config)  # Updates base_url if legacy upload is disabled.
+    connection = InsightsConnection(config)
+    assert connection.inventory_url == "https://cert-api.access.redhat.com/r/insights/platform/inventory/v1"

--- a/insights/tests/client/test_client.py
+++ b/insights/tests/client/test_client.py
@@ -622,16 +622,16 @@ def test_copy_to_output_file_obfuscate_on(shutil_, _copy_soscleaner_files):
     _copy_soscleaner_files.assert_called_once()
 
 
-@mark.parametrize(("result",), ((True,), (None,)))
-def test_checkin_result(result):
+@mark.parametrize(("expected_result",), ((True,), (None,)))
+def test_checkin_result(expected_result):
     config = InsightsConfig()
     client = InsightsClient(config)
-    client.connection = Mock(**{"checkin.return_value": result})
+    client.connection = Mock(**{"checkin.return_value": expected_result})
     client.session = True
 
-    result = client.checkin()
+    actual_result = client.checkin()
     client.connection.checkin.assert_called_once_with()
-    assert result is result
+    assert actual_result is expected_result
 
 
 def test_checkin_error():

--- a/insights/tests/client/test_config.py
+++ b/insights/tests/client/test_config.py
@@ -4,6 +4,7 @@ import os
 from io import TextIOWrapper, BytesIO
 from insights.client.config import InsightsConfig, DEFAULT_OPTS, _core_collect_default
 from mock.mock import patch
+from pytest import mark
 
 
 @patch('insights.client.config.ConfigParser.open')
@@ -127,12 +128,19 @@ def test_env_https_proxy_no_warning():
 
 
 # empty argv so parse_args isn't polluted with pytest arguments
+@mark.parametrize(("config",), (
+    ({"payload": "./payload.tar.gz", "content_type": "application/gzip"},),
+    ({"diagnosis": True},),
+    ({"compliance": True},),
+    ({"check_results": True},),
+    ({"checkin": True},),
+))
 @patch('insights.client.config.sys.argv', [sys.argv[0]])
-def test_diagnosis_implies_legacy():
+def test_implied_non_legacy_upload(config):
     '''
-    --diagnosis should always imply legacy_upload=False
+    Some arguments should always imply legacy_upload=False.
     '''
-    c = InsightsConfig(diagnosis=True)
+    c = InsightsConfig(**config)
     c.load_all()
     assert c.legacy_upload is False
 


### PR DESCRIPTION
The Inventory URL is composed incorrectly if legacy upload is enabled. There is a workaround for this in place that disables legacy upload for actions that use the Inventory API. Added the check-in to the list of such actions.

Removed _show_status_ from the workaround action list, because the legacy upload config option does not affect it in any way.