### PR TITLE
Fix Lsof parser logic (#3172)

### DIFF
--- a/insights/parsers/lsof.py
+++ b/insights/parsers/lsof.py
@@ -76,24 +76,12 @@ class Lsof(CommandParser, Scannable):
     """
 
     def _calc_indexes(self, line):
-        self.header_row = line
-        self.name_idx = self.header_row.index(" NAME")
-        self.pid_idx = self.header_row.index("  PID")
-        _, self.mid_cols = self.header_row[:self.name_idx].split(None, 1)
-        self.mid_cols = "  " + self.mid_cols
+        self.headings = [c.strip() for c in line.split(None)]
         self.indexes = {}
-        for col_name in self.mid_cols.split():
-            self.indexes[col_name] = self.mid_cols.index(col_name) + len(col_name)
-        self.indexes["FD"] += 2
-
-    def _split_middle(self, middle):
-        mid_dict = {}
-        offset = 0
-        for col in self.mid_cols.split():
-            idx = self.indexes[col]
-            mid_dict[col] = middle[offset:idx].strip()
-            offset = idx
-        return mid_dict
+        for heading in self.headings:
+            index = line.index(heading)
+            # (start, end)
+            self.indexes[heading] = (index, index + len(heading))
 
     def _start(self, content):
         """
@@ -114,12 +102,21 @@ class Lsof(CommandParser, Scannable):
         Given a line, returns a dictionary for that line. Requires _start to be
         called first.
         """
-        command, rest = line[:self.pid_idx], line[self.pid_idx:]
-        name = line[self.name_idx:]
-        middle_dict = self._split_middle(rest[:self.name_idx - len(command)])
-        middle_dict["COMMAND"] = command.strip()
-        middle_dict["NAME"] = name.strip()
-        return middle_dict
+        # Split NAME seperately as it can have extra whitespaces
+        command = line[self.indexes['NAME'][0]:].strip()
+        rest = line[:self.indexes['NAME'][0]]
+        rdict = dict.fromkeys(self.headings, '')
+        rowsplit = [i.strip() for i in rest.split(None, len(self.headings) - 2)]
+        if len(rowsplit) < len(self.headings) - 1:
+            rowsplit = iter(rowsplit)
+            for heading in self.headings[:-1]:
+                # Use value if (start, end) index of heading is not empty
+                if line[slice(*self.indexes[heading])].strip():
+                    rdict[heading] = next(rowsplit)
+        else:
+            rdict = dict(zip(self.headings, rowsplit))
+        rdict['NAME'] = command
+        return rdict
 
     def parse(self, content):
         """


### PR DESCRIPTION
Signed-off-by: Rohan Arora <roarora@redhat.com>

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Currently Parser assumes minimum start index of the values of columns but it can change if value width exceeds causing parser to give wrong data as explained in issue.