### PR TITLE
fix(compliance): RHICOMPL-1111 Use ID instead of hostname

### DIFF
--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -13,6 +13,7 @@ PATH = '/usr/share/xml/scap/ref_id.xml'
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None, compressor='gz')
 def test_oscap_scan(config, assert_rpms):
     compliance_client = ComplianceClient(config)
+    compliance_client._get_inventory_id = lambda: ''
     compliance_client.get_initial_profiles = lambda: [{'attributes': {'ref_id': 'foo', 'tailored': False}}]
     compliance_client.get_profiles_matching_os = lambda: []
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
@@ -28,6 +29,7 @@ def test_oscap_scan(config, assert_rpms):
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
 def test_missing_packages(config, call):
     compliance_client = ComplianceClient(config)
+    compliance_client._get_inventory_id = lambda: ''
     compliance_client.get_initial_profiles = lambda: [{'attributes': {'ref_id': 'foo'}}]
     compliance_client.get_profiles_matching_os = lambda: []
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
@@ -40,6 +42,7 @@ def test_missing_packages(config, call):
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
 def test_errored_rpm_call(config, call):
     compliance_client = ComplianceClient(config)
+    compliance_client._get_inventory_id = lambda: ''
     compliance_client.get_initial_profiles = lambda: [{'attributes': {'ref_id': 'foo'}}]
     compliance_client.get_profiles_matching_os = lambda: []
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
@@ -51,7 +54,7 @@ def test_errored_rpm_call(config, call):
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
 def test_get_profiles(config):
     compliance_client = ComplianceClient(config)
-    compliance_client.hostname = 'foo'
+    compliance_client.inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
     assert compliance_client.get_profiles('search string') == [{'attributes': 'data'}]
     compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'search string'})
@@ -60,7 +63,7 @@ def test_get_profiles(config):
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
 def test_get_profiles_no_profiles(config):
     compliance_client = ComplianceClient(config)
-    compliance_client.hostname = 'foo'
+    compliance_client.inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': []})))
     assert compliance_client.get_profiles('search string') == []
     compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'search string'})
@@ -69,7 +72,7 @@ def test_get_profiles_no_profiles(config):
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
 def test_get_profiles_error(config):
     compliance_client = ComplianceClient(config)
-    compliance_client.hostname = 'foo'
+    compliance_client.inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=500))
     assert compliance_client.get_profiles('search string') == []
     compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'search string'})
@@ -78,20 +81,20 @@ def test_get_profiles_error(config):
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
 def test_get_initial_profiles(config):
     compliance_client = ComplianceClient(config)
-    compliance_client.hostname = 'foo'
+    compliance_client.inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
     assert compliance_client.get_initial_profiles() == [{'attributes': 'data'}]
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo canonical=false external=false'})
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_ids=068040f1-08c8-43e4-949f-7d6470e9111c canonical=false external=false'})
 
 
 @patch("insights.client.apps.compliance.linux_distribution", return_value=(None, '6.5', None))
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
 def test_get_profiles_matching_os(config, linux_distro_mock):
     compliance_client = ComplianceClient(config)
-    compliance_client.hostname = 'foo'
+    compliance_client.inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
     assert compliance_client.get_profiles_matching_os() == [{'attributes': 'data'}]
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_names=foo canonical=false os_minor_version=5'})
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_ids=068040f1-08c8-43e4-949f-7d6470e9111c canonical=false os_minor_version=5'})
 
 
 @patch("insights.client.apps.compliance.linux_distribution", return_value=(None, '6.5', None))
@@ -232,3 +235,18 @@ def test_build_oscap_command_append_tailoring_path(config):
     compliance_client = ComplianceClient(config)
     expected_command = 'oscap xccdf eval --profile aaaaa --tailoring-file tailoring_path --results output_path xml_sample'
     assert expected_command == compliance_client.build_oscap_command('aaaaa', 'xml_sample', 'output_path', 'tailoring_path')
+
+
+@patch("insights.client.config.InsightsConfig")
+def test__get_inventory_id(config):
+    compliance_client = ComplianceClient(config)
+    compliance_client.conn._fetch_system_by_machine_id = lambda: []
+    with raises(SystemExit):
+        compliance_client._get_inventory_id()
+
+    compliance_client.conn._fetch_system_by_machine_id = lambda: [{}]
+    with raises(SystemExit):
+        compliance_client._get_inventory_id()
+
+    compliance_client.conn._fetch_system_by_machine_id = lambda: [{'id': '12345'}]
+    assert compliance_client._get_inventory_id() == '12345'


### PR DESCRIPTION
This changes all API calls to Compliance to use the host ID, retrieved
from the Inventory API via machine_id, rather than the hostname. This
fixes the use case when a user has updated the display name using the
client's --display-name option.

Signed-off-by: Andrew Kofink <akofink@redhat.com>