### PR TITLE
Add rhel9 to RedHatRelease combiner

### DIFF
--- a/insights/combiners/redhat_release.py
+++ b/insights/combiners/redhat_release.py
@@ -90,6 +90,7 @@ class RedHatRelease(object):
         rhel6 (str): The RHEL version when it's RHEL6, otherwise None
         rhel7 (str): The RHEL version when it's RHEL7, otherwise None
         rhel8 (str): The RHEL version when it's RHEL8, otherwise None
+        rhel9 (str): The RHEL version when it's RHEL9, otherwise None
 
     Raises:
         SkipComponent: If the version can't be determined even though a Uname
@@ -126,6 +127,7 @@ class RedHatRelease(object):
         self.rhel6 = self.rhel if self.major == 6 else None
         self.rhel7 = self.rhel if self.major == 7 else None
         self.rhel8 = self.rhel if self.major == 8 else None
+        self.rhel9 = self.rhel if self.major == 9 else None
 
 
 @serializer(RedHatRelease)
@@ -137,6 +139,7 @@ def serialize_RedHatRelease(obj, root=None):
             "rhel6": obj.rhel6,
             "rhel7": obj.rhel7,
             "rhel8": obj.rhel8,
+            "rhel9": obj.rhel9,
     }
 
 
@@ -149,4 +152,5 @@ def deserialize_RedHatRelease(_type, obj, root=None):
     foo.rhel6 = obj.get("rhel6")
     foo.rhel7 = obj.get("rhel7")
     foo.rhel8 = obj.get("rhel8")
+    foo.rhel9 = obj.get("rhel9")
     return foo

--- a/insights/combiners/tests/test_redhat_release.py
+++ b/insights/combiners/tests/test_redhat_release.py
@@ -74,6 +74,7 @@ def test_RedHatRelease_both():
     assert result.rhel == result.rhel7 == '7.2'
     assert result.rhel6 is None
     assert result.rhel8 is None
+    assert result.rhel9 is None
 
 
 def test_raise():

--- a/insights/components/rhel_version.py
+++ b/insights/components/rhel_version.py
@@ -1,6 +1,6 @@
 """
-IsRhel6, IsRhel7 and IsRhel8
-===============================
+IsRhel6, IsRhel7, IsRhel8, and IsRhel9
+=========================================
 
 An ``IsRhel*`` component is valid if the
 :py:class:`insights.combiners.redhat_release.RedHatRelease` combiner indicates
@@ -71,4 +71,23 @@ class IsRhel8(object):
     def __init__(self, rhel):
         if rhel.major != 8:
             raise SkipComponent('Not RHEL8')
+        self.minor = rhel.minor
+
+
+@component(RedHatRelease)
+class IsRhel9(object):
+    """
+    This component uses ``RedhatRelease`` combiner
+    to determine RHEL version. It checks if RHEL9, if not
+    RHEL9 it raises ``SkipComponent``.
+
+    Attributes:
+        minor (int): The minor version of RHEL 9.
+
+    Raises:
+        SkipComponent: When RHEL version is not RHEL9.
+    """
+    def __init__(self, rhel):
+        if rhel.major != 9:
+            raise SkipComponent('Not RHEL9')
         self.minor = rhel.minor

--- a/insights/components/tests/test_rhel_version.py
+++ b/insights/components/tests/test_rhel_version.py
@@ -1,4 +1,4 @@
-from insights.components.rhel_version import IsRhel6, IsRhel7, IsRhel8
+from insights.components.rhel_version import IsRhel6, IsRhel7, IsRhel8, IsRhel9
 from insights.combiners.redhat_release import RedHatRelease as RR
 from insights.parsers.uname import Uname
 from insights.parsers.redhat_release import RedhatRelease
@@ -23,6 +23,10 @@ Red Hat Enterprise Linux release 7.5-0.14
 
 REDHAT_RELEASE4 = """
 Red Hat Enterprise Linux release 8.0 (Ootpa)
+""".strip()
+
+REDHAT_RELEASE5 = """
+Red Hat Enterprise Linux release 9.0 Beta (Plow)
 """.strip()
 
 
@@ -96,3 +100,19 @@ def test_not_rhel8():
     with pytest.raises(SkipComponent) as e:
         IsRhel8(rel)
     assert "Not RHEL8" in str(e)
+
+
+# RHEL9 Tests
+def test_is_rhel9():
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE5))
+    rel = RR(None, rr)
+    result = IsRhel9(rel)
+    assert isinstance(result, IsRhel9)
+
+
+def test_not_rhel9():
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE2))
+    rel = RR(None, rr)
+    with pytest.raises(SkipComponent) as e:
+        IsRhel9(rel)
+    assert "Not RHEL9" in str(e)

--- a/insights/parsers/tests/test_redhat_release.py
+++ b/insights/parsers/tests/test_redhat_release.py
@@ -41,6 +41,10 @@ REDHAT_RELEASE_BETA = """
 Red Hat Enterprise Linux Server release 8.5 Beta (Ootpa)
 """.strip()
 
+REDHAT_RELEASE9_BETA = """
+Red Hat Enterprise Linux release 9.0 Beta (Plow)
+""".strip()
+
 CENTOS_STREAM = """
 CentOS Stream release 8
 """.strip()
@@ -141,6 +145,18 @@ def test_rhel_beta():
     assert release.is_beta
     assert release.parsed['code_name'] == 'Ootpa'
     assert release.product == "Red Hat Enterprise Linux Server"
+
+
+def test_rhel9_beta():
+    release = RedhatRelease(context_wrap(REDHAT_RELEASE9_BETA))
+    assert release.raw == REDHAT_RELEASE9_BETA
+    assert release.major == 9
+    assert release.minor == 0
+    assert release.version == "9.0"
+    assert release.is_rhel
+    assert release.is_beta
+    assert release.parsed['code_name'] == 'Plow'
+    assert release.product == "Red Hat Enterprise Linux"
 
 
 def test_centos_stream():


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The redhat_release combiner's RedHatRelease class, serializer, and deserializer feature specific fields for rhel6, rhel7, and rhel8, but not rhel9.  Also IsRhel9 was lacking from the rhel_version component.  Adding rhel9 to these places and to relevant tests.