### PR TITLE
[parser] GCP parser to gather license codes from instances

### DIFF
--- a/docs/shared_parsers_catalog/gcp_license_codes.rst
+++ b/docs/shared_parsers_catalog/gcp_license_codes.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.gcp_license_codes
+   :members:
+   :show-inheritance:

--- a/insights/parsers/gcp_license_codes.py
+++ b/insights/parsers/gcp_license_codes.py
@@ -29,6 +29,7 @@ class GCPLicenseCodes(CommandParser):
 
     Raises:
         SkipException: When content is empty or no parse-able content.
+        ParseException: When the json is unable to be parsed
 
     Attributes:
         ids (list): A list containing the IDs found on the instance

--- a/insights/parsers/gcp_license_codes.py
+++ b/insights/parsers/gcp_license_codes.py
@@ -1,0 +1,60 @@
+"""
+GCPLicenseCodes
+===============
+
+This parser reads the output of a command
+``curl -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/licenses/?recursive=True"``,
+which is used to check whether the google cloud instance is a licensed marketplace instance.
+
+For more details, See: https://cloud.google.com/compute/docs/reference/rest/v1/images/get#body.Image.FIELDS.license_code
+
+"""
+import json
+
+from insights.parsers import SkipException, ParseException
+from insights import parser, CommandParser
+from insights.specs import Specs
+
+
+@parser(Specs.gcp_license_codes)
+class GCPLicenseCodes(CommandParser):
+    """
+    Class for parsing the GCP License Codes returned by command
+    ``curl -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/licenses/?recursive=True"``,
+
+
+    Typical Output of this command is::
+
+        [{"id": "601259152637613565"}]
+
+    Raises:
+        SkipException: When content is empty or no parse-able content.
+
+    Attributes:
+        ids (list): A list containing the IDs found on the instance
+        raw (str): The full JSON of the plan returned by the ``curl`` command
+
+    Examples:
+        >>> gcp_licenses.ids == ["601259152637613565"]
+        True
+        >>> gcp_licenses.raw == [{"id": "601259152637613565"}]
+        True
+    """
+
+    def parse_content(self, content):
+        if not content or 'curl: ' in content[0]:
+            raise SkipException()
+        try:
+            license_list = json.loads(content[0])
+        except:
+            raise ParseException("Unable to parse JSON")
+
+        self.raw = license_list
+        self.ids = None
+        if len(license_list) >= 1:
+            self.ids = [l["id"] for l in license_list]
+
+    def __repr__(self):
+        return "ids: {i}, raw: {r}".format(
+            i=self.ids, r=self.raw
+        )

