### PR TITLE
Remove yara_binary as a config option

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -727,7 +727,7 @@ class MalwareDetectionClient:
         # Get name of process from ps command
         # -h: no output header, -q: only the specified process, -o args: just the process name and args
         try:
-            process_name = call([['ps', '-hq', source, '-o', 'args']])
+            process_name = call([['ps', '-hq', source, '-o', 'args']]).strip()
         except CalledProcessError:
             process_name = 'unknown'
 
@@ -759,10 +759,16 @@ class MalwareDetectionClient:
         # Get the file type, mime type and md5sum hash of the source file
         try:
             file_type = call([['file', '-b', source]]).strip()
+        except CalledProcessError:
+            file_type = ""
+        try:
             mime_type = call([['file', '-bi', source]]).strip()
+        except CalledProcessError:
+            mime_type = ""
+        try:
             md5sum = call([['md5sum', source]]).strip().split()[0]
-        except Exception:
-            file_type = mime_type = md5sum = ""
+        except CalledProcessError:
+            md5sum = ""
 
         grep_string_data_match_list = []
         if mime_type and 'charset=binary' not in mime_type:

--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -213,16 +213,19 @@ class MalwareDetectionClient:
 
     def _find_yara(self):
         """
-        Find the yara binary on the local system and check it's version >= MIN_YARA_VERSION
+        Find the yara binary in particular locations on the local system.  Don't use 'which yara'
+        and rely on the system path in case it finds a malicious yara.
+        Also, don't let the user specify where yara is, again in case it is a malicious version of yara
+        If found, check it's version >= MIN_YARA_VERSION
         """
         def yara_version_ok(yara):
             # Check the installed yara version >= MIN_YARA_VERSION
             installed_yara_version = call([[yara, '--version']]).strip()
             try:
                 if float(installed_yara_version[:3]) < float(MIN_YARA_VERSION[:3]):
-                    raise RuntimeError("Found yara version %s, but malware-detection requires version >= %s\n"
+                    raise RuntimeError("Found %s with version %s, but malware-detection requires version >= %s\n"
                                        "Please install a later version of yara."
-                                       % (installed_yara_version, MIN_YARA_VERSION))
+                                       % (yara, installed_yara_version, MIN_YARA_VERSION))
             except RuntimeError as e:
                 logger.error(str(e))
                 exit(constants.sig_kill_bad)
@@ -232,14 +235,16 @@ class MalwareDetectionClient:
             # If we are here then the version of yara was ok
             return True
 
