### PR TITLE
Remove lssap command from collection

### DIFF
--- a/insights/client/uploader_json_map.json
+++ b/insights/client/uploader_json_map.json
@@ -721,11 +721,6 @@
             "symbolic_name": "lspci_kernel"
         },
         {
-            "command": "/usr/sap/hostctrl/exe/lssap",
-            "pattern": [],
-            "symbolic_name": "lssap"
-        },
-        {
             "command": "/usr/sbin/lvmconfig --type full",
             "pattern": [],
             "symbolic_name": "lvmconfig"

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -558,7 +558,6 @@ class DefaultSpecs(Specs):
     lsmod = simple_command("/sbin/lsmod")
     lsof = simple_command("/usr/sbin/lsof")
     lspci = simple_command("/sbin/lspci -k")
-    lssap = simple_command("/usr/sap/hostctrl/exe/lssap")
     lsscsi = simple_command("/usr/bin/lsscsi")
     lsvmbus = simple_command("/usr/sbin/lsvmbus -vv")
     lvm_conf = simple_file("/etc/lvm/lvm.conf")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -131,7 +131,6 @@ class InsightsArchiveSpecs(Specs):
     lsmod = simple_file("insights_commands/lsmod")
     lsof = simple_file("insights_commands/lsof")
     lspci = simple_file("insights_commands/lspci_-k")
-    lssap = simple_file("insights_commands/usr.sap.hostctrl.exe.lssap")
     lsscsi = simple_file("insights_commands/lsscsi")
     lsvmbus = simple_file("insights_commands/lsvmbus_-vv")
     lvmconfig = first_file([


### PR DESCRIPTION
* The saphostctrl command is a better source of the information
* Fixes two open bugzillas with the lssap command 1922937 and 1936951
* Registry spec and parser will remain for use in the future

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>