--- a/insights/parsers/tests/test_gcp_license_codes.py
+++ b/insights/parsers/tests/test_gcp_license_codes.py
@@ -1,0 +1,70 @@
+import pytest
+import doctest
+
+from insights.parsers import gcp_license_codes
+from insights.parsers.gcp_license_codes import GCPLicenseCodes
+from insights.tests import context_wrap
+from insights.parsers import SkipException, ParseException
+
+GCP_LICENSE_CODES_1 = '[{"id": "123451234512345"}]'
+GCP_LICENSE_CODES_2 = '[{"id": "123451234512345"}, {"id": "238949287234"}]'
+GCP_LICENSE_CODES_3 = '[]'
+
+GCP_LICENSE_CODES_4 = """
+ % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                  Dload  Upload   Total   Spent    Left  Speed
+   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+ 100  1126  100  1126    0     0  1374k      0 --:--:-- --:--:-- --:--:-- 1099k
+[{"id": "123451234512345"}]
+"""
+
+GCP_LICENSE_CODES_DOC = '[{"id": "601259152637613565"}]'
+
+GCP_LICENSE_CODES_AB_1 = """
+curl: (7) Failed to connect to 169.254.169.254 port 80: Connection timed out
+""".strip()
+GCP_LICENSE_CODES_AB_2 = """
+curl: (7) couldn't connect to host
+""".strip()
+GCP_LICENSE_CODES_AB_3 = """
+curl: (28) connect() timed out!
+""".strip()
+
+
+def test_azure_instance_place_ab_other():
+    with pytest.raises(SkipException):
+        GCPLicenseCodes(context_wrap(GCP_LICENSE_CODES_AB_1))
+
+    with pytest.raises(SkipException):
+        GCPLicenseCodes(context_wrap(GCP_LICENSE_CODES_AB_2))
+
+    with pytest.raises(SkipException):
+        GCPLicenseCodes(context_wrap(GCP_LICENSE_CODES_AB_3))
+
+    with pytest.raises(SkipException):
+        GCPLicenseCodes(context_wrap(''))
+
+    with pytest.raises(ParseException):
+        GCPLicenseCodes(context_wrap(GCP_LICENSE_CODES_4))
+
+
+def test_gcp_license_codes():
+    gcp_licenses = GCPLicenseCodes(context_wrap(GCP_LICENSE_CODES_1))
+    assert gcp_licenses.ids == ["123451234512345"]
+    assert gcp_licenses.raw == [{"id": "123451234512345"}]
+
+    gcp_licenses = GCPLicenseCodes(context_wrap(GCP_LICENSE_CODES_2))
+    assert gcp_licenses.ids == ["123451234512345", "238949287234"]
+    assert gcp_licenses.raw == [{"id": "123451234512345"}, {"id": "238949287234"}]
+
+    gcp_licenses = GCPLicenseCodes(context_wrap(GCP_LICENSE_CODES_3))
+    assert gcp_licenses.ids is None
+    assert gcp_licenses.raw == []
+
+
+def test_doc_examples():
+    env = {
+        'gcp_licenses': GCPLicenseCodes(context_wrap(GCP_LICENSE_CODES_DOC))
+    }
+    failed, total = doctest.testmod(gcp_license_codes, globs=env)
+    assert failed == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -187,6 +187,7 @@ class Specs(SpecSet):
     freeipa_healthcheck_log = RegistryPoint()
     fstab = RegistryPoint()
     galera_cnf = RegistryPoint()
+    gcp_license_codes = RegistryPoint()
     getcert_list = RegistryPoint()
     getconf_page_size = RegistryPoint()
     getenforce = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -424,6 +424,16 @@ class DefaultSpecs(Specs):
     gluster_v_info = simple_command("/usr/sbin/gluster volume info")
     gnocchi_conf = first_file(["/var/lib/config-data/puppet-generated/gnocchi/etc/gnocchi/gnocchi.conf", "/etc/gnocchi/gnocchi.conf"])
     gnocchi_metricd_log = first_file(["/var/log/containers/gnocchi/gnocchi-metricd.log", "/var/log/gnocchi/metricd.log"])
+
+    @datasource(CloudProvider, HostContext)
+    def is_gcp(broker):
+        """ bool: Returns True if this node is identified as running in GCP """
+        cp = broker[CloudProvider]
+        if cp and cp.cloud_provider == CloudProvider.GOOGLE:
+            return True
+        raise SkipComponent()
+
+    gcp_license_codes = simple_command("/usr/bin/curl -s curl -H Metadata-Flavor: Google http://metadata.google.internal/computeMetadata/v1/instance/licenses/?recursive=True --connect-timeout 5", deps=[is_gcp])
     grub_conf = simple_file("/boot/grub/grub.conf")
     grub_config_perms = simple_command("/bin/ls -l /boot/grub2/grub.cfg")  # only RHEL7 and updwards
     grub_efi_conf = simple_file("/boot/efi/EFI/redhat/grub.conf")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -67,6 +67,7 @@ class InsightsArchiveSpecs(Specs):
     fcoeadm_i = simple_file("insights_commands/fcoeadm_-i")
     findmnt_lo_propagation = simple_file("insights_commands/findmnt_-lo_PROPAGATION")
     firewall_cmd_list_all_zones = simple_file("insights_commands/firewall-cmd_--list-all-zones")
+    gcp_license_codes = simple_file("insights_commands/python_-m_insights.tools.cat_--no-header_gcp_license_codes")
     getconf_page_size = simple_file("insights_commands/getconf_PAGE_SIZE")
     getenforce = simple_file("insights_commands/getenforce")
     getsebool = simple_file("insights_commands/getsebool_-a")


### PR DESCRIPTION
This is needed to identify marketplace systems in the GCP cloud.

Signed-off-by: Stephen Adams <tsadams@gmail.com>