### PR TITLE
New spec for oracle asmlib configuration

### DIFF
--- a/insights/parsers/sysconfig.py
+++ b/insights/parsers/sysconfig.py
@@ -74,6 +74,9 @@ IfCFGStaticRoute - files ``/etc/sysconfig/network-scripts/route-*``
 
 GrubSysconfig - files ``/etc/sysconfig/grub``
 ---------------------------------------------
+
+OracleasmSysconfig - files ``/etc/sysconfig/oracleasm``
+-------------------------------------------------------
 """
 
 
@@ -660,6 +663,50 @@ class GrubSysconfig(SysconfigOptions):
         False
         >>> 'GRUB_ENABLE_BLSCFG' in grub_syscfg
         True
+
+    """
+    pass
+
+
+@parser(Specs.sysconfig_oracleasm)
+class OracleasmSysconfig(SysconfigOptions):
+    """
+    Class to parse the ``/etc/sysconfig/oracleasm``
+
+    Typical content example::
+
+        #
+        # This is a configuration file for automatic loading of the Oracle
+        # Automatic Storage Management library kernel driver.  It is generated
+        # By running /etc/init.d/oracleasm configure.  Please use that method
+        # to modify this file
+        #
+
+        # ORACLEASM_ENABELED: 'true' means to load the driver on boot.
+        ORACLEASM_ENABLED=true
+
+        # ORACLEASM_UID: Default user owning the /dev/oracleasm mount point.
+        ORACLEASM_UID=oracle
+
+        # ORACLEASM_GID: Default group owning the /dev/oracleasm mount point.
+        ORACLEASM_GID=oinstall
+
+        # ORACLEASM_SCANBOOT: 'true' means scan for ASM disks on boot.
+        ORACLEASM_SCANBOOT=true
+
+        # ORACLEASM_SCANORDER: Matching patterns to order disk scanning
+        ORACLEASM_SCANORDER="dm"
+
+        # ORACLEASM_SCANEXCLUDE: Matching patterns to exclude disks from scan
+        ORACLEASM_SCANEXCLUDE="sd"
+
+    Examples:
+        >>> oracleasm_syscfg.get('ORACLEASM_SCANBOOT')
+        'true'
+        >>> 'ORACLEASM_SCANORDER' in oracleasm_syscfg
+        True
+        >>> 'ORACLEASM_SCANEXCLUDE_1' in oracleasm_syscfg
+        False
 
     """
     pass

--- a/insights/parsers/tests/test_sysconfig_doc_examples.py
+++ b/insights/parsers/tests/test_sysconfig_doc_examples.py
@@ -13,6 +13,7 @@ from insights.parsers.sysconfig import CorosyncSysconfig
 from insights.parsers.sysconfig import IfCFGStaticRoute
 from insights.parsers.sysconfig import NetworkSysconfig
 from insights.parsers.sysconfig import GrubSysconfig
+from insights.parsers.sysconfig import OracleasmSysconfig
 import doctest
 
 
