### PR TITLE
Remove the spec because it is not used by any rule

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -768,7 +768,6 @@ class DefaultSpecs(Specs):
     rhsm_katello_default_ca_cert = simple_command("/usr/bin/openssl x509 -in /etc/rhsm/ca/katello-default-ca.pem -noout -issuer")
     qemu_conf = simple_file("/etc/libvirt/qemu.conf")
     qemu_xml = glob_file(r"/etc/libvirt/qemu/*.xml")
-    qpid_stat_g = simple_command("/usr/bin/qpid-stat -g --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671")
     qpidd_conf = simple_file("/etc/qpid/qpidd.conf")
     rabbitmq_env = simple_file("/etc/rabbitmq/rabbitmq-env.conf")
     rabbitmq_report = simple_command("/usr/sbin/rabbitmqctl report")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -195,7 +195,6 @@ class InsightsArchiveSpecs(Specs):
     ps_eo = simple_file("insights_commands/ps_-eo_pid_ppid_comm")
     puppet_ca_cert_expire_date = simple_file("insights_commands/openssl_x509_-in_.etc.puppetlabs.puppet.ssl.ca.ca_crt.pem_-enddate_-noout")
     pvs_noheadings = simple_file("insights_commands/pvs_--nameprefixes_--noheadings_--separator_-a_-o_pv_all_vg_name_--config_global_locking_type_0")
-    qpid_stat_g = simple_file("insights_commands/qpid-stat_-g_--ssl-certificate_.etc.pki.katello.qpid_client_striped.crt_-b_amqps_..localhost_5671")
     rabbitmq_report = simple_file("insights_commands/rabbitmqctl_report")
     rabbitmq_users = simple_file("insights_commands/rabbitmqctl_list_users")
     readlink_e_etc_mtab = simple_file("insights_commands/readlink_-e_.etc.mtab")

--- a/insights/tests/client/collection_rules/test_map_components.py
+++ b/insights/tests/client/collection_rules/test_map_components.py
@@ -100,7 +100,8 @@ def test_get_component_by_symbolic_name():
         'sap_host_profile',
         'sched_rt_runtime_us',
         'libvirtd_qemu_log',
-        'mlx4_port'
+        'mlx4_port',
+        'qpid_stat_g'
     ]
 
     # first, make sure our list is proper and one of these


### PR DESCRIPTION
* The ssl certificate changes from satellite 6.6,
  however since no rules use this spec, no need to update it,
  we can remove it directly

Signed-off-by: Huanhuan Li <huali@redhat.com>