### PR TITLE
Refactor: read metrics from config.ros for pmlog_summary

### DIFF
--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -51,6 +51,14 @@ insights.specs.datasources.package_provides
     :show-inheritance:
     :undoc-members:
 
+insights.specs.datasources.pcp
+------------------------------
+
+.. automodule:: insights.specs.datasources.pcp
+    :members: pcp_enabled, pmlog_summary_file, pmlog_summary_metrics
+    :show-inheritance:
+    :undoc-members:
+
 insights.specs.datasources.ps
 -----------------------------
 

--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -55,7 +55,7 @@ insights.specs.datasources.pcp
 ------------------------------
 
 .. automodule:: insights.specs.datasources.pcp
-    :members: pcp_enabled, pmlog_summary_file, pmlog_summary_metrics
+    :members: pcp_enabled, pmlog_summary_args
     :show-inheritance:
     :undoc-members:
 

--- a/insights/collect.py
+++ b/insights/collect.py
@@ -219,6 +219,10 @@ plugins:
         - name: insights.components.rhel_version.IsRhel8
           enabled: true
 
+    # needed for the 'pmlog_summary' spec
+        - name: insights.parsers.ros_config.RosConfig
+          enabled: true
+
     # needed because some specs aren't given names before they're used in DefaultSpecs
         - name: insights.core.spec_factory
           enabled: true

--- a/insights/specs/datasources/pcp.py
+++ b/insights/specs/datasources/pcp.py
@@ -64,7 +64,8 @@ def pmlog_summary_metrics(broker):
     for the pmlogger summary file.
 
     Returns:
-        str: Full path to the latest pmlogger file
+        str: All the metrics specified in the "mandatory on" section in the
+        `config.ros` file, separated with a blank space.
 
     Raises:
         SkipComponent: When no metrics get from the RosConfig

--- a/insights/specs/datasources/pcp.py
+++ b/insights/specs/datasources/pcp.py
@@ -29,55 +29,40 @@ def pcp_enabled(broker):
     return True
 
 
-@datasource(Ps, HostContext)
-def pmlog_summary_file(broker):
+@datasource(Ps, RosConfig, HostContext)
+def pmlog_summary_args(broker):
     """
-    Determines the name for the pmlogger file and checks for its existence
-
-    Returns the name of the latest pmlogger summary file if a running ``pmlogger``
-    process is detected on the system.
+    Determines the pmlogger file and the metrics to collect via `pmlog_summary`
 
     Returns:
-        str: Full path to the latest pmlogger file
+        str: Full arguments string that pass to the `pmlog_summary`
 
     Raises:
-        SkipComponent: Raises this exception when the command is not present or
-            the file is not present
+        SkipComponent: Raises when meeting one of the following scenario:
+                       - No pmlogger process is running
+                       - No pmloger file
+                       - No "mandatory on" metrics in `config.ros`
     """
     ps = broker[Ps]
+
     if ps.search(COMMAND_NAME__contains='pmlogger'):
         pcp_log_date = (datetime.date.today() - datetime.timedelta(days=1)).strftime("%Y%m%d")
-        file = "/var/log/pcp/pmlogger/ros/%s.index" % (pcp_log_date)
+        pm_file = "/var/log/pcp/pmlogger/ros/%s.index" % (pcp_log_date)
         try:
-            if os.path.exists(file) and os.path.isfile(file):
-                return file
+            if not (os.path.exists(pm_file) and os.path.isfile(pm_file)):
+                raise SkipComponent("No such file: {0}".format(pm_file))
         except Exception as e:
-            SkipComponent("Failed to check for pmlogger file existence: {0}".format(str(e)))
+            raise SkipComponent("Failed to check for pmlogger file existence: {0}".format(str(e)))
 
-    raise SkipComponent
+        metrics = set()
+        ros = broker[RosConfig]
+        for spec in ros.specs:
+            if spec.get('state') == 'mandatory on':
+                metrics.update(spec.get('metrics').keys())
 
+        if not metrics:
+            raise SkipComponent("No 'mandatory on' metrics in config.ros")
 
