### PR TITLE
Compatibility layer legacy upload fix [WIP]

### DIFF
--- a/insights/client/auto_config.py
+++ b/insights/client/auto_config.py
@@ -247,10 +247,11 @@ def try_auto_configuration(config):
     if config.auto_config and not config.offline:
         if not _try_satellite6_configuration(config):
             _try_satellite5_configuration(config)
-    if not config.legacy_upload and not re.match(r'(\w+\.)?cloud\.(\w+\.)?redhat\.com\/api', config.base_url):
+    if not config.legacy_upload and re.match(r'(.+)?\/r\/insights', config.base_url):
         # When to append /platform
         #   base url ~= cloud.redhat.com/r/insights
         #   base url ~= cert-api.access.redhat.com/r/insights
+        #   base url ~= satellite.host.example.com/redhat_access/r/insights
         # When not to append /platform
         #   base url ~= cloud.redhat.com/api
         config.base_url = config.base_url + '/platform'

--- a/insights/client/auto_config.py
+++ b/insights/client/auto_config.py
@@ -247,6 +247,11 @@ def try_auto_configuration(config):
     if config.auto_config and not config.offline:
         if not _try_satellite6_configuration(config):
             _try_satellite5_configuration(config)
-    if not config.legacy_upload and not re.match(r'(\w+\.)?cloud\.(\w+\.)?redhat\.com', config.base_url):
+    if not config.legacy_upload and not re.match(r'(\w+\.)?cloud\.(\w+\.)?redhat\.com\/api', config.base_url):
+        # When to append /platform
+        #   base url ~= cloud.redhat.com/r/insights
+        #   base url ~= cert-api.access.redhat.com/r/insights
+        # When not to append /platform
+        #   base url ~= cloud.redhat.com/api
         config.base_url = config.base_url + '/platform'
     logger.debug('Updated base_url: %s', config.base_url)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Update the regex that decides whether to add `/platform` to the legacy API path to a positive check for `/r/insights`. The new compatibility layer URLs use the `cloud.redhat.com` hostname, so the hostname negative check is no longer reliable.
