### PR TITLE
[3.0] Update requires in core rpm spec for el7

### DIFF
--- a/insights-core.spec
+++ b/insights-core.spec
@@ -12,13 +12,27 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 
 Requires: python3
+Requires: python3-redis
+
+%if 0%{?rhel} == 7
+Requires: python36-CacheControl
+Requires: python36-colorama
+Requires: python36-defusedxml
+Requires: python36-jinja2
+Requires: python36-lockfile
+Requires: python36-PyYAML
+Requires: python36-requests
+Requires: python36-six
+%else
+Requires: python3-CacheControl
 Requires: python3-colorama
 Requires: python3-defusedxml
-Requires: python3-lockfile
 Requires: python3-jinja2
-Requires: python3-redis
+Requires: python3-lockfile
+Requires: python3-pyyaml
 Requires: python3-requests
 Requires: python3-six
+%endif
 
 %description
 Insights Core is a data collection and analysis framework.


### PR DESCRIPTION
* Update the requires entries in the rpm spec file to allow building it
  on el7. Since a lot of the packages start with python36 on el7.
* Added the missing CacheControl and pyyaml requirements.

Signed-off-by: Ryan Blakley <rblakley@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
I added a check for el7 in the rpm spec, so that the requirement package names are correct since for el7 a lot of python3 packages start with python36. Also added in the missing CacheControl and pyyaml requirements.