### PR TITLE
Allow scalars in parsr.query.choose results.

### DIFF
--- a/insights/parsr/query/__init__.py
+++ b/insights/parsr/query/__init__.py
@@ -351,9 +351,11 @@ class Entry(object):
                     for k, v in r.items():
                         if isinstance(v, list):
                             tmp.append(Entry(k, children=v, set_parents=False))
-                        else:
+                        elif isinstance(v, Entry):
                             for i in v.children:
                                 tmp.append(Entry(k, i.attrs, i.children, set_parents=False))
+                        else:
+                            tmp.append(Entry(k, attrs=(v,), set_parents=False))
                 else:
                     if isinstance(r, list):
                         tmp.extend(r)

--- a/insights/parsr/query/tests/test_choose.py
+++ b/insights/parsr/query/tests/test_choose.py
@@ -121,3 +121,8 @@ def test_rename():
     assert "mytype" in res
     assert "reason" in res
     assert "type" not in res
+
+
+def test_scalar_value():
+    res = conf.status.conditions.choose(lambda c: ({"reason": c.reason.value or "None Provided"}, c.status))
+    assert res.where("reason", "None Provided")


### PR DESCRIPTION
This PR allows the function passed to `parsr.query.Entry.choose` to include scalar results as part of its response.

e.g.
```python
def selector(c):
    return (
        {"status": True if c.status.value == "True" else False},
        {"reason": c.reason or "None Provided"},
        c.message
    )
df = conf.status.conditions.where("type", "Progressing").choose(selector).to_df()
```

Signed-off-by: Christopher Sams <csams@redhat.com>