### PR TITLE
Spec & parser for nss-rhel7.config

### DIFF
--- a/docs/shared_parsers_catalog/nss_rhel7.rst
+++ b/docs/shared_parsers_catalog/nss_rhel7.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.nss_rhel7
+   :members:
+   :show-inheritance:

--- a/insights/parsers/nss_rhel7.py
+++ b/insights/parsers/nss_rhel7.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+NssRhel7 - file ``/etc/pki/nss-legacy/nss-rhel7.config``
+========================================================
+"""
+
+from insights import parser, SysconfigOptions
+from insights.specs import Specs
+
+
+@parser(Specs.nss_rhel7)
+class NssRhel7(SysconfigOptions):
+    """
+    This parser reads the ``/etc/pki/nss-legacy/nss-rhel7.config``
+    file. It uses the ``SysconfigOptions`` parser class to convert the file into
+    a dictionary of options. It also provides the ``config`` property as a helper
+    to retrieve the ``config`` variable.
+
+    Attributes:
+        config (union[str, None]): The value of the ``config`` variable if it exists, else None.
+
+    Sample Input::
+
+        # To re-enable legacy algorithms, edit this file
+        # Note that the last empty line in this file must be preserved
+        library=
+        name=Policy
+        NSS=flags=policyOnly,moduleDB
+        config="disallow=MD5:RC4 allow=DH-MIN=1023:DSA-MIN=1023:RSA-MIN=1023:TLS-VERSION-MIN=tls1.0"
+
+
+    Examples:
+        >>> 'config' in nss_rhel7
+        True
+        >>> nss_rhel7.config
+        'disallow=MD5:RC4 allow=DH-MIN=1023:DSA-MIN=1023:RSA-MIN=1023:TLS-VERSION-MIN=tls1.0'
+    """
+
+    @property
+    def config(self):
+        return self.data.get("config", None)

--- a/insights/parsers/tests/test_nss_rhel7.py
+++ b/insights/parsers/tests/test_nss_rhel7.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+import doctest
+
+from insights.parsers import nss_rhel7
+from insights.parsers.nss_rhel7 import NssRhel7
+from insights.tests import context_wrap
+
+NSS_RHEL7 = """
+# To re-enable legacy algorithms, edit this file
+# Note that the last empty line in this file must be preserved
+library=
+name=Policy
+NSS=flags=policyOnly,moduleDB
+config="disallow=MD5:RC4 allow=DH-MIN=1023:DSA-MIN=1023:RSA-MIN=1023:TLS-VERSION-MIN=tls1.0"
+"""
+
+
+def test_nss_rhel7():
+    nss_rhel7 = NssRhel7(context_wrap(NSS_RHEL7))
+    assert "config" in nss_rhel7
+    assert "asdf" not in nss_rhel7
+    assert (
+        nss_rhel7.config == "disallow=MD5:RC4 allow=DH-MIN=1023:DSA-MIN=1023:RSA-MIN=1023:TLS-VERSION-MIN=tls1.0"
+    )
+    assert (
+        nss_rhel7["config"] == "disallow=MD5:RC4 allow=DH-MIN=1023:DSA-MIN=1023:RSA-MIN=1023:TLS-VERSION-MIN=tls1.0"
+    )
+    assert (
+        nss_rhel7.get("config") == "disallow=MD5:RC4 allow=DH-MIN=1023:DSA-MIN=1023:RSA-MIN=1023:TLS-VERSION-MIN=tls1.0"
+    )
+    assert nss_rhel7.get("asdf") is None
+
+
+def test_doc_examples():
+    env = {
+        "nss_rhel7": NssRhel7(context_wrap(NSS_RHEL7)),
+    }
+    failed, total = doctest.testmod(nss_rhel7, globs=env)
+    assert failed == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -422,6 +422,7 @@ class Specs(SpecSet):
     nova_uid = RegistryPoint()
     nova_migration_uid = RegistryPoint()
     nscd_conf = RegistryPoint(filterable=True)
+    nss_rhel7 = RegistryPoint()
     nsswitch_conf = RegistryPoint(filterable=True)
     ntp_conf = RegistryPoint()
     ntpq_leap = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -481,6 +481,7 @@ class DefaultSpecs(Specs):
     nova_crontab = simple_command("/usr/bin/crontab -l -u nova")
     nova_uid = simple_command("/usr/bin/id -u nova")
     nscd_conf = simple_file("/etc/nscd.conf")
+    nss_rhel7 = simple_file("/etc/pki/nss-legacy/nss-rhel7.config")
     nsswitch_conf = simple_file("/etc/nsswitch.conf")
     ntp_conf = simple_file("/etc/ntp.conf")
     ntpq_leap = simple_command("/usr/sbin/ntpq -c 'rv 0 leap'")


### PR DESCRIPTION
Signed-off-by: Jakub Svoboda <jsvoboda@redhat.com>

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Red Hat Directory Server and Red Hat Identity Management use 389-ds (389 Directory Server) for LDAP. To analyze current SSL&TLS settings on RHEL7, it is necessary to read up to four configuration directives from `dse.ldif` files and from the `nss-rhel7.config` file. To analyze current TLS settings on RHEL8, it is necessary to read the same `dse.ldif` files and `crypto-policies` configuration. This PR adds one of the two specs and parsers that are not provided yet by insights-core to achieve that goal – for `nss-rhel7.config`
