### PR TITLE
Fix candlepin broker test

### DIFF
--- a/insights/tests/datasources/test_candlepin_broker.py
+++ b/insights/tests/datasources/test_candlepin_broker.py
@@ -3,7 +3,7 @@ from mock.mock import Mock
 
 from insights.core.spec_factory import DatasourceProvider
 from insights.core.dr import SkipComponent
-from insights.specs.datasources.candlepin_broker import candlepin_broker, LocalSpecs
+from insights.specs.default import candlepin_broker
 
 
 CANDLEPIN_BROKER = """
@@ -144,8 +144,8 @@ RELATIVE_PATH = '/etc/candlepin/broker.xml'
 def test_candlepin_broker():
     candlepin_broker_file = Mock()
     candlepin_broker_file.content = CANDLEPIN_BROKER.splitlines()
-    broker = {LocalSpecs.candlepin_broker_input: candlepin_broker_file}
-    result = candlepin_broker(broker)
+    broker = {candlepin_broker.LocalSpecs.candlepin_broker_input: candlepin_broker_file}
+    result = candlepin_broker.candlepin_broker(broker)
     assert result is not None
     assert isinstance(result, DatasourceProvider)
     expected = DatasourceProvider(content=CANDLEPIN_BROKER_XML.splitlines(), relative_path=RELATIVE_PATH)
@@ -156,17 +156,17 @@ def test_candlepin_broker():
 def test_candlepin_broker_bad():
     candlepin_broker_file = Mock()
     candlepin_broker_file.content = CANDLEPIN_BROKER_BAD.splitlines()
-    broker = {LocalSpecs.candlepin_broker_input: candlepin_broker_file}
+    broker = {candlepin_broker.LocalSpecs.candlepin_broker_input: candlepin_broker_file}
     with pytest.raises(SkipComponent) as e:
-        candlepin_broker(broker)
+        candlepin_broker.candlepin_broker(broker)
     assert 'Unexpected exception' in str(e)
 
 
 def test_candlpin_broker_no_sensitive_info():
     candlepin_broker_file = Mock()
     candlepin_broker_file.content = CANDLEPIN_BROKER_NO_SENSITIVE_INFO.splitlines()
-    broker = {LocalSpecs.candlepin_broker_input: candlepin_broker_file}
-    result = candlepin_broker(broker)
+    broker = {candlepin_broker.LocalSpecs.candlepin_broker_input: candlepin_broker_file}
+    result = candlepin_broker.candlepin_broker(broker)
     assert result is not None
     assert isinstance(result, DatasourceProvider)
     expected = DatasourceProvider(content=CANDLE_BROKER_NO_SENTISVE_INFO.splitlines(), relative_path=RELATIVE_PATH)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Fixes [ESSNTL-958](https://issues.redhat.com/browse/ESSNTL-958).

_insights/tests/datasources/test_candlepin_broker.py_ contains a circular import causing tests to fail. The problem is that the _insights.specs.candlepin_broker_ module imports _from insights.specs.default_, which itself imports from _insights.specs.candlepin_broker_. Any direct import from _insights.specs.candlepin_broker_ is thus predestined to fail.

(Hot)fixed by importing _candlepin_broker_ from _from insights.specs.default_ instead. Like that, Python handles the circularity well, not failing and making the tests green again. I am not sure whether this is the best solution. The circular reference looks like a bad practice to me.