### PR TITLE
Fix deprecated generator code in Lsof parser

### DIFF
--- a/insights/parsers/lsof.py
+++ b/insights/parsers/lsof.py
@@ -92,7 +92,10 @@ class Lsof(CommandParser, Scannable):
 
         line = next(content)
         while 'COMMAND ' not in line:
-            line = next(content)
+            line = next(content, '')
+
+        if not line:
+            return iter([])
 
         self._calc_indexes(line)
         return content
@@ -112,7 +115,7 @@ class Lsof(CommandParser, Scannable):
             for heading in self.headings[:-1]:
                 # Use value if (start, end) index of heading is not empty
                 if line[slice(*self.indexes[heading])].strip():
-                    rdict[heading] = next(rowsplit)
+                    rdict[heading] = next(rowsplit, '')
         else:
             rdict = dict(zip(self.headings, rowsplit))
         rdict['NAME'] = command


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* The code utilizing the iter/next functions in the lsof parser changed
  in python 3.5 based on PEP 479
* This change makes the code compliant with that PEP and removes the
  deprecation warning for tests

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>