### PR TITLE
Add custom datasource for collecting yum/dnf updates

### DIFF
--- a/docs/shared_parsers_catalog/yum_updates.rst
+++ b/docs/shared_parsers_catalog/yum_updates.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.yum_updates
+   :members:
+   :show-inheritance:

--- a/insights/parsers/tests/test_yum_updates.py
+++ b/insights/parsers/tests/test_yum_updates.py
@@ -1,0 +1,38 @@
+from insights.parsers import yum_updates
+from insights.tests import context_wrap
+import doctest
+
+YUM_UPDATES_INPUT = """{
+      "releasever": "8",
+      "basearch": "x86_64",
+      "update_list": {
+        "NetworkManager-1:1.22.8-4.el8.x86_64": {
+          "available_updates": [
+            {
+              "package": "NetworkManager-1:1.22.8-5.el8_2.x86_64",
+              "repository": "rhel-8-for-x86_64-baseos-rpms",
+              "basearch": "x86_64",
+              "releasever": "8",
+              "erratum": "RHSA-2020:3011"
+            }
+          ]
+        }
+      },
+      "metadata_time": "2021-01-01T09:39:45Z"
+    }
+"""
+
+
+def test_yum_updates():
+    info = yum_updates.YumUpdates(context_wrap(YUM_UPDATES_INPUT))
+    assert info is not None
+    assert len(info.updates) == 1
+    assert len(info.updates["NetworkManager-1:1.22.8-4.el8.x86_64"]["available_updates"]) == 1
+
+
+def test_yum_updates_docs():
+    env = {
+        'updates': yum_updates.YumUpdates(context_wrap(YUM_UPDATES_INPUT)),
+    }
+    failed, total = doctest.testmod(yum_updates, globs=env)
+    assert failed == 0

--- a/insights/parsers/yum_updates.py
+++ b/insights/parsers/yum_updates.py
@@ -1,0 +1,54 @@
+"""
+YumUpdates - parser for the `yum_updates` datasource
+====================================================
+Provides a list of available package updates, along with related advisories. This information
+is collected using DNF/YUM python interface.
+"""
+
+from insights import JSONParser, parser
+from insights.specs import Specs
+
+
+@parser(Specs.yum_updateinfo)
+class YumUpdates(JSONParser):
+    """
+    Expected output of the command is::
+
+        {
+          "releasever": "8",
+          "basearch": "x86_64",
+          "update_list": {
+            "NetworkManager-1:1.22.8-4.el8.x86_64": {
+              "available_updates": [
+                {
+                  "package": "NetworkManager-1:1.22.8-5.el8_2.x86_64",
+                  "repository": "rhel-8-for-x86_64-baseos-rpms",
+                  "basearch": "x86_64",
+                  "releasever": "8",
+                  "erratum": "RHSA-2020:3011"
+                }
+              ]
+            }
+          },
+          "metadata_time": "2021-01-01T09:39:45Z"
+        }
+
+    Examples:
+        >>> len(updates.updates)
+        1
+        >>> updates.updates['NetworkManager-1:1.22.8-4.el8.x86_64']['available_updates'][0] == { \
+        'basearch': 'x86_64', \
+        'erratum': 'RHSA-2020:3011', \
+        'package': 'NetworkManager-1:1.22.8-5.el8_2.x86_64', \
+        'releasever': '8', \
+        'repository': 'rhel-8-for-x86_64-baseos-rpms'}
+        True
+    """
+
+    @property
+    def updates(self):
+        """
+        Returns:
+            dict: Dict(package name -> list of available updates)
+        """
+        return self.data['update_list']

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -724,6 +724,7 @@ class Specs(SpecSet):
     yum_repolist = RegistryPoint()
     yum_repos_d = RegistryPoint(multi_output=True)
     yum_updateinfo = RegistryPoint()
+    yum_updates = RegistryPoint()
     zdump_v = RegistryPoint()
     zipl_conf = RegistryPoint()
     sendq_socket_buffer = RegistryPoint()

