### PR TITLE
Fix test system

### DIFF
--- a/insights/tests/client/data_collector/test_redact.py
+++ b/insights/tests/client/data_collector/test_redact.py
@@ -59,7 +59,7 @@ def test_redact_call_walk(walk):
     Verify that redact() calls os.walk and when an
     an archive structure is present in /var/tmp/**/insights-*
     '''
-    conf = InsightsConfig()
+    conf = InsightsConfig(core_collect=False)
     arch = InsightsArchive(conf)
     arch.create_archive_dir()
 
@@ -99,7 +99,7 @@ def test_redact_call_process_redaction(_process_content_redaction):
     "regex" parameter is False in the _process_content_redaction
     call when rm_conf is empty
     '''
-    conf = InsightsConfig()
+    conf = InsightsConfig(core_collect=False)
     arch = InsightsArchive(conf)
     arch.create_archive_dir()
 
@@ -130,7 +130,7 @@ def test_redact_exclude_regex(_process_content_redaction):
     exclude == list of strings and regex == True when a list of
     regex strings is defined in rm_conf
     '''
-    conf = InsightsConfig()
+    conf = InsightsConfig(core_collect=False)
     arch = InsightsArchive(conf)
     arch.create_archive_dir()
 
@@ -159,7 +159,7 @@ def test_redact_exclude_no_regex(_process_content_redaction):
     exclude == list of strings and regex == False when a list
     of pattern strings is defined in rm_conf
     '''
-    conf = InsightsConfig()
+    conf = InsightsConfig(core_collect=False)
     arch = InsightsArchive(conf)
     arch.create_archive_dir()
 
@@ -188,7 +188,7 @@ def test_redact_exclude_empty(_process_content_redaction):
     exclude == [] and regex == False when the patterns key is
     defined but value is an empty list
     '''
-    conf = InsightsConfig()
+    conf = InsightsConfig(core_collect=False)
     arch = InsightsArchive(conf)
     arch.create_archive_dir()
 
@@ -217,7 +217,7 @@ def test_redact_exclude_none(_process_content_redaction):
     exclude == None and regex == False when the patterns key is
     defined but value is an empty dict
     '''
-    conf = InsightsConfig()
+    conf = InsightsConfig(core_collect=False)
     arch = InsightsArchive(conf)
     arch.create_archive_dir()
 
