### PR TITLE
👷🏻‍♂️ Pipeline: Upgrade PIP and revert pip install changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
             sh """
                 virtualenv .testenv
                 source .testenv/bin/activate
+                pip install --upgrade https://github.com/pypa/pip/archive/refs/tags/9.0.3.tar.gz
                 pip install https://github.com/kjd/idna/archive/refs/tags/v2.7.zip
                 pip install https://github.com/eliben/pycparser/archive/refs/tags/release_v2.18.zip
                 pip install -e .[testing]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,8 +22,8 @@ pipeline {
                 virtualenv .testenv
                 source .testenv/bin/activate
                 pip install --upgrade https://github.com/pypa/pip/archive/refs/tags/9.0.3.tar.gz
-                pip install https://github.com/kjd/idna/archive/refs/tags/v2.7.zip
-                pip install https://github.com/eliben/pycparser/archive/refs/tags/release_v2.18.zip
+                pip install "idna<=2.7"
+                pip install "pycparser<=2.18"
                 pip install -e .[testing]
                 pytest
             """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
             sh """
                 virtualenv .testenv
                 source .testenv/bin/activate
-                pip install --upgrade https://github.com/pypa/pip/archive/refs/tags/9.0.3.tar.gz
+                pip install --upgrade "pip<10"
                 pip install "idna<=2.7"
                 pip install "pycparser<=2.18"
                 pip install -e .[testing]


### PR DESCRIPTION
- Reverted #3025, because it was only an intermittent partial fix that was not targeting the real cause.
  
  The original motivation was to fix _pip_ being unable to install _idna_ and _pycparser_ from PyPI. The cause of the failure is unknown. For the time being, changing the source to direct GitHub release URL fixed the failure, but then other failures started to appear, this time for packages installed by `pip install .[testing]`. Now, the original PyPI installation works again for both cases.

- Upgraded PIP to 9.0.3, the last version supported by Python 2.6.
  
  Again, we don’t know what was the cause of the PyPI query failures. But I think we can assume that a newer version of PIP would have fewer issues with the current-day API. Also PIP ≥ 9 is able to check package compatibility with the current Python version, which may prevent some more future issues.
  ~~The actual PIP upgrade uses a direct URL to bypass the possible bug with querying PyPI.~~ The bug is not resolved. It does not make sense then to bypass it. Used PyPI search for the last PIP < 10, because the version 10 dropped Python 2.6 support.