-@datasource(RosConfig, HostContext)
-def pmlog_summary_metrics(broker):
-    """
-    Returns the metrics specified as "mandatory on" in the `config.ros` file
-    for the pmlogger summary file.
-
-    Returns:
-        str: All the metrics specified in the "mandatory on" section in the
-        `config.ros` file, separated with a blank space.
-
-    Raises:
-        SkipComponent: When no metrics get from the RosConfig
-    """
-    ros = broker[RosConfig]
-    metrics = set()
-
-    for spec in ros.specs:
-        if spec.get('state') == 'mandatory on':
-            metrics.update(spec.get('metrics').keys())
-
-    if metrics:
-        return ' '.join(sorted(metrics))
+        return "{0} {1}".format(pm_file, ' '.join(sorted(metrics)))
 
     raise SkipComponent

--- a/insights/specs/datasources/pcp.py
+++ b/insights/specs/datasources/pcp.py
@@ -1,0 +1,82 @@
+"""
+Custom datasource related PCP (Performance Co-Pilot)
+"""
+import logging
+import datetime
+import os
+
+from insights.core.dr import SkipComponent
+from insights.core.context import HostContext
+from insights.core.plugins import datasource
+from insights.parsers.ros_config import RosConfig
+from insights.combiners.ps import Ps
+from insights.combiners.services import Services
+
+logger = logging.getLogger(__name__)
+
+
+@datasource(Services, HostContext)
+def pcp_enabled(broker):
+    """
+    Returns:
+        bool: True if pmproxy service is on in services
+
+    Raises:
+        SkipComponent: When pmproxy service is not enabled
+    """
+    if not broker[Services].is_on("pmproxy"):
+        raise SkipComponent("pmproxy not enabled")
+    return True
+
+
+@datasource(Ps, HostContext)
+def pmlog_summary_file(broker):
+    """
+    Determines the name for the pmlogger file and checks for its existence
+
+    Returns the name of the latest pmlogger summary file if a running ``pmlogger``
+    process is detected on the system.
+
+    Returns:
+        str: Full path to the latest pmlogger file
+
+    Raises:
+        SkipComponent: Raises this exception when the command is not present or
+            the file is not present
+    """
+    ps = broker[Ps]
+    if ps.search(COMMAND_NAME__contains='pmlogger'):
+        pcp_log_date = (datetime.date.today() - datetime.timedelta(days=1)).strftime("%Y%m%d")
+        file = "/var/log/pcp/pmlogger/ros/%s.index" % (pcp_log_date)
+        try:
+            if os.path.exists(file) and os.path.isfile(file):
+                return file
+        except Exception as e:
+            SkipComponent("Failed to check for pmlogger file existence: {0}".format(str(e)))
+
+    raise SkipComponent
+
+
+@datasource(RosConfig, HostContext)
+def pmlog_summary_metrics(broker):
+    """
+    Returns the metrics specified as "mandatory on" in the `config.ros` file
+    for the pmlogger summary file.
+
+    Returns:
+        str: Full path to the latest pmlogger file
+
+    Raises:
+        SkipComponent: When no metrics get from the RosConfig
+    """
+    ros = broker[RosConfig]
+    metrics = set()
+
+    for spec in ros.specs:
+        if spec.get('state') == 'mandatory on':
+            metrics.update(spec.get('metrics').keys())
+
+    if metrics:
+        return ' '.join(sorted(metrics))
+
+    raise SkipComponent

--- a/insights/specs/datasources/pcp.py
+++ b/insights/specs/datasources/pcp.py
@@ -35,7 +35,8 @@ def pmlog_summary_args(broker):
     Determines the pmlogger file and the metrics to collect via `pmlog_summary`
 
     Returns:
-        str: Full arguments string that pass to the `pmlog_summary`
+        str: Full arguments string that will be passed to the `pmlog_summary`,
+             which contains the `pmloger` file and the required `metrics`.
 
     Raises:
         SkipComponent: Raises when meeting one of the following scenario:

