### PR TITLE
Fix error created by jinga2 3.0.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ runtime = set([
     'cachecontrol[filecache]',
     'defusedxml',
     'lockfile',
-    'jinja2',
+    'jinja2<=2.11.3',
 ])
 
 if (sys.version_info < (2, 7)):
@@ -66,16 +66,15 @@ develop = set([
 ])
 
 docs = set([
-    'docutils==0.16',
-    'Sphinx<=3.0.2',
+    'docutils',
+    'Sphinx',
     'nbsphinx',
     'sphinx_rtd_theme',
     'ipython',
     'colorama',
-    'jinja2',
+    'jinja2<=2.11.3',
     'Pygments',
-    'jedi<0.18.0'    # Open issue with jedi 0.18.0 and iPython <= 7.19
-                     # https://github.com/davidhalter/jedi/issues/1714
+    'jedi',
 ])
 
 testing = set([

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ docs = set([
     'colorama',
     'jinja2<=2.11.3',
     'Pygments',
-    'jedi',
+    'jedi<0.18.0',    # Open issue with jedi 0.18.0 and iPython <= 7.19
+                      # https://github.com/davidhalter/jedi/issues/1714
 ])
 
 testing = set([


### PR DESCRIPTION
* Update doc build modules to latest versions
* Pinned jinja2 to the last version that worked with core

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>