### PR TITLE
Remove the duplicated lspci_kernel

### DIFF
--- a/insights/client/map_components.py
+++ b/insights/client/map_components.py
@@ -127,7 +127,6 @@ def _get_component_by_symbolic_name(sname):
     spec_prefix = "insights.specs.default.DefaultSpecs."
     spec_conversion = {
         'getconf_pagesize': 'getconf_page_size',
-        'lspci_kernel': 'lspci',
         'netstat__agn': 'netstat_agn',
         'rpm__V_packages': 'rpm_V_packages',
 

--- a/insights/client/uploader_json_map.json
+++ b/insights/client/uploader_json_map.json
@@ -718,11 +718,6 @@
             "symbolic_name": "lspci"
         },
         {
-            "command": "/sbin/lspci -k",
-            "pattern": [],
-            "symbolic_name": "lspci_kernel"
-        },
-        {
             "command": "/sbin/lspci -vmmkn",
             "pattern": [],
             "symbolic_name": "lspci_vmmkn"


### PR DESCRIPTION
- `lspci_kenrel` is the same as the `lspci`
   It's OK that just keep the `lspci` which is used by rules.

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>