### PR TITLE
Adding ss command back in without restrictions

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -32,7 +32,6 @@ from insights.components.rhel_version import IsRhel8, IsRhel7, IsRhel6
 from insights.components.cloud_provider import IsAWS, IsAzure, IsGCP
 from insights.components.ceph import IsCephMonitor
 from insights.parsers.mdstat import Mdstat
-from insights.parsers.lsmod import LsMod
 from insights.combiners.satellite_version import SatelliteVersion, CapsuleVersion
 from insights.parsers.mount import Mount
 from insights.specs import Specs
@@ -694,20 +693,7 @@ class DefaultSpecs(Specs):
     softnet_stat = simple_file("proc/net/softnet_stat")
     software_collections_list = simple_command('/usr/bin/scl --list')
     spamassassin_channels = simple_command("/bin/grep -r '^\\s*CHANNELURL=' /etc/mail/spamassassin/channel.d")
-
-    @datasource(LsMod, HostContext)
-    def is_mod_loaded_for_ss(broker):
-        """
-        bool: Returns True if the kernel modules required by ``ss -tupna``
-        command are loaded.
-        """
-        lsmod = broker[LsMod]
-        req_mods = ['inet_diag', 'tcp_diag', 'udp_diag']
-        if all(mod in lsmod for mod in req_mods):
-            return True
-        raise SkipComponent
-
-    ss = simple_command("/usr/sbin/ss -tupna", deps=[is_mod_loaded_for_ss])
+    ss = simple_command("/usr/sbin/ss -tupna")
     ssh_config = simple_file("/etc/ssh/ssh_config")
     ssh_config_d = glob_file(r"/etc/ssh/ssh_config.d/*.conf")
     ssh_foreman_proxy_config = simple_file("/usr/share/foreman-proxy/.ssh/ssh_config")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Due to problems with netstat output formatting, ss is the best source
  for network information
* The ss command was restricted to only run if certain modules were
  already loaded since those modules were necessary for ss.  This change
  removes those restrictions. The side-effect is that the modules
  inet_diag, tcp_diag, and udp_diag may be loaded by execution of the ss
  command.
* See issue #2909 

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>