### PR TITLE
fix: check for null PATH

### DIFF
--- a/insights/util/__init__.py
+++ b/insights/util/__init__.py
@@ -61,11 +61,13 @@ def which(cmd, env=None):
             return cmd
         return None
 
-    paths = env.get("PATH").split(os.pathsep)
-    for path in paths:
-        c = os.path.join(path, cmd)
-        if os.access(c, os.X_OK) and os.path.isfile(c):
-            return c
+    envpath = env.get("PATH")
+    if envpath:
+        paths = envpath.split(os.pathsep)
+        for path in paths:
+            c = os.path.join(path, cmd)
+            if os.access(c, os.X_OK) and os.path.isfile(c):
+                return c
     return None
 
 


### PR DESCRIPTION
When importing insights-core as a Python module, if the process has no PATH in the env, the import will crash.

Check for a nonexistent PATH value before trying to split the value in the init here.