### PR TITLE
Fix "KeyError" bug

### DIFF
--- a/insights/parsers/logrotate_conf.py
+++ b/insights/parsers/logrotate_conf.py
@@ -116,7 +116,7 @@ class LogrotateConf(Parser, LegacyItemAccess):
                     self.options.append(key1)
             else:
                 # in log_file section
-                if line.endswith('}'):
+                if line.endswith('}') and script is None:
                     # end of the section,
                     # save options for each log_file individually
                     for lf in log_files:

--- a/insights/parsers/tests/test_logrotate_conf.py
+++ b/insights/parsers/tests/test_logrotate_conf.py
@@ -161,3 +161,5 @@ def test_logrotate_conf_4():
     log_rt = LogrotateConf(context_wrap(LOGROTATE_CONF_4, path='/etc/logrotate.d/abc'))
     assert '/var/log/news/olds.crit' in log_rt.log_files
     assert 'mv -f $E /var/log/actlog/sysinfo/${E_backup}' in log_rt['/var/log/news/olds.crit']['prerotate']
+    assert '} >>${ACTLOG_RLOG} 2>&1' in log_rt['/var/log/news/olds.crit']['prerotate']
+    assert len(log_rt['/var/log/news/olds.crit']['prerotate']) == 12

--- a/insights/parsers/tests/test_logrotate_conf.py
+++ b/insights/parsers/tests/test_logrotate_conf.py
@@ -97,6 +97,31 @@ compress
 """.strip()
 
 
+LOGROTATE_CONF_4 = """
+/var/log/news/olds.crit  {
+    monthly
+    rotate 2
+    olddir /var/log/news/old
+    missingok
+    prerotate
+        export LANG=C
+        ACTLOG_RLOG=/var/log/actlog/selfinfo/postrotate
+        {
+                E=/var/log/actlog.exports/eventlog.1
+                C=/var/log/actlog.exports/cpuload.1
+                if [ -e ${C}.gz -a -e $E ] ; then
+                        E_backup=eventlog.1-`date -r $E +%F.%H%M%S`
+                        echo "WARNING: Both ${C}.gz and $E exist ; move eventlog.1 to sysinfo/${E_backup}"
+                        mv -f $E /var/log/actlog/sysinfo/${E_backup}
+                fi
+        } >>${ACTLOG_RLOG} 2>&1
+        exit 0
+  endscript
+    nocompress
+}
+""".strip()
+
+
 def test_web_xml_doc_examples():
     env = {
             'log_rt': LogrotateConf(context_wrap(LOGROTATE_MAN_PAGE_DOC, path='/etc/logrotate.conf')),
@@ -130,3 +155,9 @@ def test_logrotate_conf_3():
     assert log_rt['/var/log/cron']['sharedscripts'] is True
     assert log_rt['/var/log/messages']['postrotate'] == [
             '/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true']
+
+
+def test_logrotate_conf_4():
+    log_rt = LogrotateConf(context_wrap(LOGROTATE_CONF_4, path='/etc/logrotate.d/abc'))
+    assert '/var/log/news/olds.crit' in log_rt.log_files
+    assert 'mv -f $E /var/log/actlog/sysinfo/${E_backup}' in log_rt['/var/log/news/olds.crit']['prerotate']


### PR DESCRIPTION
* When one line endswith "}" in script part, the parser will consider it is ending of
  current section.

Signed-off-by: Huanhuan Li <huali@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
It fixes https://github.com/RedHatInsights/insights-core/issues/3152
