### PR TITLE
Revert "Add make_none response for rules"

### DIFF
--- a/docs/manpages/insights-run.rst
+++ b/docs/manpages/insights-run.rst
@@ -75,9 +75,6 @@ OPTIONS
     -m --missing
         Show missing requirements.
 
-    -n --none
-        Show rules returning ``None``.
-
     -p PLUGINS --plugins PLUGINS
         Comma-separated list without spaces of package(s) or module(s) containing plugins.
 

--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -38,7 +38,7 @@ from .core.hydration import create_context, initialize_broker  # noqa: F401
 from .core.plugins import combiner, fact, metadata, parser, rule  # noqa: F401
 from .core.plugins import datasource, condition, incident  # noqa: F401
 from .core.plugins import make_response, make_metadata, make_fingerprint  # noqa: F401
-from .core.plugins import make_pass, make_fail, make_info, make_none  # noqa: F401
+from .core.plugins import make_pass, make_fail, make_info  # noqa: F401
 from .core.filters import add_filter, apply_filters, get_filters  # noqa: F401
 from .formats import get_formatter
 from .parsers import get_active_lines  # noqa: F401

--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -302,7 +302,7 @@ class rule(PluginType):
             return _make_skip(dr.get_name(self.component), missing)
         r = self.invoke(broker)
         if r is None:
-            return make_none()
+            raise dr.SkipComponent()
         if not isinstance(r, Response):
             raise Exception("rules must return Response objects.")
         return r
@@ -660,17 +660,3 @@ class _make_skip(Response):
                                         rule_fqdn=rule_fqdn,
                                         reason="MISSING_REQUIREMENTS",
                                         details=details)
-
-
-class make_none(Response):
-    """
-    Used to create a response for a rule that returns None
-
-    This is not intended to be used by plugins, only infrastructure
-    but it not private so that we can easily add it to reporting.
-    """
-    response_type = "none"
-    key_name = "none_key"
-
-    def __init__(self):
-        super(make_none, self).__init__(key="NONE_KEY")

--- a/insights/formats/text.py
+++ b/insights/formats/text.py
@@ -90,11 +90,9 @@ class HumanReadableFormat(Formatter):
             tracebacks=False,
             dropped=False,
             fail_only=False,
-            none=False,
             stream=sys.stdout):
         self.broker = broker
         self.missing = missing
-        self.none = none
         self.tracebacks = tracebacks
         self.dropped = dropped
         self.fail_only = fail_only
@@ -117,8 +115,7 @@ class HumanReadableFormat(Formatter):
                                   title="Fingerprint : "),
             'metadata': response(color=Fore.YELLOW, label="META", intl='M', title="Metadata    : "),
             'metadata_key': response(color=Fore.MAGENTA, label="META", intl='K', title="Metadata Key: "),
-            'exception': response(color=Fore.RED, label="EXCEPT", intl='E', title="Exceptions  : "),
-            'none': response(color=Fore.BLUE, label="RETURNED NONE", intl='N', title="Ret'd None  : ")
+            'exception': response(color=Fore.RED, label="EXCEPT", intl='E', title="Exceptions  : ")
         }
 
         self.counts = {}
@@ -180,26 +177,19 @@ class HumanReadableFormat(Formatter):
             name = "%s%s%s" % (resp.color, name, Style.RESET_ALL)
             print(name, file=self.stream)
             print(underline, file=self.stream)
-            if v.get('type') != 'none':
-                print(render(c, v), file=self.stream)
+            print(render_links(c), file=self.stream)
+            print(render(c, v), file=self.stream)
             print(file=self.stream)
 
         for c in sorted(self.broker.get_by_type(rule), key=dr.get_name):
             v = self.broker[c]
             _type = v.get('type')
-            if _type is None:
-                continue
-
             if _type in self.responses:
                 self.counts[_type] += 1
-
-            if ((self.fail_only and _type == 'rule') or
-                (self.missing and _type == 'skip') or
-                    (self.none and _type == 'none')):
+            if (_type and ((self.fail_only and _type == 'rule') or
+                           ((self.missing and _type == 'skip') or
+                            (not self.fail_only and _type != 'skip')))):
                 printit(c, v)
-            elif not self.fail_only and _type not in ['skip', 'none']:
-                printit(c, v)
-
         print(file=self.stream)
 
         self.print_header("Rule Execution Summary", Fore.CYAN)
@@ -224,31 +214,23 @@ class HumanReadableFormatAdapter(FormatterAdapter):
     @staticmethod
     def configure(p):
         p.add_argument("-m", "--missing", help="Show missing requirements.", action="store_true")
-        p.add_argument("-n", "--none", help="Show rules returning None", action="store_true")
         p.add_argument("-t", "--tracebacks", help="Show stack traces.", action="store_true")
         p.add_argument("-d", "--dropped", help="Show collected files that weren't processed.", action="store_true")
-        p.add_argument("-F", "--fail-only", help="Show FAIL results only. Conflict with '-m' and '-n' or '-f', will be dropped when using them together", action="store_true")
+        p.add_argument("-F", "--fail-only", help="Show FAIL results only. Conflict with '-m' or '-f', will be dropped when using them together", action="store_true")
 
     def __init__(self, args):
         self.missing = args.missing
-        self.none = args.none
         self.tracebacks = args.tracebacks
         self.dropped = args.dropped
         self.fail_only = args.fail_only
         self.formatter = None
-        if (self.missing or self.none) and self.fail_only:
-            print(Fore.YELLOW + 'Options conflict: -m/-n and -F, drops -F', file=sys.stderr)
+        if self.missing and self.fail_only:
+            print(Fore.YELLOW + 'Options conflict: -m and -F, drops -F', file=sys.stderr)
             self.fail_only = False
 
     def preprocess(self, broker):
-        self.formatter = HumanReadableFormat(
-            broker,
-            self.missing,
-            self.tracebacks,
-            self.dropped,
-            self.fail_only,
-            self.none
-        )
+        self.formatter = HumanReadableFormat(broker,
+                self.missing, self.tracebacks, self.dropped, self.fail_only)
         self.formatter.preprocess()
 
     def postprocess(self, broker):

--- a/insights/tests/test_rules_fixture.py
+++ b/insights/tests/test_rules_fixture.py
@@ -1,4 +1,4 @@
-from insights.core.plugins import make_pass, make_fail, make_none
+from insights.core.plugins import make_pass, make_fail
 from insights.specs import Specs
 from insights.plugins import rules_fixture_plugin
 from insights.tests import InputData
@@ -37,5 +37,4 @@ def test_rules_fixture(run_rule):
 
     input_data = InputData('test_ret_none')
     results = run_rule(rules_fixture_plugin.report, input_data)
-    expected = make_none()
-    assert results == expected
+    assert results is None


### PR DESCRIPTION
Reverts RedHatInsights/insights-core#3135 as it will require changes in tests that depend on the results being `None` instead of `make_none()`.