### PR TITLE
[testing] start using github actions for tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,90 @@
+name: Insights Core Test
+
+on:
+  push:
+    branches: [ master, '3.0']
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  code-test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-versions: [2.7, 3.6]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-versions }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-versions }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+    - name: flake8
+      run: |
+        pip install -e .[linting]
+        flake8 .
+    - name: pytest
+      run: |
+        pip install -e .[testing]
+        pytest
+
+  python26-test:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: apt-install python26
+      run: |
+        sudo add-apt-repository ppa:deadsnakes/ppa
+        sudo apt-get update
+        sudo apt-get install python2.6
+        sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.6 1
+        sudo update-alternatives --set python /usr/bin/python2.6
+    - name: get depenencies
+      run: |
+        git clone https://github.com/SteveHNH/jenkins-s2i-example.git pips
+        CUR_DIR=$(pwd)
+        mkdir ../tools && cd ../tools
+        curl -L -O https://files.pythonhosted.org/packages/b8/04/be569e393006fa9a2c10ef72ea33133c2902baa115dd1d4279dae55c3b3b/setuptools-36.8.0.zip
+        unzip setuptools-36.8.0.zip && cd setuptools-36.8.0
+        python setup.py install --user && cd ..
+        curl -L -O https://github.com/pypa/pip/archive/refs/tags/9.0.3.tar.gz
+        tar -xvzf 9.0.3.tar.gz && cd pip-9.0.3
+        python setup.py install --user && cd ${CUR_DIR}
+        pip install --user -r ./pips/slave26/ci_requirements.txt -f ./pips/slave26/pip_packages
+        mkdir ../collections_module
+        sudo curl -L -o ./../collections_module/collections.py https://raw.githubusercontent.com/RedHatInsights/insights-core/5c8ca0f2fb3de45908e8d931d40758af34a7997a/.collections.py
+    - name: flake8
+      run: |
+        pip install --user -e .[linting] -f ./pips/slave26/pip_packages
+        flake8 .
+    - name: pytest
+      run: |
+        pip install --user -e .[testing] -f ./pips/slave26/pip_packages
+        export PYTHONPATH=${PYTHONPATH}:./../collections_module
+        pytest
+
+  docs-test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: install dependencies
+      run: |
+        sudo apt-get install pandoc
+        python -m pip install --upgrade pip
+    - name: docs Test
+      run: |
+        pip install docutils==0.17
+        pip install -e .[docs]
+        sphinx-build -W -b html -qa -E docs docs/_build/html


### PR DESCRIPTION
The old jenkins CI that this runs on is far out of date and very
unstable. Moving to Github actions satisfies all the requirements we
have for testing the project

Signed-off-by: Stephen Adams <tsadams@gmail.com>