### PR TITLE
Remove spec ansible_tower_settings

### DIFF
--- a/insights/core/archives.py
+++ b/insights/core/archives.py
@@ -70,7 +70,7 @@ class TarExtractor(object):
             tar_flag = self._tar_flag_for_content_type(self.content_type)
             self.tmp_dir = tempfile.mkdtemp(prefix="insights-", dir=extract_dir)
             self.created_tmp_dir = True
-            command = "tar --delay-directory-restore %s -x --exclude=*/dev/null -f %s -C %s" % (tar_flag, path, self.tmp_dir)
+            command = "tar  %s -x --exclude=*/dev/null -f %s -C %s" % (tar_flag, path, self.tmp_dir)
             logging.debug("Extracting files in '%s'", self.tmp_dir)
             subproc.call(command, timeout=self.timeout)
         return self

--- a/insights/core/archives.py
+++ b/insights/core/archives.py
@@ -70,7 +70,7 @@ class TarExtractor(object):
             tar_flag = self._tar_flag_for_content_type(self.content_type)
             self.tmp_dir = tempfile.mkdtemp(prefix="insights-", dir=extract_dir)
             self.created_tmp_dir = True
-            command = "tar  %s -x --exclude=*/dev/null -f %s -C %s" % (tar_flag, path, self.tmp_dir)
+            command = "tar --delay-directory-restore %s -x --exclude=*/dev/null -f %s -C %s" % (tar_flag, path, self.tmp_dir)
             logging.debug("Extracting files in '%s'", self.tmp_dir)
             subproc.call(command, timeout=self.timeout)
         return self

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -5,7 +5,6 @@ class Specs(SpecSet):
     abrt_ccpp_conf = RegistryPoint(filterable=True)
     abrt_status_bare = RegistryPoint()
     alternatives_display_python = RegistryPoint()
-    ansible_tower_settings = RegistryPoint(filterable=True, multi_output=True)
     amq_broker = RegistryPoint(multi_output=True)
     ansible_host = RegistryPoint()
     auditctl_status = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -84,7 +84,6 @@ class DefaultSpecs(Specs):
     abrt_status_bare = simple_command("/usr/bin/abrt status --bare=True")
     alternatives_display_python = simple_command("/usr/sbin/alternatives --display python")
     amq_broker = glob_file("/var/opt/amq-broker/*/etc/broker.xml")
-    ansible_tower_settings = glob_file(["/etc/tower/settings.py", "/etc/tower/conf.d/*.py"])
     auditctl_status = simple_command("/sbin/auditctl -s")
     auditd_conf = simple_file("/etc/audit/auditd.conf")
     audit_log = simple_file("/var/log/audit/audit.log")


### PR DESCRIPTION
Signed-off-by: jiazhang <jiazhang@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The spec "ansible_tower_settings" has been replaced by "awx_manage_print_settings", currently there is no rule using this spec, remove the spec temporarily, and add it back if there is new rule using it.
