### PR TITLE
Add new switch to run to choose the color output

### DIFF
--- a/docs/manpages/insights-run.rst
+++ b/docs/manpages/insights-run.rst
@@ -39,6 +39,12 @@ OPTIONS
     -c CONFIG --config CONFIG
         Configure components.
 
+    \-\-color [=WHEN]
+        Choose if and how the color encoding is outputted. When can be 'always', 'auto', or
+        'never'. If always the color encoding isn't stripped from the output, so it can be
+        piped. If auto the color is outputted in the terminal but is stripped if piped. If
+        never then no color encoding is outputted.
+
     \-\-context CONTEXT
         Execution Context. Defaults to HostContext if an archive isn't passed.
         See :ref:`context-label` for additional information.

--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -56,6 +56,8 @@ package_info = dict((k, None) for k in ["RELEASE", "COMMIT", "VERSION", "NAME"])
 for name in package_info:
     package_info[name] = pkgutil.get_data(__name__, name).strip().decode("utf-8")
 
+_COLOR = "auto"
+
 
 def get_nvr():
     return "{0}-{1}-{2}".format(package_info["NAME"],
@@ -263,6 +265,8 @@ def run(component=None, root=None, print_summary=False,
         p.add_argument("--tags", help="Expression to select rules by tag.")
         p.add_argument("-D", "--debug", help="Verbose debug output.", action="store_true")
         p.add_argument("--context", help="Execution Context. Defaults to HostContext if an archive isn't passed.")
+        p.add_argument("--color", default="auto", choices=["always", "auto", "never"], metavar="[=WHEN]",
+                       help="Choose if and how the color encoding is outputted. When is 'always', 'auto', or 'never'.")
 
         class Args(object):
             pass
@@ -270,6 +274,8 @@ def run(component=None, root=None, print_summary=False,
         formatters = []
         args = Args()
         p.parse_known_args(namespace=args)
+        global _COLOR
+        _COLOR = args.color
         p = argparse.ArgumentParser(parents=[p])
         args.format = "insights.formats._json" if args.format == "json" else args.format
         args.format = "insights.formats._yaml" if args.format == "yaml" else args.format

--- a/insights/formats/text.py
+++ b/insights/formats/text.py
@@ -6,14 +6,30 @@ from collections import namedtuple
 
 from pprint import pprint
 from six import StringIO
-from insights import dr, datasource, rule, condition, incident, parser
+from insights import _COLOR, dr, datasource, rule, condition, incident, parser
 from insights.core.context import ExecutionContext
 from insights.formats import Formatter, FormatterAdapter, render
 
 
 try:
-    from colorama import Fore, Style, init
-    init()
+    from colorama import init
+
+    if _COLOR == "always":
+        from colorama import Fore, Style
+        init(strip=False)
+    elif _COLOR == "auto":
+        from colorama import Fore, Style
+        init()
+    elif _COLOR == "never":
+        class Default(type):
+            def __getattr__(*args):
+                return ""
+
+        class Fore(six.with_metaclass(Default)):
+            pass
+
+        class Style(six.with_metaclass(Default)):
+            pass
 except ImportError:
     print("Install colorama if console colors are preferred.")
 


### PR DESCRIPTION
* Add new switch --color[=WHEN] to allow the choice of color output
  encoding. The options for when are always, auto, and never. Always
  sets colorama to not strip the encoding, so the color can be piped.
  Auto sets colorama to the default, and never disables color encoding.
* Fixes #2980

Signed-off-by: Ryan Blakley <rblakley@redhat.com>