### PR TITLE
Replace assert with parse exception in netstat parser

### DIFF
--- a/insights/parsers/netstat.py
+++ b/insights/parsers/netstat.py
@@ -272,7 +272,9 @@ class NetstatSection(object):
 
     def __init__(self, name):
         self.name = name.strip()
-        assert self.name in NETSTAT_SECTION_ID
+        if self.name not in NETSTAT_SECTION_ID:
+            raise ParseException("The name '{name}' isn't a valid name.".format(name=self.name))
+
         self.meta = NETSTAT_SECTION_ID[self.name]
         self.data = {}
         for m in self.meta:


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
The netstat parser previously used an assert to make sure self.name was in the NETSTAT_SECTION_ID dictionary. Instead use an if statement and raise a parser exception if not met.