### PR TITLE
Fix excludes not working in _load_components

### DIFF
--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -394,20 +394,22 @@ def _import(path, continue_on_error):
 
 
 def _load_components(path, include=".*", exclude="test", continue_on_error=True):
+    do_include = re.compile(include).search if include else lambda x: True
+    do_exclude = re.compile(exclude).search if exclude else lambda x: False
+
     num_loaded = 0
     if path.endswith(".py"):
         path, _ = os.path.splitext(path)
 
     path = path.rstrip("/").replace("/", ".")
+    if do_exclude(path):
+        return 0
 
     package = _import(path, continue_on_error)
     if not package:
         return 0
 
     num_loaded += 1
-
-    do_include = re.compile(include).search if include else lambda x: True
-    do_exclude = re.compile(exclude).search if exclude else lambda x: False
 
     if not hasattr(package, "__path__"):
         return num_loaded


### PR DESCRIPTION
* Moved the do_include and do_exclude to the top and added a check for
  excludes before importing path.

Signed-off-by: Ryan Blakley <rblakley@redhat.com>

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
There was an issue reported that running insights info was throwing no module pytest. After looking into it I noticed that the default exclude in _load_components wasn't actually getting excluded, so it was trying to load all of the tests.