### PR TITLE
Fix non aws systems from being detected as aws

### DIFF
--- a/insights/combiners/cloud_provider.py
+++ b/insights/combiners/cloud_provider.py
@@ -235,10 +235,12 @@ class AmazonCloudProvider(CloudProviderInstance):
         self.rpm = 'rh-amazon-rhui-client'
         self.bios_vendor_version = 'amazon'
         self.uuid = 'ec2'
+        self.asset_tag = 'Amazon EC2'
         self.cp_bios_vendor = self._get_cp_bios_vendor(self.bios_vendor_version)
         self.cp_bios_version = self._get_cp_bios_version(self.bios_vendor_version)
         self.cp_rpms = self._get_rpm_cp_info(self.rpm)
         self.cp_uuid = self._get_cp_from_uuid(self.uuid)
+        self.cp_asset_tag = self._get_cp_from_asset_tag(self.asset_tag)
 
 
 class AzureCloudProvider(CloudProviderInstance):
@@ -387,7 +389,7 @@ class CloudProvider(object):
         if self._cp_objects[self.AZURE].cp_yum or self._cp_objects[self.AZURE].cp_asset_tag:
             return self.AZURE
 
-        if self._cp_objects[self.AWS].cp_uuid:
+        if self._cp_objects[self.AWS].cp_uuid and self._cp_objects[self.AWS].cp_asset_tag:
             return self.AWS
 
         if self._cp_objects[self.ALIBABA].cp_manufacturer:

--- a/insights/combiners/tests/test_cloud_provider.py
+++ b/insights/combiners/tests/test_cloud_provider.py
@@ -209,7 +209,7 @@ System Information
 \tProduct Name: X9SCL/X9SCM
 \tVersion: 0123456789
 \tSerial Number: 0123456789
-\tUUID: 12345678-1234-1234-1234-123456681234
+\tUUID: EC245678-1234-1234-1234-123456681234
 \tWake-up Type: Power Switch
 \tSKU Number: To be filled by O.E.M.
 \tFamily: To be filled by O.E.M.
@@ -313,7 +313,7 @@ Chassis Information
 \tLock: Not Present
 \tVersion: Not Specified
 \tSerial Number: Not Specified
-\tAsset Tag: Not Specified
+\tAsset Tag: Amazon EC2
 \tBoot-up State: Safe
 \tPower Supply State: Safe
 \tThermal State: Safe
@@ -664,6 +664,15 @@ def test__uuid():
     ret = CloudProvider(irpms, dmi, yrl, None)
     assert ret.cloud_provider == CloudProvider.AWS
     assert ret.cp_uuid[CloudProvider.AWS] == 'EC2F58AF-2DAD-C57E-88C0-A81CB6084290'
+
+
+def test__uuid_not_aws():
+    irpms = IRPMS(context_wrap(RPMS))
+    dmi = DMIDecode(context_wrap(DMIDECODE_BARE_METAL))
+    yrl = YumRepoList(context_wrap(YUM_REPOLIST_NOT_AZURE))
+    ret = CloudProvider(irpms, dmi, yrl, None)
+    assert ret.cloud_provider is None
+    assert ret.cp_uuid[CloudProvider.AWS] == 'EC245678-1234-1234-1234-123456681234'
 
 
 def test_dmidecode_alibaba():


### PR DESCRIPTION
* There are systems that end up with uuids that start with ec2 that
  aren't aws systems. I added an extra check on the asset tag so non aws
  systems aren't detected.
* Added a new test for a non aws system with a uuid starting with ec2.
* Fixes #2904

Signed-off-by: Ryan Blakley <rblakley@redhat.com>

**Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.**

### All Pull Requests:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Issue/Bug Fix:
Provide complete details of the issue and how this PR fixes the issue. You can link to one or more existing open, publicly-accessible issue(s) that provide details.
* Some non aws systems have uuid's starting with ec2. Currently it checks the bios_vendor, then bios_version, then rpms before last checking if the uuid starts with ec2 for aws detection. I added an additional check, that checks for the uuid and if the asset tag states Amazon EC2, from my test this prevents the non aws systems from being detected.