### PR TITLE
Insert the 'Slot' to the parser result of LsPci

### DIFF
--- a/insights/combiners/tests/test_lspci.py
+++ b/insights/combiners/tests/test_lspci.py
@@ -102,6 +102,7 @@ def test_lspci_k():
     assert sorted(lspci.pci_dev_list) == ['00:00.0', '00:02.0', '00:03.0', '00:16.0', '00:19.0', '00:1b.0']
     assert lspci.search(Dev_Details__contains='I218') == [
         {
+            'Slot': '00:19.0',
             'Driver': 'e1000e', 'Module': ['e1000e'],
             'Subsystem': 'Lenovo ThinkPad X240',
             'Dev_Details': 'Ethernet controller: Intel Corporation Ethernet Connection I218-LM (rev 04)'

--- a/insights/parsers/lspci.py
+++ b/insights/parsers/lspci.py
@@ -77,21 +77,23 @@ class LsPci(CommandParser, LogFileOutput):
             scanner(self)
         # Parse kernel driver lines
         self.data = {}
-        bus_device_function = None
-        bus_device_function_re = re.compile(r'[0-9a-f]+:[0-9a-f]+.[0-9a-f]+')
+        slot = None
+        solt_re = re.compile(r'^[0-9a-f]+:[0-9a-f]+.[0-9a-f]+')
 
         fields = ["Subsystem", "Kernel driver in use", "Kernel modules"]
 
         for line in get_active_lines(content):
             parts = line.split()
 
-            if bus_device_function_re.match(parts[0]):
-                bus_device_function = parts[0]
+            if solt_re.match(parts[0]):
+                slot = parts[0]
                 device_details = line.split(None, 1)[-1]  # keep the raw line
-                self.data[bus_device_function] = {'Dev_Details': device_details.lstrip()}
-            elif bus_device_function and (line.split(":")[0].strip() in fields):
+                self.data[slot] = {
+                        'Slot': slot,
+                        'Dev_Details': device_details.lstrip()}
+            elif slot and (line.split(":")[0].strip() in fields):
                 parts = line.split(':')
-                self.data[bus_device_function][parts[0]] = parts[1].lstrip()
+                self.data[slot][parts[0]] = parts[1].lstrip()
 
     def pci_dev_details(self, dev_name):
         """

--- a/insights/parsers/lspci.py
+++ b/insights/parsers/lspci.py
@@ -57,6 +57,8 @@ class LsPci(CommandParser, LogFileOutput):
         False
         >>> sorted(lspci.pci_dev_list)
         ['00:00.0', '00:01.0', '00:02.0', '03:00.0', '06:00.0']
+        >>> lspci.pci_dev_details('00:00.0')['Slot']
+        '00:00.0'
         >>> lspci.pci_dev_details('00:00.0')['Subsystem']
         'Cisco Systems Inc Device 0101'
         >>> lspci.pci_dev_details('00:00.0')['Dev_Details']

--- a/insights/parsers/lspci.py
+++ b/insights/parsers/lspci.py
@@ -80,14 +80,14 @@ class LsPci(CommandParser, LogFileOutput):
         # Parse kernel driver lines
         self.data = {}
         slot = None
-        solt_re = re.compile(r'^[0-9a-f]+:[0-9a-f]+.[0-9a-f]+')
+        slot_re = re.compile(r'^[0-9a-f]+:[0-9a-f]+.[0-9a-f]+')
 
         fields = ["Subsystem", "Kernel driver in use", "Kernel modules"]
 
         for line in get_active_lines(content):
             parts = line.split()
 
-            if solt_re.match(parts[0]):
+            if slot_re.match(parts[0]):
                 slot = parts[0]
                 device_details = line.split(None, 1)[-1]  # keep the raw line
                 self.data[slot] = {

--- a/insights/parsers/tests/test_lspci.py
+++ b/insights/parsers/tests/test_lspci.py
@@ -274,14 +274,16 @@ def test_lspci_driver():
     lspci_obj = LsPci(context_wrap(LSPCI_DRIVER_DETAILS))
     assert len(lspci_obj.data) == 44
     dev_info = lspci_obj.pci_dev_details('00:01.0')
-    assert len(dev_info) == 3
+    assert len(dev_info) == 4
     assert dev_info['Kernel driver in use'] == 'pcieport'
+    assert dev_info['Slot'] == '00:01.0'
     assert len(lspci_obj.pci_dev_list) == 44
 
     lspci_obj = LsPci(context_wrap(LSPCI_DRIVER_DETAILS_2))
     assert len(lspci_obj.data) == 4
     dev_info = lspci_obj.pci_dev_details('04:00.0')
-    assert len(dev_info) == 1
+    assert len(dev_info) == 2
+    assert dev_info['Slot'] == '04:00.0'
     assert 'Kernel driver in use' not in dev_info
     assert len(lspci_obj.pci_dev_list) == 4
 
@@ -298,10 +300,14 @@ def test_lspci_vmmkn():
     lspci_vmmkn = LsPciVmmkn(context_wrap(LSPCI_VMMKN))
     assert sorted(lspci_vmmkn.pci_dev_list) == ['00:00.0', '00:01.0', '00:01.1', '00:03.0']
     assert lspci_vmmkn[0].get('Driver') is None
+    assert lspci_vmmkn[0].get('Slot') == '00:00.0'
     assert lspci_vmmkn[1].get('Vendor') == '8086'
+    assert lspci_vmmkn[1].get('Slot') == '00:01.0'
     assert lspci_vmmkn[1].get('Device') == '7010'
+    assert lspci_vmmkn[2].get('Slot') == '00:01.1'
     assert lspci_vmmkn[2].get('SVendor') == '1af4'
     assert lspci_vmmkn[3].get('SDevice') == '0001'
+    assert lspci_vmmkn[3].get('Slot') == '00:03.0'
     assert lspci_vmmkn[-1].get('Driver') == 'virtio-pci'
     assert sorted(lspci_vmmkn[1].get('Module')) == sorted(['ata_piix', 'ata_generic'])
     assert lspci_vmmkn[-1].get('Module') is None


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
The `Slot` is Key information for each PCI device outputted by the `lspci -k` command.
Typical output of `lspci -k`:
```
]# lspci -k
00:00.0 Host bridge: Intel Corporation 440FX - 82441FX PMC [Natoma] (rev 02)
        Subsystem: Red Hat, Inc. Qemu virtual machine
00:01.0 ISA bridge: Intel Corporation 82371SB PIIX3 ISA [Natoma/Triton II]
        Subsystem: Red Hat, Inc. Qemu virtual machine
```
And since it is named as `Slot` in the output of `lspci -vmmkn`, I renamed the name of the variable `bus_device_function` used in the parser to `slot` too.
Typical output of `lspci -vmmkn`
```
insights_repos]# lspci -vmmkn
Slot:   00:00.0
Class:  0600
Vendor: 8086
Device: 1237
SVendor:        1af4
SDevice:        1100
Rev:    02

Slot:   00:01.0
Class:  0601
Vendor: 8086
Device: 7000
SVendor:        1af4
SDevice:        1100
```


This PR added it to the existing result and won't break the current rules.
