### PR TITLE
Add invalid YAML check to CustomHiera

### DIFF
--- a/insights/parsers/satellite_installer_configurations.py
+++ b/insights/parsers/satellite_installer_configurations.py
@@ -9,10 +9,12 @@ CustomHiera - file ``/etc/foreman-installer/custom-hiera.yaml``
 Parsers the file `/etc/foreman-installer/custom-hiera.yaml`
 
 """
+import sys
+import six
 
 from insights import parser, YAMLParser
 from insights.specs import Specs
-from insights.parsers import SkipException
+from insights.parsers import SkipException, ParseException
 
 
 @parser(Specs.satellite_custom_hiera)
@@ -27,7 +29,13 @@ class CustomHiera(YAMLParser):
         582
     """
     def parse_content(self, content):
+        self.is_invalid_yaml = False
         try:
             super(CustomHiera, self).parse_content(content)
         except SkipException:
             pass
+        except ParseException as ex:
+            if "couldn't parse yaml" in str(ex):
+                self.is_invalid_yaml = True
+            else:
+                six.reraise(*sys.exc_info())

--- a/insights/parsers/tests/test_satellite_installer_configurations.py
+++ b/insights/parsers/tests/test_satellite_installer_configurations.py
@@ -35,6 +35,14 @@ CUSTOM_HIERA_CONFIG_2 = """
 
 """
 
+CUSTOM_HIERA_INVALID_YAML = """
+---
+This is invalid YAML
+
+# Foreman Proxy
+foreman_proxy::tls_disabled_versions: ['1.1']
+"""
+
 
 def test_custom_hiera():
     result = satellite_installer_configurations.CustomHiera(context_wrap(CUSTOM_HIERA_CONFIG))
@@ -44,6 +52,11 @@ def test_custom_hiera():
 
     result = satellite_installer_configurations.CustomHiera(context_wrap(CUSTOM_HIERA_CONFIG_2))
     assert result.data is None
+    assert result.is_invalid_yaml is False
+
+    result = satellite_installer_configurations.CustomHiera(context_wrap(CUSTOM_HIERA_INVALID_YAML))
+    assert hasattr(result, 'data') is False
+    assert result.is_invalid_yaml is True
 
 
 def test_doc():


### PR DESCRIPTION
A rule plugin requires to check if the config file has invalid yaml syntax. This change adds an is_invalid_yaml property to the parser.