### PR TITLE
[Draft] Fix malware-detection scan_only option bug

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -43,14 +43,20 @@ scan_processes: false
 # Once verified, disable this option to perform actual malware scans.
 test_scan: true
 
-# scan_only: a single or list of files/directories/process IDs to scan, for example:
+# scan_only: a single or list of files/directories/process IDs to scan
+# Specifying values means scan ONLY those items (ignoring the values of scan_filesystem and scan_processes)
+# No value means scan ALL files/directories/PIDs (depending on the values of scan_filesystem and scan_processes)
+Examples:
 # scan_only:
 # - /var/www
 # - /home
 # ... means scan only files in /var/www and /home.  May also be written as scan_only: [/var/www, /home]
 # scan_only: 12345
 #... means scan only process ID 12345
-# No value means scan all files/directories/PIDs
+# scan_only:
+# - /tmp
+# - 123
+#... means scan only /tmp and process ID 123
 scan_only:
 
 # scan_exclude: a single or list of files/directories to be excluded from filesystem scanning
@@ -298,10 +304,12 @@ class MalwareDetectionClient:
             # Process the scan_only option as a list of items to scan
             # There may be both files/directories and PIDs all together
             # Strings are assumed to be files/directories and ints are assumed to be process IDs
+            self.do_filesystem_scan = False
+            self.do_process_scan = False
             if not isinstance(scan_only, list):
                 scan_only = [scan_only]
             for item in scan_only:
-                if isinstance(item, str) and self.do_filesystem_scan:
+                if isinstance(item, str):
                     # Remove extras slashes (/) in the file name and leading double slashes too (normpath doesn't)
                     item = os.path.normpath(item).replace('//', '/')
                     # Assume the item represents a filesystem item
@@ -309,7 +317,7 @@ class MalwareDetectionClient:
                         self.scan_fsobjects.append(item)
                     else:
                         logger.info("Skipping missing scan_only filesystem item: '%s'", item)
-                elif isinstance(item, int) and self.do_process_scan:
+                elif isinstance(item, int):
                     # Assume the item represents a process ID
                     if os.path.exists('/proc/%s' % item):
                         self.scan_pids.append(str(item))
@@ -319,9 +327,11 @@ class MalwareDetectionClient:
                     logger.info("Skipping scan_only item: %s", item)
 
             if self.scan_fsobjects:
+                self.do_filesystem_scan = True
                 logger.info("Scan only the specified filesystem item%s: %s", "s" if len(self.scan_fsobjects) > 1 else "",
                             self.scan_fsobjects)
             if self.scan_pids:
+                self.do_process_scan = True
                 logger.info("Scan only the specified process ID%s: %s", "s" if len(self.scan_pids) > 1 else "",
                             self.scan_pids)
             if not (self.scan_fsobjects or self.scan_pids):

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -427,41 +427,57 @@ class TestMalwareDetectionOptions:
 
     @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
     def test_scan_only_option(self, conf, yara, rules, cmd):
-        # Test various combinations of scan_only and the scan_filesystem and scan_processes options
-        # Firstly, test the default option values
+        # Test various combinations of scan_only and scanning files and processes
+        # Firstly, test the default of nothing set for scan_only
         mdc = MalwareDetectionClient(None)
         assert mdc.do_filesystem_scan is True
         assert mdc.do_process_scan is False
         assert mdc.scan_fsobjects == []
         assert mdc.scan_pids == []
 
-        # Add scan_only for a process - expect to exit because we can't scan processes because do_process_scan is false
+        # Add scan_only for a process - expect to only scan that process and no filesystem scanning
         os.environ['SCAN_ONLY'] = '1'
-        with pytest.raises(SystemExit):
-            MalwareDetectionClient(None)
-
-        # Enable process scanning and now the scan_only value should be used
-        os.environ['SCAN_PROCESSES'] = 'true'
         mdc = MalwareDetectionClient(None)
         assert mdc.scan_fsobjects == []
         assert mdc.scan_pids == ['1']
+        assert mdc.do_filesystem_scan is False
+        assert mdc.do_process_scan is True
 
-        # Add directories and processes and expect all to be scanned
+        # Add both directories and processes to be scanned - expect both to be scanned
         os.environ['SCAN_ONLY'] = '1,/tmp'
         mdc = MalwareDetectionClient(None)
         assert mdc.scan_fsobjects == ['/tmp']
         assert mdc.scan_pids == ['1']
+        assert mdc.do_filesystem_scan is True
+        assert mdc.do_process_scan is True
 
-        # Disable filesystem scanning and only expect the process to be scanned
-        os.environ['SCAN_FILESYSTEM'] = 'FALSE'
+        # Specify just a directory to be scanned - expect to only scan that directory and no process scanning
+        os.environ['SCAN_ONLY'] = '/tmp'
+        mdc = MalwareDetectionClient(None)
+        assert mdc.scan_fsobjects == ['/tmp']
+        assert mdc.scan_pids == []
+        assert mdc.do_filesystem_scan is True
+        assert mdc.do_process_scan is False
+
+    @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
+    @patch(LOGGER_TARGET)
+    def test_missing_scan_only_values(self, log_mock, conf, yara, rules, cmd):
+        # Test scan_only with missing values
+        os.environ['SCAN_ONLY'] = '-1,0,1'
         mdc = MalwareDetectionClient(None)
         assert mdc.scan_fsobjects == []
         assert mdc.scan_pids == ['1']
+        assert mdc.do_filesystem_scan is False
+        assert mdc.do_process_scan is True
+        log_mock.info.assert_any_call("Skipping missing scan_only filesystem item: '%s'", "-1")
+        log_mock.info.assert_any_call("Skipping missing scan_only PID: %s", 0)
 
-        # Disable both filesystem and process scanning and expect an error as there is nothing to scan
-        os.environ['SCAN_PROCESSES'] = 'FALSE'
+        os.environ['SCAN_ONLY'] = '/shouldnt_exist,relative_path,100000000'
         with pytest.raises(SystemExit):
             MalwareDetectionClient(None)
+        log_mock.info.assert_any_call("Skipping missing scan_only filesystem item: '%s'", "/shouldnt_exist")
+        log_mock.info.assert_any_call("Skipping missing scan_only PID: %s", 100000000)
+        log_mock.error.assert_called_with("Unable to scan the items specified for the scan_only option")
 
     @patch(LOGGER_TARGET)
     def test_invalid_config_values(self, log_mock, yara, rules, cmd, create_test_files):


### PR DESCRIPTION
* https://issues.redhat.com/browse/YARA-257
* Scanning a process shouldn't also mean the filesystem is scanned too

Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

There was a bug in scan_only, where if a process ID was specified to scan, then it would also try to scan the filesystem.  This was because do_filesystem_scan was set to true.  This PR fixes that and sets do_filesystem_scan to false when all you want to do is just scan a process ID.  Likewise if you just want to scan a file or directory, then do_process_scan is set to false.