### PR TITLE
[lsvmbus] Use datasource(core-collection) instead of third-party pkg

### DIFF
--- a/insights/parsers/tests/test_lsvmbus.py
+++ b/insights/parsers/tests/test_lsvmbus.py
@@ -7,39 +7,22 @@ from insights.tests import context_wrap
 
 
 OUTPUT = """
-VMBUS ID 18: Class_ID = {44c4f61d-4444-4400-9d52-802e27ede19f} - PCI Express pass-through
-        Device_ID = {47505500-0001-0000-3130-444531303244}
-        Sysfs path: /sys/bus/vmbus/devices/47505500-0001-0000-3130-444531303244
-        Rel_ID=18, target_cpu=0
-VMBUS ID 26: Class_ID = {44c4f61d-4444-4400-9d52-802e27ede19f} - PCI Express pass-through
-        Device_ID = {47505500-0002-0000-3130-444531303244}
-        Sysfs path: /sys/bus/vmbus/devices/47505500-0002-0000-3130-444531303244
-        Rel_ID=26, target_cpu=0
-VMBUS ID 73: Class_ID = {44c4f61d-4444-4400-9d52-802e27ede19f} - PCI Express pass-through
-        Device_ID = {47505500-0003-0001-3130-444531303244}
-        Sysfs path: /sys/bus/vmbus/devices/47505500-0003-0001-3130-444531303244
-        Rel_ID=73, target_cpu=0
-VMBUS ID 74: Class_ID = {44c4f61d-4444-4400-9d52-802e27ede19f} - PCI Express pass-through
-        Device_ID = {47505500-0004-0001-3130-444531303244}
-        Sysfs path: /sys/bus/vmbus/devices/47505500-0004-0001-3130-444531303244
-        Rel_ID=74, target_cpu=0
+[{'device_id': '5620e0c7-8062-4dce-aeb7-520c7ef76171', 'class_id': 'da0a7802-e377-4aac-8e77-0558eb1073f8', 'description': 'Synthetic framebuffer adapter'}, {'device_id': '47505500-0001-0000-3130-444531444234', 'class_id': '44c4f61d-4444-4400-9d52-802e27ede19f', 'description': 'PCI Express pass-through'}, {'device_id': '4487b255-b88c-403f-bb51-d1f69cf17f87', 'class_id': '3375baf4-9e15-4b30-b765-67acb10d607b', 'description': 'Unknown'}]
 """.strip()
 
 
 def test_lsvmbus():
-    output = lsvmbus.LsvmBus(context_wrap(OUTPUT))
-    assert len(output.devices) == 4
-    assert output.devices[0].get('vmbus_id', None) == '18'
-    assert output.devices[0].get('device_id', None) == '47505500-0001-0000-3130-444531303244'
-    assert output.devices[0].get('rel_id', None) == '18'
-    assert output.devices[0].get('sysfs_path', None) == '/sys/bus/vmbus/devices/47505500-0001-0000-3130-444531303244'
-    assert output.devices[0].get('target_cpu', None) == '0'
+    output = lsvmbus.LsVMBus(context_wrap(OUTPUT))
+    # import pdb; pdb.set_trace()
+    assert len(output.devices) == 3
+    assert output.devices[1].get('device_id', None) == '47505500-0001-0000-3130-444531444234'
+    assert output.devices[1].get('description', None) == 'PCI Express pass-through'
 
     with pytest.raises(SkipException):
-        assert lsvmbus.LsvmBus(context_wrap("")) is None
+        assert lsvmbus.LsVMBus(context_wrap("")) is None
 
 
 def test_docs():
-    env = {'lsvmbus': lsvmbus.LsvmBus(context_wrap(OUTPUT))}
+    env = {'lsvmbus': lsvmbus.LsVMBus(context_wrap(OUTPUT))}
     failed, total = doctest.testmod(lsvmbus, globs=env)
     assert failed == 0

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -131,7 +131,6 @@ class InsightsArchiveSpecs(Specs):
     lspci = simple_file("insights_commands/lspci_-k")
     lssap = simple_file("insights_commands/usr.sap.hostctrl.exe.lssap")
     lsscsi = simple_file("insights_commands/lsscsi")
-    lsvmbus = simple_file("insights_commands/lsvmbus_-vv")
     lvmconfig = first_file([
         "insights_commands/lvmconfig_--type_full",
         "insights_commands/lvm_dumpconfig_--type_full"


### PR DESCRIPTION
The 'lsvmbus' command is provided by hyperv-tools package. This patch replace
the command with the core collection spec.

Signed-off-by: Sachin Patil <psachin@redhat.com>