### PR TITLE
Fix ethtool parse exceptions due to a spec issue

### DIFF
--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -27,6 +27,14 @@ insights.specs.datasources.cloud_init
     :show-inheritance:
     :undoc-members:
 
+insights.specs.datasources.ethernet
+-------------------------------------
+
+.. automodule:: insights.specs.datasources.ethernet
+    :members: interfaces, LocalSpecs
+    :show-inheritance:
+    :undoc-members:
+
 insights.specs.datasources.ipcs
 -------------------------------
 

--- a/insights/specs/datasources/ethernet.py
+++ b/insights/specs/datasources/ethernet.py
@@ -1,0 +1,57 @@
+"""
+Custom datasource for gathering a list of the ethernet interface names.
+"""
+from insights.core.context import HostContext
+from insights.core.dr import SkipComponent
+from insights.core.plugins import datasource
+from insights.core.spec_factory import simple_command
+from insights.specs import Specs
+
+
+class LocalSpecs(Specs):
+    """ Local specs used only by ethernet_interfaces datasource. """
+    ip_link = simple_command("/sbin/ip -o link")
+
+
+@datasource(LocalSpecs.ip_link, HostContext)
+def interfaces(broker):
+    """
+    This datasource provides a list of the ethernet interfaces available.
+
+    Typical content of the spec is::
+
+        1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000\\    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+        2: enp1s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000\\    link/ether 52:54:00:13:14:b5 brd ff:ff:ff:ff:ff:ff
+        3: enp8s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000\\    link/ether 52:54:00:e5:11:d4 brd ff:ff:ff:ff:ff:ff
+        4: enp1s0.2@enp1s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000\\    link/ether 52:54:00:13:14:b5 brd ff:ff:ff:ff:ff:ff
+        5: ib0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 4092 qdisc mq state DOWN group default qlen 256\\    link/infiniband 00:01:02:03:fd:90:0:00:00:00:00:00:ef:0d:8b:02:01:d9:82:fd
+
+    Note:
+        This datasource may be executed using the following command:
+
+        ``insights cat --no-header ethernet_interfaces``
+
+    Sample data returned::
+
+        ['enp1s0', 'enp8s0', 'enp1s0.2']
+
+    Returns:
+        list: List of the ethernet interfaces available.
+
+    Raises:
+        SkipComponent: When there is not any content.
+    """
+    content = broker[LocalSpecs.ip_link].content
+    if content:
+        ifaces = []
+        for x in content:
+            # Only process lines that have link/ether, this should exclude non ethernet devices.
+            if "link/ether" in x:
+                # Split first on : the interface name should be the second entry.
+                # Then split again on @ since vlans append @ and the parent interface name to the end.
+                ifaces.append(x.split(':')[1].split('@')[0].strip())
+
+        if ifaces:
+            return sorted(ifaces)
+
+    raise SkipComponent

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -38,7 +38,7 @@ from insights.combiners.satellite_version import SatelliteVersion, CapsuleVersio
 from insights.parsers.mount import Mount
 from insights.specs import Specs
 from insights.specs.datasources import (
-    cloud_init, candlepin_broker, get_running_commands, ipcs, package_provides, ps as ps_datasource)
+    cloud_init, candlepin_broker, ethernet, get_running_commands, ipcs, package_provides, ps as ps_datasource)
 
 
 logger = logging.getLogger(__name__)
@@ -244,13 +244,13 @@ class DefaultSpecs(Specs):
                                        "/usr/lib/udev/rules.d/40-redhat.rules", "/usr/local/lib/udev/rules.d/40-redhat.rules"])
     etcd_conf = simple_file("/etc/etcd/etcd.conf")
     ethernet_interfaces = listdir("/sys/class/net", context=HostContext)
