### PR TITLE
Add partitions spec to default and insights archive

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -707,6 +707,7 @@ class DefaultSpecs(Specs):
 
     package_provides_command = command_with_args("/usr/bin/echo '%s'", cmd_and_pkg)
     pacemaker_log = first_file(["/var/log/pacemaker.log", "/var/log/pacemaker/pacemaker.log"])
+    partitions = simple_file("/proc/partitions")
     pci_rport_target_disk_paths = simple_command("/usr/bin/find /sys/devices/ -maxdepth 10 -mindepth 9 -name stat -type f")
 
     @datasource(Services, HostContext)

--- a/insights/tests/client/collection_rules/test_map_components.py
+++ b/insights/tests/client/collection_rules/test_map_components.py
@@ -77,7 +77,6 @@ def test_get_component_by_symbolic_name():
         'freeipa_healthcheck_log',
         'ironic_conf',
         'octavia_conf',
-        'partitions',
         'rhn_entitlement_cert_xml',
         'rhn_hibernate_conf',
         'rhn_schema_version',


### PR DESCRIPTION
**Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.**

### All Pull Requests:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Is this PR an enhancement?

### Enhancement:
The specs partitions is already available for sos archive however it
is missing from default and insights archive. This commits add
partition spec to default and insights archive so that archive
generated by insights would also gather /proc/partitions file.

Since a new rule is developed to use partitions specs, hence it is
removed from skipped_specs list. See CEECBA-4818 for a reference.