-        try:
-            yara = str(call([['which', 'yara']])).strip()
-        except CalledProcessError:
-            logger.error("Couldn't find yara.  Please ensure the yara package is installed")
-            exit(constants.sig_kill_bad)
-        yara_version_ok(yara)   # Generates an error if not ok
-        logger.debug("Using yara binary: %s", yara)
-        return yara
+        # Try to find yara in only these usual locations.
+        # /bin/yara and /usr/bin/yara will exist if yara is installed via rpm
+        # /usr/local/bin/yara will (likely) exist if the user has compiled and installed yara manually
+        for yara in ['/bin/yara', '/usr/bin/yara', '/usr/local/bin/yara']:
+            if os.path.exists(yara) and yara_version_ok(yara):
+                logger.debug("Using yara binary: %s", yara)
+                return yara
+
+        logger.error("Couldn't find yara.  Please ensure the yara package is installed")
+        exit(constants.sig_kill_bad)
 
     def _process_scan_options(self):
         """

--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -92,10 +92,6 @@ network_filesystem_types: [nfs, nfs4, cifs, smbfs, fuse.sshfs, ceph, glusterfs, 
 # The extra metadata will display in the webUI along with the scan matches
 add_metadata: true
 
-# Specific location of the yara binary file.  Autodetected if not specified.  For example:
-# yara_binary: /usr/local/bin/yara
-yara_binary:
-
 # Abort a particular scan if it takes longer than scan_timeout seconds.  Default is 3600 seconds (1 hour)
 scan_timeout: # 3600
 
@@ -113,8 +109,7 @@ ENV_VAR_TYPES = {
                 'EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'],
     'list': ['SCAN_ONLY', 'SCAN_EXCLUDE', 'NETWORK_FILESYSTEM_TYPES'],
     'integer': ['SCAN_TIMEOUT', 'NICE_VALUE', 'CPU_THREAD_LIMIT', 'STRING_MATCH_LIMIT'],
-    'int_or_str': ['SCAN_SINCE'],
-    'string': ['YARA_BINARY']
+    'int_or_str': ['SCAN_SINCE']
 }
 
 
@@ -232,18 +227,10 @@ class MalwareDetectionClient:
                 logger.error(str(e))
                 exit(constants.sig_kill_bad)
             except Exception as e:
-                logger.error("Error getting the version of the specified yara binary %s: %s" % (yara, str(e)))
+                logger.error("Error getting the version of the specified yara binary %s: %s", yara, str(e))
                 exit(constants.sig_kill_bad)
             # If we are here then the version of yara was ok
             return True
-
-        yara = self._get_config_option('yara_binary')
-        if yara and not os.path.isfile(yara):
-            logger.error("Couldn't find the specified yara binary %s.  Please check it exists", yara)
-            exit(constants.sig_kill_bad)
-        elif yara and yara_version_ok(yara):
-            logger.debug("Using specified yara binary: %s", yara)
-            return yara
 
         try:
             yara = str(call([['which', 'yara']])).strip()

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -96,7 +96,6 @@ class TestDefaultValues:
 
     def test_default_options(self):
         # Read in the default malware_detection_config options and check their values
-        assert CONFIG['yara_binary'] is None
         assert CONFIG['test_scan'] is True
         assert CONFIG['scan_filesystem'] is True
         assert CONFIG['scan_processes'] is False
@@ -153,45 +152,55 @@ class TestDefaultValues:
 @patch(BUILD_YARA_COMMAND_TARGET)
 @patch(GET_RULES_TARGET, return_value=RULES_FILE)
 @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
+@patch(LOGGER_TARGET)
 class TestFindYara:
 
-    @patch.dict(os.environ)
-    def test_find_yara_binary(self, conf, rules, cmd):
-        # Testing finding yara
-        os.environ['YARA_BINARY'] = '/bin/yara'
-        with patch('os.path.isfile', return_value=True):
-            with patch("insights.client.apps.malware_detection.call", return_value='4.1'):
-                mdc = MalwareDetectionClient(None)
+    def test_find_yara_binary(self, log_mock, conf, rules, cmd):
+        # Testing finding yara with correct version
+        with patch("insights.client.apps.malware_detection.call", side_effect=['/bin/yara', '4.1']):
+            mdc = MalwareDetectionClient(None)
         assert mdc.yara_binary == '/bin/yara'
         cmd.assert_called()
 
-    @patch.dict(os.environ)
-    def test_missing_yara_binary(self, conf, rules, cmd):
-        # Test yara_binary option with non-existent file
-        os.environ['YARA_BINARY'] = '/bin/notyara'
-        with pytest.raises(SystemExit):
-            MalwareDetectionClient(None)
+    def test_find_unsupported_yara(self, log_mock, conf, rules, cmd):
+        # Test finding unsupported yara version
+        with patch("insights.client.apps.malware_detection.call", side_effect=['/bin/yara3', '3.10']):
+            with pytest.raises(SystemExit):
+                MalwareDetectionClient(None)
+        log_mock.error.assert_called_with("Found yara version 3.10, but malware-detection requires version >= 4.1.0\n"
+                                          "Please install a later version of yara.")
         cmd.assert_not_called()
 
-        # Test yara_binary option with non-yara file
-        os.environ['YARA_BINARY'] = '/bin/ls'
-        with pytest.raises(SystemExit):
-            MalwareDetectionClient(None)
+    def test_find_invalid_yara(self, log_mock, conf, rules, cmd):
+        # Test finding a binary called yara, but its not yara
+        with patch("insights.client.apps.malware_detection.call", side_effect=['/bin/yaranot', 'yaranot 1.2.3']):
+            with pytest.raises(SystemExit):
+                MalwareDetectionClient(None)
+        log_mock.error.assert_called_with("Error getting the version of the specified yara binary %s: %s", "/bin/yaranot", ANY)
+        cmd.assert_not_called()
+
+    def test_cant_find_yara(self, log_mock, conf, rules, cmd):
+        # Test can't find yara on the system
+        with patch("insights.client.apps.malware_detection.call") as call_mock:
+            call_mock.side_effect = CalledProcessError(1, 'which yara', 'no yara found')
+            with pytest.raises(SystemExit):
+                MalwareDetectionClient(None)
+        log_mock.error.assert_called_with("Couldn't find yara.  Please ensure the yara package is installed")
         cmd.assert_not_called()
 
     @patch("insights.client.apps.malware_detection.call")  # mock call to 'yara --version'
-    def test_invalid_yara_versions(self, version_mock, conf, rules, cmd):
+    def test_invalid_yara_versions(self, version_mock, log_mock, conf, rules, cmd):
         # Test checking the version of yara
         # Invalid versions of yara
         for version in ['4.0.99', '4']:
-            version_mock.return_value = version
+            version_mock.side_effect = ['yara', version]
             with pytest.raises(SystemExit):
                 MalwareDetectionClient(None)
         cmd.assert_not_called()  # We won't get to the build_yara_cmd method because we exit before its called
 
         # Valid versions of yara
         for version in ['4.1', '10.0.0']:
-            version_mock.return_value = version
+            version_mock.side_effect = ['yara', version]
             mdc = MalwareDetectionClient(None)
             assert mdc.yara_binary
         cmd.assert_called()

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -157,52 +157,62 @@ class TestFindYara:
 
     def test_find_yara_binary(self, log_mock, conf, rules, cmd):
         # Testing finding yara with correct version
-        with patch("insights.client.apps.malware_detection.call", side_effect=['/bin/yara', '4.1']):
-            mdc = MalwareDetectionClient(None)
+        with patch('os.path.exists', return_value=True):
+            with patch("insights.client.apps.malware_detection.call", return_value='4.1'):
+                mdc = MalwareDetectionClient(None)
         assert mdc.yara_binary == '/bin/yara'
+        cmd.assert_called()
+
+        # 'Find' yara in /usr/local/bin/yara (fails to 'find' /bin/yara and /usr/bin/yara)
+        with patch('os.path.exists', side_effect=[False, False, True]):
+            with patch("insights.client.apps.malware_detection.call", return_value='4.1'):
+                mdc = MalwareDetectionClient(None)
+        assert mdc.yara_binary == '/usr/local/bin/yara'
         cmd.assert_called()
 
     def test_find_unsupported_yara(self, log_mock, conf, rules, cmd):
         # Test finding unsupported yara version
-        with patch("insights.client.apps.malware_detection.call", side_effect=['/bin/yara3', '3.10']):
-            with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
-        log_mock.error.assert_called_with("Found yara version 3.10, but malware-detection requires version >= 4.1.0\n"
+        with patch('os.path.exists', return_value=True):
+            with patch("insights.client.apps.malware_detection.call", return_value='3.10'):
+                with pytest.raises(SystemExit):
+                    MalwareDetectionClient(None)
+        log_mock.error.assert_called_with("Found /bin/yara with version 3.10, but malware-detection requires version >= 4.1.0\n"
                                           "Please install a later version of yara.")
         cmd.assert_not_called()
 
     def test_find_invalid_yara(self, log_mock, conf, rules, cmd):
         # Test finding a binary called yara, but its not yara
-        with patch("insights.client.apps.malware_detection.call", side_effect=['/bin/yaranot', 'yaranot 1.2.3']):
-            with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
-        log_mock.error.assert_called_with("Error getting the version of the specified yara binary %s: %s", "/bin/yaranot", ANY)
+        with patch('os.path.exists', return_value=True):
+            with patch("insights.client.apps.malware_detection.call", return_value='not yara 1.2.3'):
+                with pytest.raises(SystemExit):
+                    MalwareDetectionClient(None)
+        log_mock.error.assert_called_with("Error getting the version of the specified yara binary %s: %s", "/bin/yara", ANY)
         cmd.assert_not_called()
 
     def test_cant_find_yara(self, log_mock, conf, rules, cmd):
         # Test can't find yara on the system
-        with patch("insights.client.apps.malware_detection.call") as call_mock:
-            call_mock.side_effect = CalledProcessError(1, 'which yara', 'no yara found')
+        with patch('os.path.exists', return_value=False):
             with pytest.raises(SystemExit):
                 MalwareDetectionClient(None)
         log_mock.error.assert_called_with("Couldn't find yara.  Please ensure the yara package is installed")
         cmd.assert_not_called()
 
+    @patch("os.path.exists", return_value=True)
     @patch("insights.client.apps.malware_detection.call")  # mock call to 'yara --version'
-    def test_invalid_yara_versions(self, version_mock, log_mock, conf, rules, cmd):
+    def test_invalid_yara_versions(self, version_mock, exists_mock, log_mock, conf, rules, cmd):
         # Test checking the version of yara
         # Invalid versions of yara
         for version in ['4.0.99', '4']:
-            version_mock.side_effect = ['yara', version]
+            version_mock.return_value = version
             with pytest.raises(SystemExit):
                 MalwareDetectionClient(None)
         cmd.assert_not_called()  # We won't get to the build_yara_cmd method because we exit before its called
 
         # Valid versions of yara
         for version in ['4.1', '10.0.0']:
-            version_mock.side_effect = ['yara', version]
+            version_mock.return_value = version
             mdc = MalwareDetectionClient(None)
-            assert mdc.yara_binary
+            assert mdc.yara_binary == '/bin/yara'
         cmd.assert_called()
 
 


### PR DESCRIPTION
* https://bugzilla.redhat.com/show_bug.cgi?id=2025009

Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This PR removes the yara_binary config option and only looks for yara in specific/known locations, ie /bin/yara, /usr/bin/yara and /usr/local/bin/yara.  This prevents a user from pointing to a specific rogue yara binary, or modifying the search path so it finds a rogue yara binary.  Of course, this doesn't stop someone from replacing a good yara binary with a rogue one, but at least these changes make malware-detection less likely to be coerced to use a rogue yara binary.