### PR TITLE
Fix: Add raise SkipException to ConfigCombiner for missing main_file

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -129,12 +129,6 @@ def default_parser_deserializer(_type, data):
     return obj
 
 
-def find_main(confs, name):
-    for c in confs:
-        if c.file_name == name:
-            return c
-
-
 def flatten(docs, pred):
     """
     Replace include nodes with their config trees.  Allows the same files to be
@@ -370,7 +364,7 @@ class ConfigCombiner(ConfigComponent):
     """
     def __init__(self, confs, main_file, include_finder):
         self.confs = confs
-        self.main = find_main(confs, main_file)
+        self.main = self.find_main(main_file)
         server_root = self.conf_path
 
         # Set the children of all include directives to the contents of the
@@ -390,6 +384,13 @@ class ConfigCombiner(ConfigComponent):
     def find_matches(self, confs, pattern):
         results = [c for c in confs if fnmatch(c.file_path, pattern)]
         return sorted(results, key=operator.attrgetter("file_name"))
+
+    def find_main(self, name):
+        for c in self.confs:
+            if c.file_name == name:
+                return c
+
+        raise SkipException("The main conf {main_conf} doesn't exist.".format(main_conf=name))
 
 
 class LegacyItemAccess(object):


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
Moved find_main into the ConfigCombiner class since it's not used anywhere else, and find_matches is already in the class. Added a raise SkipException to find_main, so if no files are returned in the loop it doesn't return None.

Fixes #3276