### PR TITLE
Add kernel-alt release mappings

### DIFF
--- a/insights/parsers/tests/test_uname.py
+++ b/insights/parsers/tests/test_uname.py
@@ -258,6 +258,18 @@ def test_from_release():
     from_nvr = uname.Uname.from_kernel("2.6.32-358")
     assert str(from_release) == str(from_nvr)
 
+    # Test the regular 7.4 version.
+    release = ("7", "4")
+    from_release = uname.Uname.from_release(release)
+    from_nvr = uname.Uname.from_kernel("3.10.0-693")
+    assert str(from_release) == str(from_nvr)
+
+    # Test the kernel-alt 7.4 version.
+    release = ("7", "4", "alt")
+    from_release = uname.Uname.from_release(release)
+    from_nvr = uname.Uname.from_kernel("4.11.0-44")
+    assert str(from_release) == str(from_nvr)
+
     unknown_list = ["2.4.21-3", "2.6.9-4", "2.6.18-7", "2.6.32-70", "3.10.0-53"]
     known_list = [{'version': "2.4.21-4", 'rhel_release': ["3", "0"]},
                   {'version': "2.6.9-55", 'rhel_release': ["4", "5"]},

--- a/insights/parsers/uname.py
+++ b/insights/parsers/uname.py
@@ -101,6 +101,12 @@ rhel_release_map = {
     "3.10.0-1062": "7.7",
     "3.10.0-1127": "7.8",
     "3.10.0-1160": "7.9",
+    # Added alt to the below 3 kernel entries since they're part of the
+    # kernel-alt pkg, if we don't it would create duplicate entries and
+    # mess with what's returned by from_release.
+    "4.11.0-44": "7.4.alt",
+    "4.14.0-49": "7.5.alt",
+    "4.14.0-115": "7.6.alt",
     "4.18.0-80": "8.0",
     "4.18.0-147": "8.1",
     "4.18.0-193": "8.2",


### PR DESCRIPTION
* Add the mappings for the 3 kernel-alt releases, I added -alt to the
  release number to distinguish it from the normal release kernel versions.
* Fixes #2770

Signed-off-by: Ryan Blakley <rblakley@redhat.com>