### PR TITLE
Update the default exclude in load_components

### DIFF
--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -393,7 +393,7 @@ def _import(path, continue_on_error):
             raise
 
 
-def _load_components(path, include=".*", exclude="insights\\..+\\.tests", continue_on_error=True):
+def _load_components(path, include=".*", exclude="\\.tests", continue_on_error=True):
     do_include = re.compile(include).search if include else lambda x: True
     do_exclude = re.compile(exclude).search if exclude else lambda x: False
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
The default exclude was updated to only exclude insights core tests directories, but this causes other tools tests directories that use core to not be excluded. So change the default to exclude any tests directories.
