### PR TITLE
fix: update the pmlog_summary to support new metrics

### DIFF
--- a/insights/parsers/pmlog_summary.py
+++ b/insights/parsers/pmlog_summary.py
@@ -88,6 +88,7 @@ class PmLogSummary(CommandParser, dict):
     Keys are a hierarchy of the input key value split on the "." character.
 
     For instance::
+
         1. Input line "mem.util.used  3133919.812 Kbyte" is parsed as:
             {
                 'mem': {

--- a/insights/parsers/pmlog_summary.py
+++ b/insights/parsers/pmlog_summary.py
@@ -10,14 +10,14 @@ from insights.specs import Specs
 
 def parse(data):
     """
-    Parse a set of key/value pairs into a heirarchical dictionary of
+    Parse a set of key/value pairs into a hierarchical dictionary of
     typed values
 
     Arguments:
         data (dict): Input dictionary of key/value pairs
 
     Returns:
-        dict: Heirarchical dictionary with keys separated at "." and type
+        dict: Hierarchical dictionary with keys separated at "." and type
         conversion of the numerical values
     """
     result = {}
@@ -31,6 +31,11 @@ def parse(data):
     def insert(k, v):
         cur = result
         key_parts = k.split(".")
+        # process the '["xxx"]' part as a sub-key
+        if v.startswith('['):
+            mk, _, v = v.partition(']')
+            key_parts.append(mk.strip('"[]'))
+            v = v.strip()
 
         # walk down the structure to the correct leaf
         for part in key_parts:
@@ -70,24 +75,43 @@ class PmLogSummary(CommandParser, dict):
         kernel.all.cpu.nice  0.000 none
         kernel.all.cpu.steal  0.000 none
         kernel.all.cpu.idle  3.986 none
+        kernel.all.pressure.io.full.avg ["10 second"] 0.001 none
+        kernel.all.pressure.cpu.some.avg ["1 minute"] 14.942 none
+        kernel.all.pressure.memory.full.avg ["5 minute"] 0.002 none
         disk.all.total  0.252 count / sec
+        disk.dev.total ["vda"] 0.016 count / sec
+        disk.dev.total ["vdb"] 0.445 count / sec
+        disk.dev.total ["vdc"] 2.339 count / sec
 
     Output is parsed and stored as a dictionary.  Each value is
     stored as a dict in the form ``{'val': number or string, 'units': string}``.
     Keys are a hierarchy of the input key value split on the "." character.
-    For instance input line "mem.util.used  3133919.812 Kbyte" is parsed
-    as::
 
-        {
-            'mem': {
-                'util': {
-                    'used': {
-                        'val': 3133919.812,
-                        'units': 'Kbyte'
+    For instance::
+        1. Input line "mem.util.used  3133919.812 Kbyte" is parsed as:
+            {
+                'mem': {
+                    'util': {
+                        'used': {
+                            'val': 3133919.812,
+                            'units': 'Kbyte'
+                        }
                     }
                 }
             }
-        }
+        2. Input line "disk.dev.total ["vdc"] 2.339 count / sec" is parsed as:
+            {
+                'disk': {
+                    'dev': {
+                        'total': {
+                            'vdc': {
+                                'val': 2.339
+                                'units': 'count / sec'
+                            }
+                        }
+                    }
+                }
+            }
 
     Example:
         >>> type(pmlog_summary)
@@ -95,6 +119,10 @@ class PmLogSummary(CommandParser, dict):
         >>> 'mem' in pmlog_summary
         True
         >>> pmlog_summary['disk']['all']['total'] == {'val': 0.252, 'units': 'count / sec'}
+        True
+        >>> pmlog_summary['disk']['dev']['total']['vdc'] == {'val': 2.339, 'units': 'count / sec'}
+        True
+        >>> pmlog_summary['kernel']['all']['pressure']['memory']['full']['avg']['5 minute'] == {'val': 0.002, 'units': 'none'}
         True
     """
 

--- a/insights/parsers/tests/test_pmlog_summary.py
+++ b/insights/parsers/tests/test_pmlog_summary.py
@@ -14,7 +14,13 @@ kernel.all.cpu.sys  0.004 none
 kernel.all.cpu.nice  0.000 none
 kernel.all.cpu.steal  0.000 none
 kernel.all.cpu.idle  3.986 none
+kernel.all.pressure.io.full.avg ["10 second"] 0.001 none
+kernel.all.pressure.cpu.some.avg ["1 minute"] 14.942 none
+kernel.all.pressure.memory.full.avg ["5 minute"] 0.002 none
 disk.all.total  0.252 count / sec
+disk.dev.total ["vda"] 0.016 count / sec
+disk.dev.total ["vdb"] 0.445 count / sec
+disk.dev.total ["vdc"] 2.339 count / sec
 """
 
 PMLOG_EMPTY = """
@@ -28,15 +34,19 @@ def test_pmlog_summary():
     assert pmlog_summary['mem']['util']['used'] == {'val': 3133919.812, 'units': 'Kbyte'}
     assert pmlog_summary['mem']['physmem'] == {'val': 3997600.0, 'units': 'Kbyte'}
     assert pmlog_summary['disk']['all']['total'] == {'val': 0.252, 'units': 'count / sec'}
+    assert pmlog_summary['kernel']['all']['pressure']['cpu']['some']['avg']['1 minute'] == {'val': 14.942, 'units': 'none'}
     assert 'not.present' not in pmlog_summary
-    assert pmlog_summary['kernel'] == {
-        'all': {'cpu': {
-            'user': {'val': 0.003, 'units': 'none'},
-            'sys': {'val': 0.004, 'units': 'none'},
-            'nice': {'val': 0.0, 'units': 'none'},
-            'steal': {'val': 0.0, 'units': 'none'},
-            'idle': {'val': 3.986, 'units': 'none'},
-        }}
+    assert pmlog_summary['kernel']['all']['cpu'] == {
+        'user': {'val': 0.003, 'units': 'none'},
+        'sys': {'val': 0.004, 'units': 'none'},
+        'nice': {'val': 0.0, 'units': 'none'},
+        'steal': {'val': 0.0, 'units': 'none'},
+        'idle': {'val': 3.986, 'units': 'none'},
+    }
+    assert pmlog_summary['disk']['dev']['total'] == {
+        'vda': {'val': 0.016, 'units': 'count / sec'},
+        'vdb': {'val': 0.445, 'units': 'count / sec'},
+        'vdc': {'val': 2.339, 'units': 'count / sec'},
     }
 
 


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Enhance the PmLogSummary for the following lines of new metrics.
```
        kernel.all.pressure.io.full.avg ["10 second"] 0.001 none
        kernel.all.pressure.cpu.some.avg ["1 minute"] 14.942 none
        kernel.all.pressure.memory.full.avg ["5 minute"] 0.002 none
        disk.dev.total ["vda"] 0.016 count / sec
        disk.dev.total ["vdb"] 0.445 count / sec
        disk.dev.total ["vdc"] 2.339 count / sec
```