@@ -169,6 +170,27 @@ GRUB_DISABLE_RECOVERY="true"
 GRUB_ENABLE_BLSCFG=true
 """.strip()
 
+ORACLEASM_SYSCONFIG = """
+#
+# This is a configuration file for automatic loading of the Oracle
+# Automatic Storage Management library kernel driver.  It is generated
+# By running /etc/init.d/oracleasm configure.  Please use that method
+# to modify this file
+#
+# ORACLEASM_ENABELED: 'true' means to load the driver on boot.
+ORACLEASM_ENABLED=true
+# ORACLEASM_UID: Default user owning the /dev/oracleasm mount point.
+ORACLEASM_UID=oracle
+# ORACLEASM_GID: Default group owning the /dev/oracleasm mount point.
+ORACLEASM_GID=oinstall
+# ORACLEASM_SCANBOOT: 'true' means scan for ASM disks on boot.
+ORACLEASM_SCANBOOT=true
+# ORACLEASM_SCANORDER: Matching patterns to order disk scanning
+ORACLEASM_SCANORDER="dm"
+# ORACLEASM_SCANEXCLUDE: Matching patterns to exclude disks from scan
+ORACLEASM_SCANEXCLUDE="sd"
+""".strip()
+
 
 def test_sysconfig_doc():
     env = {
@@ -193,7 +215,8 @@ def test_sysconfig_doc():
             'cs_syscfg': CorosyncSysconfig(context_wrap(COROSYNCSYSCONFIG)),
             'conn_info': IfCFGStaticRoute(context_wrap(STATIC_ROUTE_1, CONTEXT_PATH_DEVICE_1)),
             'net_syscfg': NetworkSysconfig(context_wrap(NETWORK_SYSCONFIG)),
-            'grub_syscfg': GrubSysconfig(context_wrap(GRUB_SYSCONFIG))
+            'grub_syscfg': GrubSysconfig(context_wrap(GRUB_SYSCONFIG)),
+            'oracleasm_syscfg': OracleasmSysconfig(context_wrap(ORACLEASM_SYSCONFIG))
           }
     failed, total = doctest.testmod(sysconfig, globs=env)
     assert failed == 0

--- a/insights/parsers/tests/test_sysconfig_oracleasm.py
+++ b/insights/parsers/tests/test_sysconfig_oracleasm.py
@@ -1,0 +1,38 @@
+from insights.tests import context_wrap
+from insights.parsers.sysconfig import OracleasmSysconfig
+
+ORACLEASM_SYSCONFIG = """
+#
+# This is a configuration file for automatic loading of the Oracle
+# Automatic Storage Management library kernel driver.  It is generated
+# By running /etc/init.d/oracleasm configure.  Please use that method
+# to modify this file
+#
+
+# ORACLEASM_ENABELED: 'true' means to load the driver on boot.
+ORACLEASM_ENABLED=true
+
+# ORACLEASM_UID: Default user owning the /dev/oracleasm mount point.
+ORACLEASM_UID=oracle
+
+# ORACLEASM_GID: Default group owning the /dev/oracleasm mount point.
+ORACLEASM_GID=oinstall
+
+# ORACLEASM_SCANBOOT: 'true' means scan for ASM disks on boot.
+ORACLEASM_SCANBOOT=true
+
+# ORACLEASM_SCANORDER: Matching patterns to order disk scanning
+ORACLEASM_SCANORDER="dm"
+
+# ORACLEASM_SCANEXCLUDE: Matching patterns to exclude disks from scan
+ORACLEASM_SCANEXCLUDE="sd"
+""".strip()
+
+
+def test_sysconfig_oracleasm():
+    result = OracleasmSysconfig(context_wrap(ORACLEASM_SYSCONFIG))
+    assert result["ORACLEASM_SCANORDER"] == 'dm'
+    assert result.get("ORACLEASM_SCANBOOT") == 'true'
+    assert result.get("NONEXISTENT_VAR") is None
+    assert "NONEXISTENT_VAR" not in result
+    assert "ORACLEASM_SCANEXCLUDE" in result

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -627,6 +627,7 @@ class Specs(SpecSet):
     sysconfig_mongod = RegistryPoint(multi_output=True)
     sysconfig_network = RegistryPoint()
     sysconfig_ntpd = RegistryPoint()
+    sysconfig_oracleasm = RegistryPoint()
     sysconfig_prelink = RegistryPoint()
     sysconfig_sshd = RegistryPoint()
     sysconfig_virt_who = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -718,6 +718,7 @@ class DefaultSpecs(Specs):
     sysconfig_libvirt_guests = simple_file("etc/sysconfig/libvirt-guests")
     sysconfig_network = simple_file("etc/sysconfig/network")
     sysconfig_ntpd = simple_file("/etc/sysconfig/ntpd")
+    sysconfig_oracleasm = simple_file("/etc/sysconfig/oracleasm")
     sysconfig_prelink = simple_file("/etc/sysconfig/prelink")
     sysconfig_sshd = simple_file("/etc/sysconfig/sshd")
     sysconfig_virt_who = simple_file("/etc/sysconfig/virt-who")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
This spec is used to detect the Oracle ASMlib configuration issue proactively. If the configuration doesn't ignore the single disk scan, the oracle service will crash when a single path in multipath fails. Detailed info is in the CEECBA-5575.
