### PR TITLE
feat: RHICOMPL-1401 Send OS info in profile request

### DIFF
--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -13,7 +13,8 @@ PATH = '/usr/share/xml/scap/ref_id.xml'
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None, compressor='gz')
 def test_oscap_scan(config, assert_rpms):
     compliance_client = ComplianceClient(config)
-    compliance_client.get_policies = lambda: [{'attributes': {'ref_id': 'foo', 'tailored': False}}]
+    compliance_client.get_initial_profiles = lambda: [{'attributes': {'ref_id': 'foo', 'tailored': False}}]
+    compliance_client.get_profiles_matching_os = lambda: []
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
     compliance_client.run_scan = lambda ref_id, policy_xml, output_path, tailoring_file_path: None
     compliance_client.archive.archive_tmp_dir = '/tmp'
@@ -27,7 +28,8 @@ def test_oscap_scan(config, assert_rpms):
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
 def test_missing_packages(config, call):
     compliance_client = ComplianceClient(config)
-    compliance_client.get_policies = lambda: [{'attributes': {'ref_id': 'foo'}}]
+    compliance_client.get_initial_profiles = lambda: [{'attributes': {'ref_id': 'foo'}}]
+    compliance_client.get_profiles_matching_os = lambda: []
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
     compliance_client.run_scan = lambda ref_id, policy_xml: None
     with raises(SystemExit):
@@ -38,7 +40,8 @@ def test_missing_packages(config, call):
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
 def test_errored_rpm_call(config, call):
     compliance_client = ComplianceClient(config)
-    compliance_client.get_policies = lambda: [{'attributes': {'ref_id': 'foo'}}]
+    compliance_client.get_initial_profiles = lambda: [{'attributes': {'ref_id': 'foo'}}]
+    compliance_client.get_profiles_matching_os = lambda: []
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
     compliance_client.run_scan = lambda ref_id, policy_xml: None
     with raises(SystemExit):
@@ -46,37 +49,70 @@ def test_errored_rpm_call(config, call):
 
 
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
-def test_get_policies(config):
+def test_get_profiles(config):
     compliance_client = ComplianceClient(config)
     compliance_client.hostname = 'foo'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
-    assert compliance_client.get_policies() == [{'attributes': 'data'}]
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo external=false canonical=false'})
+    assert compliance_client.get_profiles('search string') == [{'attributes': 'data'}]
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'search string'})
 
 
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
-def test_get_policies_no_policies(config):
+def test_get_profiles_no_profiles(config):
     compliance_client = ComplianceClient(config)
     compliance_client.hostname = 'foo'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': []})))
-    assert compliance_client.get_policies() == []
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo external=false canonical=false'})
+    assert compliance_client.get_profiles('search string') == []
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'search string'})
 
 
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
-def test_get_policies_error(config):
+def test_get_profiles_error(config):
     compliance_client = ComplianceClient(config)
     compliance_client.hostname = 'foo'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=500))
-    assert compliance_client.get_policies() == []
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo external=false canonical=false'})
+    assert compliance_client.get_profiles('search string') == []
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'search string'})
+
+
+@patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
+def test_get_initial_profiles(config):
+    compliance_client = ComplianceClient(config)
+    compliance_client.hostname = 'foo'
+    compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
+    assert compliance_client.get_initial_profiles() == [{'attributes': 'data'}]
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo canonical=false external=false'})
+
+
+@patch("insights.client.apps.compliance.linux_distribution", return_value=(None, '6.5', None))
+@patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
+def test_get_profiles_matching_os(config, linux_distro_mock):
+    compliance_client = ComplianceClient(config)
+    compliance_client.hostname = 'foo'
+    compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
+    assert compliance_client.get_profiles_matching_os() == [{'attributes': 'data'}]
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo canonical=false os_minor_version=5'})
 
 
 @patch("insights.client.apps.compliance.linux_distribution", return_value=(None, '6.5', None))
 @patch("insights.client.config.InsightsConfig")
 def test_os_release(config, linux_distro_mock):
     compliance_client = ComplianceClient(config)
