### PR TITLE
Strip progress messages from testparm output

### DIFF
--- a/insights/parsers/samba.py
+++ b/insights/parsers/samba.py
@@ -135,6 +135,10 @@ class SambaConfigs(SambaConfig):
         server_role (string): Server role as reported by the command.
     """
     def parse_content(self, content):
+        # The output of `testparm` sometimes includes progress lines such as
+        # `Processing section "[homes]"`, so those should be removed.
+        content = [line for line in content if not line.startswith("Processing section")]
+
         # Parse server role
         for line in content:
             r = re.search(r"Server role:\s+(\S+)", line)

--- a/insights/parsers/samba.py
+++ b/insights/parsers/samba.py
@@ -135,20 +135,22 @@ class SambaConfigs(SambaConfig):
         server_role (string): Server role as reported by the command.
     """
     def parse_content(self, content):
-        # The output of `testparm` sometimes includes progress lines such as
-        # `Processing section "[homes]"`, so those should be removed.
-        content = [line for line in content if not line.startswith("Processing section")]
-
         # Parse server role
-        for line in content:
+        # The output of `testparm` sometimes includes progress lines such as
+        # `Processing section "[homes]"`. These lines are output before the server
+        # role definition, so only pass output from that line onward.
+        server_role_line = None
+        for i, line in enumerate(content):
             r = re.search(r"Server role:\s+(\S+)", line)
             if r:
                 self.server_role = r.group(1)
+                server_role_line = i
                 break
-        else:
+
+        if server_role_line is None:
             raise ParseException("Server role not found.")
 
-        super(SambaConfigs, self).parse_content(content)
+        super(SambaConfigs, self).parse_content(content[server_role_line:])
 
 
 @parser(Specs.testparm_v_s)

--- a/insights/parsers/tests/test_samba.py
+++ b/insights/parsers/tests/test_samba.py
@@ -197,8 +197,12 @@ this another option should also be in global = 1
 #
 # Load smb config files from /etc/samba/smb.conf
 # Loaded services file OK.
+# Because status messages include section names, they aren't
+# removed by filtering.
 
 TESTPARM = """
+Processing section "[homes]"
+Processing section "[printers]"
 Server role: ROLE_STANDALONE
 
 # Global parameters


### PR DESCRIPTION
On some older releases of Samba, testparm -v -s contains progress
messages such as `Processing section "[homes]"`. Because these
messages contain section names, they aren't removed by filtering.
This change removes them in the testparm parser.

Signed-off-by: Keith Grant <kgrant@redhat.com>

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Some older versions of Samba contain messages in the output of `testparm` that cause exceptions in the testparm parsers. This change removes those lines in the parser.
