### PR TITLE
Add new datasource and parser for ps eo pid,args

### DIFF
--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -10,3 +10,11 @@ insights.specs.datasources.cloud_init
     :members: cloud_cfg, LocalSpecs
     :show-inheritance:
     :undoc-members:
+
+insights.specs.datasources.ps
+-----------------------------
+
+.. automodule:: insights.specs.datasources.ps
+    :members: ps_eo_cmd, LocalSpecs
+    :show-inheritance:
+    :undoc-members:

--- a/insights/combiners/ps.py
+++ b/insights/combiners/ps.py
@@ -6,8 +6,8 @@ This combiner provides information about running processes based on the ``ps`` c
 More specifically this consolidates data from
 :py:class:`insights.parsers.ps.PsEo`,
 :py:class:`insights.parsers.ps.PsAuxcww`,
-:py:class:`insights.parsers.ps.PsEf`,
 :py:class:`insights.parsers.ps.PsEoCmd`,
+:py:class:`insights.parsers.ps.PsEf`,
 :py:class:`insights.parsers.ps.PsAux`,
 :py:class:`insights.parsers.ps.PsAuxww` and
 :py:class:`insights.parsers.ps.PsAlxwww` parsers (in that specific order).
@@ -22,7 +22,7 @@ Note:
 
 Examples:
 
-    >>> ps_combiner.pids
+    >>> sorted(ps_combiner.pids)
     [1, 2, 3, 8, 9, 10, 11, 12, 13]
     >>> '[kthreadd]' in ps_combiner.commands
     True
@@ -106,6 +106,8 @@ class Ps(object):
             self.__update_data(ps_eo)
         if ps_auxcww:
             self.__update_data(ps_auxcww)
+        if ps_eo_cmd:
+            self.__update_data(ps_eo_cmd)
         if ps_ef:
             # mapping configurations to combine PsEf data
             mapping = {
@@ -116,8 +118,6 @@ class Ps(object):
                 'STIME': ('START', True)
             }
             self.__update_data(ps_ef, mapping)
-        if ps_eo_cmd:
-            self.__update_data(ps_eo_cmd)
         if ps_aux:
             self.__update_data(ps_aux)
         if ps_auxww:

--- a/insights/combiners/ps.py
+++ b/insights/combiners/ps.py
@@ -7,6 +7,7 @@ More specifically this consolidates data from
 :py:class:`insights.parsers.ps.PsEo`,
 :py:class:`insights.parsers.ps.PsAuxcww`,
 :py:class:`insights.parsers.ps.PsEf`,
+:py:class:`insights.parsers.ps.PsEoCmd`,
 :py:class:`insights.parsers.ps.PsAux`,
 :py:class:`insights.parsers.ps.PsAuxww` and
 :py:class:`insights.parsers.ps.PsAlxwww` parsers (in that specific order).
@@ -22,7 +23,7 @@ Note:
 Examples:
 
     >>> ps_combiner.pids
-    [1, 2, 3, 8, 9, 10, 11, 12]
+    [1, 2, 3, 8, 9, 10, 11, 12, 13]
     >>> '[kthreadd]' in ps_combiner.commands
     True
     >>> '[kthreadd]' in ps_combiner
@@ -53,10 +54,10 @@ Examples:
 
 from insights.core.plugins import combiner
 from insights.parsers import keyword_search
