### PR TITLE
Docutils 0.17 break doc build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ develop = set([
 ])
 
 docs = set([
+    'docutils==0.16',
     'Sphinx<=3.0.2',
     'nbsphinx',
     'sphinx_rtd_theme',


### PR DESCRIPTION
The latest version of docutils break the documentation build

* Change setup.py to use an older version of docutils for the Jenkin build

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>