### PR TITLE
Add make none ci fix

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -28,7 +28,7 @@ def run_rule():
     internal support rules that will not be used in the customer facing Insights
     product.
     """
-    def _run_rule(rule, input_data):
+    def _run_rule(rule, input_data, return_make_none=False):
         """
         Fixture for rule integration testing
 
@@ -47,11 +47,15 @@ def run_rule():
             rule (object): Your rule function object.
             data (InputData):  InputData obj containing all of the necessary data
                 for the test.
+            return_make_none (bool): Set to true if you are testing for ``make_none()``
+                results in your CI tests instead of ``None``.
         """
-        result = run_test(rule, input_data)
+        result = run_test(rule, input_data, return_make_none=return_make_none)
         # Check result for skip to be compatible with archive_provider decorator
         # Return None instead of result indicating missing component(s)
-        if result is not None and 'type' in result and result['type'] == 'skip':
+        if (result is not None and 'type' in result and
+            (result['type'] == 'skip' or
+                (result['type'] == 'none' and not return_make_none))):
             return None
         else:
             return result

--- a/docs/manpages/insights-run.rst
+++ b/docs/manpages/insights-run.rst
@@ -75,6 +75,9 @@ OPTIONS
     -m --missing
         Show missing requirements.
 
+    -n --none
+        Show rules returning ``None``.
+
     -p PLUGINS --plugins PLUGINS
         Comma-separated list without spaces of package(s) or module(s) containing plugins.
 

--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -38,7 +38,7 @@ from .core.hydration import create_context, initialize_broker  # noqa: F401
 from .core.plugins import combiner, fact, metadata, parser, rule  # noqa: F401
 from .core.plugins import datasource, condition, incident  # noqa: F401
 from .core.plugins import make_response, make_metadata, make_fingerprint  # noqa: F401
-from .core.plugins import make_pass, make_fail, make_info  # noqa: F401
+from .core.plugins import make_pass, make_fail, make_info, make_none  # noqa: F401
 from .core.filters import add_filter, apply_filters, get_filters  # noqa: F401
 from .formats import get_formatter
 from .parsers import get_active_lines  # noqa: F401

--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -302,7 +302,7 @@ class rule(PluginType):
             return _make_skip(dr.get_name(self.component), missing)
         r = self.invoke(broker)
         if r is None:
-            raise dr.SkipComponent()
+            return make_none()
         if not isinstance(r, Response):
             raise Exception("rules must return Response objects.")
         return r
@@ -660,3 +660,17 @@ class _make_skip(Response):
                                         rule_fqdn=rule_fqdn,
                                         reason="MISSING_REQUIREMENTS",
                                         details=details)
+
+
+class make_none(Response):
+    """
+    Used to create a response for a rule that returns None
+
+    This is not intended to be used by plugins, only infrastructure
+    but it not private so that we can easily add it to reporting.
+    """
+    response_type = "none"
+    key_name = "none_key"
+
+    def __init__(self):
+        super(make_none, self).__init__(key="NONE_KEY")

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from itertools import groupby
 from operator import itemgetter
 
-from insights import make_info, make_fail, make_response, make_pass
+from insights import make_info, make_fail, make_response, make_pass, make_none
 from insights.formats import FormatterAdapter
 from insights.formats.template import TemplateFormat
 
@@ -135,7 +135,7 @@ class HtmlFormat(TemplateFormat):
             sorted_rules[response_type] = rules
 
         ctx["rules"] = OrderedDict()
-        for key in (make_info, make_fail, make_response, make_pass):
+        for key in (make_info, make_fail, make_response, make_pass, make_none):
             name = key.__name__
             if name in sorted_rules:
                 ctx["rules"][name] = sorted_rules[name]

--- a/insights/formats/html.py
+++ b/insights/formats/html.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from itertools import groupby
 from operator import itemgetter
 
-from insights import make_info, make_fail, make_response, make_pass, make_none
+from insights import make_info, make_fail, make_response, make_pass
 from insights.formats import FormatterAdapter
 from insights.formats.template import TemplateFormat
 
@@ -135,7 +135,7 @@ class HtmlFormat(TemplateFormat):
             sorted_rules[response_type] = rules
 
         ctx["rules"] = OrderedDict()
-        for key in (make_info, make_fail, make_response, make_pass, make_none):
+        for key in (make_info, make_fail, make_response, make_pass):
             name = key.__name__
             if name in sorted_rules:
                 ctx["rules"][name] = sorted_rules[name]

--- a/insights/formats/text.py
+++ b/insights/formats/text.py
@@ -115,7 +115,8 @@ class HumanReadableFormat(Formatter):
                                   title="Fingerprint : "),
             'metadata': response(color=Fore.YELLOW, label="META", intl='M', title="Metadata    : "),
             'metadata_key': response(color=Fore.MAGENTA, label="META", intl='K', title="Metadata Key: "),
-            'exception': response(color=Fore.RED, label="EXCEPT", intl='E', title="Exceptions  : ")
+            'exception': response(color=Fore.RED, label="EXCEPT", intl='E', title="Exceptions  : "),
+            'none': response(color=Fore.BLUE, label="RETURNED NONE", intl='N', title="Ret'd None  : ")
         }
 
         self.counts = {}

--- a/insights/formats/text.py
+++ b/insights/formats/text.py
@@ -187,9 +187,10 @@ class HumanReadableFormat(Formatter):
             _type = v.get('type')
             if _type in self.responses:
                 self.counts[_type] += 1
-            if (_type and ((self.fail_only and _type == 'rule') or
-                           ((self.missing and _type == 'skip') or
-                            (not self.fail_only and _type != 'skip')))):
+            if (_type and _type != 'none' and
+                ((self.fail_only and _type == 'rule') or
+                 ((self.missing and _type == 'skip') or
+                    (not self.fail_only and _type != 'skip')))):
                 printit(c, v)
         print(file=self.stream)
 

--- a/insights/formats/text.py
+++ b/insights/formats/text.py
@@ -181,6 +181,7 @@ class HumanReadableFormat(Formatter):
             print(name, file=self.stream)
             print(underline, file=self.stream)
             if v.get('type') != 'none':
+                print(render_links(c), file=self.stream)
                 print(render(c, v), file=self.stream)
             print(file=self.stream)
 

--- a/insights/formats/text.py
+++ b/insights/formats/text.py
@@ -90,9 +90,11 @@ class HumanReadableFormat(Formatter):
             tracebacks=False,
             dropped=False,
             fail_only=False,
+            none=False,
             stream=sys.stdout):
         self.broker = broker
         self.missing = missing
+        self.none = none
         self.tracebacks = tracebacks
         self.dropped = dropped
         self.fail_only = fail_only
@@ -178,20 +180,26 @@ class HumanReadableFormat(Formatter):
             name = "%s%s%s" % (resp.color, name, Style.RESET_ALL)
             print(name, file=self.stream)
             print(underline, file=self.stream)
-            print(render_links(c), file=self.stream)
-            print(render(c, v), file=self.stream)
+            if v.get('type') != 'none':
+                print(render(c, v), file=self.stream)
             print(file=self.stream)
 
         for c in sorted(self.broker.get_by_type(rule), key=dr.get_name):
             v = self.broker[c]
             _type = v.get('type')
+            if _type is None:
+                continue
+
             if _type in self.responses:
                 self.counts[_type] += 1
-            if (_type and _type != 'none' and
-                ((self.fail_only and _type == 'rule') or
-                 ((self.missing and _type == 'skip') or
-                    (not self.fail_only and _type != 'skip')))):
+
+            if ((self.fail_only and _type == 'rule') or
+                (self.missing and _type == 'skip') or
+                    (self.none and _type == 'none')):
                 printit(c, v)
+            elif not self.fail_only and _type not in ['skip', 'none']:
+                printit(c, v)
+
         print(file=self.stream)
 
         self.print_header("Rule Execution Summary", Fore.CYAN)
@@ -216,23 +224,31 @@ class HumanReadableFormatAdapter(FormatterAdapter):
     @staticmethod
     def configure(p):
         p.add_argument("-m", "--missing", help="Show missing requirements.", action="store_true")
+        p.add_argument("-n", "--none", help="Show rules returning None", action="store_true")
         p.add_argument("-t", "--tracebacks", help="Show stack traces.", action="store_true")
         p.add_argument("-d", "--dropped", help="Show collected files that weren't processed.", action="store_true")
-        p.add_argument("-F", "--fail-only", help="Show FAIL results only. Conflict with '-m' or '-f', will be dropped when using them together", action="store_true")
+        p.add_argument("-F", "--fail-only", help="Show FAIL results only. Conflict with '-m' and '-n' or '-f', will be dropped when using them together", action="store_true")
 
     def __init__(self, args):
         self.missing = args.missing
+        self.none = args.none
         self.tracebacks = args.tracebacks
         self.dropped = args.dropped
         self.fail_only = args.fail_only
         self.formatter = None
-        if self.missing and self.fail_only:
-            print(Fore.YELLOW + 'Options conflict: -m and -F, drops -F', file=sys.stderr)
+        if (self.missing or self.none) and self.fail_only:
+            print(Fore.YELLOW + 'Options conflict: -m/-n and -F, drops -F', file=sys.stderr)
             self.fail_only = False
 
     def preprocess(self, broker):
-        self.formatter = HumanReadableFormat(broker,
-                self.missing, self.tracebacks, self.dropped, self.fail_only)
+        self.formatter = HumanReadableFormat(
+            broker,
+            self.missing,
+            self.tracebacks,
+            self.dropped,
+            self.fail_only,
+            self.none
+        )
         self.formatter.preprocess()
 
     def postprocess(self, broker):

--- a/insights/plugins/returns_none.py
+++ b/insights/plugins/returns_none.py
@@ -1,0 +1,25 @@
+from insights.core.dr import SkipComponent
+from insights import rule
+from insights.parsers.redhat_release import RedhatRelease
+from insights.core.plugins import make_none
+
+
+@rule(RedhatRelease)
+def report_none(u):
+    return
+
+
+@rule(RedhatRelease)
+def report_make_none(u):
+    return make_none()
+
+
+@rule(RedhatRelease)
+def report_skip_exception(u):
+    raise SkipComponent()
+
+
+if __name__ == "__main__":
+    from insights import run
+
+    broker = run([report_none, report_make_none], print_summary=True)

--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -19,6 +19,7 @@ import insights
 from insights import apply_filters
 from insights.core import dr, filters, spec_factory
 from insights.core.context import Context
+from insights.core.plugins import make_none
 from insights.core.spec_factory import RegistryPoint
 from insights.specs import Specs
 
@@ -82,12 +83,20 @@ HEARTBEAT_NAME = "insights-heartbeat-9cd6f607-6b28-44ef-8481-62b0e7773614"
 DEFAULT_RELEASE = "Red Hat Enterprise Linux Server release 7.2 (Maipo)"
 DEFAULT_HOSTNAME = "hostname.example.com"
 
+MAKE_NONE_RESULT = make_none()
+
 
 def deep_compare(result, expected):
     """
     Deep compare rule reducer results when testing.
     """
     logger.debug("--Comparing-- (%s) %s to (%s) %s", type(result), result, type(expected), expected)
+
+    # This case ensures that when rules return a make_none() response, all of the older
+    # CI tests that are looking for None instead of make_none() will still pass
+    if result is None or (isinstance(result, dict) and result.get("type") == "none"):
+        assert (expected is None or expected == MAKE_NONE_RESULT), result
+        return
 
     if isinstance(result, dict) and expected is None:
         assert result["type"] == "skip", result
@@ -108,7 +117,7 @@ def run_input_data(component, input_data):
     return broker
 
 
-def run_test(component, input_data, expected=None):
+def run_test(component, input_data, expected=None, return_make_none=False):
     if filters.ENABLED:
         mod = component.__module__
         sup_mod = '.'.join(mod.split('.')[:-1])
@@ -121,9 +130,14 @@ def run_test(component, input_data, expected=None):
             raise Exception(msg % (mod, ", ".join(names)))
 
     broker = run_input_data(component, input_data)
+    result = broker.get(component)
     if expected:
-        deep_compare(broker.get(component), expected)
-    return broker.get(component)
+        deep_compare(result, expected)
+    elif result == MAKE_NONE_RESULT and not return_make_none:
+        # Convert make_none() result to None as default unless
+        # make_none explicitly requested
+        return None
+    return result
 
 
 def integrate(input_data, component):

--- a/insights/tests/test_plugins/test_returns_none.py
+++ b/insights/tests/test_plugins/test_returns_none.py
@@ -1,0 +1,72 @@
+from insights.specs import Specs
+from insights.tests import InputData, archive_provider, RHEL7, MAKE_NONE_RESULT
+from insights.plugins import returns_none
+
+
+@archive_provider(returns_none.report_make_none)
+def integration_tests_1():
+    input_data = InputData("test_return_make_none_1")
+    input_data.add(Specs.redhat_release, RHEL7)
+    yield input_data, None
+
+    input_data = InputData("test_return_make_none_2")
+    input_data.add(Specs.redhat_release, RHEL7)
+    yield input_data, MAKE_NONE_RESULT
+
+
+@archive_provider(returns_none.report_none)
+def integration_tests_2():
+    input_data = InputData("test_return_none_1")
+    input_data.add(Specs.redhat_release, RHEL7)
+    yield input_data, None
+
+    input_data = InputData("test_return_none_2")
+    input_data.add(Specs.redhat_release, RHEL7)
+    yield input_data, MAKE_NONE_RESULT
+
+
+@archive_provider(returns_none.report_skip_exception)
+def integration_tests_3():
+    input_data = InputData("test_return_skip_exception_1")
+    input_data.add(Specs.redhat_release, RHEL7)
+    yield input_data, None
+
+    input_data = InputData("test_return_skip_exception_2")
+    input_data.add(Specs.redhat_release, RHEL7)
+    yield input_data, None
+
+
+def test_integration_1(run_rule):
+    input_data = InputData("test_return_make_none_1_1")
+    input_data.add(Specs.redhat_release, RHEL7)
+    result = run_rule(returns_none.report_make_none, input_data)
+    assert result is None
+
+    input_data = InputData("test_return_make_none_2_2")
+    input_data.add(Specs.redhat_release, RHEL7)
+    result = run_rule(returns_none.report_make_none, input_data, return_make_none=True)
+    assert result == MAKE_NONE_RESULT
+
+
+def test_integration_2(run_rule):
+    input_data = InputData("test_return_none_2_1")
+    input_data.add(Specs.redhat_release, RHEL7)
+    result = run_rule(returns_none.report_none, input_data)
+    assert result is None
+
+    input_data = InputData("test_return_none_2_2")
+    input_data.add(Specs.redhat_release, RHEL7)
+    result = run_rule(returns_none.report_none, input_data, return_make_none=True)
+    assert result == MAKE_NONE_RESULT
+
+
+def test_integration_3(run_rule):
+    input_data = InputData("test_return_skip_exception_2_1")
+    input_data.add(Specs.redhat_release, RHEL7)
+    result = run_rule(returns_none.report_skip_exception, input_data)
+    assert result is None
+
+    input_data = InputData("test_return_skip_exception_2_2")
+    input_data.add(Specs.redhat_release, RHEL7)
+    result = run_rule(returns_none.report_skip_exception, input_data, return_make_none=True)
+    assert result is None

--- a/insights/tests/test_rules_fixture.py
+++ b/insights/tests/test_rules_fixture.py
@@ -1,4 +1,4 @@
-from insights.core.plugins import make_pass, make_fail
+from insights.core.plugins import make_pass, make_fail, make_none
 from insights.specs import Specs
 from insights.plugins import rules_fixture_plugin
 from insights.tests import InputData
@@ -37,4 +37,5 @@ def test_rules_fixture(run_rule):
 
     input_data = InputData('test_ret_none')
     results = run_rule(rules_fixture_plugin.report, input_data)
-    assert results is None
+    expected = make_none()
+    assert results == expected

--- a/insights/tests/test_rules_fixture.py
+++ b/insights/tests/test_rules_fixture.py
@@ -36,6 +36,6 @@ def test_rules_fixture(run_rule):
     assert results == expected
 
     input_data = InputData('test_ret_none')
-    results = run_rule(rules_fixture_plugin.report, input_data)
+    results = run_rule(rules_fixture_plugin.report, input_data, return_make_none=True)
     expected = make_none()
     assert results == expected


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:
Add make_none response for rules
    
* Changes how rules that return none are handled. Instead of raising a
   SkipComponent and ignoring the rule, they will now be counted in the
    results.
* Add a make_none response type
* Update formatters to handle the new type
* Update tests
* Fix #3026
* Remove none rules from detailed output
* Update to add none option to text format

Fix legacy CI tests that check for None
    
* This change allows the legacy tests that check for None result from a
   rule to work with make_none() without requiring changes to the rules
* The simplified integration testing fixture includes a new flag that
   allows turning switching to the new functionality on a per test basis

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>
