### PR TITLE
Add spec for the systemctl_cat_dnsmasq_service to the insights archive spec

### DIFF
--- a/insights/parsers/systemd/config.py
+++ b/insights/parsers/systemd/config.py
@@ -16,8 +16,8 @@ SystemdLogindConf - file ``/etc/systemd/logind.conf``
 SystemdRpcbindSocketConf - unit file ``rpcbind.socket``
 -------------------------------------------------------
 
-SystemdDnsmasqConf - unit file ``dnsmasq.service``
---------------------------------------------------
+SystemdDnsmasqServiceConf - unit file ``dnsmasq.service``
+---------------------------------------------------------
 
 SystemdOpenshiftNode - file ``/usr/lib/systemd/system/atomic-openshift-node.service``
 -------------------------------------------------------------------------------------

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -227,6 +227,7 @@ class InsightsArchiveSpecs(Specs):
     subscription_manager_id = simple_file("insights_commands/subscription-manager_identity")
     subscription_manager_installed_product_ids = simple_file("insights_commands/find_.etc.pki.product-default._.etc.pki.product._-name_pem_-exec_rct_cat-cert_--no-content")
     sysctl = simple_file("insights_commands/sysctl_-a")
+    systemctl_cat_dnsmasq_service = simple_file("insights_commands/systemctl_cat_dnsmasq.service")
     systemctl_cat_rpcbind_socket = simple_file("insights_commands/systemctl_cat_rpcbind.socket")
     systemctl_cinder_volume = simple_file("insights_commands/systemctl_show_openstack-cinder-volume")
     systemctl_httpd = simple_file("insights_commands/systemctl_show_httpd")


### PR DESCRIPTION
Signed-off-by: Rahul <rasrivas@redhat.com>

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This MR is to add spec for the `systemctl_cat_dnsmasq_service` parser to the insights archive spec to fix: https://github.com/RedHatInsights/insights-core/issues/3165 issue and also correct the docstring for it.
