### PR TITLE
Fixed flake8 errors for the newest version of flake8 for the client

### DIFF
--- a/insights/client/apps/ansible/playbook_verifier/__init__.py
+++ b/insights/client/apps/ansible/playbook_verifier/__init__.py
@@ -61,15 +61,15 @@ def createSnippetHash(snippet):
 
 
 def getPublicKey(gpg):
-        if not PUBLIC_KEY_FOLDER:
-            raise PlaybookVerificationError(message="PUBLIC KEY IMPORT ERROR: Public key file not found")
+    if not PUBLIC_KEY_FOLDER:
+        raise PlaybookVerificationError(message="PUBLIC KEY IMPORT ERROR: Public key file not found")
 
-        publicKey = PUBLIC_KEY_FOLDER
-        importResults = gpg.import_keys(publicKey)
-        if (importResults.count < 1):
-            raise PlaybookVerificationError(message="PUBLIC KEY NOT IMPORTED: Public key import failed")
+    publicKey = PUBLIC_KEY_FOLDER
+    importResults = gpg.import_keys(publicKey)
+    if (importResults.count < 1):
+        raise PlaybookVerificationError(message="PUBLIC KEY NOT IMPORTED: Public key import failed")
 
-        return importResults
+    return importResults
 
 
 def excludeDynamicElements(snippet):

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -244,9 +244,8 @@ DEFAULT_OPTS = {
     'module': {
         'default': None,
         'opt': ['--module', '-m'],
-        'help': 'Directly run a Python module within the insights-core package',
-        'action': 'store',
-        'help': argparse.SUPPRESS
+        'help': argparse.SUPPRESS,
+        'action': 'store'
     },
     'obfuscate': {
         # non-CLI

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -379,7 +379,7 @@ class InsightsConnection(object):
                 }
                 test_req = self.post(url, files=test_files)
             elif method == "GET":
-                    test_req = self.get(url)
+                test_req = self.get(url)
             if test_req.status_code in (200, 201, 202):
                 logger.info(
                     "Successfully connected to: %s", url)

--- a/insights/tests/client/collection_rules/test_map_components.py
+++ b/insights/tests/client/collection_rules/test_map_components.py
@@ -25,6 +25,7 @@ def get_uploader_json():
     uploader_json = requests.get(url).json()
     return uploader_json
 
+
 uploader_json = get_uploader_json()
 
 


### PR DESCRIPTION
* Fixed the few flake8 errors thrown by the latest version of flake8 for
  the client only.

Signed-off-by: Ryan Blakley <rblakley@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
This is a continuation of #3222 but for the client side only. Each issue was a simple fix except for the config module, which had duplicate help keys being set. I choose the suppress one based on the comments in #2792, please let me know if this was incorrect.
