### PR TITLE
Fix datasourceproviders to deserialize as text

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -1076,4 +1076,4 @@ def serialize_datasource_provider(obj, root):
 
 @deserializer(DatasourceProvider)
 def deserialize_datasource_provider(_type, data, root):
-    return SerializedRawOutputProvider(data["relative_path"], root)
+    return SerializedOutputProvider(data["relative_path"], root)


### PR DESCRIPTION
* Fix #2970 issue with datasources where the DatasourceProvider output
  was being deserialized as raw instead of text

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>