### PR TITLE
[testing] download idna 2.7 directly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                 virtualenv .testenv
                 source .testenv/bin/activate
                 pip install https://github.com/kjd/idna/archive/refs/tags/v2.7.zip
-                pip install "pycparser<=2.18"
+                pip install https://github.com/eliben/pycparser/archive/refs/tags/release_v2.18.zip
                 pip install -e .[testing]
                 pytest
             """
@@ -31,7 +31,7 @@ pipeline {
                 virtualenv .lintenv
                 source .lintenv/bin/activate
                 pip install https://github.com/kjd/idna/archive/refs/tags/v2.7.zip
-                pip install "pycparser<=2.18"
+                pip install https://github.com/eliben/pycparser/archive/refs/tags/release_v2.18.zip
                 pip install -e .[linting]
                 flake8
             """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
             sh """
                 virtualenv .testenv
                 source .testenv/bin/activate
-                pip install "idna<=2.7"
+                pip install https://github.com/kjd/idna/archive/refs/tags/v2.7.zip
                 pip install "pycparser<=2.18"
                 pip install -e .[testing]
                 pytest
@@ -30,7 +30,7 @@ pipeline {
             sh """
                 virtualenv .lintenv
                 source .lintenv/bin/activate
-                pip install "idna<=2.7"
+                pip install https://github.com/kjd/idna/archive/refs/tags/v2.7.zip
                 pip install "pycparser<=2.18"
                 pip install -e .[linting]
                 flake8


### PR DESCRIPTION
This package was removed from pypi. We still need it for python2, so
we'll download it directly via git.

Signed-off-by: Stephen Adams <tsadams@gmail.com>