### PR TITLE
Fix: RHICOMPL-1980 Adding the 'relationships' API attribute to the client profiles API call

### DIFF
--- a/insights/client/apps/compliance/__init__.py
+++ b/insights/client/apps/compliance/__init__.py
@@ -93,7 +93,7 @@ class ComplianceClient:
 
     def get_profiles(self, search):
         response = self.conn.session.get("https://{0}/compliance/profiles".format(self.config.base_url),
-                                         params={'search': search})
+                                         params={'search': search, 'relationships': 'false'})
         logger.debug("Content of the response: {0} - {1}".format(response,
                                                                  response.json()))
         if response.status_code == 200:

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -101,7 +101,7 @@ def test_get_profiles(config):
     compliance_client.inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
     assert compliance_client.get_profiles('search string') == [{'attributes': 'data'}]
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'search string'})
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'search string', 'relationships': 'false'})
 
 
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
@@ -110,7 +110,7 @@ def test_get_profiles_no_profiles(config):
     compliance_client.inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': []})))
     assert compliance_client.get_profiles('search string') == []
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'search string'})
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'search string', 'relationships': 'false'})
 
 
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
@@ -119,7 +119,7 @@ def test_get_profiles_error(config):
     compliance_client.inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=500))
     assert compliance_client.get_profiles('search string') == []
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'search string'})
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'search string', 'relationships': 'false'})
 
 
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
@@ -128,7 +128,7 @@ def test_get_initial_profiles(config):
     compliance_client.inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
     assert compliance_client.get_initial_profiles() == [{'attributes': 'data'}]
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_ids=068040f1-08c8-43e4-949f-7d6470e9111c canonical=false external=false'})
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_ids=068040f1-08c8-43e4-949f-7d6470e9111c canonical=false external=false', 'relationships': 'false'})
 
 
 @patch("insights.client.apps.compliance.os_release_info", return_value=(None, '6.5'))
@@ -138,7 +138,7 @@ def test_get_profiles_matching_os(config, os_release_info_mock):
     compliance_client.inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
     assert compliance_client.get_profiles_matching_os() == [{'attributes': 'data'}]
-    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_ids=068040f1-08c8-43e4-949f-7d6470e9111c canonical=false os_minor_version=5'})
+    compliance_client.conn.session.get.assert_called_with('https://localhost/app/compliance/profiles', params={'search': 'system_ids=068040f1-08c8-43e4-949f-7d6470e9111c canonical=false os_minor_version=5', 'relationships': 'false'})
 
 
 @patch("insights.client.apps.compliance.os_release_info", return_value=(None, '6.5'))


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Using the relationships=false API attribute during the client call to get the assigned host policies. The purpose of this update is so that unnecessary relationships are not requested in the client profiles API call.

This PR is a draft because the new 'relationships' parameter still needs to be added to the API before we can use it. Will take this ticket out of draft when this functionality has been added to the API. That work is here: https://github.com/RedHatInsights/compliance-backend/pull/1023
