### PR TITLE
Added SystemdDnsmasqServiceConf method to the systemd_config parser

### DIFF
--- a/insights/parsers/systemd/config.py
+++ b/insights/parsers/systemd/config.py
@@ -16,6 +16,9 @@ SystemdLogindConf - file ``/etc/systemd/logind.conf``
 SystemdRpcbindSocketConf - unit file ``rpcbind.socket``
 -------------------------------------------------------
 
+SystemdDnsmasqConf - unit file ``dnsmasq.service``
+--------------------------------------------------
+
 SystemdOpenshiftNode - file ``/usr/lib/systemd/system/atomic-openshift-node.service``
 -------------------------------------------------------------------------------------
 
@@ -204,6 +207,30 @@ class SystemdRpcbindSocketConf(SystemdConf):
     Example:
         >>> rpcbind_socket["Socket"]["ListenStream"]
         ['/run/rpcbind.sock', '0.0.0.0:111', '[::]:111']
+    """
+    pass
+
+
+@parser(Specs.systemctl_cat_dnsmasq_service)
+class SystemdDnsmasqServiceConf(SystemdConf):
+    """
+    Class for systemd configuration for dnsmasq.service unit.
+
+    Typical content of the ``dnsmasq.service`` unit file is::
+
+        [Unit]
+        Description=DNS caching server.
+        After=network.target
+
+        [Service]
+        ExecStart=/usr/sbin/dnsmasq -k
+
+        [Install]
+        WantedBy=multi-user.target
+
+    Example:
+        >>> dnsmasq_service["Unit"]["After"]
+        'network.target'
     """
     pass
 

--- a/insights/parsers/tests/test_systemd_config.py
+++ b/insights/parsers/tests/test_systemd_config.py
@@ -137,6 +137,18 @@ ListenDatagram=[::]:111
 WantedBy=sockets.target
 """.strip()
 
+SYSTEMD_DNSMASQ_SERVICE = """
+[Unit]
+Description=DNS caching server.
+After=network.target
+
+[Service]
+ExecStart=/usr/sbin/dnsmasq -k
+
+[Install]
+WantedBy=multi-user.target
+""".strip()
+
 SYSTEMD_SYSTEM_CONF = """
 #  This file is part of systemd.
 #
@@ -258,6 +270,11 @@ def test_systemd_rpcbind_socket_conf():
     assert rpcbind_socket["Socket"]["ListenDatagram"] == ['0.0.0.0:111', '[::]:111']
 
 
+def test_systemd_dnsmasq_conf():
+    dnsmasq_service_conf = config.SystemdDnsmasqServiceConf(context_wrap(SYSTEMD_DNSMASQ_SERVICE))
+    assert dnsmasq_service_conf["Unit"]["After"] == "network.target"
+
+
 def test_systemd_empty():
     with pytest.raises(SkipException):
         assert config.SystemdLogindConf(context_wrap('')) is None
@@ -270,7 +287,8 @@ def test_doc_examples():
             'system_origin_accounting': config.SystemdOriginAccounting(context_wrap(SYSTEMD_SYSTEM_ORIGIN_ACCOUNTING)),
             'openshift_node_service': config.SystemdOpenshiftNode(context_wrap(SYSTEMD_OPENSHIFT_NODE)),
             'logind_conf': config.SystemdLogindConf(context_wrap(SYSTEMD_LOGIND_CONF)),
-            'rpcbind_socket': config.SystemdRpcbindSocketConf(context_wrap(SYSTEMD_RPCBIND_SOCKET))
+            'rpcbind_socket': config.SystemdRpcbindSocketConf(context_wrap(SYSTEMD_RPCBIND_SOCKET)),
+            'dnsmasq_service': config.SystemdDnsmasqServiceConf(context_wrap(SYSTEMD_DNSMASQ_SERVICE))
           }
     failed, total = doctest.testmod(config, globs=env)
     assert failed == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -633,6 +633,7 @@ class Specs(SpecSet):
     sysctl_conf_initramfs = RegistryPoint(multi_output=True)
     sysctl_conf = RegistryPoint()
     sysctl = RegistryPoint()
+    systemctl_cat_dnsmasq_service = RegistryPoint()
     systemctl_cat_rpcbind_socket = RegistryPoint()
     systemctl_cinder_volume = RegistryPoint()
     systemctl_httpd = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -723,6 +723,7 @@ class DefaultSpecs(Specs):
     sysconfig_virt_who = simple_file("/etc/sysconfig/virt-who")
     sysctl = simple_command("/sbin/sysctl -a")
     sysctl_conf = simple_file("/etc/sysctl.conf")
+    systemctl_cat_dnsmasq_service = simple_command("/bin/systemctl cat dnsmasq.service")
     systemctl_cat_rpcbind_socket = simple_command("/bin/systemctl cat rpcbind.socket")
     systemctl_cinder_volume = simple_command("/bin/systemctl show openstack-cinder-volume")
     systemctl_httpd = simple_command("/bin/systemctl show httpd")


### PR DESCRIPTION
Signed-off-by: Rahul Srivastava <rasrivas@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This is an enhancement PR to check for the `/bin/systemctl cat dnsmasq.service` config
