### PR TITLE
RFC: Introduce commands

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -35,7 +35,7 @@ from .core import dr  # noqa: F401
 from .core.context import ClusterArchiveContext, HostContext, HostArchiveContext, SerializedArchiveContext, ExecutionContext  # noqa: F401
 from .core.dr import SkipComponent  # noqa: F401
 from .core.hydration import create_context, initialize_broker  # noqa: F401
-from .core.plugins import combiner, fact, metadata, parser, rule  # noqa: F401
+from .core.plugins import combiner, fact, metadata, parser, rule, command # noqa: F401
 from .core.plugins import datasource, condition, incident  # noqa: F401
 from .core.plugins import make_response, make_metadata, make_fingerprint  # noqa: F401
 from .core.plugins import make_pass, make_fail, make_info  # noqa: F401

--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -79,6 +79,7 @@ COMPONENTS_BY_TYPE = defaultdict(set)
 DEPENDENCIES = defaultdict(set)
 DEPENDENTS = defaultdict(set)
 COMPONENTS = defaultdict(lambda: defaultdict(set))
+COMMANDS = defaultdict()
 
 DELEGATES = {}
 HIDDEN = set()
@@ -1023,3 +1024,13 @@ def run_all(components=None, broker=None, pool=None):
         return [f.result() for f in futures]
     else:
         return list(run_incremental(components=components, broker=broker))
+
+
+def run_command(name, broker, *args, **kwargs):
+    """ Run a command on the results stored on a broker
+    """
+    cmd = COMMANDS.get(name)
+    if not cmd:
+        raise Exception("%s is not a registered command" % name)
+
+    return cmd.run(broker, *args, **kwargs)

--- a/insights/shell.py
+++ b/insights/shell.py
@@ -258,6 +258,18 @@ class Models(dict):
         dr.run(tasks, broker=self._broker)
         self.show_timings(match, ignore)
 
+    def commands(self):
+        """ Prints the available commands and their documentation
+        """
+        for cmd, component in dr.COMMANDS.items():
+            print("{}: ".format(cmd))
+            print(component.doc())
+
+    def run_command(self, name, *args, **kwargs):
+        """ Run a command
+        """
+        return dr.run_command(name, self._broker, *args, **kwargs)
+
     def evaluate(self, name):
         """
         Evaluate a component and return its result. Prints diagnostic


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Insights components are able to nicely capture (potentially a big amount of) parsed data and expose it in a consumable manner. However, a user wanting to explore that data for troubleshooting or mere investigation purposes might sometime want to perform some degree of processing on that data: comparing, searching, filtering, etc.

Since many of the components are normal python objects, an easy way to expose this kind of functionality would be to just write a method that implements such generic processing based on some arguments. Some very simple examples of this already exist in `parsers` and `combiners`, e.g: https://github.com/RedHatInsights/insights-core/blob/f7409aeda1bda237889b3853eb8af7128710f0b9/insights/parsers/iptables.py#L127

In order to consistently expose these capabilities to the `shell` user, I'd like to propose adding the concept of `commands`.
A `command` is just a `component`'s method that can be called with arbitrary parameters to perform some kind of processing on the data its `component` holds. This PR introduces a decorator that can be used to decorate such method so the available commands are query-able and call-able externally.

The PR is just a quick write up to get some feedback, it will probably need some cleaning.

Here is an example of how this decorator can be used:

```
# myplugin.py
from insights import  combiner, command

@combiner(MyParser1,MyParser2)
class MyCombiner:
    def __init__(self, parser1, parser2):
        self.data = {"data1": parser1.data, "data2": parser2.data}

    @command
    def get(self, whatever):
        """ Looks for a something

        Args:
            whatever (str): The substring to look for
        """
        return self.data.get("data1").get(whatever) or self.data.get("data2").get(whatever)
```

In the insights-shell

```
In [1]: models.commands()
MyCombiner.get: 
 Looks for a something

        Args:
            whatever (str): The substring to look for

In [2]: models.run_command("MyCombiner.get", "something")
Out[2]: {"foo", "bar"}
```


### Alternatives considered
I consider the following alternatives to achieve this:

- Creating another component: Creating another component seems unnecessary since commands do not have extra dependencies (their arguments are dynamic) and their execution sequence is different from a component, e.g: their result is not cache in a broker
- External processing: The user could write wrappers around its parsers and combiners in external classes. However, keeping common, simple processing tightly coupled with the data format yields better maintainability of such processing logic. Also, I believe a common way to list and explore available commands offers a better use experience.


What do you think?

