### PR TITLE
Fix issues in rhel6/python26 CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,19 +21,18 @@ pipeline {
             sh """
                 virtualenv .testenv
                 source .testenv/bin/activate
-                pip install --upgrade "pip<10"
-                pip install "idna<=2.7"
-                pip install "pycparser<=2.18"
-                pip install -e .[testing]
+                pip install /pip_packages/pip-9.0.3-py2.py3-none-any.whl
+                pip install -r /var/lib/jenkins/ci_requirements.txt -f /pip_packages
+                pip install -e .[testing] -f /pip_packages
                 pytest
             """
             echo "Testing with Linter..."
             sh """
                 virtualenv .lintenv
                 source .lintenv/bin/activate
-                pip install https://github.com/kjd/idna/archive/refs/tags/v2.7.zip
-                pip install https://github.com/eliben/pycparser/archive/refs/tags/release_v2.18.zip
-                pip install -e .[linting]
+                pip install /pip_packages/pip-9.0.3-py2.py3-none-any.whl
+                pip install -r /var/lib/jenkins/ci_requirements.txt -f /pip_packages
+                pip install -e .[linting] -f /pip_packages
                 flake8
             """
           }


### PR DESCRIPTION
* This fix uses a new python26 image with required modules included
* This goes with [this image](https://github.com/SteveHNH/jenkins-s2i-example/pull/4)

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>