-    assert compliance_client.os_release() == '6'
+    assert compliance_client.os_release() == '6.5'
+
+
+@patch("insights.client.apps.compliance.linux_distribution", return_value=(None, '6.5', None))
+@patch("insights.client.config.InsightsConfig")
+def test_os_minor_version(config, linux_distro_mock):
+    compliance_client = ComplianceClient(config)
+    assert compliance_client.os_minor_version() == '5'
+
+
+@patch("insights.client.apps.compliance.linux_distribution", return_value=(None, '6.5', None))
+@patch("insights.client.config.InsightsConfig")
+def test_os_major_version(config, linux_distro_mock):
+    compliance_client = ComplianceClient(config)
+    assert compliance_client.os_major_version() == '6'
 
 
 @patch("insights.client.config.InsightsConfig")
@@ -156,11 +192,32 @@ def test_tailored_file_is_not_downloaded_if_tailored_is_missing(config):
 
 @patch("insights.client.apps.compliance.open", new_callable=mock_open)
 @patch("insights.client.config.InsightsConfig")
-def test_tailored_file_is_downloaded_if_needed(config, call):
+def test_tailored_file_is_downloaded_from_initial_profile_if_os_minor_version_is_missing(config, call):
     compliance_client = ComplianceClient(config)
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
     tailoring_file_path = "/var/tmp/oscap_tailoring_file-aaaaa.xml"
     assert tailoring_file_path == compliance_client.download_tailoring_file({'id': 'foo', 'attributes': {'tailored': True, 'ref_id': 'aaaaa'}})
+    assert compliance_client.download_tailoring_file({'id': 'foo', 'attributes': {'tailored': False, 'ref_id': 'aaaaa'}}) is None
+
+
+@patch("insights.client.apps.compliance.linux_distribution", return_value=(None, '6.5', None))
+@patch("insights.client.config.InsightsConfig")
+def test_tailored_file_is_not_downloaded_if_os_minor_version_mismatches(config, linux_distro_mock):
+    compliance_client = ComplianceClient(config)
+    compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
+    assert compliance_client.download_tailoring_file({'id': 'foo', 'attributes': {'tailored': True, 'ref_id': 'aaaaa', 'os_minor_version': '2'}}) is None
+    assert compliance_client.download_tailoring_file({'id': 'foo', 'attributes': {'tailored': False, 'ref_id': 'aaaaa', 'os_minor_version': '2'}}) is None
+
+
+@patch("insights.client.apps.compliance.linux_distribution", return_value=(None, '6.5', None))
+@patch("insights.client.apps.compliance.open", new_callable=mock_open)
+@patch("insights.client.config.InsightsConfig")
+def test_tailored_file_is_downloaded_if_needed(config, call, linux_distro_mock):
+    compliance_client = ComplianceClient(config)
+    compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
+    tailoring_file_path = "/var/tmp/oscap_tailoring_file-aaaaa.xml"
+    assert tailoring_file_path == compliance_client.download_tailoring_file({'id': 'foo', 'attributes': {'tailored': True, 'ref_id': 'aaaaa', 'os_minor_version': '5'}})
+    assert compliance_client.download_tailoring_file({'id': 'foo', 'attributes': {'tailored': False, 'ref_id': 'aaaaa', 'os_minor_version': '5'}}) is None
 
 
 @patch("insights.client.config.InsightsConfig")


### PR DESCRIPTION
Tailoring will now happen against specific rule sets per OS minor version rather than the initial profile of each policy. If a policy has no profile with a matching OS minor version (i.e. the UI tab does not exist), tailoring will not occur; the host will scan against the canonical rule set. If os_minor_version is missing completely from the API response (via old behavior or feature flag), the initial profile on the policy will be used for tailoring, the same behavior we have before COMP-E-133.

Related backend feature flag PR: https://github.com/RedHatInsights/compliance-backend/pull/787

This is part of COMP-E-133.

Signed-off-by: Andrew Kofink <akofink@redhat.com>