### PR TITLE
New specs and parsers for analyzing 389-ds TLS-related settings.

### DIFF
--- a/docs/shared_parsers_catalog/dse_ldif_simple.rst
+++ b/docs/shared_parsers_catalog/dse_ldif_simple.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.dse_ldif_simple
+   :members:
+   :show-inheritance:

--- a/insights/parsers/dse_ldif_simple.py
+++ b/insights/parsers/dse_ldif_simple.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""
+DseLdifSimple - file ``/etc/dirsrv/*/dse.ldif``
+===============================================
+"""
+
+
+from insights import Parser, parser
+from insights.specs import Specs
+
+
+@parser(Specs.dse_ldif)
+class DseLdifSimple(Parser, dict):
+    """
+    Parse the attributes out of the filtered lines of the dse.ldif file into
+    dict[attribute name] = attribute value.
+
+    Please note the difference between the LDIF format and this parser.
+
+    The file dse.ldif is in the LDIF format (see ``man 5 ldif``). LDIF contains
+    multi-row records where each record is identified by a ``dn:`` line ("dn"
+    as in "distinguished name") and the record's other lines are attributes.
+    Attributes may also have base64-encoded values, multiline values, and
+    file-stored values.
+
+    The parser processes lines independently without tracking what the line is
+    and which record it belongs to. Only plaintext single-line values are
+    supported.
+
+    This allows for filterable, efficient, and privacy-preserving processing of
+    attributes whose names are valid only in a single distinguished name, and
+    whose values are single-line plaintext only.
+
+    Sample input data::
+
+        dn: cn=config
+        nsslapd-securePort: 636
+        nsslapd-security: on
+
+        dn: cn=encryption,cn=config
+        sslVersionMin: SSLv3
+        sslVersionMax: TLS1.1
+        nsSSL3: on
+
+    Examples:
+        >>> type(dse_ldif_simple)
+        <class 'insights.parsers.dse_ldif_simple.DseLdifSimple'>
+        >>> dse_ldif_simple["nsslapd-security"]
+        'on'
+        >>> "sslVersionMin" in dse_ldif_simple
+        True
+        >>> dict(dse_ldif_simple)["nsSSL3"]
+        'on'
+
+    """
+
+    def parse_content(self, content):
+        data = {}
+        for line in content:
+            if line.startswith("#"):
+                # lines beginning with # are ignored
+                continue
+            if ":" not in line:
+                # only attribute: value lines supported
+                continue
+            if line.startswith(" "):
+                # multi-line values not supported
+                continue
+            attr_name, attr_value = line.split(":", 1)
+            if attr_value.startswith(":"):
+                # base64-encrypted values not supported
+                continue
+            if attr_value.startswith("<"):
+                # file-backed values not supported
+                continue
+
+            # Whitespace at either side of the value has no effect.
+            attr_value = attr_value.strip()
+
+            # If the same attribute is declared multiple times, the first
+            # instance takes into effect, the rest is ignored by the 386
+            # Directory Server.
+            if attr_name not in data:
+                data[attr_name] = attr_value
+        self.update(data)

--- a/insights/parsers/tests/test_dse_ldif_simple.py
+++ b/insights/parsers/tests/test_dse_ldif_simple.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+
+import doctest
+
+from insights import add_filter
+from insights.parsers import dse_ldif_simple
+from insights.parsers.dse_ldif_simple import DseLdifSimple
+from insights.specs import Specs
+from insights.tests import context_wrap
+
+add_filter(
+    Specs.dse_ldif, [
+        "nsslapd-security",
+        "sslVersionMin",
+        "sslVersionMax",
+        "nsSSL3",
+        "cn: config",  # Note that this can serve as a canary for knowing whether the spec is collected.
+    ]
+)
+
+DSE_LDIF_REAL_EXAMPLE = """
+
+dn: cn=config
+cn: config
+objectClass: top
+objectClass: extensibleObject
+objectClass: nsslapdConfig
+nsslapd-schemadir: /etc/dirsrv/slapd-dir/schema
+nsslapd-lockdir: /var/lock/dirsrv/slapd-dir
+nsslapd-tmpdir: /tmp
+nsslapd-certdir: /etc/dirsrv/slapd-dir
+nsslapd-ldifdir: /var/lib/dirsrv/slapd-dir/ldif
+nsslapd-bakdir: /var/lib/dirsrv/slapd-dir/bak
+nsslapd-rundir: /var/run/dirsrv
+nsslapd-instancedir: /usr/lib64/dirsrv/slapd-dir
+nsslapd-accesslog: /var/log/dirsrv/slapd-dir/access
+nsslapd-localhost: testinstance.local
+nsslapd-port: 389
+nsslapd-localuser: dirsrv
+nsslapd-errorlog: /var/log/dirsrv/slapd-dir/errors
+nsslapd-auditlog: /var/log/dirsrv/slapd-dir/audit
+nsslapd-auditfaillog: /var/log/dirsrv/slapd-dir/audit
+nsslapd-rootdn: cn=Directory Manager
+nsslapd-ldapifilepath: /var/run/slapd-dir.socket
+nsslapd-ldapilisten: off
+nsslapd-ldapiautobind: off
+nsslapd-ldapimaprootdn: cn=Directory Manager
+nsslapd-ldapimaptoentries: off
+nsslapd-ldapiuidnumbertype: uidNumber
+nsslapd-ldapigidnumbertype: gidNumber
+nsslapd-ldapientrysearchbase: dc=testinstance,dc=local
+nsslapd-defaultnamingcontext: dc=testinstance,dc=local
+aci: (targetattr="*")(version 3.0; acl "Configuration Administrators Group"; a
+ llow (all) groupdn="ldap:///cn=Configuration Administrators,ou=Groups,ou=Topo
+ logyManagement,o=NetscapeRoot";)
+aci: (targetattr="*")(version 3.0; acl "Configuration Administrator"; allow (a
+ ll) userdn="ldap:///uid=admin,ou=Administrators,ou=TopologyManagement,o=Netsc
+ apeRoot";)
+aci: (targetattr = "*")(version 3.0; acl "SIE Group"; allow (all) groupdn = "l
+ dap:///cn=slapd-dir,cn=Red Hat Directory Server,cn=Server Group,cn=testinstan
+ ce.local,ou=testinstance.local,o=NetscapeRoot";)
+modifiersName: cn=directory manager
+modifyTimestamp: 20211015231914Z
+nsslapd-securePort: 636
+nsslapd-security: on
+nsslapd-rootpw: {SSHA512}la6KbVGTR3XKHN6CoZ/PcYvOrS7qGAVSC9kjvGtyuPzSJGbHXReTs
+ FUBF6QnP0jHAONEx4784x6PNPcMzTOdpoJw0gOQkXKM
+numSubordinates: 10
+
+
+dn: cn=monitor
+objectClass: top
+objectClass: extensibleObject
+cn: monitor
+aci: (target ="ldap:///cn=monitor*")(targetattr != "aci || connection")(versio
+ n 3.0; acl "monitor"; allow( read, search, compare ) userdn = "ldap:///anyone
+ ";)
+creatorsName: cn=server,cn=plugins,cn=config
+modifiersName: cn=server,cn=plugins,cn=config
+createTimestamp: 20211015215626Z
+modifyTimestamp: 20211015215626Z
+numSubordinates: 3
+
+dn: cn=encryption,cn=config
+objectClass: top
+objectClass: nsEncryptionConfig
+cn: encryption
+nsSSLSessionTimeout: 0
+nsSSLClientAuth: allowed
+sslVersionMin: TLS1.0
+sslVersionMax: TLS1.1
+nsSSL3: on
+nsTLS1: on
+allowWeakCipher: on
+nsSSL3Ciphers: +all
+creatorsName: cn=server,cn=plugins,cn=config
+modifiersName: cn=server,cn=plugins,cn=config
+createTimestamp: 20211015215626Z
+modifyTimestamp: 20211015231142Z
+CACertExtractFile: /etc/dirsrv/slapd-dir/server-cert.pem
+numSubordinates: 1
+
+dn: cn=features,cn=config
+objectClass: top
+objectClass: nsContainer
+cn: features
+numSubordinates: 5
+
+"""
+
+DSE_LDIF_SMOKE = """
+cn: config
+nsslapd-security: on
+sslVersionMin: TLS1.0
+sslVersionMax: TLS1.1
+nsSSL3: on
+# a comment : with a colon
+"""
+
+# This is purely for coverage testing. Real deployments don't use these features
+# for these attributes.
+DSE_LDIF_COVERAGE = """
+# a comment
+nsslapd-security: o
+ n
+sslVersionMax:: VExTMS4yIA==
+sslVersionMin:< file:///tmp/somefile
+nsSSL3: on
+"""
+
+DSE_LDIF_DOCTEST = """
+dn: cn=config
+nsslapd-securePort: 636
+nsslapd-security: on
+
+dn: cn=encryption,cn=config
+sslVersionMin: SSLv3
+sslVersionMax: TLS1.1
+nsSSL3: on
+"""
+
+
+def test_dse_ldif_smoke():
+    dse_ldif_simple = DseLdifSimple(context_wrap(DSE_LDIF_SMOKE))
+    assert None is dse_ldif_simple.get("asdf")
+    assert len(dse_ldif_simple) == 5
+    expected = {
+        "cn": "config",  # just a canary to detect spec collection status
+        "nsslapd-security": "on",
+        "sslVersionMin": "TLS1.0",
+        "sslVersionMax": "TLS1.1",
+        "nsSSL3": "on",
+    }
+    assert dict(dse_ldif_simple) == expected
+    assert dse_ldif_simple["nsslapd-security"] == "on"
+    assert "sslVersionMin" in dse_ldif_simple
+    for k in dse_ldif_simple:
+        assert expected[k] == dse_ldif_simple[k]
+        assert expected[k] == dse_ldif_simple.get(k)
+
+
+def test_dse_ldif_coverage():
+    dse_ldif_simple = DseLdifSimple(context_wrap(DSE_LDIF_COVERAGE))
+    assert "sslVersionMin" not in dse_ldif_simple
+    assert "sslVersionMax" not in dse_ldif_simple
+    assert "nsSSL3" in dse_ldif_simple
+    assert len(dse_ldif_simple) == 2
+    expected = {
+        "nsSSL3": "on",
+        # This doesn't happen in real deployments because 389-ds automatically
+        # reformats it back to a single line.
+        "nsslapd-security": "o",
+    }
+    assert dict(dse_ldif_simple) == expected
+
+
+def test_dse_ldif_filtered():
+    dse_ldif_simple = DseLdifSimple(context_wrap(DSE_LDIF_REAL_EXAMPLE, filtered_spec=Specs.dse_ldif))
+    assert dse_ldif_simple["nsslapd-security"] == "on"
+    assert len(dse_ldif_simple) == 6
+    expected = {
+        "cn": "config",  # just a canary to detect spec collection status
+        "nsslapd-security": "on",
+        "sslVersionMin": "TLS1.0",
+        "sslVersionMax": "TLS1.1",
+        "nsSSL3": "on",
+        "nsSSL3Ciphers": "+all",
+    }
+    assert dict(dse_ldif_simple) == expected
+
+
+def test_doc_examples():
+    env = {
+        "dse_ldif_simple": DseLdifSimple(context_wrap(DSE_LDIF_DOCTEST)),
+    }
+    failed, total = doctest.testmod(dse_ldif_simple, globs=env)
+    assert failed == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -139,6 +139,7 @@ class Specs(SpecSet):
     dotnet_version = RegistryPoint()
     doveconf = RegistryPoint(filterable=True)
     dracut_kdump_capture_service = RegistryPoint()
+    dse_ldif = RegistryPoint(multi_output=True, filterable=True)
     du_dirs = RegistryPoint(multi_output=True)
     dumpe2fs_h = RegistryPoint(multi_output=True)
     engine_config_all = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -82,6 +82,7 @@ class DefaultSpecs(Specs):
     abrt_status_bare = simple_command("/usr/bin/abrt status --bare=True")
     alternatives_display_python = simple_command("/usr/sbin/alternatives --display python")
     amq_broker = glob_file("/var/opt/amq-broker/*/etc/broker.xml")
+    dse_ldif = glob_file("/etc/dirsrv/*/dse.ldif")
     auditctl_status = simple_command("/sbin/auditctl -s")
     auditd_conf = simple_file("/etc/audit/auditd.conf")
     audit_log = simple_file("/var/log/audit/audit.log")


### PR DESCRIPTION
Signed-off-by: Jakub Svoboda <jsvoboda@redhat.com>

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Red Hat Directory Server and Red Hat Identity Management use 389-ds (389 Directory Server) for LDAP. To analyze current SSL&TLS settings on RHEL7, it is necessary to read up to four configuration directives from `dse.ldif` files and from the `nss-rhel7.config` file. To analyze current TLS settings on RHEL8, it is necessary to read the same `dse.ldif` files and `crypto-policies` configuration. This PR adds one of the two specs and parsers that are not provided yet by insights-core to achieve that goal – for `dse.ldif`