--- a/insights/specs/datasources/yum_updates.py
+++ b/insights/specs/datasources/yum_updates.py
@@ -1,0 +1,141 @@
+"""
+Custom datasource for collecting yum updates
+"""
+import json
+import time
+
+from insights import datasource, HostContext, SkipComponent
+from insights.components.rhel_version import IsRhel7
+from insights.core.spec_factory import DatasourceProvider
+
+sorted_cmp = None
+try:
+    # cmp_to_key is not available in python 2.6, but it has sorted function which accepts cmp function
+    def sorted_cmp(it, cmp):
+        from functools import cmp_to_key
+        return sorted(it, key=cmp_to_key(cmp))
+except ImportError:
+    sorted_cmp = sorted
+
+
+class UpdatesManager:
+    """ Performs package resolution on yum based systems """
+    def __init__(self):
+        import yum
+
+        self.base = yum.YumBase()
+        self.base.doGenericSetup(cache=1)
+        self.releasever = self.base.conf.yumvar['releasever']
+        self.basearch = self.base.conf.yumvar['basearch']
+        self.packages = []
+        self.repos = []
+        self.updict = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    @staticmethod
+    def pkg_cmp(a, b):
+        vercmp = a.verCMP(b)
+        if vercmp != 0:
+            return vercmp
+        if a.repoid != b.repoid:
+            return -1 if a.repoid < b.repoid else 1
+        return 0
+
+    def sorted_pkgs(self, pkgs):
+        return sorted_cmp(pkgs, self.pkg_cmp)
+
+    def load(self):
+        self.base.doRepoSetup()
+        self.base.doSackSetup()
+        self.packages = self.base.pkgSack.returnPackages()
+        self.repos = self.base.repos.repos
+        self._build_updict()
+
+    def _build_updict(self):
+        self.updict = {}
+        for pkg in self.packages:
+            self.updict.setdefault(pkg.na, []).append(pkg)
+
+    def enabled_repos(self):
+        return [repo.id for repo in self.base.repos.listEnabled()]
+
+    def installed_packages(self):
+        return self.base.rpmdb.returnPackages()
+
+    def updates(self, pkg):
+        nevra = pkg.nevra
+        updates_list = []
+        for upg in self.updict[pkg.na]:
+            if upg.verGT(pkg):
+                updates_list.append(upg)
+        return nevra, updates_list
+
+    @staticmethod
+    def pkg_nevra(pkg):
+        return "{}-{}:{}-{}.{}".format(pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch)
+
+    @staticmethod
+    def pkg_repo(pkg):
+        return pkg.repoid
+
+    def advisory(self, pkg):
+        adv = self.base.upinfo.get_notice(pkg.nvr)
+        if adv:
+            return adv.get_metadata()['update_id']
+        return None
+
+    @staticmethod
+    def last_update():
+        return 0
+
+
+@datasource(HostContext, [IsRhel7])
+def yum_updates(_broker):
+    """
+    This datasource provides a list of available updates on the system.
+    It uses the yum python library installed locally, and collects list of
+    available package updates, along with advisory info where applicable.
+    """
+
+    if not _broker.get(IsRhel7):
+        raise SkipComponent("Yum updates currently only works on RHEL 7")
+
+    with UpdatesManager() as umgr:
+        umgr.load()
+
+        response = {
+            "releasever": umgr.releasever,
+            "basearch": umgr.basearch,
+            "update_list": {},
+        }
+
+        data = {'package_list': umgr.installed_packages()}
+        updates = {}
+        for pkg in data["package_list"]:
+            (nevra, updates_list) = umgr.updates(pkg)
+            updates[nevra] = updates_list
+            for (nevra, update_list) in updates.items():
+                if update_list:
+                    out_list = []
+                    for pkg in umgr.sorted_pkgs(update_list):
+                        pkg_dict = {
+                            "package": umgr.pkg_nevra(pkg),
+                            "repository": umgr.pkg_repo(pkg),
+                            "basearch": response["basearch"],
+                            "releasever": response["releasever"],
+                        }
+                        erratum = umgr.advisory(pkg)
+                        if erratum:
+                            pkg_dict["erratum"] = erratum
+                        out_list.append(pkg_dict)
+                    response["update_list"][nevra] = {"available_updates": out_list}
+
+        ts = umgr.last_update()
+        if ts:
+            response["metadata_time"] = time.strftime("%FT%TZ", time.gmtime(ts))
+    return DatasourceProvider(content=json.dumps(response), relative_path='insights_commands/yum_updates_list')

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -37,7 +37,7 @@ from insights.parsers.mount import Mount
 from insights.specs import Specs
 from insights.specs.datasources import (
     awx_manage, cloud_init, candlepin_broker, ethernet, get_running_commands, ipcs, lpstat, package_provides,
-    ps as ps_datasource, sap, satellite_missed_queues)
+    ps as ps_datasource, sap, satellite_missed_queues, yum_updates)
 from insights.specs.datasources.sap import sap_hana_sid, sap_hana_sid_SID_nr
 
 
@@ -786,6 +786,8 @@ class DefaultSpecs(Specs):
     yum_repolist = simple_command("/usr/bin/yum -C --noplugins repolist", signum=signal.SIGTERM)
     yum_repos_d = glob_file("/etc/yum.repos.d/*.repo")
     yum_updateinfo = simple_command("/usr/bin/yum -C updateinfo list", signum=signal.SIGTERM)
+    yum_updates = yum_updates.yum_updates
+
     zipl_conf = simple_file("/etc/zipl.conf")
     rpm_format = format_rpm()
     installed_rpms = simple_command("/bin/rpm -qa --qf '%s'" % rpm_format, context=HostContext, signum=signal.SIGTERM)


### PR DESCRIPTION
Dynamically imports os-specific library for handling DNF/YUM interaction.
Performs a resolution of updateable packages, and outputs it as JSON.
Expected performance is on the order of seconds for both RHEL7 and RHEL8.

cc: @MichaelMraka 