### PR TITLE
Improved excluding of the insights-client log files

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -5,6 +5,7 @@ import json
 import yaml
 from sys import exit
 import logging
+from glob import glob
 from datetime import datetime
 from tempfile import NamedTemporaryFile
 try:
@@ -55,8 +56,7 @@ scan_only:
 
 # scan_exclude: a single or list of files/directories to be excluded from filesystem scanning
 # If an item appears in both scan_only and scan_exclude, scan_exclude takes precedence and the item will be excluded
-# The scan_exclude list is pre-populated with a number of top level directories that are recommended to be excluded,
-# as well as the insights-client log directory which could cause extra matches itself
+# scan_exclude is pre-populated with a list of top level directories that are recommended to be excluded
 scan_exclude:
 - /proc
 - /sys
@@ -66,7 +66,6 @@ scan_exclude:
 - /mnt
 - /media
 - /dev
-- /var/log/insights-client
 
 # scan_since: scan files created or modified since X days ago or since the 'last' scan.
 # Valid values are integers >= 1 or the string 'last'.  For example:
@@ -411,8 +410,6 @@ class MalwareDetectionClient:
         Obtain the rules used by yara for scanning from the rules_location option.
         They can either be downloaded from the malware backend or obtained from a local file.
         """
-        from glob import glob
-
         # The rules file that is downloaded from the backend should be automatically removed when the
         # malware-detection client exits.
         # However it can happen that the rules file isn't removed for some reason, so remove any existing
@@ -523,15 +520,20 @@ class MalwareDetectionClient:
         return yara_cmd
 
     def scan_filesystem(self):
+        """
+        Process the filesystem items to scan
+        If self.scan_fsobjects is set, then just scan its items, less any items in the exclude list
+        scan_dict will contain all the toplevel directories to scan, and any particular files/subdirectories to scan
+        """
         if not self.do_filesystem_scan:
             return False
 
-        # Process the filesystem items to scan
-        # If self.scan_fsobjects is set, then just scan its items, less any items in the exclude list
-        # And exclude the rules file, unless that's the thing we specifically want to scan
-        # scan_dict will contain all the toplevel directories to scan, and any particular files/subdirectories to scan
+        # Exclude the rules file and insights-client log files, unless they are things we specifically want to scan
         if self.rules_file not in self.scan_fsobjects:
             self.scan_exclude_list.append(self.rules_file)
+        insights_log_files = glob(constants.default_log_file + '*')
+        self.scan_exclude_list.extend(list(set(insights_log_files) - set(self.scan_fsobjects)))
+
         scan_dict = process_include_exclude_items(include_items=self.scan_fsobjects,
                                                   exclude_items=self.scan_exclude_list,
                                                   exclude_mountpoints=self.network_filesystem_mountpoints)

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -898,6 +898,39 @@ class TestScanning:
         assert len(contents) == 2
         assert contents == [scan_me_file, scan_me_too_file]
 
+    @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
+    @patch.dict(os.environ)
+    def test_rule_n_glob_files_excluded(self, conf, log_mock, yara, cmd, remove, extract_tmp_files, create_test_files):
+        # Fake a scan but make sure we are excluding the rules file and globbed files (they are supposed to be
+        # insights log files, but that's hard to mock).
+        # Also test we are not excluding ones we actually want to scan
+        glob_files = [os.path.join(TEMP_TEST_DIR, 'scan_me', f) for f in ['new_file', 'old_file']]
+        os.environ['TEST_SCAN'] = 'false'
+        os.environ['RULES_LOCATION'] = TEST_RULE_FILE
+        os.environ['SCAN_ONLY'] = "%s,%s" % (TEMP_TEST_DIR, glob_files[1])  # we actually want to scan glob_files[1]
+        mdc = MalwareDetectionClient(None)
+        assert mdc.rules_file == TEST_RULE_FILE
+        assert mdc.scan_fsobjects == [TEMP_TEST_DIR, glob_files[1]]
+
+        # Patch the call to glob so it returns a specific list of files
+        # Patch the calls for running yara and have it return no matches
+        with patch("insights.client.apps.malware_detection.glob", return_value=glob_files):
+            with patch("insights.client.apps.malware_detection.call", return_value=""):
+                mdc.scan_filesystem()
+        assert mdc.rules_file in mdc.scan_exclude_list
+        assert glob_files[0] in mdc.scan_exclude_list
+        # Make sure glob_files[1] isn't excluded because we actually want to scan that file
+        assert glob_files[1] not in mdc.scan_exclude_list
+
+        # This time patch glob so it returns an empty list, ie simulating no extra files to exclude
+        mdc = MalwareDetectionClient(None)
+        with patch("insights.client.apps.malware_detection.glob", return_value=[]):
+            with patch("insights.client.apps.malware_detection.call", return_value=""):
+                mdc.scan_filesystem()
+        assert mdc.rules_file in mdc.scan_exclude_list
+        # None of the glob files should be excluded this time
+        assert all([f not in mdc.scan_exclude_list for f in glob_files])
+
 
 class TestIncludeExcludeMethods:
 


### PR DESCRIPTION
* https://issues.redhat.com/browse/YARA-249
* Scanning the log files may cause false positives

Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Need to do a better job of excluding the insights-client log files from being scanned.  Previously I had them listed as a scan_exclude entry in the config file, but that entry can be easily removed and the log files will be scanned, possibly causing false positives.  This PR now gets the list of log files and adds them to the exclude items within the code, so it can't be easily changed.