### PR TITLE
Remove futures module from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ client = set([
 ])
 
 develop = set([
-    'futures==3.0.5',
     'wheel',
 ])
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Fixes #3113 
* Futures is included in python3 but a separate module in python2
* Installing the python2 module when using python3 causes problems
* Collect.py is the only place that futures was used, and it was only
  loaded if the client collection was run in parallel.  This is not
  feature we currently use.
* The parallel collection feature will still work with python3, but not
  with python2

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>