### PR TITLE
force _boolify to always return bool

### DIFF
--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -528,12 +528,8 @@ class InsightsConfig(object):
         "INSIGHTS_" prepended to it.
         '''
         def _boolify(v):
-            if v.lower() == 'true':
-                return True
-            elif v.lower() == 'false':
-                return False
-            else:
-                return v
+            # anything not specifically False is treated as True
+            return not v.lower() in ("false", "")
 
         # put this warning here so the error msg only prints once
         if os.environ.get('HTTP_PROXY') and not os.environ.get('HTTPS_PROXY') and self._print_errors:


### PR DESCRIPTION
Signed-off-by: Jeremy <jcrafts@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The function for parsing env vars in `insights.client.config` has an nested function `_boolify`. This function will return the same string it is given, if this string is not recognized as True or False. In our logic, this is fine, since strings will evaluate to True, but this will make it a bit cleaner.