### PR TITLE
Add MII polling interval attribute to the bond parser

### DIFF
--- a/insights/parsers/bond.py
+++ b/insights/parsers/bond.py
@@ -96,6 +96,7 @@ class Bond(Parser):
         self.xmit_hash_policy = None
         self._arp_polling_interval = None
         self._arp_ip_target = None
+        self._mii_polling_interval = None
         self._slave_interface = []
         self._aggregator_id = []
         self._mii_status = []
@@ -162,6 +163,8 @@ class Bond(Parser):
                 self._arp_polling_interval = line.strip().split(':', 1)[1].strip()
             elif line.strip().startswith("ARP IP target/s (n.n.n.n form):"):
                 self._arp_ip_target = line.strip().split(':', 1)[1].strip()
+            elif line.strip().startswith("MII Polling Interval (ms):"):
+                self._mii_polling_interval = line.strip().split(':', 1)[1].strip()
             elif line.strip().startswith("Primary Slave"):
                 self._primary_slave = line.split(":", 1)[1].strip()
             elif line.strip().startswith("Up Delay (ms):"):
@@ -254,6 +257,13 @@ class Bond(Parser):
         if no "ARP IP target/s (n.n.n.n form)" key is found.
         """
         return self._arp_ip_target
+
+    @property
+    def mii_polling_interval(self):
+        """Returns the mii polling interval as a string. ``None`` is returned
+        if no "MII Polling Interval (ms)" key is found.
+        """
+        return self._mii_polling_interval
 
     @property
     def primary_slave(self):

--- a/insights/parsers/tests/test_bond.py
+++ b/insights/parsers/tests/test_bond.py
@@ -301,11 +301,13 @@ def test_bond_class():
     assert bond_obj_3.mii_status == ['up', 'up', 'up']
     assert bond_obj_3.arp_polling_interval is None
     assert bond_obj_3.arp_ip_target is None
+    assert bond_obj_3.mii_polling_interval == "100"
 
     bond_obj_4 = Bond(context_wrap(BONDINFO_MODE_7, CONTEXT_PATH))
     assert bond_obj_4.file_name == 'bond0'
     assert bond_obj_4.arp_polling_interval == "1000"
     assert bond_obj_4.arp_ip_target == "10.152.1.1"
+    assert bond_obj_4.mii_polling_interval == "0"
     assert bond_obj_4.primary_slave == 'em3 (primary_reselect failure)'
 
     bond_obj = Bond(context_wrap(BOND_MODE_4, CONTEXT_PATH))


### PR DESCRIPTION
* Added in the missing attribute that is often set in the bond opts.
* Added in testing to confirm the attribute was set properly.

Signed-off-by: Ryan Blakley <rblakley@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
I found that the MII polling interval wasn't parsed from the output, even though it is set quite often in the bonding opts config. I figured since ARP polling interval is parsed the MII should be as well.
