### PR TITLE
shell: support running shell in kernel mode

### DIFF
--- a/insights/shell.py
+++ b/insights/shell.py
@@ -789,7 +789,7 @@ class Holder(dict):
         return self.keys()
 
 
-def start_session(paths, change_directory=False, __coverage=None):
+def start_session(paths, change_directory=False, __coverage=None, kernel=False):
     __cwd = os.path.abspath(os.curdir)
 
     def callback(brokers):
@@ -815,7 +815,12 @@ def start_session(paths, change_directory=False, __coverage=None):
         __ns = {}
         __ns.update(globals())
         __ns.update({"models": models})
-        IPython.start_ipython([], user_ns=__ns, config=__cfg)
+
+        if kernel:
+            from ipykernel import kernelapp
+            kernelapp.launch_new_instance([], user_ns=__ns, config=__cfg)
+        else:
+            IPython.start_ipython([], user_ns=__ns, config=__cfg)
 
     with_brokers(paths, callback)
     if change_directory:
@@ -859,6 +864,11 @@ def _parse_args():
     p.add_argument(
         "-v", "--verbose", action="store_true", help="Global debug level logging."
     )
+    p.add_argument(
+        "-k", "--kernel", action="store_true", default=False,
+        help="Start an IPython kernel instead of an interactive session."
+        " Requires ipykernel module"
+    )
 
     path_desc = "Archives or paths to analyze. Leave off to target the current system."
     p.add_argument("paths", nargs="*", help=path_desc)
@@ -884,7 +894,7 @@ def main():
     load_packages(parse_plugins(args.plugins))
     _handle_config(args.config)
 
-    start_session(args.paths, args.cd, __coverage=cov)
+    start_session(args.paths, args.cd, __coverage=cov, kernel=args.kernel)
     if cov:
         cov.stop()
         cov.erase()


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Insights-core does a very good job detecting, parsing and caching large amount of data in archives. The main interface it exposes is an iypthon shell (`insights shell`). The use of ipython shell is quite convenient because, apart from exposing an interactive shell, it supports client-server mode, or in ipython terminology client-kernel mode. That way, both data and logic living inside the insights shell can be exposed to an external process such as command line tool or even a jupyter frontend.

This small patch just allows insights shell to start a ipython server in "kernel" mode allowing jupyter clients to connect and interact with it. Example

```
$ insights shell -k $ARCHIVE
NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.

To exit, you will have to explicitly quit this process, by either sending
"quit" from a client, or using Ctrl-\ in UNIX-like environments.

To read more about this, see https://github.com/ipython/ipython/issues/2049


To connect another client to this kernel, use:
    --existing kernel-2098166.json
    
```
On another terminal:

```
$ jupyter run --existing kernel-2098166.json <<EOF                                                                                
models
EOF
{'SystemdLogindConf': insights.parsers.systemd.config.SystemdLogindConf,
 'AuditdConf': insights.parsers.auditd_conf.AuditdConf,
 'NmcliDevShowSos': insights.parsers.nmcli.NmcliDevShowSos,
 'PvsHeadings': insights.parsers.lvm.PvsHeadings,
 'Up2Date': insights.parsers.up2date.Up2Date,
 'EtcSshConfig': insights.parsers.ssh_client_config.EtcSshConfig,
...

```

#### Security model


In order to be absolutely sure the ipython kernel was not being exposed to other users, my initial intention was to use zmq's `ipc` transport (i.e: UNIX socket based).
However, I hit an ugly bug that makes ipykernel to leak the socket files when exiting.

I've reported the bug but it's still being dealt with:

https://github.com/ipython/ipykernel/issues/730
https://github.com/ipython/ipykernel/pull/731#

Until that gets fixed, I looked at the default `tcp` transport configuration.

The configuration needed for a client to connect to a kernel is stored in a json file that lives in the users's profile with reasonable permissions:

```
$ ls -lha ~/.local/share/jupyter/runtime/kernel-2098166.json 
-rw------T 1 amorenoz adrian 263 Jul 15 17:49 /home/amorenoz/.local/share/jupyter/runtime/kernel-2098166.json
```

The key that allows the zmq channel to be stablished is stored in that file:

```
cat ~/.local/share/jupyter/runtime/kernel-2098166.json 
{
  "shell_port": 39303,
  "iopub_port": 34885,
  "stdin_port": 38819,
  "control_port": 42341,
  "hb_port": 58417,
  "ip": "127.0.0.1",
  "key": "de7d886d-6ff56dbd8854bf64684042da",
  "transport": "tcp",
  "signature_scheme": "hmac-sha256",
  "kernel_name": ""
}
```

Therefore, I believe the security model should not change significantly since only the user that runs the "insights kernel" would be able to run code on it afterwards.