### PR TITLE
Remove old rules files before starting a new scan

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -411,6 +411,17 @@ class MalwareDetectionClient:
         Obtain the rules used by yara for scanning from the rules_location option.
         They can either be downloaded from the malware backend or obtained from a local file.
         """
+        from glob import glob
+
+        # The rules file that is downloaded from the backend should be automatically removed when the
+        # malware-detection client exits.
+        # However it can happen that the rules file isn't removed for some reason, so remove any existing
+        # rules files before beginning a new scan, otherwise they may show up as matches in the scan results.
+        old_rules_files = glob('/tmp/tmp_malware-detection-client_rules.*')
+        for old_rules_file in old_rules_files:
+            logger.debug("Removing old rules file %s", old_rules_file)
+            os.remove(old_rules_file)
+
         self.rules_location = self._get_config_option(
             'rules_location', "https://console.redhat.com/api/malware-detection/v1/signatures.yar"
         )

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -217,6 +217,7 @@ class TestFindYara:
 
 
 # Use patch.object, just because I wanted to try using patch.object instead of using patch all the time :shrug:
+@patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
 @patch.object(InsightsConnection, 'get', return_value=Mock(status_code=200, content=b"Rule Content"))
 @patch.object(InsightsConnection, 'get_proxies')
 @patch.object(InsightsConnection, '_init_session', return_value=Mock())
@@ -227,7 +228,7 @@ class TestGetRules:
     """ Testing the _get_rules method """
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true'})
-    def test_download_rules_cert_auth(self, conf, yara, cmd, session, proxies, get):
+    def test_download_rules_cert_auth(self, conf, yara, cmd, session, proxies, get, remove):
         # Test the standard rules_location urls, but will result in cert auth being used to download the rules
         # Test with insights-config None, expect an error when trying to use the insights-config object
         with pytest.raises(SystemExit):
@@ -259,7 +260,7 @@ class TestGetRules:
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true'})
     @patch(LOGGER_TARGET)
-    def test_download_rules_basic_auth(self, log_mock, conf, yara, cmd, session, proxies, get):
+    def test_download_rules_basic_auth(self, log_mock, conf, yara, cmd, session, proxies, get, remove):
         # Test the standard rules_location urls, with basic auth attempting to be used to download the rules
         # Basic auth is used by default, but needs to have a valid username and password for it to work
         # Without a username and password, then cert auth will be used
@@ -290,7 +291,7 @@ class TestGetRules:
         get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': 'console.redhat.com/rules.yar'})
-    def test_get_rules_missing_protocol(self, conf, yara, cmd, session, proxies, get):
+    def test_get_rules_missing_protocol(self, conf, yara, cmd, session, proxies, get, remove):
         # Non-standard rules URLS - without https:// at the start and not signatures.yar
         # test-scan true and BASIC auth by default expect test-rule.yar and no 'cert.' in URL
         mdc = MalwareDetectionClient(InsightsConfig(username='user', password='pass'))
@@ -305,7 +306,7 @@ class TestGetRules:
 
     @patch.dict(os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'http://localhost/rules.yar'})
     @patch(LOGGER_TARGET)
-    def test_download_failures(self, log_mock, conf, yara, cmd, session, proxies, get):
+    def test_download_failures(self, log_mock, conf, yara, cmd, session, proxies, get, remove):
         from requests.exceptions import ConnectionError, Timeout
         # Test various problems downloading rules
         # 404 error - unlikely to occur unless an incorrect rules_location was manually specified
@@ -331,7 +332,7 @@ class TestGetRules:
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': '//console.redhat.com/rules.yar'})
     @patch("os.path.isfile", return_value=True)
-    def test_get_rules_location_files(self, isfile, conf, yara, cmd, session, proxies, get):
+    def test_get_rules_location_files(self, isfile, conf, yara, cmd, session, proxies, get, remove):
         # Test using files for rules_location, esp irregular file names
         # rules_location that starts with a '/' is assumed to be a file, even if its a double '//'
         # Re-writing the rule to be test-rule.yar doesn't apply to local files
@@ -749,12 +750,13 @@ class TestMalwareDetectionOptions:
         log_mock.error.assert_called_with("No items to scan because the specified exclude items cancel them out")
 
 
+@patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
 @patch(BUILD_YARA_COMMAND_TARGET)
 @patch(FIND_YARA_TARGET, return_value=YARA)
 @patch(LOGGER_TARGET)
 class TestScanning:
 
-    def test_scan_rules_file_with_extra_slashes(self, log_mock, yara, cmd, create_test_files):
+    def test_scan_rules_file_with_extra_slashes(self, log_mock, yara, cmd, remove, create_test_files):
         # Test scanning RULES_FILE with an extra slash only in the rules_location one
         # Even with the extra slashes in the rules_location there will be rules matched
         # because */rules_compiled.yar and *//rules_compiled.yar are the same file
@@ -780,7 +782,7 @@ class TestScanning:
         assert rule_match[0]['string_offset'] == 74
         log_mock.info.assert_any_call("Matched rule %s in %s %s", "TEST_RedHatInsightsMalwareDetection", "file", TEST_RULE_FILE)
 
-    def test_scan_root_with_extra_slashes(self, log_mock, yara, cmd, create_test_files):
+    def test_scan_root_with_extra_slashes(self, log_mock, yara, cmd, remove, create_test_files):
         # Testing we handle the situation where items in scan_only & scan_exclude contain multiple slashes
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
             line = "test_scan: false" if line.startswith("test_scan:") else line
@@ -803,7 +805,7 @@ class TestScanning:
 
     @patch('insights.client.apps.malware_detection.NamedTemporaryFile')
     @patch("insights.client.apps.malware_detection.call", return_value="")
-    def test_scan_since_tmp_files(self, call_mock, tmp_file_mock, log_mock, yara, cmd, extract_tmp_files, create_test_files):
+    def test_scan_since_tmp_files(self, call_mock, tmp_file_mock, log_mock, yara, cmd, remove, extract_tmp_files, create_test_files):
         # Set scan_only, scan_exclude options to some of the tmp files and then 'scan' them
         # Then touch files to test the scan_since option and make sure that only the touched files will be scanned
         yara_file_list = os.path.join(TEMP_TEST_DIR, 'yara_file_list')


### PR DESCRIPTION
* https://issues.redhat.com/browse/YARA-249
* Old rules files may cause false positives

Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The rules file that is downloaded from the backend should be automatically removed when the malware-detection client exits. 
However it *can* happen that the rules file isn't removed for some reason.  This PR makes sure any old rules files are removed before beginning a new scan, otherwise they may show up as matches in the scan results.
