### PR TITLE
Revert the 'ntpq_pn' spec back

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -529,6 +529,7 @@ class DefaultSpecs(Specs):
     nsswitch_conf = simple_file("/etc/nsswitch.conf")
     ntp_conf = simple_file("/etc/ntp.conf")
     ntpq_leap = simple_command("/usr/sbin/ntpq -c 'rv 0 leap'")
+    ntpq_pn = simple_command("/usr/sbin/ntpq -pn")
     ntptime = simple_command("/usr/sbin/ntptime")
     numa_cpus = glob_file("/sys/devices/system/node/node[0-9]*/cpulist")
     numeric_user_group_name = simple_command("/bin/grep -c '^[[:digit:]]' /etc/passwd /etc/group")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -173,6 +173,7 @@ class InsightsArchiveSpecs(Specs):
     nova_crontab = simple_file("insights_commands/crontab_-l_-u_nova")
     nova_uid = simple_file("insights_commands/id_-u_nova")
     ntpq_leap = simple_file("insights_commands/ntpq_-c_rv_0_leap")
+    ntpq_pn = simple_file("insights_commands/ntpq_-pn")
     ntptime = simple_file("insights_commands/ntptime")
     numeric_user_group_name = simple_file("insights_commands/grep_-c_digit_.etc.passwd_.etc.group")
     oc_get_clusterrole_with_config = simple_file("insights_commands/oc_get_clusterrole_--config_.etc.origin.master.admin.kubeconfig")

--- a/insights/tests/client/collection_rules/test_map_components.py
+++ b/insights/tests/client/collection_rules/test_map_components.py
@@ -59,7 +59,6 @@ def test_get_component_by_symbolic_name():
         'ls_usr_sbin',
         'lvmconfig',
         'nova_migration_uid',
-        'ntpq_pn',
         'rabbitmq_queues',
         'rhev_data_center',
         'root_crontab',


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
This spec `ntpq_pn = simple_command("/usr/bin/ntqp -pn")` is required by an enhancement of an existing rule. It's in the uploader.json already, NO need to require SPEC approval for this change.
