### PR TITLE
Update _load_component's default exclude

### DIFF
--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -393,7 +393,7 @@ def _import(path, continue_on_error):
             raise
 
 
-def _load_components(path, include=".*", exclude="test", continue_on_error=True):
+def _load_components(path, include=".*", exclude="insights\\..+\\.tests", continue_on_error=True):
     do_include = re.compile(include).search if include else lambda x: True
     do_exclude = re.compile(exclude).search if exclude else lambda x: False
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
Since all of the paths and names that are processed by _load_components, set the default exclude to insights.*.tests. That way it only exlcudes insights core test files, and not every file that has test in it's name.

Fixes #3250