### PR TITLE
Add log_response_text flag to log downloads or not in verbose mode

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -454,14 +454,16 @@ class MalwareDetectionClient:
                 self.rules_location = urlunparse(parsed_url._replace(netloc='cert.' + parsed_url.netloc))
 
         # If doing a test scan, replace signatures.yar (or any other file suffix) with test-rule.yar
+        log_rule_contents = False
         if self.test_scan:
             self.rules_location = self._get_test_rule_location(self.rules_location)
+            log_rule_contents = True
 
         logger.debug("Downloading rules from: %s", self.rules_location)
         try:
             self.insights_config.cert_verify = True
             conn = InsightsConnection(self.insights_config)
-            response = conn.get(self.rules_location)
+            response = conn.get(self.rules_location, log_response_text=log_rule_contents)
             if response.status_code != 200:
                 logger.error("%s %s: %s", response.status_code, response.reason, response.text)
                 exit(constants.sig_kill_bad)

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -175,7 +175,7 @@ class InsightsConnection(object):
                 connection.proxy_headers = auth_map
         return session
 
-    def _http_request(self, url, method, **kwargs):
+    def _http_request(self, url, method, log_response_text=True, **kwargs):
         '''
         Perform an HTTP request, net logging, and error handling
         Parameters
@@ -188,7 +188,8 @@ class InsightsConnection(object):
         logger.log(NETWORK, "%s %s", method, url)
         res = self.session.request(url=url, method=method, timeout=self.config.http_timeout, **kwargs)
         logger.log(NETWORK, "HTTP Status: %d %s", res.status_code, res.reason)
-        logger.log(NETWORK, "HTTP Response Text: %s", res.text)
+        if log_response_text or res.status_code != 200:
+            logger.log(NETWORK, "HTTP Response Text: %s", res.text)
         return res
 
     def get(self, url, **kwargs):

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -220,23 +220,23 @@ class TestGetRules:
         mdc = MalwareDetectionClient(InsightsConfig())
         assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
         assert mdc.rules_file.startswith('/tmp')  # rules will be saved into a temp file
-        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar")
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
 
         # With authmethod=CERT, expect 'cert.' to be prefixed to the url
         mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
         assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
-        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar")
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
 
         # With authmethod=BASIC and test scan false ...
         # Expect to still use cert auth because no username or password specified
         os.environ['TEST_SCAN'] = 'false'
         mdc = MalwareDetectionClient(InsightsConfig(authmethod='BASIC'))
         assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
-        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar")
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar", log_response_text=False)
 
         mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
         assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
-        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar")
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar", log_response_text=False)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true'})
     @patch(LOGGER_TARGET)
@@ -249,26 +249,26 @@ class TestGetRules:
         get.return_value = Mock(status_code=401, reason="Unauthorized", text="No can do")
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(username='user'))
-        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar")
+        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
         log_mock.error.assert_called_with("%s %s: %s", 401, "Unauthorized", ANY)
 
         # Test with just a password specified - expect basic auth to be used but fails
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(password='pass'))
-        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar")
+        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
         log_mock.error.assert_called_with("%s %s: %s", 401, "Unauthorized", ANY)
 
         # Test with 'incorrect' username and/or password - expect basic auth failure
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(username='user', password='badpass'))
-        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar")
+        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
         log_mock.error.assert_called_with("%s %s: %s", 401, "Unauthorized", ANY)
 
         # Test with 'correct' username and password - expect basic auth success
         get.return_value = Mock(status_code=200, content=b"Rule Content")
         mdc = MalwareDetectionClient(InsightsConfig(username='user', password='goodpass'))
         assert mdc.rules_location == "https://console.redhat.com/api/malware-detection/v1/test-rule.yar"
-        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar")
+        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': 'console.redhat.com/rules.yar'})
     def test_get_rules_missing_protocol(self, conf, yara, cmd, session, proxies, get):
@@ -276,13 +276,13 @@ class TestGetRules:
         # test-scan true and BASIC auth by default expect test-rule.yar and no 'cert.' in URL
         mdc = MalwareDetectionClient(InsightsConfig(username='user', password='pass'))
         assert mdc.rules_location == "https://console.redhat.com/test-rule.yar"
-        get.assert_called_with("https://console.redhat.com/test-rule.yar")
+        get.assert_called_with("https://console.redhat.com/test-rule.yar", log_response_text=True)
 
         # test-scan false and CERT auth - expect 'cert.' prefixed to the URL and not test-rule.yar
         os.environ['TEST_SCAN'] = 'false'
         mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
         assert mdc.rules_location == "https://cert.console.redhat.com/rules.yar"
-        get.assert_called_with("https://cert.console.redhat.com/rules.yar")
+        get.assert_called_with("https://cert.console.redhat.com/rules.yar", log_response_text=False)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'http://localhost/rules.yar'})
     @patch(LOGGER_TARGET)


### PR DESCRIPTION
* https://issues.redhat.com/browse/YARA-232
* Don't log the malware signatures download in verbose mode
* It is a big binary blob and may leave artifacts on the command line afterwards

Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
The malware-detection app downloads the malware signatures as a big binary blob.  When running insights-client in verbose mode, this binary blob is displayed on the terminal and can leave trailing text after the command has finished.  There is no real need to display this binary blob and this PR adds a flag to the connection module to toggle displaying the response.text or not when in verbose mode.  It is on by default which maintains the current behaviour, but for malware-detection, it is turned off so the binary blob isn't displayed on the terminal or in the logs.