### PR TITLE
Update ethtool's parsing logic

### DIFF
--- a/insights/parsers/tests/test_ethtool.py
+++ b/insights/parsers/tests/test_ethtool.py
@@ -732,6 +732,8 @@ TEST_ETHTOOL_DOCS = '''
 '''
 
 ETHTOOL_INFO = """
+Cannot get wake-on-lan settings: Operation not permitted
+Cannot get link status: Operation not permitted
 Settings for eth1:
     Supported ports: [ TP MII ]
     Supported link modes: 10baseT/Half 10baseT/Full
@@ -815,7 +817,7 @@ def test_ethtool_fail():
 
     with pytest.raises(ParseException) as e:
         ethtool.Ethtool(context_wrap(ETHTOOL_INFO_BAD_2, path="ethtool_eth1"))
-    assert "ethtool: unrecognised first line " in str(e.value)
+    assert "Ethtool does not contain Settings for <nic>:" in str(e.value)
 
     with pytest.raises(ParseException) as e:
         ethtool.Ethtool(context_wrap(ETHTOOL_INFO_BAD_3, path="ethtool_eth1"))


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
Updated the logic to loop through the content and start parsing after finding the starting line. This way operation not permitted messages at the beginning of content are ignored. Updated the tests to test with operation not permitted messages at the top of content. Fixes #3268