### PR TITLE
Remove the spec mssql_api_assessment from default

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -475,7 +475,6 @@ class DefaultSpecs(Specs):
     mount = simple_command("/bin/mount")
     mounts = simple_file("/proc/mounts")
     mssql_conf = simple_file("/var/opt/mssql/mssql.conf")
-    mssql_api_assessment = simple_file("/var/opt/mssql/log/assessments/assessment-latest")
     multicast_querier = simple_command("/usr/bin/find /sys/devices/virtual/net/ -name multicast_querier -print -exec cat {} \;")
     multipath_conf = simple_file("/etc/multipath.conf")
     multipath_conf_initramfs = simple_command("/bin/lsinitrd -f /etc/multipath.conf")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

Remove "mssql_api_assessment = simple_file("/var/opt/mssql/log/assessments/assessment-latest")" as the path has not been determined currently
