### PR TITLE
Fix IndexError exception in smt combiner

### DIFF
--- a/insights/combiners/smt.py
+++ b/insights/combiners/smt.py
@@ -43,7 +43,13 @@ class CpuTopology(object):
         max_cpu_core_id = max([core.core_id for core in cpu_online])
         for n in range(max_cpu_core_id + 1):
             online = [core for core in cpu_online if core.core_id == n]
-            online = online[0].on
+            # On some boxes cpu0 doesn't have the online file, since technically cpu0 will always
+            # be online. So check if online returns anything before trying to access online[0].
+            # If it returns nothing and n is 0 set online to True.
+            if online:
+                online = online[0].on
+            elif not online and n == 0:
+                online = True
             siblings = [sibling for sibling in cpu_siblings if sibling.core_id == n]
             if len(siblings) != 0:
                 siblings = siblings[0].siblings

--- a/insights/combiners/tests/test_smt.py
+++ b/insights/combiners/tests/test_smt.py
@@ -142,3 +142,20 @@ def test_doc_examples(cpu_all_online):
     }
     failed, total = doctest.testmod(smt, globs=env)
     assert failed == 0
+
+
+def test_without_hyperthreading_all_online_missing_cpu0_online_file():
+    online = [
+        CpuCoreOnline(context_wrap("1", path=ONLINE_PATH.format(1))),
+    ]
+    siblings = [
+        CpuSiblings(context_wrap("0", path=SIBLINGS_PATH.format(0))),
+        CpuSiblings(context_wrap("1", path=SIBLINGS_PATH.format(1)))
+    ]
+
+    cpu_topology = CpuTopology(online, siblings)
+    assert cpu_topology.online(0)
+    assert cpu_topology.siblings(0) == [0]
+    assert cpu_topology.online(1)
+    assert cpu_topology.siblings(1) == [1]
+    assert cpu_topology.all_solitary


### PR DESCRIPTION
* On some systems the /sys/devices/system/cpu0/online file doesn't
  exist, which causes an IndexError in the combiner. Updated it to
  to handle the missing file since cpu0 will always be online.
* Add test to replicate the missing cpu0 online file.
* Fixes #3073

Signed-off-by: Ryan Blakley <rblakley@redhat.com>