### PR TITLE
Fix fixture error in pytest 4 for test_empty_skip

### DIFF
--- a/insights/parsers/tests/__init__.py
+++ b/insights/parsers/tests/__init__.py
@@ -38,11 +38,10 @@ def ic_testmod(m, name=None, globs=None, verbose=None,
     return doctest.TestResults(runner.failures, runner.tries)
 
 
-@pytest.fixture()
-def test_empty_skip(parser_obj):
+def skip_exception_check(parser_obj, output_str=""):
     from insights.parsers import SkipException
     from insights.tests import context_wrap
 
     with pytest.raises(SkipException) as ex:
-        parser_obj(context_wrap(""))
+        parser_obj(context_wrap(output_str))
     return str(ex)

--- a/insights/parsers/tests/test_awx_manage.py
+++ b/insights/parsers/tests/test_awx_manage.py
@@ -4,7 +4,7 @@ import pytest
 from insights.core import ContentException, ParseException
 from insights.parsers import awx_manage, SkipException
 from insights.parsers.awx_manage import AnsibleTowerLicenseType, AnsibleTowerLicense
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 GOOD_LICENSE = """
@@ -59,7 +59,7 @@ def test_ansible_tower_license_data():
 
 
 def test_ansible_tower_license__data_ab_type():
-    assert 'Empty output.' in test_empty_skip(AnsibleTowerLicense)
+    assert 'Empty output.' in skip_exception_check(AnsibleTowerLicense)
 
     with pytest.raises(ContentException):
         AnsibleTowerLicense(context_wrap(NG_COMMAND_1))

--- a/insights/parsers/tests/test_ceph_cmd_json_parsing.py
+++ b/insights/parsers/tests/test_ceph_cmd_json_parsing.py
@@ -4,7 +4,7 @@ import pytest
 from insights.parsers import ceph_cmd_json_parsing, ParseException
 from insights.parsers.ceph_cmd_json_parsing import CephOsdDump, CephOsdDf, CephS, CephECProfileGet, CephCfgInfo, \
     CephHealthDetail, CephDfDetail, CephOsdTree, CephReport
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 CEPH_OSD_DUMP_INFO = """
@@ -535,7 +535,7 @@ class TestCephOsdDump():
         assert result['pools'][0]['min_size'] == 2
 
     def test_ceph_osd_dump_empty(self):
-        assert 'Empty output.' in test_empty_skip(CephOsdDump)
+        assert 'Empty output.' in skip_exception_check(CephOsdDump)
 
 
 class TestCephOsdDf():
@@ -574,7 +574,7 @@ class TestCephOsdDf():
         assert result['nodes'][0]['pgs'] == 945
 
     def test_ceph_os_df_empty(self):
-        assert 'Empty output.' in test_empty_skip(CephOsdDf)
+        assert 'Empty output.' in skip_exception_check(CephOsdDf)
 
 
 class TestCephS():
@@ -607,7 +607,7 @@ class TestCephS():
         assert result['pgmap']['pgs_by_state'][0]['state_name'] == 'active+clean'
 
     def test_ceph_s_empty(self):
-        assert 'Empty output.' in test_empty_skip(CephS)
+        assert 'Empty output.' in skip_exception_check(CephS)
 
 
 class TestCephECProfileGet():
@@ -624,7 +624,7 @@ class TestCephECProfileGet():
         assert result['m'] == "1"
 
     def test_ceph_ec_profile_get_empty(self):
-        assert 'Empty output.' in test_empty_skip(CephECProfileGet)
+        assert 'Empty output.' in skip_exception_check(CephECProfileGet)
 
 
 class TestCephCfgInfo():
@@ -650,7 +650,7 @@ class TestCephCfgInfo():
         assert result.max_open_files == '131072'
 
     def test_ceph_cfg_info_empty(self):
-        assert 'Empty output.' in test_empty_skip(CephCfgInfo)
+        assert 'Empty output.' in skip_exception_check(CephCfgInfo)
 
 
 class TestCephHealthDetail():
@@ -672,7 +672,7 @@ class TestCephHealthDetail():
         assert result['overall_status'] == 'HEALTH_OK'
 
     def test_ceph_health_detail_empty(self):
-        assert 'Empty output.' in test_empty_skip(CephHealthDetail)
+        assert 'Empty output.' in skip_exception_check(CephHealthDetail)
 
 
 class TestCephDfDetail():
@@ -724,7 +724,7 @@ class TestCephDfDetail():
         assert result['stats']['total_avail_bytes'] == 16910123008
 
     def test_ceph_df_detail_empty(self):
-        assert 'Empty output.' in test_empty_skip(CephDfDetail)
+        assert 'Empty output.' in skip_exception_check(CephDfDetail)
 
 
 class TestCephOsdTree():
@@ -858,7 +858,7 @@ class TestCephOsdTree():
         assert len(result['nodes'][0]['children']) == 4
 
     def test_ceph_osd_tree_empty(self):
-        assert 'Empty output.' in test_empty_skip(CephOsdTree)
+        assert 'Empty output.' in skip_exception_check(CephOsdTree)
 
 
 class TestCephReport():
@@ -877,4 +877,4 @@ class TestCephReport():
         assert "Could not parse json." in str(e)
 
     def test_ceph_report_empty(self):
-        assert 'Empty output.' in test_empty_skip(CephReport)
+        assert 'Empty output.' in skip_exception_check(CephReport)

--- a/insights/parsers/tests/test_cloud_cfg.py
+++ b/insights/parsers/tests/test_cloud_cfg.py
@@ -1,7 +1,7 @@
 import doctest
 
 from insights.parsers import cloud_cfg
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 
@@ -23,7 +23,7 @@ def test_cloud_cfg():
 
 
 def test_cloud_cfg_empty():
-    assert 'Empty output.' in test_empty_skip(cloud_cfg.CloudCfg)
+    assert 'Empty output.' in skip_exception_check(cloud_cfg.CloudCfg)
 
 
 def test_doc_examples():

--- a/insights/parsers/tests/test_cni_podman_bridge_conf.py
+++ b/insights/parsers/tests/test_cni_podman_bridge_conf.py
@@ -2,7 +2,7 @@ import doctest
 
 from insights.parsers import cni_podman_bridge_conf
 from insights.parsers.cni_podman_bridge_conf import CNIPodmanBridgeConf
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 PODMAN_CNI_FILE = '''
@@ -65,4 +65,4 @@ def test_cni_podman_bridge_conf():
 
 
 def test_cni_podman_bridge_conf_empty():
-    assert 'Empty output.' in test_empty_skip(CNIPodmanBridgeConf)
+    assert 'Empty output.' in skip_exception_check(CNIPodmanBridgeConf)

--- a/insights/parsers/tests/test_engine_db_query.py
+++ b/insights/parsers/tests/test_engine_db_query.py
@@ -2,7 +2,7 @@ import doctest
 import pytest
 
 from insights.parsers import engine_db_query, ParseException
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 
@@ -93,7 +93,7 @@ def test_edbq():
     assert output.result == [{'vds_name': 'hosto', 'rpm_version': 'vdsm-4.40.20-33.git1b7dedcf3.fc30'}, {'vds_name': 'hosto2', 'rpm_version': 'vdsm-4.40.13-38.gite9bae3c68.fc30'}]
 
     # No content
-    assert 'Empty output.' in test_empty_skip(engine_db_query.EngineDBQueryVDSMversion)
+    assert 'Empty output.' in skip_exception_check(engine_db_query.EngineDBQueryVDSMversion)
 
     # Error
     with pytest.raises(ParseException) as e:

--- a/insights/parsers/tests/test_freeipa_healthcheck_log.py
+++ b/insights/parsers/tests/test_freeipa_healthcheck_log.py
@@ -2,7 +2,7 @@ import doctest
 
 from insights.parsers import freeipa_healthcheck_log
 from insights.parsers.freeipa_healthcheck_log import FreeIPAHealthCheckLog
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 LONG_FREEIPA_HEALTHCHECK_LOG_OK = """
@@ -99,7 +99,7 @@ def test_freeipa_healthcheck_get_results_not_ok():
 
 
 def test_freeipa_healthcheck_log_empty():
-    assert 'Empty output.' in test_empty_skip(FreeIPAHealthCheckLog)
+    assert 'Empty output.' in skip_exception_check(FreeIPAHealthCheckLog)
 
 
 def test_freeipa_healthcheck_log__documentation():

--- a/insights/parsers/tests/test_httpd_open_nfs.py
+++ b/insights/parsers/tests/test_httpd_open_nfs.py
@@ -2,7 +2,7 @@ import doctest
 
 from insights.parsers import httpd_open_nfs
 from insights.parsers.httpd_open_nfs import HttpdOnNFSFilesCount
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 http_nfs = """
@@ -19,7 +19,7 @@ def test_http_nfs():
 
 
 def test_empty():
-    assert 'Empty output.' in test_empty_skip(HttpdOnNFSFilesCount)
+    assert 'Empty output.' in skip_exception_check(HttpdOnNFSFilesCount)
 
 
 def test_http_nfs_documentation():

--- a/insights/parsers/tests/test_ndctl_list.py
+++ b/insights/parsers/tests/test_ndctl_list.py
@@ -2,7 +2,7 @@ import doctest
 
 from insights.parsers import ndctl_list
 from insights.parsers.ndctl_list import NdctlListNi
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 NDCTL_OUTPUT = """
@@ -54,4 +54,4 @@ def test_get_dev_attr():
 
 
 def test_empty():
-    assert 'Empty output.' in test_empty_skip(NdctlListNi)
+    assert 'Empty output.' in skip_exception_check(NdctlListNi)

--- a/insights/parsers/tests/test_rhsm_releasever.py
+++ b/insights/parsers/tests/test_rhsm_releasever.py
@@ -3,7 +3,7 @@ import pytest
 
 from insights.parsers import rhsm_releasever as rhsm_releasever_module, SkipException
 from insights.parsers.rhsm_releasever import RhsmReleaseVer
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 RHEL_MAJ_MIN = '{"releaseVer": "6.10"}'
@@ -51,7 +51,7 @@ def test_rhsm_releasever():
 
 
 def test_empty():
-    assert 'Empty output.' in test_empty_skip(RhsmReleaseVer)
+    assert 'Empty output.' in skip_exception_check(RhsmReleaseVer)
 
 
 def test_doc_examples():

--- a/insights/parsers/tests/test_rhv_log_collector_analyzer.py
+++ b/insights/parsers/tests/test_rhv_log_collector_analyzer.py
@@ -1,5 +1,5 @@
 from insights.parsers.rhv_log_collector_analyzer import RhvLogCollectorJson
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 RHV_ANALYZER_JSON = """
@@ -139,4 +139,4 @@ class TestRhvLogCollectorJson():
         assert result['rhv-log-collector-analyzer'][0]['file'] == 'cluster_query_migration_policy_check_legacy.sql'
 
     def test_empty(self):
-        assert 'Empty output.' in test_empty_skip(RhvLogCollectorJson)
+        assert 'Empty output.' in skip_exception_check(RhvLogCollectorJson)

--- a/insights/parsers/tests/test_tags.py
+++ b/insights/parsers/tests/test_tags.py
@@ -1,5 +1,5 @@
 from insights.parsers.tags import Tags
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 tags_json_content = """
@@ -18,4 +18,4 @@ def test_tags_json():
 
 
 def test_tags_empty():
-    assert 'Empty output.' in test_empty_skip(Tags)
+    assert 'Empty output.' in skip_exception_check(Tags)

--- a/insights/parsers/tests/test_teamdctl_config_dump.py
+++ b/insights/parsers/tests/test_teamdctl_config_dump.py
@@ -2,7 +2,7 @@ import doctest
 
 from insights.parsers import teamdctl_config_dump
 from insights.parsers.teamdctl_config_dump import TeamdctlConfigDump
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 TEAMDCTL_CONFIG_DUMP_INFO = """
@@ -41,7 +41,7 @@ def test_teamdctl_state_dump():
 
 
 def test_teamdctl_state_dump_empty():
-    assert 'Empty output.' in test_empty_skip(TeamdctlConfigDump)
+    assert 'Empty output.' in skip_exception_check(TeamdctlConfigDump)
 
 
 def test_nmcli_doc_examples():

--- a/insights/parsers/tests/test_teamdctl_state_dump.py
+++ b/insights/parsers/tests/test_teamdctl_state_dump.py
@@ -1,5 +1,5 @@
 from insights.parsers.teamdctl_state_dump import TeamdctlStateDump
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 TEAMDCTL_STATE_DUMP_INFO = """
@@ -114,4 +114,4 @@ def test_teamdctl_state_dump_none():
 
 
 def test_teamdctl_state_dump_empty():
-    assert 'Empty output.' in test_empty_skip(TeamdctlStateDump)
+    assert 'Empty output.' in skip_exception_check(TeamdctlStateDump)

--- a/insights/parsers/tests/test_version_info.py
+++ b/insights/parsers/tests/test_version_info.py
@@ -1,7 +1,7 @@
 import doctest
 
 from insights.parsers import version_info
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.tests import context_wrap
 
 
@@ -25,7 +25,7 @@ def test_version_info():
 
 
 def test_version_info_empty():
-    assert 'Empty output.' in test_empty_skip(version_info.VersionInfo)
+    assert 'Empty output.' in skip_exception_check(version_info.VersionInfo)
 
 
 def test_doc_examples():

--- a/insights/parsers/tests/test_virt_uuid_facts.py
+++ b/insights/parsers/tests/test_virt_uuid_facts.py
@@ -1,7 +1,7 @@
 import doctest
 
 from insights.parsers import virt_uuid_facts
-from insights.parsers.tests import test_empty_skip
+from insights.parsers.tests import skip_exception_check
 from insights.parsers.virt_uuid_facts import VirtUuidFacts
 from insights.tests import context_wrap
 
@@ -22,7 +22,7 @@ def test_virt_uuid_facts():
 
 
 def test_virt_uuid_facts_empty():
-    assert 'Empty output.' in test_empty_skip(VirtUuidFacts)
+    assert 'Empty output.' in skip_exception_check(VirtUuidFacts)
 
 
 def test_virt_uuid_facts_doc_examples():


### PR DESCRIPTION
* In pytest 4 fixtures can't be called directly, so I changed
  test_empty_skip to skip_exception_check and removed the fixture 
  decorator.

Signed-off-by: Ryan Blakley <rblakley@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
In pytest 4 fixtures can't be called directly, and shared function names can't start with test. To fix this I renamed test_empty_skip to skip_exception_check, and removed the fixture decorator.
