### PR TITLE
Fix lsblk parsing raid1 types

### DIFF
--- a/insights/parsers/lsblk.py
+++ b/insights/parsers/lsblk.py
@@ -224,7 +224,7 @@ class LSBlock(BlockDevices):
         See the discussion of the key ``PARENT_NAMES`` above.
     """
     def parse_content(self, content):
-        r = re.compile(r"([\s\|\`\-]*)(\S+.*) (\d+:\d+)\s+(\d)\s+(\d+(\.\d)?[A-Z])\s+(\d)\s+([a-z]+)(.*)")
+        r = re.compile(r"([\s\|\`\-]*)(\S+.*) (\d+:\d+)\s+(\d)\s+(\d+(\.\d)?[A-Z])\s+(\d)\s+([a-z0-9]+)(.*)")
         device_list = []
         parents = [None] * MAX_GENERATIONS
         for line in content[1:]:


### PR DESCRIPTION
* Fix the regex to catch the various raid types raid0, raid1, etc.

Signed-off-by: Ryan Blakley <rblakley@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
The regex only catches lower case letters for the type field, so if the type is raid1 then the mountpoint was being set to "1 /boot" for example if /dev/md127 is mounted on /boot. So I added 0-9 to the regex to catch the various raid types properly.
