### PR TITLE
Manually overide skipVerify

### DIFF
--- a/insights/client/apps/ansible/playbook_verifier/__init__.py
+++ b/insights/client/apps/ansible/playbook_verifier/__init__.py
@@ -41,7 +41,6 @@ class PlaybookVerificationError(Exception):
 
 def eggVersioningCheck(checkVersion):
     currentVersion = requests.get(VERSIONING_URL)
-    print('currentVersion: ', currentVersion)
     currentVersion = currentVersion.text
     runningVersion = get_version_info()['core_version']
 
@@ -119,7 +118,7 @@ def verifyPlaybookSnippet(snippet):
     return executeVerification(snippetCopy, encodedSignature)
 
 
-def verify(playbook, checkVersion=True, skipVerify=False):
+def verify(playbook, checkVersion=False, skipVerify=True):
     """
     Verify the signed playbook.
 

--- a/insights/client/apps/ansible/playbook_verifier/__main__.py
+++ b/insights/client/apps/ansible/playbook_verifier/__main__.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from insights.client.apps.ansible.playbook_verifier import verify, loadPlaybookYaml
 
@@ -15,9 +16,16 @@ def read_playbook():
 
 playbook = read_playbook()
 playbook_yaml = loadPlaybookYaml(playbook)
+skipVerify = True
+checkVersion = False
+
+if (os.environ.get('SKIP_VERIFY')):
+    skipVerify = False
+if (os.environ.get('CHECK_VERSION')):
+    checkVersion = True
 
 try:
-    verified_playbook = verify(playbook_yaml, checkVersion=False)
+    verified_playbook = verify(playbook_yaml, checkVersion, skipVerify)
 except Exception as e:
     sys.stderr.write(e.message)
     sys.exit(1)

--- a/insights/tests/client/apps/test_playbook_verifier.py
+++ b/insights/tests/client/apps/test_playbook_verifier.py
@@ -9,8 +9,8 @@ from pytest import raises
 
 @pytest.mark.skipif(sys.version_info < (2, 7), reason='Playbook verifier must be run on python 2.7 or above')
 def test_skip_validation():
-    result = verify([{'name': "test playbook"}], skipVerify=True, checkVersion=False)
-    assert result == [{'name': "test playbook"}]
+    result = verify([{'name': "test playbook", 'vars': {}}], skipVerify=True, checkVersion=False)
+    assert result == [{'name': "test playbook", 'vars': {}}]
 
 
 @pytest.mark.skipif(sys.version_info < (2, 7), reason='Playbook verifier must be run on python 2.7 or above')
@@ -21,7 +21,7 @@ def test_egg_validation_error(mock_get):
     fake_playbook = [{'name': "test playbook"}]
 
     with raises(PlaybookVerificationError) as error:
-        verify(fake_playbook)
+        verify(fake_playbook, checkVersion=True)
     assert egg_error in str(error.value)
 
 
@@ -31,7 +31,7 @@ def test_vars_not_found_error():
     fake_playbook = [{'name': "test playbook"}]
 
     with raises(PlaybookVerificationError) as error:
-        verify(fake_playbook, checkVersion=False)
+        verify(fake_playbook, skipVerify=False)
     assert vars_error in str(error.value)
 
 
@@ -41,7 +41,7 @@ def test_signature_not_found_error():
     fake_playbook = [{'name': "test playbook", 'vars': {}}]
 
     with raises(PlaybookVerificationError) as error:
-        verify(fake_playbook, checkVersion=False)
+        verify(fake_playbook, skipVerify=False)
     assert sig_error in str(error.value)
 
 
@@ -58,7 +58,7 @@ def test_key_not_imported():
     }]
 
     with raises(PlaybookVerificationError) as error:
-        verify(fake_playbook, checkVersion=False)
+        verify(fake_playbook, skipVerify=False)
     assert key_error in str(error.value)
 
 
@@ -75,7 +75,7 @@ def test_key_import_error():
     }]
 
     with raises(PlaybookVerificationError) as error:
-        verify(fake_playbook, checkVersion=False)
+        verify(fake_playbook, skipVerify=False)
     assert key_error in str(error.value)
 
 
@@ -92,7 +92,7 @@ def test_playbook_verification_error(call):
     }]
 
     with raises(PlaybookVerificationError) as error:
-        verify(fake_playbook, checkVersion=False)
+        verify(fake_playbook, skipVerify=False)
     assert key_error in str(error.value)
 
 
@@ -108,5 +108,5 @@ def test_playbook_verification_success(mock_method):
         }
     }]
 
-    result = verify(fake_playbook, checkVersion=False)
+    result = verify(fake_playbook, skipVerify=False)
     assert result == fake_playbook


### PR DESCRIPTION
Change Validation function to manually skipVerify until all playbook-snippets are signed.

I also commented out most of the tests for the playbook verifier until such a time when we can remove the manual skip verify. 