-from insights.parsers.ps import PsAlxwww, PsAuxww, PsAux, PsAuxcww, PsEo, PsEf
+from insights.parsers.ps import PsAlxwww, PsAuxww, PsAux, PsAuxcww, PsEo, PsEf, PsEoCmd
 
 
-@combiner([PsAlxwww, PsAuxww, PsAux, PsEf, PsAuxcww, PsEo])
+@combiner([PsAlxwww, PsAuxww, PsAux, PsEf, PsAuxcww, PsEo, PsEoCmd])
 class Ps(object):
     """
     ``Ps`` combiner consolidates data from the parsers in ``insights.parsers.ps`` module.
@@ -97,7 +98,7 @@ class Ps(object):
         'WCHAN': None
     }
 
-    def __init__(self, ps_alxwww, ps_auxww, ps_aux, ps_ef, ps_auxcww, ps_eo):
+    def __init__(self, ps_alxwww, ps_auxww, ps_aux, ps_ef, ps_auxcww, ps_eo, ps_eo_cmd):
         self._pid_data = {}
 
         # order of parsers is important here
@@ -115,6 +116,8 @@ class Ps(object):
                 'STIME': ('START', True)
             }
             self.__update_data(ps_ef, mapping)
+        if ps_eo_cmd:
+            self.__update_data(ps_eo_cmd)
         if ps_aux:
             self.__update_data(ps_aux)
         if ps_auxww:

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -511,6 +511,7 @@ class Specs(SpecSet):
     ps_auxww = RegistryPoint(filterable=True)
     ps_ef = RegistryPoint(filterable=True)
     ps_eo = RegistryPoint()
+    ps_eo_cmd = RegistryPoint()
     pulp_worker_defaults = RegistryPoint()
     puppet_ssl_cert_ca_pem = RegistryPoint()
     puppetserver_config = RegistryPoint(filterable=True)

--- a/insights/specs/datasources/ps.py
+++ b/insights/specs/datasources/ps.py
@@ -1,0 +1,77 @@
+"""
+Custom datasources for ps information
+"""
+from insights.core.context import HostContext
+from insights.core.dr import SkipComponent
+from insights.core.plugins import datasource
+from insights.core.spec_factory import DatasourceProvider, simple_command
+from insights.specs import Specs
+
+
+class LocalSpecs(Specs):
+    """ Local specs used only by ps datasources """
+
+    ps_eo_args = simple_command("/bin/ps -eo pid,args")
+    """ Returns ps output including pid and full args """
+
+
+@datasource(LocalSpecs.ps_eo_args, HostContext)
+def ps_eo_cmd(broker):
+    """
+    Custom datasource to collect the full paths to all running commands on the system
+    provided by the ``ps -eo pid,args`` command.  After collecting the data, all of the
+    args are trimmed to leave only the command including full path.
+
+    Sample output from the ``ps -eo pid, args`` command::
+
+        PID COMMAND
+          1 /usr/lib/systemd/systemd --switched-root --system --deserialize 31
+          2 [kthreadd]
+          3 [rcu_gp]
+          4 [rcu_par_gp]
+          6 [kworker/0:0H-events_highpri]
+          9 [mm_percpu_wq]
+         10 [rcu_tasks_kthre]
+         11 /usr/bin/python3 /home/user1/python_app.py
+         12 [kworker/u16:0-kcryptd/253:0]
+
+    This datasource trims off the args to minimize possible PII and sensitive information.
+    After trimming the data looks like this::
+
+        PID COMMAND
+          1 /usr/lib/systemd/systemd
+          2 [kthreadd]
+          3 [rcu_gp]
+          4 [rcu_par_gp]
+          6 [kworker/0:0H-events_highpri]
+          9 [mm_percpu_wq]
+         10 [rcu_tasks_kthre]
+         11 /usr/bin/python3
+         12 [kworker/u16:0-kcryptd/253:0]
+
+    Returns:
+        str: Returns a multiline string in the same format as ``ps`` output
+
+    Raises:
+        SkipComponent: Raised if no data is available
+    """
+    content = broker[LocalSpecs.ps_eo_args].content
+    data = []
+    data.append('PID COMMAND')
+    for l in content:
+        if 'PID' in l and 'COMMAND' in l:
+            start = True
+            continue
+        if not start:
+            continue
+        pid, args = l.strip().split(None, 1)
+        if ' ' in args:
+            cmd, _ = args.split(None, 1)
+        else:
+            cmd = args
+        data.append('{0} {1}'.format(pid, cmd))
+
+    if len(data) > 1:
+        return DatasourceProvider('\n'.join(data), relative_path='insights_commands/ps_eo_cmd')
+
+    raise SkipComponent()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -35,7 +35,7 @@ from insights.parsers.lsmod import LsMod
 from insights.combiners.satellite_version import SatelliteVersion, CapsuleVersion
 from insights.parsers.mount import Mount
 from insights.specs import Specs
-from insights.specs.datasources import cloud_init
+from insights.specs.datasources import cloud_init, ps as ps_datasource
 import datetime
 
 
@@ -175,6 +175,7 @@ class DefaultSpecs(Specs):
     ps_auxww = simple_command("/bin/ps auxww")
     ps_ef = simple_command("/bin/ps -ef")
     ps_eo = simple_command("/usr/bin/ps -eo pid,ppid,comm")
+    ps_eo_cmd = ps_datasource.ps_eo_cmd
 
     @datasource(ps_auxww, HostContext)
     def tomcat_base(broker):


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* This new datasource/parser will enhance the ps combiner output by
  ensuring that we have the full command path but don't collect args
  that may include PII and sensitive info
* Add new datasource for ps eo pid,args that removes args leaving the
  command only
* Add new parser for the datasource
* Update ps combiner to use new parser
* Add tests and docs for both

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>