@@ -247,7 +247,7 @@ def test_redact_bad_location(_process_content_redaction, walk):
     if the directory present in InsightsArchive is
     in a location other than /var/tmp/**/insights-*
     '''
-    conf = InsightsConfig()
+    conf = InsightsConfig(core_collect=False)
     arch = InsightsArchive(conf)
 
     for bad_path in ['/', '/home', '/etc', '/var/log/', '/home/test', '/var/tmp/f22D1d/ins2ghts']:

--- a/insights/tests/client/test_skip_commands_files.py
+++ b/insights/tests/client/test_skip_commands_files.py
@@ -11,7 +11,7 @@ def test_omit_before_expanded_paths(InsightsFile, parse_file_spec):
     """
     Files are omitted based on representation of exact string matching in uploader.json
     """
-    c = InsightsConfig()
+    c = InsightsConfig(core_collect=False)
     data_collector = DataCollector(c)
 
     collection_rules = {'files': [{"file": "/etc/pam.d/vsftpd", "pattern": [], "symbolic_name": "vsftpd"}], 'commands': {}}
@@ -27,7 +27,7 @@ def test_omit_after_expanded_paths(InsightsFile, parse_file_spec):
     """
     Files are omitted based on the expanded paths of the uploader.json path
     """
-    c = InsightsConfig()
+    c = InsightsConfig(core_collect=False)
     data_collector = DataCollector(c)
 
     collection_rules = {'files': [{"file": "/etc/yum.repos.d/()*.*\\.repo", "pattern": [], "symbolic_name": "yum_repos_d"}], 'commands': {}}
@@ -44,7 +44,7 @@ def test_omit_symbolic_name(InsightsCommand, InsightsFile, parse_file_spec):
     """
     Files/commands are omitted based on their symbolic name in uploader.json
     """
-    c = InsightsConfig()
+    c = InsightsConfig(core_collect=False)
     data_collector = DataCollector(c)
 
     collection_rules = {'files': [{"file": "/etc/pam.d/vsftpd", "pattern": [], "symbolic_name": "vsftpd"}],
@@ -86,7 +86,7 @@ def test_dont_archive_when_command_not_found(write_data_to_file):
     """
     If the command is not found do not archive it
     """
-    arch = InsightsArchive(InsightsConfig())
+    arch = InsightsArchive(InsightsConfig(core_collect=False))
     arch.archive_dir = arch.create_archive_dir()
     arch.cmd_dir = arch.create_command_dir()
 
@@ -108,7 +108,7 @@ def test_dont_archive_when_missing_dep(write_data_to_file):
     """
     If missing dependencies do not archive it
     """
-    arch = InsightsArchive(InsightsConfig())
+    arch = InsightsArchive(InsightsConfig(core_collect=False))
     arch.archive_dir = arch.create_archive_dir()
     arch.cmd_dir = arch.create_command_dir()
 
@@ -126,7 +126,7 @@ def test_omit_after_parse_command(InsightsCommand, run_pre_command):
     """
     Files are omitted based on the expanded paths of the uploader.json path
     """
-    c = InsightsConfig()
+    c = InsightsConfig(core_collect=False)
     data_collector = DataCollector(c)
 
     collection_rules = {'commands': [{"command": "/sbin/ethtool -i", "pattern": [], "pre_command": "iface", "symbolic_name": "ethtool"}], 'files': [], "pre_commands": {"iface": "/sbin/ip -o link | awk -F ': ' '/.*link\\/ether/ {print $2}'"}}
@@ -138,7 +138,7 @@ def test_omit_after_parse_command(InsightsCommand, run_pre_command):
 @patch("insights.client.data_collector.DataCollector._parse_glob_spec", return_value=[{'glob': '/etc/yum.repos.d/*.repo', 'symbolic_name': 'yum_repos_d', 'pattern': [], 'file': '/etc/yum.repos.d/test.repo'}])
 @patch("insights.client.data_collector.logger.warn")
 def test_run_collection_logs_skipped_globs(warn, parse_glob_spec):
-    c = InsightsConfig()
+    c = InsightsConfig(core_collect=False)
     data_collector = DataCollector(c)
 
     collection_rules = {'commands': [], 'files': [], 'globs': [{'glob': '/etc/yum.repos.d/*.repo', 'symbolic_name': 'yum_repos_d', 'pattern': []}]}
@@ -149,7 +149,7 @@ def test_run_collection_logs_skipped_globs(warn, parse_glob_spec):
 
 @patch("insights.client.data_collector.logger.warn")
 def test_run_collection_logs_skipped_files_by_file(warn):
-    c = InsightsConfig()
+    c = InsightsConfig(core_collect=False)
     data_collector = DataCollector(c)
 
     collection_rules = {'commands': [], 'files': [{'file': '/etc/machine-id', 'pattern': [], 'symbolic_name': 'etc_machine_id'}], 'globs': []}
@@ -160,7 +160,7 @@ def test_run_collection_logs_skipped_files_by_file(warn):
 
 @patch("insights.client.data_collector.logger.warn")
 def test_run_collection_logs_skipped_files_by_symbolic_name(warn):
-    c = InsightsConfig()
+    c = InsightsConfig(core_collect=False)
     data_collector = DataCollector(c)
 
     collection_rules = {'commands': [], 'files': [{'file': '/etc/machine-id', 'pattern': [], 'symbolic_name': 'etc_machine_id'}], 'globs': []}
@@ -172,7 +172,7 @@ def test_run_collection_logs_skipped_files_by_symbolic_name(warn):
 @patch("insights.client.data_collector.DataCollector._parse_file_spec", return_value=[{'file': '/etc/sysconfig/network-scripts/ifcfg-enp0s3', 'pattern': [], 'symbolic_name': 'ifcfg'}])
 @patch("insights.client.data_collector.logger.warn")
 def test_run_collection_logs_skipped_files_by_wildcard(warn, parse_file_spec):
-    c = InsightsConfig()
+    c = InsightsConfig(core_collect=False)
     data_collector = DataCollector(c)
 
     collection_rules = {'commands': [], 'files': [{'file': '/etc/sysconfig/network-scripts/()*ifcfg-.*', 'pattern': [], 'symbolic_name': 'ifcfg'}], 'globs': []}
@@ -183,7 +183,7 @@ def test_run_collection_logs_skipped_files_by_wildcard(warn, parse_file_spec):
 
 @patch("insights.client.data_collector.logger.warn")
 def test_run_collection_logs_skipped_commands_by_command(warn):
-    c = InsightsConfig()
+    c = InsightsConfig(core_collect=False)
     data_collector = DataCollector(c)
 
     collection_rules = {'commands': [{'command': '/bin/date', 'pattern': [], 'symbolic_name': 'date'}], 'files': [], 'globs': []}
@@ -194,7 +194,7 @@ def test_run_collection_logs_skipped_commands_by_command(warn):
 
 @patch("insights.client.data_collector.logger.warn")
 def test_run_collection_logs_skipped_commands_by_symbolic_name(warn):
-    c = InsightsConfig()
+    c = InsightsConfig(core_collect=False)
     data_collector = DataCollector(c)
 
     collection_rules = {'commands': [{'command': '/bin/date', 'pattern': [], 'symbolic_name': 'date'}], 'files': [], 'globs': []}
@@ -206,7 +206,7 @@ def test_run_collection_logs_skipped_commands_by_symbolic_name(warn):
 @patch("insights.client.data_collector.DataCollector._parse_command_spec", return_value=[{'command': '/sbin/ethtool enp0s3', 'pattern': [], 'pre_command': 'iface', 'symbolic_name': 'ethtool'}])
 @patch("insights.client.data_collector.logger.warn")
 def test_run_collection_logs_skipped_commands_by_pre_command(warn, parse_command_spec):
-    c = InsightsConfig()
+    c = InsightsConfig(core_collect=False)
     data_collector = DataCollector(c)
 
     collection_rules = {'commands': [{'command': '/sbin/ethtool', 'pattern': [], 'pre_command': 'iface', 'symbolic_name': 'ethtool'}], 'files': [], 'globs': [], 'pre_commands': {'iface': '/sbin/ip -o link | awk -F \': \' \'/.*link\\/ether/ {print $2}\''}}


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

By running the tests with the flag --system-site-packages set to true (which is needed in the virtual environment for the client), some tests are failing:

Added the parameter core_collect to false when the InsightsConfig is created. This solution prevents InsightsConfig from checking the client's version that is in the system packages and modifying the core_collect value that should be false. 

The error is produced by using the --system-site-packages while ruining the tests.



