### PR TITLE
New spec for getting oracle asm disks udev rules

### DIFF
--- a/insights/parsers/etc_udev_rules.py
+++ b/insights/parsers/etc_udev_rules.py
@@ -9,10 +9,6 @@ The parsers included in this module are:
 
 UdevRules40Redhat - file ``/etc/udev/rules.d/40-redhat.rules``
 --------------------------------------------------------------
-
-UdevRulesOracleASM - file ``/etc/udev/rules.d/*asm*.rules``
------------------------------------------------------------
-
 """
 from insights import parser
 from insights.core import LogFileOutput
@@ -55,39 +51,3 @@ class UdevRules40Redhat(LogFileOutput):
     def __init__(self, *args, **kwargs):
         deprecated(UdevRules40Redhat, "Import UdevRules40Redhat from insights.parsers.udev_rules instread.")
         super(UdevRules40Redhat, self).__init__(*args, **kwargs)
-
-
-@parser(Specs.etc_udev_oracle_asm_rules)
-class UdevRulesOracleASM(LogFileOutput):
-    """
-    Read the content of ``/etc/udev/rules.d/*asm*.rules`` file.
-
-    .. note::
-
-        The syntax of the `.rules` file is complex, and no rules require to
-        get the serialized parsed result currently.  An only existing rule's
-        supposed to check the syntax of some specific lines, so here the
-        :class:`insights.core.LogFileOutput` is the base class.
-
-    Sample input::
-
-        KERNEL=="dm*", PROGRAM=="scsi_id --page=0x83 --whitelisted --device=/dev/%k", \
-        RESULT=="360060e80164c210000014c2100007a8f", \
-        SYMLINK+="oracleasm/disks/asm_sbe80_7a8f", OWNER="oracle", GROUP="dba", MODE="0660"
-
-
-        KERNEL=="dm*", PROGRAM=="scsi_id --page=0x83 --whitelisted --device=/dev/%k", \
-        RESULT=="360060e80164c210000014c2100007a91", \
-        SYMLINK+="oracleasm/disks/asm_sbe80_7a91", OWNER="oracle", GROUP="dba", MODE="0660"
-
-        # NOTE: Insert new Oracle ASM LUN configuration before this comment
-        ACTION=="add|change", KERNEL=="sd*", OPTIONS:="nowatch"
-
-    Examples:
-
-    >>> 'ACTION=="add|change", KERNEL=="sd*", OPTIONS:="nowatch"' in udev_oracle_asm_rules.lines
-    True
-    >>> udev_oracle_asm_rules.get('ACTION')[0]['raw_message']
-    'ACTION=="add|change", KERNEL=="sd*", OPTIONS:="nowatch"'
-    """
-    pass

--- a/insights/parsers/etc_udev_rules.py
+++ b/insights/parsers/etc_udev_rules.py
@@ -10,6 +10,9 @@ The parsers included in this module are:
 UdevRules40Redhat - file ``/etc/udev/rules.d/40-redhat.rules``
 --------------------------------------------------------------
 
+UdevRulesOracleASM - file ``/etc/udev/rules.d/*asm*.rules``
+-----------------------------------------------------------
+
 """
 from insights import parser
 from insights.core import LogFileOutput
@@ -52,3 +55,39 @@ class UdevRules40Redhat(LogFileOutput):
     def __init__(self, *args, **kwargs):
         deprecated(UdevRules40Redhat, "Import UdevRules40Redhat from insights.parsers.udev_rules instread.")
         super(UdevRules40Redhat, self).__init__(*args, **kwargs)
+
+
+@parser(Specs.etc_udev_oracle_asm_rules)
+class UdevRulesOracleASM(LogFileOutput):
+    """
+    Read the content of ``/etc/udev/rules.d/*asm*.rules`` file.
+
+    .. note::
+
+        The syntax of the `.rules` file is complex, and no rules require to
+        get the serialized parsed result currently.  An only existing rule's
+        supposed to check the syntax of some specific lines, so here the
+        :class:`insights.core.LogFileOutput` is the base class.
+
+    Sample input::
+
+        KERNEL=="dm*", PROGRAM=="scsi_id --page=0x83 --whitelisted --device=/dev/%k", \
+        RESULT=="360060e80164c210000014c2100007a8f", \
+        SYMLINK+="oracleasm/disks/asm_sbe80_7a8f", OWNER="oracle", GROUP="dba", MODE="0660"
+
+
+        KERNEL=="dm*", PROGRAM=="scsi_id --page=0x83 --whitelisted --device=/dev/%k", \
+        RESULT=="360060e80164c210000014c2100007a91", \
+        SYMLINK+="oracleasm/disks/asm_sbe80_7a91", OWNER="oracle", GROUP="dba", MODE="0660"
+
+        # NOTE: Insert new Oracle ASM LUN configuration before this comment
+        ACTION=="add|change", KERNEL=="sd*", OPTIONS:="nowatch"
+
+    Examples:
+
+    >>> 'ACTION=="add|change", KERNEL=="sd*", OPTIONS:="nowatch"' in udev_oracle_asm_rules.lines
+    True
+    >>> udev_oracle_asm_rules.get('ACTION')[0]['raw_message']
+    'ACTION=="add|change", KERNEL=="sd*", OPTIONS:="nowatch"'
+    """
+    pass

--- a/insights/parsers/tests/test_etc_udev_rules.py
+++ b/insights/parsers/tests/test_etc_udev_rules.py
@@ -1,6 +1,6 @@
 import doctest
 from insights.parsers import etc_udev_rules
-from insights.parsers.etc_udev_rules import UdevRules40Redhat, UdevRulesOracleASM
+from insights.parsers.etc_udev_rules import UdevRules40Redhat
 from insights.tests import context_wrap
 
 UDEV_RULES_CONTENT = """
@@ -64,23 +64,6 @@ PROGRAM="/bin/uname -p", RESULT=="s390*", GOTO="memory_hotplug_end"
 LABEL="memory_hotplug_end"
 """.strip()
 
-ORACLE_ASM_UDEV_RULES = """
-KERNEL=="dm*", PROGRAM=="scsi_id --page=0x83 --whitelisted --device=/dev/%k", \
-RESULT=="360060e80164c210000014c2100007a8f", \
-SYMLINK+="oracleasm/disks/asm_sbe80_7a8f", OWNER="oracle", GROUP="dba", MODE="0660"
-
-KERNEL=="dm*", PROGRAM=="scsi_id --page=0x83 --whitelisted --device=/dev/%k", \
-RESULT=="360060e80164c210000014c2100007a90", \
-SYMLINK+="oracleasm/disks/asm_sbe80_7a90", OWNER="oracle", GROUP="dba", MODE="0660"
-
-KERNEL=="dm*", PROGRAM=="scsi_id --page=0x83 --whitelisted --device=/dev/%k", \
-RESULT=="360060e80164c210000014c2100007a91", \
-SYMLINK+="oracleasm/disks/asm_sbe80_7a91", OWNER="oracle", GROUP="dba", MODE="0660"
-
-# NOTE: Insert new Oracle ASM LUN configuration before this comment
-ACTION=="add|change", KERNEL=="sd*", OPTIONS:="nowatch"
-""".strip()
-
 
 def test_udev_rules():
     result = UdevRules40Redhat(context_wrap(UDEV_RULES_CONTENT))
@@ -91,17 +74,6 @@ def test_udev_rules():
 
 
 def test_documentation():
-    env = {'udev_rules': UdevRules40Redhat(context_wrap(SAMPLE_INPUT)),
-           'udev_oracle_asm_rules': UdevRulesOracleASM(context_wrap(ORACLE_ASM_UDEV_RULES))}
+    env = {'udev_rules': UdevRules40Redhat(context_wrap(SAMPLE_INPUT))}
     failed_count, tests = doctest.testmod(etc_udev_rules, globs=env)
     assert failed_count == 0
-
-
-def test_udev_oracle_asm_rules():
-    result = UdevRulesOracleASM(context_wrap(ORACLE_ASM_UDEV_RULES))
-    for line in ['ACTION=="add|change", KERNEL=="sd*", OPTIONS:="nowatch"',
-                 'KERNEL=="dm*", PROGRAM=="scsi_id --page=0x83 --whitelisted --device=/dev/%k", RESULT=="360060e80164c210000014c2100007a8f", SYMLINK+="oracleasm/disks/asm_sbe80_7a8f", OWNER="oracle", GROUP="dba", MODE="0660"']:
-        assert line in result.lines
-    actions = result.get('ACTION')
-    assert len(actions) == 1
-    assert actions[0]['raw_message'] == 'ACTION=="add|change", KERNEL=="sd*", OPTIONS:="nowatch"'

--- a/insights/parsers/udev_rules.py
+++ b/insights/parsers/udev_rules.py
@@ -1,6 +1,6 @@
 """
-UdevRules - file ``/usr/lib/udev/rules.d/``
-===========================================
+UdevRules - files ``/usr/lib/udev/rules.d/*`` and ``/etc/udev/rules.d/``
+========================================================================
 
 The parsers included in this module are:
 
@@ -9,6 +9,9 @@ UdevRulesFCWWPN - file ``/usr/lib/udev/rules.d/59-fc-wwpn-id.rules``
 
 UdevRules40Redhat - files ``/etc/udev/rules.d/40-redhat.rules``, ``/run/udev/rules.d/40-redhat.rules``, ``/usr/lib/udev/rules.d/40-redhat.rules``, ``/usr/local/lib/udev/rules.d/40-redhat.rules``
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+UdevRulesOracleASM - file ``/etc/udev/rules.d/*asm*.rules``
+-----------------------------------------------------------
 """
 from insights import parser
 from insights.core import LogFileOutput
@@ -63,5 +66,41 @@ class UdevRules40Redhat(LogFileOutput):
     Examples:
         >>> 'LABEL="memory_hotplug_end"' in udev_40_redhat_rules.lines
         True
+    """
+    pass
+
+
+@parser(Specs.etc_udev_oracle_asm_rules)
+class UdevRulesOracleASM(LogFileOutput):
+    """
+    Read the content of ``/etc/udev/rules.d/*asm*.rules`` file.
+
+    .. note::
+
+        The syntax of the `.rules` file is complex, and no rules require to
+        get the serialized parsed result currently.  An only existing rule's
+        supposed to check the syntax of some specific lines, so here the
+        :class:`insights.core.LogFileOutput` is the base class.
+
+    Sample input::
+
+        KERNEL=="dm*", PROGRAM=="scsi_id --page=0x83 --whitelisted --device=/dev/%k", \
+        RESULT=="360060e80164c210000014c2100007a8f", \
+        SYMLINK+="oracleasm/disks/asm_sbe80_7a8f", OWNER="oracle", GROUP="dba", MODE="0660"
+
+
+        KERNEL=="dm*", PROGRAM=="scsi_id --page=0x83 --whitelisted --device=/dev/%k", \
+        RESULT=="360060e80164c210000014c2100007a91", \
+        SYMLINK+="oracleasm/disks/asm_sbe80_7a91", OWNER="oracle", GROUP="dba", MODE="0660"
+
+        # NOTE: Insert new Oracle ASM LUN configuration before this comment
+        ACTION=="add|change", KERNEL=="sd*", OPTIONS:="nowatch"
+
+    Examples:
+
+    >>> 'ACTION=="add|change", KERNEL=="sd*", OPTIONS:="nowatch"' in udev_oracle_asm_rules.lines
+    True
+    >>> udev_oracle_asm_rules.get('ACTION')[0]['raw_message']
+    'ACTION=="add|change", KERNEL=="sd*", OPTIONS:="nowatch"'
     """
     pass

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -146,7 +146,7 @@ class Specs(SpecSet):
     etc_journald_conf = RegistryPoint()
     etc_machine_id = RegistryPoint()
     etc_udev_40_redhat_rules = RegistryPoint(filterable=True)
-    etc_udev_oracle_asm_rules = RegistryPoint(filterable=True)
+    etc_udev_oracle_asm_rules = RegistryPoint(multi_output=True, filterable=True)
     etcd_conf = RegistryPoint(filterable=True)
     ethernet_interfaces = RegistryPoint()
     ethtool_a = RegistryPoint(multi_output=True)

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -146,6 +146,7 @@ class Specs(SpecSet):
     etc_journald_conf = RegistryPoint()
     etc_machine_id = RegistryPoint()
     etc_udev_40_redhat_rules = RegistryPoint(filterable=True)
+    etc_udev_oracle_asm_rules = RegistryPoint(filterable=True)
     etcd_conf = RegistryPoint(filterable=True)
     ethernet_interfaces = RegistryPoint()
     ethtool_a = RegistryPoint(multi_output=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -242,6 +242,7 @@ class DefaultSpecs(Specs):
     etc_machine_id = simple_file("/etc/machine-id")
     etc_udev_40_redhat_rules = first_file(["/etc/udev/rules.d/40-redhat.rules", "/run/udev/rules.d/40-redhat.rules",
                                        "/usr/lib/udev/rules.d/40-redhat.rules", "/usr/local/lib/udev/rules.d/40-redhat.rules"])
+    etc_udev_oracle_asm_rules = glob_file(r"/etc/udev/rules.d/*asm*.rules")
     etcd_conf = simple_file("/etc/etcd/etcd.conf")
     ethernet_interfaces = listdir("/sys/class/net", context=HostContext)
     ethtool = foreach_execute(ethernet.interfaces, "/sbin/ethtool %s")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
This spec is used to detect the Oracle ASM diskgroup outage issue proactively. If the disks in the Oracle ASM diskgroup are managed by udev, and the `add|change` actions are not configured `nowatch` in the udev rule, the customer will hit this issue. Detailed info is in the CEECBA-5525.
