### PR TITLE
Divert collect output to a separate debug log in archive

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -361,7 +361,7 @@ def collect(manifest=default_manifest, tmp_path=None, compress=False, rm_conf=No
 
     # Capture all logging for dr.run_all in a separate archive log
     LOG_FORMAT = ("%(asctime)s %(levelname)8s %(name)s %(message)s")
-    log_path = os.path.join(output_path, 'metadata', 'collection.log')
+    log_path = os.path.join(output_path, 'meta_data')
     fs.ensure_path(log_path)
     log_file = os.path.join(log_path, 'collection.log')
     file_handler = logging.FileHandler(log_file)

--- a/insights/collect.py
+++ b/insights/collect.py
@@ -359,6 +359,18 @@ def collect(manifest=default_manifest, tmp_path=None, compress=False, rm_conf=No
     fs.ensure_path(output_path)
     fs.touch(os.path.join(output_path, "insights_archive.txt"))
 
+    # Capture all logging for dr.run_all in a separate archive log
+    LOG_FORMAT = ("%(asctime)s %(levelname)8s %(name)s %(message)s")
+    log_path = os.path.join(output_path, 'metadata', 'collection.log')
+    fs.ensure_path(log_path)
+    log_file = os.path.join(log_path, 'collection.log')
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    dr_logger = logging.getLogger(dr.run_all.__module__)
+    dr_logger.setLevel(logging.DEBUG)
+    dr_logger.addHandler(file_handler)
+    dr_logger.propagate = False
+
     broker = dr.Broker()
     ctx = create_context(client.get("context", {}))
     broker[ctx.__class__] = ctx

--- a/insights/collect.py
+++ b/insights/collect.py
@@ -377,22 +377,11 @@ def collect(manifest=default_manifest, tmp_path=None, compress=False, rm_conf=No
     file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
     info_filter = IgnoreInfoFilter()
     file_handler.addFilter(info_filter)
-    mod_loggers = {
-        dr.__name__: None,
-        core_plugins.__name__: None,
-        spec_factory.__name__: None
-    }
-    mod_logger_levels = {
-        dr.__name__: None,
-        core_plugins.__name__: None,
-        spec_factory.__name__: None
-    }
-    for mod in mod_loggers.keys():
-        mod_loggers[mod] = logging.getLogger(mod)
-        mod_logger_levels[mod] = mod_loggers[mod].getEffectiveLevel()
-        mod_loggers[mod].setLevel(logging.DEBUG)
-        mod_loggers[mod].addHandler(file_handler)
-        mod_loggers[mod].propagate = False
+    dr_logger = logging.getLogger(dr.__name__)
+    dr_logger_level = dr_logger.getEffectiveLevel()
+    dr_logger.setLevel(logging.DEBUG)
+    dr_logger.addHandler(file_handler)
+    dr_logger.propagate = False
 
     broker = dr.Broker()
     ctx = create_context(client.get("context", {}))
@@ -406,9 +395,9 @@ def collect(manifest=default_manifest, tmp_path=None, compress=False, rm_conf=No
         dr.run_all(broker=broker, pool=pool)
 
     # Restore logging state and close log  before completing
-    for mod in mod_loggers.keys():
-        mod_loggers[mod].removeHandler(file_handler)
-        mod_loggers[mod].setLevel(mod_logger_levels[mod])
+    dr_logger.removeHandler(file_handler)
+    dr_logger.setLevel(dr_logger_level)
+    dr_logger.propagate = True
     file_handler.close()
 
     if compress:

--- a/insights/collect.py
+++ b/insights/collect.py
@@ -18,7 +18,7 @@ import yaml
 from datetime import datetime
 
 from insights import apply_configs, apply_default_enabled, dr
-from insights.core import blacklist, filters, plugins as core_plugins, spec_factory
+from insights.core import blacklist, filters
 from insights.core.serde import Hydration
 from insights.util import fs
 from insights.util.subproc import call, CalledProcessError

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -326,7 +326,7 @@ class CommandOutputProvider(ContentProvider):
             raise dr.SkipComponent()
 
         if not which(shlex.split(self.cmd)[0], env=self.create_env()):
-            raise ContentException("Couldn't execute: %s" % self.cmd)
+            raise ContentException("Command not present/executable: %s" % self.cmd)
 
     def create_args(self):
         command = [shlex.split(self.cmd)]


### PR DESCRIPTION
* During collection in dr.run_all, exceptions may be added to the log
  when in DEBUG mode, so capture all output from dr.run_all into a
  separate log and save it in the archive for analysis.
* These exceptions are expected, and do not normally impact the
  execution of the client, but may be confusing in the client log.
* Fix #2943

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>