--- a/insights/specs/datasources/pcp.py
+++ b/insights/specs/datasources/pcp.py
@@ -33,15 +33,16 @@ def pcp_enabled(broker):
 def pmlog_summary_args(broker):
     """
     Determines the pmlogger file and the metrics to collect via `pmlog_summary`
+    spec.
 
     Returns:
-        str: Full arguments string that will be passed to the `pmlog_summary`,
-             which contains the `pmloger` file and the required `metrics`.
+        str: Full arguments string that will be passed to the `pmlogsummary`,
+             which contains the `pmlogger` archive file and the required `metrics`.
 
     Raises:
         SkipComponent: Raises when meeting one of the following scenario:
                        - No pmlogger process is running
-                       - No pmloger file
+                       - No pmlogger file
                        - No "mandatory on" metrics in `config.ros`
     """
     pm_file = None
@@ -54,7 +55,7 @@ def pmlog_summary_args(broker):
         pm_file = "/var/log/pcp/pmlogger/ros/{0}.index".format(pcp_log_date)
 
         if not (os.path.exists(pm_file) and os.path.isfile(pm_file)):
-            raise SkipComponent("No pmlogger file: {0}".format(pm_file))
+            raise SkipComponent("No pmlogger archive file: {0}".format(pm_file))
 
     except Exception as e:
         raise SkipComponent("Failed to check pmlogger file existence: {0}".format(str(e)))

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -35,8 +35,7 @@ from insights.specs.datasources import (
     awx_manage, cloud_init, candlepin_broker, ethernet, get_running_commands, ipcs, lpstat, package_provides,
     ps as ps_datasource, sap, satellite_missed_queues, ssl_certificate, yum_updates)
 from insights.specs.datasources.sap import sap_hana_sid, sap_hana_sid_SID_nr
-from insights.specs.datasources.pcp import (
-    pcp_enabled, pmlog_summary_metrics, pmlog_summary_file)
+from insights.specs.datasources.pcp import pcp_enabled, pmlog_summary_args
 
 
 logger = logging.getLogger(__name__)
@@ -521,7 +520,7 @@ class DefaultSpecs(Specs):
     pcs_status = simple_command("/usr/sbin/pcs status")
     php_ini = first_file(["/etc/opt/rh/php73/php.ini", "/etc/opt/rh/php72/php.ini", "/etc/php.ini"])
     pluginconf_d = glob_file("/etc/yum/pluginconf.d/*.conf")
-    pmlog_summary = command_with_args("/usr/bin/pmlogsummary %s {0}".format(pmlog_summary_metrics), pmlog_summary_file)
+    pmlog_summary = command_with_args("/usr/bin/pmlogsummary %s", pmlog_summary_args)
     pmrep_metrics = simple_command("/usr/bin/pmrep -t 1s -T 1s network.interface.out.packets network.interface.collisions swap.pagesout mssql.memory_manager.stolen_server_memory mssql.memory_manager.total_server_memory -o csv")
     postconf_builtin = simple_command("/usr/sbin/postconf -C builtin")
     postconf = simple_command("/usr/sbin/postconf")