-    ethtool = foreach_execute(ethernet_interfaces, "/sbin/ethtool %s")
-    ethtool_S = foreach_execute(ethernet_interfaces, "/sbin/ethtool -S %s")
-    ethtool_T = foreach_execute(ethernet_interfaces, "/sbin/ethtool -T %s")
-    ethtool_c = foreach_execute(ethernet_interfaces, "/sbin/ethtool -c %s")
-    ethtool_g = foreach_execute(ethernet_interfaces, "/sbin/ethtool -g %s")
-    ethtool_i = foreach_execute(ethernet_interfaces, "/sbin/ethtool -i %s")
-    ethtool_k = foreach_execute(ethernet_interfaces, "/sbin/ethtool -k %s")
+    ethtool = foreach_execute(ethernet.interfaces, "/sbin/ethtool %s")
+    ethtool_S = foreach_execute(ethernet.interfaces, "/sbin/ethtool -S %s")
+    ethtool_T = foreach_execute(ethernet.interfaces, "/sbin/ethtool -T %s")
+    ethtool_c = foreach_execute(ethernet.interfaces, "/sbin/ethtool -c %s")
+    ethtool_g = foreach_execute(ethernet.interfaces, "/sbin/ethtool -g %s")
+    ethtool_i = foreach_execute(ethernet.interfaces, "/sbin/ethtool -i %s")
+    ethtool_k = foreach_execute(ethernet.interfaces, "/sbin/ethtool -k %s")
     facter = simple_command("/usr/bin/facter")
     fc_match = simple_command("/bin/fc-match -sv 'sans:regular:roman' family fontformat")
     fcoeadm_i = simple_command("/usr/sbin/fcoeadm -i")

--- a/insights/tests/datasources/test_ethernet.py
+++ b/insights/tests/datasources/test_ethernet.py
@@ -1,0 +1,37 @@
+import pytest
+
+from insights.core.dr import SkipComponent
+from insights.specs.datasources.ethernet import interfaces, LocalSpecs
+from mock.mock import Mock
+
+RELATIVE_PATH = "insights_commands/ethernet_interfaces"
+
+IP_LINK = """
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000\\    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+2: enp1s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000\\    link/ether 52:54:00:13:14:b5 brd ff:ff:ff:ff:ff:ff
+3: enp8s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000\\    link/ether 52:54:00:e5:11:d4 brd ff:ff:ff:ff:ff:ff
+4: enp1s0.2@enp1s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000\\    link/ether 52:54:00:13:14:b5 brd ff:ff:ff:ff:ff:ff
+5: ib0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 4092 qdisc mq state DOWN group default qlen 256\\    link/infiniband 00:01:02:03:fd:90:0:00:00:00:00:00:ef:0d:8b:02:01:d9:82:fd
+"""
+
+IP_LINK_BAD = ""
+
+EXPECTED = ['enp1s0', 'enp8s0', 'enp1s0.2']
+
+
+def test_ethernet_interfaces():
+    ip_link_command = Mock()
+    ip_link_command.content = IP_LINK.splitlines()
+    broker = {LocalSpecs.ip_link: ip_link_command}
+    result = interfaces(broker)
+    assert result is not None
+    assert isinstance(result, list)
+    assert result == sorted(EXPECTED)
+
+
+def test_ethernet_interfaces_bad():
+    ip_link_command = Mock()
+    ip_link_command.content = IP_LINK_BAD.splitlines()
+    broker = {LocalSpecs.ip_link: ip_link_command}
+    with pytest.raises(SkipComponent):
+        interfaces(broker)


### PR DESCRIPTION
* Add new ethernet interfaces datasource, to properly gather a list of
  valid ethernet interface names. That way ethtool is ran against the
  proper interface names.
* Fixes #1791

Signed-off-by: Ryan Blakley <rblakley@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
Switch from just listing the files under the /sys/class/net to run ethtool against, instead parse the ip -o link command for any interfaces with link/ether in it. Also correct the interface name when it is a vlan interface, as it appends the parent interface on the end after an @ symbol. This plus an update to the uploader.json should fix the majority of the ethtool parse exceptions that occur in production.