### PR TITLE
Feat: Add spec filtering to context_wrap for unit tests

### DIFF
--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -152,12 +152,16 @@ def context_wrap(lines,
                  machine_id="machine_id",
                  strip=True,
                  split=True,
+                 filtered_spec=None,
                  **kwargs):
     if isinstance(lines, six.string_types):
         if strip:
             lines = lines.strip()
         if split:
             lines = lines.splitlines()
+
+    if filtered_spec is not None and filtered_spec in filters.FILTERS:
+        lines = [l for l in lines if any([f in l for f in filters.FILTERS[filtered_spec]])]
 
     return Context(content=lines,
                    path=path, hostname=hostname,

--- a/insights/tests/test_context_wrap.py
+++ b/insights/tests/test_context_wrap.py
@@ -1,0 +1,32 @@
+from insights.core.filters import add_filter
+from insights.specs import Specs
+from insights.tests import context_wrap, DEFAULT_RELEASE, DEFAULT_HOSTNAME
+
+DATA = """
+One
+Two
+Three
+Four
+"""
+DATA_FILTERED = """
+Two
+Four
+"""
+
+add_filter(Specs.messages, ["Two", "Four", "Five"])
+
+
+def test_context_wrap_unfiltered():
+    context = context_wrap(DATA)
+    assert context is not None
+    assert context.content == DATA.strip().splitlines()
+    assert context.release == DEFAULT_RELEASE
+    assert context.hostname == DEFAULT_HOSTNAME
+    assert context.version == ["-1", "-1"]
+    assert context.machine_id == "machine_id"
+
+
+def test_context_wrap_filtered():
+    context = context_wrap(DATA, filtered_spec=Specs.messages)
+    assert context is not None
+    assert context.content == DATA_FILTERED.strip().splitlines()


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:
* Add capability to pass in a filter and automatically filter the data
  before building the Context object
* This enables parser/combiner CI testing using filters

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>