--- a/insights/tests/datasources/test_pcp.py
+++ b/insights/tests/datasources/test_pcp.py
@@ -1,0 +1,143 @@
+import pytest
+import datetime
+from mock.mock import patch
+
+from insights import dr
+from insights.core.dr import SkipComponent
+from insights.parsers.ps import PsAuxcww
+from insights.parsers.systemd.unitfiles import UnitFiles
+from insights.parsers.ros_config import RosConfig
+from insights.combiners.ps import Ps
+from insights.combiners.services import Services
+from insights.specs.datasources.pcp import pcp_enabled, pmlog_summary_metrics, pmlog_summary_file
+from insights.tests import context_wrap
+
+PS_AUXCWW = """
+USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root         1  0.0  0.0  19356  1544 ?        Ss   May31   0:01 init
+root      1821  0.0  0.0      0     0 ?        S    May31   0:29 kondemand/0
+root     20357  0.0  0.0   9120   832 ?        Ss   10:09   0:00 dhclient
+pcp      71277  0.0  0.1 127060  8384 ?        S    Oct09   0:06 pmlogger
+""".strip()
+
+PS_AUXCWW_NG = """
+USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root         1  0.0  0.0  19356  1544 ?        Ss   May31   0:01 init
+root      1821  0.0  0.0      0     0 ?        S    May31   0:29 kondemand/0
+root     20357  0.0  0.0   9120   832 ?        Ss   10:09   0:00 dhclient
+""".strip()
+
+LIST_UNIT_FILES = """
+UNIT FILE                                   STATE
+pmlogger.service                            enabled
+pmlogger_check.service                      disabled
+pmlogger_daily-poll.service                 static
+pmlogger_daily.service                      static
+pmproxy.service                             enabled
+
+5 unit files listed.
+""".strip()
+
+LIST_UNIT_FILES_no_pmproxy = """
+UNIT FILE                                   STATE
+pmlogger.service                            enabled
+pmlogger_check.service                      disabled
+pmlogger_daily-poll.service                 static
+pmlogger_daily.service                      static
+
+5 unit files listed.
+""".strip()
+
+ROS_CONFIG = """
+log mandatory on default {
+    mem.util.used
+    kernel.all.cpu.user
+    disk.all.total
+    mem.util.free
+}
+[access]
+disallow .* : all;
+disallow :* : all;
+allow local:* : enquire;
+""".strip()
+
+ROS_CONFIG_NG = """
+log mandatory off {
+    mem.util.used
+    kernel.all.cpu.user
+    disk.all.total
+    mem.util.free
+}
+[access]
+disallow .* : all;
+disallow :* : all;
+allow local:* : enquire;
+"""
+
+
+def test_pcp_enabled():
+    unitfiles = UnitFiles(context_wrap(LIST_UNIT_FILES))
+    services = Services(None, unitfiles)
+    broker = dr.Broker()
+    broker[Services] = services
+
+    result = pcp_enabled(broker)
+    assert result is True
+
+    unitfiles = UnitFiles(context_wrap(LIST_UNIT_FILES_no_pmproxy))
+    services = Services(None, unitfiles)
+    broker = dr.Broker()
+    broker[Services] = services
+
+    with pytest.raises(SkipComponent):
+        pcp_enabled(broker)
+
+
+@patch("insights.specs.datasources.pcp.os.path.exists", return_value=True)
+@patch("insights.specs.datasources.pcp.os.path.isfile", return_value=True)
+def test_pmlog_summary_file(isfile, exists):
+    ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW))
+    ps = Ps(None, None, None, None, ps_auxcww, None, None)
+    broker = dr.Broker()
+    broker[Ps] = ps
+
+    pcp_log_date = (datetime.date.today() - datetime.timedelta(days=1)).strftime("%Y%m%d")
+    mock_file = "/var/log/pcp/pmlogger/ros/%s.index" % (pcp_log_date)
+
+    result = pmlog_summary_file(broker)
+    assert result == mock_file
+
+    ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_NG))
+    ps = Ps(None, None, None, None, ps_auxcww, None, None)
+    broker = dr.Broker()
+    broker[Ps] = ps
+
+    with pytest.raises(SkipComponent):
+        pmlog_summary_file(broker)
+
+
+@patch("insights.specs.datasources.pcp.os.path.exists", return_value=False)
+def test_pmlog_summary_file_exp(isfile):
+    ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW))
+    ps = Ps(None, None, None, None, ps_auxcww, None, None)
+    broker = dr.Broker()
+    broker[Ps] = ps
+
+    with pytest.raises(SkipComponent):
+        pmlog_summary_file(broker)
+
+
+def test_pmlog_summary_metrics():
+    ros = RosConfig(context_wrap(ROS_CONFIG))
+    broker = dr.Broker()
+    broker[RosConfig] = ros
+
+    result = pmlog_summary_metrics(broker)
+    assert result == ' '.join(sorted([i.strip() for i in ROS_CONFIG.split('\n')[1:5]]))
+
+    ros = RosConfig(context_wrap(ROS_CONFIG_NG))
+    broker = dr.Broker()
+    broker[RosConfig] = ros
+
+    with pytest.raises(SkipComponent):
+        pmlog_summary_metrics(broker)


### PR DESCRIPTION
- Update pmlog_summary to read all "mandatory on" metrics in config.ros
- Move the depended specs to the new datasource directory
- Add test for these datasources

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
- Update pmlog_summary to read all "mandatory on" metrics in config.ros
- Move the depended specs to the new datasource directory
- Add test for these datasources
