### PR TITLE
Revert "Fix deprecated generator code in Lsof parser"

### DIFF
--- a/insights/parsers/lsof.py
+++ b/insights/parsers/lsof.py
@@ -92,10 +92,7 @@ class Lsof(CommandParser, Scannable):
 
         line = next(content)
         while 'COMMAND ' not in line:
-            line = next(content, '')
-
-        if not line:
-            return iter([])
+            line = next(content)
 
         self._calc_indexes(line)
         return content
@@ -115,7 +112,7 @@ class Lsof(CommandParser, Scannable):
             for heading in self.headings[:-1]:
                 # Use value if (start, end) index of heading is not empty
                 if line[slice(*self.indexes[heading])].strip():
-                    rdict[heading] = next(rowsplit, '')
+                    rdict[heading] = next(rowsplit)
         else:
             rdict = dict(zip(self.headings, rowsplit))
         rdict['NAME'] = command


### PR DESCRIPTION
Reverts RedHatInsights/insights-core#3185 which is causing a problem when the lsof command fails with data like this:

```
lsof: WARNING: can't stat() xfs file system /var/lib/origin/openshift.local.volumes/pods/abca2a21-da4c-22eb-b49c-011d3a938eb5/volume-subpaths/config/wh/0
```