### PR TITLE
Fix attribute error in AllModProbe combiner

### DIFF
--- a/insights/combiners/modprobe.py
+++ b/insights/combiners/modprobe.py
@@ -82,7 +82,7 @@ class AllModProbe(LegacyItemAccess):
                 if section not in self.data:
                     self.data[section] = {}
                 for name, value in sectdict.items():
-                    if name in self.data[section]:
+                    if name in self.data[section] and type(self.data[section][name][0]) == list:
                         # append to this module's value - should only
                         # happen for aliases.
                         self.data[section][name][0].append(value)

--- a/insights/combiners/tests/test_modprobe.py
+++ b/insights/combiners/tests/test_modprobe.py
@@ -5,6 +5,9 @@ from insights.tests import context_wrap
 MOD_OPTION_INFO = """
 options ipv6 disable=1
 install ipv6 /bin/true
+
+# Test duplicate entry.
+blacklist vfat
 """
 
 MOD_OPTION_INFO_PATH = "/etc/modprobe.d/ipv6.conf"
@@ -38,6 +41,9 @@ options bnx2 disable_msi=1
 alias
 alias scsi_hostadapter2 ata_piix failed comment
 balclkist ieee80211
+
+# Test duplicate entry.
+blacklist vfat
 """
 
 MOD_COMPLETE_PATH = "/etc/modprobe.conf"
@@ -59,6 +65,7 @@ def test_all_modprobe():
     assert 'blacklist' in all_data
     assert all_data['blacklist'] == {
         'i8xx_tco': ModProbeValue(value=True, source=MOD_COMPLETE_PATH),
+        'vfat': ModProbeValue(value=True, source=MOD_OPTION_INFO_PATH),
     }
 
     assert 'install' in all_data


### PR DESCRIPTION
* Added a check that the type of the entry is a list before attempting
  to append.
* Added duplicate blacklist entries to the test.
* Fixes #3107

Signed-off-by: Ryan Blakley <rblakley@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
When there is duplicate blacklist entries it will cause an attribute error due to blacklist entries being bools not list, which can't be appended to. So I added a check to make sure the entry is a list before appending.