### PR TITLE
Correct the `unit_files` format in pydoc

### DIFF
--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -243,7 +243,7 @@ class rule(PluginType):
 
     At least one of the arguments to parameters of an "at least one"
     list will not be ``None``. In the example, either or both of ``chk_config``
-    and unit_files will not be ``None``.
+    and ``unit_files`` will not be ``None``.
 
     Any or all arguments for optional parameters may be ``None``.
 


### PR DESCRIPTION
Bugfix for: https://github.com/RedHatInsights/insights-core/issues/3069