### PR TITLE
Merge the -N (show make_none rules) to -S (show rules per type)

### DIFF
--- a/insights/formats/__init__.py
+++ b/insights/formats/__init__.py
@@ -184,7 +184,7 @@ def get_response_of_types(response, missing=True, show_rules=None):
     if not show_rules:
         #  - Discard the "make_none" by default when no "-S"
         #  That means show "make_none" rules only when "none" is specified in "-S"
-        response.pop('none')
+        response.pop('none') if 'none' in response else None
         return response
     #  - Discard the "medadata" rules when it's not specified in the "-S" option
     if 'metadata' not in show_rules and 'metadata' in response.get('system', {}):

--- a/insights/formats/_markdown.py
+++ b/insights/formats/_markdown.py
@@ -54,6 +54,7 @@ class MarkdownFormat(Formatter):
             'pass': self.response(label="PASS", title="Passed      : "),
             'rule': self.response(label="FAIL", title="Failed      : "),
             'info': self.response(label="INFO", title="Info        : "),
+            'none': self.response(label="RETURNED NONE", title="Ret'd None  : "),
             'metadata': self.response(label="META", title="Metadata    : "),
             'metadata_key': self.response(label="META", title="Metadata Key: "),
             'fingerprint': self.response(label="FINGERPRINT", title="Fingerprint : "),
@@ -148,8 +149,10 @@ class MarkdownFormat(Formatter):
             if _type:
                 if self.missing and _type == 'skip':
                     print_missing(c, v)
-                elif ((self.show_rules and _type in self.show_rules) or
-                        (not self.show_rules and _type != 'skip')):
+                elif (
+                        (self.show_rules and _type in self.show_rules) or
+                        (not self.show_rules and _type not in ['skip', 'none'])
+                ):
                     printit(c, v)
         print(file=self.stream)
 
@@ -184,9 +187,9 @@ class MarkdownFormatAdapter(FormatterAdapter):
         p.add_argument("-d", "--dropped", help="Show collected files that weren't processed.", action="store_true")
         p.add_argument("-m", "--missing", help="Show missing requirements.", action="store_true")
         p.add_argument("-S", "--show-rules", nargs="+",
-                       choices=["fail", "info", "pass", "metadata", "fingerprint"],
+                       choices=["fail", "info", "pass", "none", "metadata", "fingerprint"],
                        metavar="TYPE",
-                       help="Show results per rule type(s).")
+                       help="Show results per rule's type: 'fail', 'info', 'pass', 'none', 'metadata', and 'fingerprint'")
         p.add_argument("-F", "--fail-only",
                        help="Show FAIL results only. Conflict with '-m', will be dropped when using them together. This option is deprecated by '-S fail'",
                        action="store_true")
@@ -197,7 +200,7 @@ class MarkdownFormatAdapter(FormatterAdapter):
         if args.missing and fail_only:
             print('Options conflict: -m and -F, drops -F', file=sys.stderr)
             fail_only = None
-        self.show_rules = []  # Empty by default, means show ALL types
+        self.show_rules = []  # Empty by default, means show ALL types (exclude "none")
         if not args.show_rules and fail_only:
             self.show_rules = ['rule']
         elif args.show_rules:

--- a/insights/formats/_markdown.py
+++ b/insights/formats/_markdown.py
@@ -48,7 +48,7 @@ class MarkdownFormat(Formatter):
         self.dropped = dropped
         self.show_rules = [] if show_rules is None else show_rules
 
-        self.counts = {'skip': 0, 'pass': 0, 'rule': 0, 'info': 0, 'metadata': 0, 'metadata_key': 0, 'fingerprint': 0, 'exception': 0}
+        self.counts = {'skip': 0, 'pass': 0, 'rule': 0, 'info': 0, 'none': 0, 'metadata': 0, 'metadata_key': 0, 'fingerprint': 0, 'exception': 0}
         self.responses = {
             'skip': self.response(label="SKIP", title="Missing Deps: "),
             'pass': self.response(label="PASS", title="Passed      : "),

--- a/insights/formats/text.py
+++ b/insights/formats/text.py
@@ -106,15 +106,14 @@ class HumanReadableFormat(Formatter):
     def preprocess(self):
         response = namedtuple('response', 'color label intl title')
         self.responses = {
+            'skip': response(color=Fore.BLUE, label="SKIP", intl='S', title="Missing Deps: "),
             'pass': response(color=Fore.GREEN, label="PASS", intl='P', title="Passed      : "),
             'rule': response(color=Fore.RED, label="FAIL", intl='F', title="Failed      : "),
             'info': response(color=Fore.WHITE, label="INFO", intl='I', title="Info        : "),
             'none': response(color=Fore.BLUE, label="RETURNED NONE", intl='N', title="Ret'd None  : "),
-            'skip': response(color=Fore.BLUE, label="SKIP", intl='S', title="Missing Deps: "),
-            'fingerprint': response(color=Fore.YELLOW, label="FINGERPRINT", intl='P',
-                                  title="Fingerprint : "),
             'metadata': response(color=Fore.YELLOW, label="META", intl='M', title="Metadata    : "),
             'metadata_key': response(color=Fore.MAGENTA, label="META", intl='K', title="Metadata Key: "),
+            'fingerprint': response(color=Fore.YELLOW, label="FINGERPRINT", intl='P', title="Fingerprint : "),
             'exception': response(color=Fore.RED, label="EXCEPT", intl='E', title="Exceptions  : "),
         }
 


### PR DESCRIPTION
- the 'make_none' is also a type of rules
- do not show the 'make_none' rule by default
   it means show 'make_none' only when "none" is specified in the `--show-rules`

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
The `make_none` rule is also a type of rule, how about merge this option `--none` to the `--show-rules`
