### PR TITLE
Docs typo: extra dot at the end of URL points to the wrong page

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -167,7 +167,7 @@ many customization options to optimize each customer's specific needs.
 .. Links:
 
 .. _Red Hat Customer Portal: https://access.redhat.com
-.. _Red Hat Insights Portal: https://access.redhat.com/products/red-hat-insights.
+.. _Red Hat Insights Portal: https://access.redhat.com/products/red-hat-insights
 .. _insights-core Repository: https://github.com/RedHatInsights/insights-core
 .. _Mozilla OpenSSH Security Guidelines: https://wiki.mozilla.org/Security/Guidelines/OpenSSH
 .. _Red Hat Insights Client GitHub Project: http://github.com/redhataccess/insights-client


### PR DESCRIPTION
Signed-off-by: Thibault Guittet <tguittet@redhat.com>

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Just a typo.
