### PR TITLE
Correctly handle uppercase VM name in "VirshListAll.get_vm_state()"

### DIFF
--- a/insights/parsers/tests/test_virsh_list_all.py
+++ b/insights/parsers/tests/test_virsh_list_all.py
@@ -41,6 +41,7 @@ def test_virsh_output():
     assert output.get_vm_state('rhel9.0') is None
     assert ('cfme' in output) is False
     assert ('cfme-5.7.13' in output) is True
+    assert output.get_vm_state("RHOSP10") == "shut off"
 
 
 def test_virsh_output_no_vms():

--- a/insights/parsers/virsh_list_all.py
+++ b/insights/parsers/virsh_list_all.py
@@ -132,7 +132,6 @@ class VirshListAll(CommandParser):
 
             str: State of VM. Returns None if, ``vmname`` does not exist.
         '''
-        vmname = vmname.lower()
-        if vmname in self.keywords:
+        if vmname.lower() in self.keywords:
             return self.search(name=vmname)[0]['state']
         return None


### PR DESCRIPTION
The `keywords` attribute stores VM names in lowercase, however
`search()` look-up into `self.cols` that does not contains VM names
in lowercase.
