### PR TITLE
Add Spec path of chronyc_sources for sos_archive

### DIFF
--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -31,6 +31,7 @@ class SosSpecs(Specs):
     ceph_health_detail = simple_file("sos_commands/ceph/ceph_health_detail_--format_json-pretty")
     checkin_conf = simple_file("/etc/splice/checkin.conf")
     chkconfig = first_file(["sos_commands/startup/chkconfig_--list", "sos_commands/services/chkconfig_--list"])
+    chronyc_sources = simple_file("sos_commands/chrony/chronyc_-n_sources")
     cib_xml = first_of(
         [
             simple_file("/var/lib/pacemaker/cib/cib.xml"),


### PR DESCRIPTION
Signed-off-by: Rohan Arora <roarora@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Though sos report runs the sources command with "-n" switch, the output works fine with existing parser in core.
~~~
➜  sosreport-test1-2021-04-22-qtdzftt ls -lrt sos_commands/chrony 
total 32
-rw-r--r--. 1 roarora roarora 1122 Apr 22 11:20 journalctl_--no-pager_--unit_chronyd
-rw-r--r--. 1 roarora roarora  465 Apr 22 11:20 chronyc_tracking
-rw-r--r--. 1 roarora roarora  500 Apr 22 11:20 chronyc_sourcestats
-rw-r--r--. 1 roarora roarora  159 Apr 22 11:20 chronyc_serverstats
-rw-r--r--. 1 roarora roarora 3121 Apr 22 11:20 chronyc_ntpdata
-rw-r--r--. 1 roarora roarora  506 Apr 22 11:20 chronyc_-n_sources
-rw-r--r--. 1 roarora roarora  207 Apr 22 11:20 chronyc_-n_clients
-rw-r--r--. 1 roarora roarora  156 Apr 22 11:20 chronyc_activity
~~~