### PR TITLE
Add parser mssql api assessment

### DIFF
--- a/docs/shared_parsers_catalog/mssql_api_assessment.rst
+++ b/docs/shared_parsers_catalog/mssql_api_assessment.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.mssql_api_assessment
+   :members:
+   :show-inheritance:

--- a/insights/parsers/mssql_api_assessment.py
+++ b/insights/parsers/mssql_api_assessment.py
@@ -8,18 +8,16 @@ MssqlApiAssessment - file ``/var/opt/mssql/api_assessment_output``
 --------------------------------------------------------------------------
 """
 
-from insights import JSONParser, parser, CommandParser
-from insights.parsers import SkipException, ParseException
+from insights import JSONParser, parser
 from insights.specs import Specs
-
 
 
 @parser(Specs.mssql_api_assessment)
 class MssqlApiAssessment(JSONParser):
     """
-    Parses the output of command  ``/var/opt/mssql/api_assessment_output``
+    Parses the file: ``/var/opt/mssql/api_assessment_output``
 
-    Sample output of the command::
+    Sample content of the file::
 
         [
           {

--- a/insights/parsers/mssql_api_assessment.py
+++ b/insights/parsers/mssql_api_assessment.py
@@ -1,0 +1,60 @@
+"""
+MssqlApiAssessment - file ``/var/opt/mssql/api_assessment_output``
+==================================================================
+
+Parsers contains in this module are:
+
+MssqlApiAssessment - file ``/var/opt/mssql/api_assessment_output``
+--------------------------------------------------------------------------
+"""
+
+from insights import JSONParser, parser, CommandParser
+from insights.parsers import SkipException, ParseException
+from insights.specs import Specs
+
+
+
+@parser(Specs.mssql_api_assessment)
+class MssqlApiAssessment(JSONParser):
+    """
+    Parses the output of command  ``/var/opt/mssql/api_assessment_output``
+
+    Sample output of the command::
+
+        [
+          {
+            "Timestamp": "2021-05-05T21:51:55.2317511-04:00",
+            "Severity": "Information",
+            "TargetType": "Server",
+            "TargetName": "ceph4-mon",
+            "TargetPath": "Server[@Name='ceph4-mon']",
+            "CheckId": "TF174",
+            "CheckName": "TF 174 increases plan cache bucket count",
+            "Message": "Enable trace flag 174 to increase plan cache bucket count",
+            "RulesetName": "Microsoft ruleset",
+            "RulesetVersion": "1.0.305",
+            "HelpLink": "https://docs.microsoft.com/sql/t-sql/database-console-commands/dbcc-traceon-trace-flags-transact-sql"
+          },
+          {
+            "Timestamp": "2021-05-05T21:51:55.2323431-04:00",
+            "Severity": "Information",
+            "TargetType": "Server",
+            "TargetName": "ceph4-mon",
+            "TargetPath": "Server[@Name='ceph4-mon']",
+            "CheckId": "TF834",
+            "CheckName": "TF 834 enables large-page allocations",
+            "Message": "Enable trace flag 834 to use large-page allocations to improve analytical and data warehousing workloads",
+            "RulesetName": "Microsoft ruleset",
+            "RulesetVersion": "1.0.305",
+            "HelpLink": "https://support.microsoft.com/kb/3210239"
+          }
+        ]
+    Examples:
+        >>> type(mssql_api_assessment_output)
+        <class 'insights.parsers.mssql_api_assessment.MssqlApiAssessment'>
+        >>> mssql_api_assessment_output[0]["Severity"]
+        u'Information'
+        >>> mssql_api_assessment_output[0]["CheckId"]
+        u'TF174'
+    """
+    pass

--- a/insights/parsers/mssql_api_assessment.py
+++ b/insights/parsers/mssql_api_assessment.py
@@ -1,11 +1,10 @@
 """
-MssqlApiAssessment - file ``/var/opt/mssql/api_assessment_output``
-==================================================================
+MssqlApiAssessment - file ``/var/opt/mssql/log/assessments/assessment-latest``
+==============================================================================
 
 Parsers contains in this module are:
 
-MssqlApiAssessment - file ``/var/opt/mssql/api_assessment_output``
---------------------------------------------------------------------------
+MssqlApiAssessment - file ``/var/opt/mssql/log/assessments/assessment-latest``
 """
 
 from insights import JSONParser, parser
@@ -15,7 +14,7 @@ from insights.specs import Specs
 @parser(Specs.mssql_api_assessment)
 class MssqlApiAssessment(JSONParser):
     """
-    Parses the file: ``/var/opt/mssql/api_assessment_output``
+    Parses the file: ``/var/opt/mssql/log/assessments/assessment-latest``
 
     Sample content of the file::
 
@@ -47,12 +46,11 @@ class MssqlApiAssessment(JSONParser):
             "HelpLink": "https://support.microsoft.com/kb/3210239"
           }
         ]
+
     Examples:
         >>> type(mssql_api_assessment_output)
         <class 'insights.parsers.mssql_api_assessment.MssqlApiAssessment'>
-        >>> mssql_api_assessment_output[0]["Severity"]
-        u'Information'
-        >>> mssql_api_assessment_output[0]["CheckId"]
-        u'TF174'
+        >>> mssql_api_assessment_output[0]["Severity"] == 'Information'
+        True
     """
     pass

--- a/insights/parsers/tests/test_mssql_api_assessment.py
+++ b/insights/parsers/tests/test_mssql_api_assessment.py
@@ -1,0 +1,52 @@
+import doctest
+
+from insights.parsers import mssql_api_assessment
+from insights.parsers.mssql_api_assessment import MssqlApiAssessment
+from insights.tests import context_wrap
+
+API_OUTPUT = """
+[
+  {
+    "Timestamp": "2021-05-05T21:51:55.2317511-04:00",
+    "Severity": "Information",
+    "TargetType": "Server",
+    "TargetName": "ceph4-mon",
+    "TargetPath": "Server[@Name='ceph4-mon']",
+    "CheckId": "TF174",
+    "CheckName": "TF 174 increases plan cache bucket count",
+    "Message": "Enable trace flag 174 to increase plan cache bucket count",
+    "RulesetName": "Microsoft ruleset",
+    "RulesetVersion": "1.0.305",
+    "HelpLink": "https://docs.microsoft.com/sql/t-sql/database-console-commands/dbcc-traceon-trace-flags-transact-sql"
+  },
+  {
+    "Timestamp": "2021-05-05T21:51:55.2323431-04:00",
+    "Severity": "Information",
+    "TargetType": "Server",
+    "TargetName": "ceph4-mon",
+    "TargetPath": "Server[@Name='ceph4-mon']",
+    "CheckId": "TF834",
+    "CheckName": "TF 834 enables large-page allocations",
+    "Message": "Enable trace flag 834 to use large-page allocations to improve analytical and data warehousing workloads",
+    "RulesetName": "Microsoft ruleset",
+    "RulesetVersion": "1.0.305",
+    "HelpLink": "https://support.microsoft.com/kb/3210239"
+  }
+]
+""".strip()
+
+
+def test_mssql_api_assessment():
+    ret = MssqlApiAssessment(context_wrap(API_OUTPUT))
+    assert ret[0]["Severity"] == "Information"
+    assert ret[0]["TargetName"] == "ceph4-mon"
+    assert ret[0]["CheckId"] == "TF174"
+    assert ret[0]["Message"] == "Enable trace flag 174 to increase plan cache bucket count"
+
+
+def test_mssql_api_assessment_doc_examples():
+    env = {
+        'mssql_api_assessment_output': MssqlApiAssessment(context_wrap(API_OUTPUT))
+    }
+    failed, total = doctest.testmod(mssql_api_assessment, globs=env)
+    assert failed == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -368,6 +368,7 @@ class Specs(SpecSet):
     mount = RegistryPoint()
     mounts = RegistryPoint()
     mssql_conf = RegistryPoint()
+    mssql_api_assessment = RegistryPoint()
     multicast_querier = RegistryPoint()
     multipath_conf = RegistryPoint()
     multipath_conf_initramfs = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -475,6 +475,7 @@ class DefaultSpecs(Specs):
     mount = simple_command("/bin/mount")
     mounts = simple_file("/proc/mounts")
     mssql_conf = simple_file("/var/opt/mssql/mssql.conf")
+    mssql_api_assessment = simple_file("/var/opt/mssql/api_assessment_output")
     multicast_querier = simple_command("/usr/bin/find /sys/devices/virtual/net/ -name multicast_querier -print -exec cat {} \;")
     multipath_conf = simple_file("/etc/multipath.conf")
     multipath_conf_initramfs = simple_command("/bin/lsinitrd -f /etc/multipath.conf")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -475,7 +475,7 @@ class DefaultSpecs(Specs):
     mount = simple_command("/bin/mount")
     mounts = simple_file("/proc/mounts")
     mssql_conf = simple_file("/var/opt/mssql/mssql.conf")
-    mssql_api_assessment = simple_file("/var/opt/mssql/api_assessment_output")
+    mssql_api_assessment = simple_file("/var/opt/mssql/log/assessments/assessment-latest")
     multicast_querier = simple_command("/usr/bin/find /sys/devices/virtual/net/ -name multicast_querier -print -exec cat {} \;")
     multipath_conf = simple_file("/etc/multipath.conf")
     multipath_conf_initramfs = simple_command("/bin/lsinitrd -f /etc/multipath.conf")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Currently, RedHat insights team is cooperating with MSFT to create a script to run MSSQL Assessment API rulesets[0], and store the result on "/var/opt/mssql/log/assessments/assessment-latest". Then Insights-client will read the content of the file, and insights-plugin will return valuable items for customers. Although script execution method is under discussion, the content and store path of the output are determined(we can update it if there is any change in the future). This parser is used to parse the content of file "/var/opt/mssql/log/assessments/assessment-latest".

[0] https://github.com/microsoft/sql-server-samples/blob/master/samples/manage/sql-assessment-api/ruleset.json

