### PR TITLE
Fix: Remove old grub specs from client tests

### DIFF
--- a/insights/client/map_components.py
+++ b/insights/client/map_components.py
@@ -127,8 +127,6 @@ def _get_component_by_symbolic_name(sname):
         'machine_id1': 'machine_id',
         'machine_id2': 'machine_id',
         'machine_id3': 'machine_id',
-        'grub2_efi_grubenv': None,
-        'grub2_grubenv': None,
         'limits_d': 'limits_conf',
         'modprobe_conf': 'modprobe',
         'modprobe_d': 'modprobe',

--- a/insights/tests/client/collection_rules/test_map_components.py
+++ b/insights/tests/client/collection_rules/test_map_components.py
@@ -115,9 +115,7 @@ def test_map_rm_conf_to_components_sym_names():
         # files should be empty, components should have 1 item
         # except for these which cannot be mapped to specs.
         # in which case, components empty and these remain in files
-        if sym_name in ['grub2_efi_grubenv',
-                        'grub2_grubenv',
-                        'redhat_access_proactive_log']:
+        if sym_name == 'redhat_access_proactive_log':
             assert len(new_rm_conf['files']) == 1
             assert new_rm_conf['files'][0] == sym_name
             assert len(new_rm_conf['components']) == 0
@@ -169,9 +167,7 @@ def test_map_rm_conf_to_components_raw_cmds_files():
         # files should be empty, components should have 1 item
         # except for these which cannot be mapped to specs.
         # in which case, components empty and these remain in files
-        if fil['file'] in ['/boot/efi/EFI/redhat/grubenv',
-                           '/boot/grub2/grubenv',
-                           '/var/log/redhat_access_proactive/redhat_access_proactive.log']:
+        if fil['file'] == '/var/log/redhat_access_proactive/redhat_access_proactive.log':
             assert len(new_rm_conf['files']) == 1
             assert new_rm_conf['files'][0] == fil['file']
             assert len(new_rm_conf['components']) == 0


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
* These specs have been removed from the JSON and are no longer valid
  for use in the client tests

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>