### PR TITLE
Change to use 'Hostname' instead of 'hostname' combiner

### DIFF
--- a/insights/combiners/multinode.py
+++ b/insights/combiners/multinode.py
@@ -1,11 +1,11 @@
 from insights import combiner
-from insights.combiners.hostname import hostname
+from insights.combiners.hostname import Hostname
 from insights.core.context import create_product
 from insights.parsers.metadata import MetadataJson
 from insights.specs import Specs
 
 
-@combiner(MetadataJson, [hostname, Specs.machine_id])
+@combiner(MetadataJson, [Hostname, Specs.machine_id])
 def multinode_product(md, hn, machine_id):
     hn = hn.fqdn if hn else machine_id.content[0].rstrip()
     return create_product(md.data, hn)

--- a/insights/combiners/sap.py
+++ b/insights/combiners/sap.py
@@ -11,7 +11,7 @@ Prefer the ``SAPHostCtrlInstances`` to ``Lssap``.
 from collections import namedtuple
 from insights import SkipComponent
 from insights.core.plugins import combiner
-from insights.combiners.hostname import hostname
+from insights.combiners.hostname import Hostname
 from insights.parsers.lssap import Lssap
 from insights.parsers.saphostctrl import SAPHostCtrlInstances
 
@@ -38,7 +38,7 @@ JC     :    NetWeaver (Java App Server Instance)
 """
 
 
-@combiner(hostname, [SAPHostCtrlInstances, Lssap])
+@combiner(Hostname, [SAPHostCtrlInstances, Lssap])
 class Sap(dict):
     """
     Combiner for combining the result of :class:`insights.parsers.lssap.Lssap`

--- a/insights/core/evaluators.py
+++ b/insights/core/evaluators.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from ..formats import Formatter
 from ..specs import Specs
-from ..combiners.hostname import hostname as combiner_hostname
+from ..combiners.hostname import Hostname as combiner_hostname
 from ..parsers.branch_info import BranchInfo
 from ..util import utc
 from . import dr, plugins

--- a/insights/tests/test_evaluators.py
+++ b/insights/tests/test_evaluators.py
@@ -1,7 +1,7 @@
 from insights import dr, rule, make_fail, make_pass, make_fingerprint
 from insights.core.plugins import component, Response
 from insights.core.evaluators import InsightsEvaluator, SingleEvaluator
-from insights.combiners.hostname import hostname
+from insights.combiners.hostname import Hostname
 from insights.specs import Specs
 from insights.tests import context_wrap
 
@@ -66,7 +66,7 @@ def show_links():
 
 
 components = [
-    hostname,
+    Hostname,
     Specs.redhat_release,
     Specs.machine_id,
     one,
@@ -235,7 +235,7 @@ def test_insights_evaluator_make_unsure():
 
 def test_insights_evaluator_show_links():
     components = [
-        hostname,
+        Hostname,
         Specs.redhat_release,
         Specs.machine_id,
         show_links,


### PR DESCRIPTION
- The hostname combiner is deprecated, change to use the Hostname
   To avoid the "DeprecationWarning"s in test of rules.

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>