### PR TITLE
always update uploader.json

### DIFF
--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -130,8 +130,7 @@ def update(client, config):
     if config.payload:
         logger.debug('Uploading a payload. Bypassing rules update.')
         return
-    if not config.core_collect:
-        client.update_rules()
+    client.update_rules()
 
 
 @phase

--- a/insights/tests/client/phase/test_update.py
+++ b/insights/tests/client/phase/test_update.py
@@ -50,7 +50,9 @@ def test_update_core_collect_on(insights_config, insights_client):
     except SystemExit:
         pass
     insights_client.return_value.update.assert_called_once()
-    insights_client.return_value.update_rules.assert_not_called()
+    # we still want to download uploader.json because it's used
+    #   for remove.conf component name resolution
+    insights_client.return_value.update_rules.assert_called_once()
 
 
 @patch("insights.client.phase.v1.InsightsClient")


### PR DESCRIPTION
Signed-off-by: Jeremy Crafts <jcrafts@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

In order to facilitate removal of the `uploader_json_map.json` file from the egg, resume update of the `/etc/insights-client/.cache.json` file so that the file on disk is updated along with the egg.
