### PR TITLE
Refactor is_aws, is_azure, is_gcp to Component

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -123,6 +123,16 @@ plugins:
         - name: insights.combiners.cloud_provider
           enabled: true
 
+    # needed for the cloud related specs
+        - name: insights.components.cloud_provider.IsAWS
+          enabled: true
+
+        - name: insights.components.cloud_provider.IsAzure
+          enabled: true
+
+        - name: insights.components.cloud_provider.IsGCP
+          enabled: true
+
     # needed for the Services combiner
         - name: insights.parsers.chkconfig
           enabled: true

--- a/insights/components/cloud_provider.py
+++ b/insights/components/cloud_provider.py
@@ -4,7 +4,7 @@ Components identify Cloud Provider
 
 The ``Is*`` component is valid if the
 :py:class:`insights.combiners.cloud_provider.CloudProvider` combiner indicates
-the host is from the specifiec Cloud Provider.  Otherwise, it raises a
+the host is from the specific Cloud Provider.  Otherwise, it raises a
 :py:class:`insights.core.dr.SkipComponent` to prevent dependent components from
 executing.
 

--- a/insights/components/cloud_provider.py
+++ b/insights/components/cloud_provider.py
@@ -25,7 +25,7 @@ class IsAWS(object):
         SkipComponent: When it's not an instance from AWS.
     """
     def __init__(self, cp):
-        if not(cp and cp.cloud_provider == CloudProvider.AWS):
+        if not cp or cp.cloud_provider != CloudProvider.AWS:
             raise SkipComponent("Not AWS instance")
 
 
@@ -40,7 +40,7 @@ class IsAzure(object):
         SkipComponent: When it's not an instance from Azure.
     """
     def __init__(self, cp):
-        if not(cp and cp.cloud_provider == CloudProvider.AZURE):
+        if not cp or cp.cloud_provider != CloudProvider.AZURE:
             raise SkipComponent("Not Azure instance")
 
 
@@ -55,5 +55,5 @@ class IsGCP(object):
         SkipComponent: When it's not an instance from GCP.
     """
     def __init__(self, cp):
-        if not(cp and cp.cloud_provider == CloudProvider.GOOGLE):
+        if not cp or cp.cloud_provider != CloudProvider.GOOGLE:
             raise SkipComponent("Not Google Cloud Platform instance")

--- a/insights/components/cloud_provider.py
+++ b/insights/components/cloud_provider.py
@@ -1,0 +1,59 @@
+"""
+Components identify Cloud Provider
+===================================
+
+The ``Is*`` component is valid if the
+:py:class:`insights.combiners.cloud_provider.CloudProvider` combiner indicates
+the host is from the specifiec Cloud Provider.  Otherwise, it raises a
+:py:class:`insights.core.dr.SkipComponent` to prevent dependent components from
+executing.
+
+"""
+from insights.core.dr import SkipComponent
+from insights.core.plugins import component
+from insights.combiners.cloud_provider import CloudProvider
+
+
+@component(CloudProvider)
+class IsAWS(object):
+    """
+    This component uses ``CloudProvider`` combiner to determine the cloud
+    provider of the instance.
+    It checks if AWS, if not AWS it raises ``SkipComponent``.
+
+    Raises:
+        SkipComponent: When it's not an instance from AWS.
+    """
+    def __init__(self, cp):
+        if not(cp and cp.cloud_provider == CloudProvider.AWS):
+            raise SkipComponent("Not AWS instance")
+
+
+@component(CloudProvider)
+class IsAzure(object):
+    """
+    This component uses ``CloudProvider`` combiner to determine the cloud
+    provider of the instance.
+    It checks if Azure, if not Azure it raises ``SkipComponent``.
+
+    Raises:
+        SkipComponent: When it's not an instance from Azure.
+    """
+    def __init__(self, cp):
+        if not(cp and cp.cloud_provider == CloudProvider.AZURE):
+            raise SkipComponent("Not Azure instance")
+
+
+@component(CloudProvider)
+class IsGCP(object):
+    """
+    This component uses ``CloudProvider`` combiner to determine the cloud
+    provider of the instance.
+    It checks if Google Cloud Platform (GCP), if not GCP it raises ``SkipComponent``.
+
+    Raises:
+        SkipComponent: When it's not an instance from GCP.
+    """
+    def __init__(self, cp):
+        if not(cp and cp.cloud_provider == CloudProvider.GOOGLE):
+            raise SkipComponent("Not Google Cloud Platform instance")

--- a/insights/components/tests/test_cloud_provider.py
+++ b/insights/components/tests/test_cloud_provider.py
@@ -1,0 +1,27 @@
+from insights.tests import context_wrap
+from insights.parsers.dmidecode import DMIDecode
+from insights.combiners.cloud_provider import CloudProvider
+from insights.components.cloud_provider import IsAWS, IsAzure, IsGCP
+from insights.combiners.tests.test_cloud_provider import (
+        DMIDECODE_AWS, DMIDECODE_GOOGLE, DMIDECODE_AZURE_ASSET_TAG)
+
+
+def test_is_aws():
+    dmi = DMIDecode(context_wrap(DMIDECODE_AWS))
+    cp = CloudProvider(None, dmi, None, None)
+    result = IsAWS(cp)
+    assert isinstance(result, IsAWS)
+
+
+def test_is_azure():
+    dmi = DMIDecode(context_wrap(DMIDECODE_AZURE_ASSET_TAG))
+    cp = CloudProvider(None, dmi, None, None)
+    result = IsAzure(cp)
+    assert isinstance(result, IsAzure)
+
+
+def test_is_gcp():
+    dmi = DMIDecode(context_wrap(DMIDECODE_GOOGLE))
+    cp = CloudProvider(None, dmi, None, None)
+    result = IsGCP(cp)
+    assert isinstance(result, IsGCP)


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
The `is_aws`, `is_azure`, `is_gcp` look more like Components than datasources, this PR move them to the `insights.components.cloud_provider` module.
