### PR TITLE
Separate scan_only and scan_exclude options for filesystem and processes

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -27,7 +27,8 @@ logger = logging.getLogger(__name__)
 MIN_YARA_VERSION = "4.1.0"
 MALWARE_APP_URL = 'https://console.redhat.com/insights/malware'
 MALWARE_CONFIG_FILE = os.path.join(constants.default_conf_dir, "malware-detection-config.yml")
-LAST_SCAN_FILE = os.path.join(constants.default_conf_dir, '.last_malware-detection_scan')
+LAST_FILESYSTEM_SCAN_FILE = os.path.join(constants.default_conf_dir, '.last_malware-detection_filesystem_scan')
+LAST_PROCESSES_SCAN_FILE = os.path.join(constants.default_conf_dir, '.last_malware-detection_processes_scan')
 DEFAULT_MALWARE_CONFIG = """
 # Configuration file for the Red Hat Insights Malware Detection Client app
 # File format is YAML
@@ -63,14 +64,14 @@ filesystem_scan_exclude:
 - /media
 - /dev
 
-# scan_since: scan files created or modified since X days ago or since the 'last' scan.
+# filesystem_scan_since: scan files created or modified since X days ago or since the 'last' scan.
 # Valid values are integers >= 1 or the string 'last'.  For example:
-# scan_since: 1
+# filesystem_scan_since: 1
 # ... means scan files created/modified since 1 day ago
-# scan_since: last
+# filesystem_scan_since: last
 # ... means scan files created/modified since the last successful scan
 # No value means scan all files regardless of created/modified date
-scan_since:
+filesystem_scan_since:
 
 # Exclude mounted network/external filesystems mountpoints?
 # Scanning files within mounted network filesystems may be slow and cause extra network traffic.
@@ -89,23 +90,31 @@ network_filesystem_types: [nfs, nfs4, cifs, smbfs, fuse.sshfs, ceph, glusterfs, 
 # When it is false, no processes are scanned and the processes_scan_* options that follow are ignored
 scan_processes: false
 
-# processes_scan_only: process IDs to be scanned and no others, for example:
+# processes_scan_only: processes to be scanned and no others, for example:
 # processes_scan_only:
 # - 123
 # - 1..100
 # - 10000..
 # - docker
 # - chrome
-#... means only scan PID 123, PIDs from 1 to 100 inclusive, PIDs >= 10000 and PIDs for process names containing the
-#    strings docker or chrome
+#... means only scan PID 123, PIDs from 1 to 100 inclusive, PIDs >= 10000 and process names containing the strings docker or chrome
 # No value means scan all processes
 processes_scan_only:
 
-# processes_scan_exclude: process ID(s) to be excluded from processes scanning
+# processes_scan_exclude: processes to be excluded from scanning.  Uses the same syntax as processes_scan_only.
 # If an item appears in both processes_scan_only and processes_scan_exclude, processes_scan_exclude takes precedence
 # and the item will be excluded
 # No value means don't exclude any processes
 processes_scan_exclude:
+
+# processes_scan_since: scan processes created since X days ago or since the 'last' scan.
+# Valid values are integers >= 1 or the string 'last'.  For example:
+# processes_scan_since: 1
+# ... means scan processes created since 1 day ago
+# processes_scan_since: last
+# ... means scan processes created since the last successful scan
+# No value means scan all processes regardless of created date
+processes_scan_since:
 
 # Add extra metadata about each scan match (if possible), eg file type & md5sum, matching line numbers, process name
 # The extra metadata will display in the webUI along with the scan matches
@@ -129,7 +138,7 @@ ENV_VAR_TYPES = {
     'list': ['FILESYSTEM_SCAN_ONLY', 'FILESYSTEM_SCAN_EXCLUDE', 'PROCESSES_SCAN_ONLY', 'PROCESSES_SCAN_EXCLUDE',
              'NETWORK_FILESYSTEM_TYPES'],
     'integer': ['SCAN_TIMEOUT', 'NICE_VALUE', 'CPU_THREAD_LIMIT', 'STRING_MATCH_LIMIT'],
-    'int_or_str': ['SCAN_SINCE']
+    'int_or_str': ['FILESYSTEM_SCAN_SINCE', 'PROCESSES_SCAN_SINCE']
 }
 
 
@@ -181,8 +190,9 @@ class MalwareDetectionClient:
 
     def run(self):
         # Start the scans and record the time they were started
-        scan_start = get_time()
+        filesystem_scan_start = get_time()
         self.scan_filesystem()
+        processes_scan_start = get_time()
         self.scan_processes()
 
         if self.do_filesystem_scan or self.do_process_scan:
@@ -198,11 +208,16 @@ class MalwareDetectionClient:
                 if not self.test_scan:
                     logger.info("Please visit %s for more information\n", MALWARE_APP_URL)
 
-            # Write the scan start time to disk (its used by the 'scan_since: last' option)
+            # Write the scan start times to disk if scans were performed
+            # (used by the 'filesystem_scan_since: last' and 'processes_scan_since: last' options)
             # Only write the scan time after scans have completed without error or interruption, and its not a test scan
             if not self.test_scan:
-                write_data_to_file(scan_start, LAST_SCAN_FILE)
-                os.chmod(LAST_SCAN_FILE, 0o644)
+                if self.do_filesystem_scan:
+                    write_data_to_file(filesystem_scan_start, LAST_FILESYSTEM_SCAN_FILE)
+                    os.chmod(LAST_FILESYSTEM_SCAN_FILE, 0o644)
+                if self.do_process_scan:
+                    write_data_to_file(processes_scan_start, LAST_PROCESSES_SCAN_FILE)
+                    os.chmod(LAST_PROCESSES_SCAN_FILE, 0o644)
             else:
                 logger.info("\nRed Hat Insights malware-detection app test scan complete.\n"
                             "Test scan results are not recorded in the Insights UI (%s)\n"
@@ -280,12 +295,12 @@ class MalwareDetectionClient:
             exit(constants.sig_kill_bad)
 
         # Check if old options are still in use and inform the user of their replacements
-        if self._get_config_option('scan_only'):
-            logger.error("The scan_only option has been replaced with the filesystem_scan_only and processes_scan_only options")
-            exit(constants.sig_kill_bad)
-        if self._get_config_option('scan_exclude'):
-            logger.error("The scan_exclude option has been replaced with the filesystem_scan_exclude and processes_scan_exclude options")
-            exit(constants.sig_kill_bad)
+        for replaced_scan_option in ('scan_only', 'scan_exclude', 'scan_since'):
+            if self._get_config_option(replaced_scan_option):
+                logger.error("The '{0}' option has been replaced with the 'filesystem_{0}' and 'processes_{0}' options in {1}"
+                             .format(replaced_scan_option, MALWARE_CONFIG_FILE))
+                logger.error("Please remove the %s file and a new config file will be written with the new options", MALWARE_CONFIG_FILE)
+                exit(constants.sig_kill_bad)
 
         # Try parsing the filesystem and processes scan_only options and exit under certain conditions
         parse_filesystem_scan_only = self._parse_filesystem_scan_only_option()
@@ -308,7 +323,8 @@ class MalwareDetectionClient:
 
         self._parse_filesystem_scan_exclude_option()
         self._parse_processes_scan_exclude_option()
-        self._parse_scan_since_option()
+        self._parse_filesystem_scan_since_option()
+        self._parse_processes_scan_since_option()
         self._parse_exclude_network_filesystem_mountpoints_option()
 
     def _parse_test_scan_option(self):
@@ -316,9 +332,10 @@ class MalwareDetectionClient:
         if not self.test_scan:
             return False
 
-        self.scan_since_dict = {'timestamp': None}
         self.filesystem_scan_exclude_list = []
         self.processes_scan_exclude_list = []
+        self.filesystem_scan_since_dict = {'timestamp': None}
+        self.processes_scan_since_dict = {'timestamp': None}
         self.network_filesystem_mountpoints = []
 
         # For matching the test rule, scan the insights config file and the currently running process
@@ -340,11 +357,13 @@ class MalwareDetectionClient:
     def _parse_filesystem_scan_only_option(self):
         """
         Parse the filesystem_scan_only option, if specified, to get a list of files/dirs to scan
+        If parsing was successful, then self.scan_fsobjects is populated and true is returned
+        If parsing was not successful, self.scan_fsobjects remains empty and false is returned
         """
         filesystem_scan_only = self._get_config_option('filesystem_scan_only')
         if filesystem_scan_only:
             if not self.do_filesystem_scan:
-                logger.error("Skipping filesystems_scan_only option because scan_filesystem is false")
+                logger.error("Skipping filesystem_scan_only option because scan_filesystem is false")
                 return False
             # Process the filesystem_scan_only option as a list of files/dirs
             if not isinstance(filesystem_scan_only, list):
@@ -390,15 +409,23 @@ class MalwareDetectionClient:
                         self.filesystem_scan_exclude_list)
 
     @staticmethod
-    def _parse_processes_scan_options(option):
-        # Process the processes option as a list of processes to scan or exclude
+    def _parse_processes_scan_option(option_items):
+        """
+        'option_items' is the list of items provided for either the processes_scan_only or processes_scan_exclude options
+        It is parsed as a list of items that may contain:
+        - a single PID, eg 1
+        - a range of PIDs, eg 10..100 or 10000..  or  ..500
+        - a process_name, eg chrome
+
+        A list of PIDs is returned representing all the PIDs that were matched from parsing the items
+        """
         pids = []
-        ps_output = call([['ps', '-eo', 'pid=,comm=']]).splitlines()
+        ps_output = call([['ps', '-eo', 'pid=', '-o', 'comm=']]).splitlines()
         proc_names = list(map(lambda x: (int(x[0]), str(x[1])), map(lambda x: tuple(x.split()), ps_output)))
         proc_pids = list(map(lambda x: x[0], proc_names))
-        if not isinstance(option, list):
-            option = [str(option)]
-        for item in option:
+        if not isinstance(option_items, list):
+            option_items = [str(option_items)]
+        for item in option_items:
             if isinstance(item, float):
                 # Handle floats so they don't cause exceptions
                 item = str(item)
@@ -419,7 +446,7 @@ class MalwareDetectionClient:
                 except Exception as err:
                     logger.error("Unable to parse '%s' in to a range of PIDs: %s", item, str(err))
                     continue
-                logger.info("Found PID(s) in range '%s': %s", item, pid_matches)
+                logger.debug("Found PID(s) in range '%s': %s", item, pid_matches)
                 if pid_matches:
                     pids.extend(pid_matches)
                 else:
@@ -429,7 +456,7 @@ class MalwareDetectionClient:
                 pid_matches = [str(proc[0]) for proc in proc_names if item in proc[1]]
                 if pid_matches:
                     pids.extend(pid_matches)
-                    logger.info("Found PID(s) for string '%s': %s", item, pid_matches)
+                    logger.debug("Found PID(s) for string '%s': %s", item, pid_matches)
                 else:
                     logger.info("No PID matches found for process name '%s'", item)
 
@@ -445,7 +472,7 @@ class MalwareDetectionClient:
                 logger.error("Skipping processes_scan_only option because scan_processes is false")
                 return False
 
-            pids = self._parse_processes_scan_options(processes_scan_only)
+            pids = self._parse_processes_scan_option(processes_scan_only)
             if pids:
                 self.scan_pids = sorted(set(pids), key=lambda pid: int(pid))
                 logger.info("Scan only the specified process ID%s: %s", "s" if len(self.scan_pids) > 1 else "",
@@ -460,6 +487,9 @@ class MalwareDetectionClient:
         """
         Simple parse of the processes_scan_exclude option (if specified) to get a list of processes to exclude
         """
+        if not self.do_process_scan:
+            return
+
         self.processes_scan_exclude_list = []
         processes_scan_exclude = self._get_config_option('processes_scan_exclude')
         if processes_scan_exclude:
@@ -467,7 +497,7 @@ class MalwareDetectionClient:
                 logger.error("Skipping processes_scan_exclude option because scan_processes is false")
                 return
 
-            pids = self._parse_processes_scan_options(processes_scan_exclude)
+            pids = self._parse_processes_scan_option(processes_scan_exclude)
             if pids:
                 self.processes_scan_exclude_list = sorted(set(pids), key=lambda pid: int(pid))
                 logger.info("Excluding specified process ID%s: %s", "s" if len(self.processes_scan_exclude_list) > 1 else "",
@@ -475,25 +505,51 @@ class MalwareDetectionClient:
             else:
                 logger.error("Unable to find the items specified for the processes_scan_exclude option.  Skipping ...")
 
-    def _parse_scan_since_option(self):
+    def _parse_filesystem_scan_since_option(self):
         """
-        scan_since is specified as an integer representing the number of days ago to scan for modified files
+        filesystem_scan_since is specified as an integer representing the number of days ago to scan for modified files
         If the option was specified and valid, then get the corresponding unix timestamp for the specified
         number of days ago from now, which is used for comparing file modification times
         """
-        self.scan_since_dict = {'timestamp': None, 'datetime': None}
-        scan_since = self._get_config_option('scan_since')
-        if scan_since is not None:
-            timestamp = get_scan_since_timestamp(scan_since)
+        if not self.do_filesystem_scan:
+            return
+
+        self.filesystem_scan_since_dict = {'timestamp': None, 'datetime': None}
+        filesystem_scan_since = self._get_config_option('filesystem_scan_since')
+        if filesystem_scan_since is not None:
+            timestamp = get_scan_since_timestamp('filesystem_scan_since', filesystem_scan_since)
             if timestamp:
-                self.scan_since_dict['timestamp'] = timestamp
-                self.scan_since_dict['datetime'] = datetime.fromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
+                self.filesystem_scan_since_dict['timestamp'] = timestamp
+                self.filesystem_scan_since_dict['datetime'] = datetime.fromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
                 message = "Scan for files created/modified since %s%s"
-                if isinstance(scan_since, str):
+                if isinstance(filesystem_scan_since, str):
                     submessage = 'last successful scan on '
                 else:
-                    submessage = '%s day%s ago on ' % (scan_since, "s" if scan_since > 1 else "")
-                logger.info(message, submessage, self.scan_since_dict['datetime'])
+                    submessage = '%s day%s ago on ' % (filesystem_scan_since, "s" if filesystem_scan_since > 1 else "")
+                logger.info(message, submessage, self.filesystem_scan_since_dict['datetime'])
+
+    def _parse_processes_scan_since_option(self):
+        """
+        processes_scan_since is specified as an integer representing the number of days ago to scan for new processes
+        If the option was specified and valid, then get the corresponding unix timestamp for the specified
+        number of days ago from now, which is used for comparing process start times
+        """
+        if not self.do_process_scan:
+            return
+
+        self.processes_scan_since_dict = {'timestamp': None, 'datetime': None}
+        processes_scan_since = self._get_config_option('processes_scan_since')
+        if processes_scan_since is not None:
+            timestamp = get_scan_since_timestamp('processes_scan_since', processes_scan_since)
+            if timestamp:
+                self.processes_scan_since_dict['timestamp'] = timestamp
+                self.processes_scan_since_dict['datetime'] = datetime.fromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
+                message = "Scan for processes started since %s%s"
+                if isinstance(processes_scan_since, str):
+                    submessage = 'last successful scan on '
+                else:
+                    submessage = '%s day%s ago on ' % (processes_scan_since, "s" if processes_scan_since > 1 else "")
+                logger.info(message, submessage, self.processes_scan_since_dict['datetime'])
 
     def _parse_exclude_network_filesystem_mountpoints_option(self):
         """
@@ -678,16 +734,16 @@ class MalwareDetectionClient:
             dir_scan_start = time.time()
 
             specified_log_txt = "specified " if 'include' in scan_dict[toplevel_dir] else ""
-            if self.scan_since_dict['timestamp']:
+            if self.filesystem_scan_since_dict['timestamp']:
                 logger.info("Scanning %sfiles in %s modified since %s ...", specified_log_txt, toplevel_dir,
-                            self.scan_since_dict['datetime'])
+                            self.filesystem_scan_since_dict['datetime'])
                 # Find the recently modified files in the given top level directory
                 scan_list_file = NamedTemporaryFile(prefix='%s_scan_list.' % os.path.basename(toplevel_dir),
                                                     mode='w', delete=True)
                 if 'include' in scan_dict[toplevel_dir]:
-                    find_modified_include_items(scan_dict[toplevel_dir]['include'], self.scan_since_dict['timestamp'], scan_list_file)
+                    find_modified_include_items(scan_dict[toplevel_dir]['include'], self.filesystem_scan_since_dict['timestamp'], scan_list_file)
                 else:
-                    find_modified_in_directory(toplevel_dir, self.scan_since_dict['timestamp'], scan_list_file)
+                    find_modified_in_directory(toplevel_dir, self.filesystem_scan_since_dict['timestamp'], scan_list_file)
 
                 scan_list_file.flush()
                 cmd.extend(['--scan-list', scan_list_file.name])
@@ -706,7 +762,7 @@ class MalwareDetectionClient:
             try:
                 output = call([cmd]).strip()
             except CalledProcessError as cpe:
-                logger.error("Unable to scan %s: %s", toplevel_dir, cpe.output.strip())
+                logger.debug("Unable to scan %s: %s", toplevel_dir, cpe.output.strip())
                 continue
 
             self.parse_scan_output(output.strip())
@@ -737,6 +793,27 @@ class MalwareDetectionClient:
             self.do_process_scan = False
             return False
 
+        # If process_scan_since is specified, get a list of processes started since the specified date
+        if hasattr(self, 'processes_scan_since_dict') and self.processes_scan_since_dict['timestamp']:
+            # First get a list of all running processes and their start times
+            ps_output = call([['ps', '-eo', 'pid=', '-o', 'lstart=']]).splitlines()
+            all_proc_starts = list(map(lambda x: (str(x[0]), str(x[1])), map(lambda x: tuple(x.strip().split(' ', 1)), ps_output)))
+            scan_since_pids = []
+            # Loop through all processes and if the process start time <= the specified scan_since time then
+            # make note of the process
+            for proc in all_proc_starts:
+                proc_start_secs = float(datetime.strptime(proc[1], '%a %b %d %H:%M:%S %Y').strftime('%s'))
+                if proc_start_secs >= self.processes_scan_since_dict['timestamp']:
+                    scan_since_pids.append(proc[0])
+            # Finally, do a set intersection of the current list of scan_pids and the list of processes started
+            # since processes_scan_since.  The resulting list is the list of processes to scan.
+            self.scan_pids = sorted(list(set(self.scan_pids) & set(scan_since_pids)), key=lambda pid: int(pid))
+
+            if not self.scan_pids:
+                logger.error("No processes to scan because none were started since %s", self.processes_scan_since_dict['datetime'])
+                self.do_process_scan = False
+                return False
+
         logger.info("Starting processes scan ...")
         pids_scan_start = time.time()
 
@@ -748,7 +825,7 @@ class MalwareDetectionClient:
             try:
                 output = call([cmd]).strip()
             except CalledProcessError as cpe:
-                logger.error("Unable to scan process %s: %s", scan_pid, cpe.output.strip())
+                logger.debug("Unable to scan process %s: %s", scan_pid, cpe.output.strip())
                 continue
 
             self.parse_scan_output(output)
@@ -913,15 +990,15 @@ class MalwareDetectionClient:
         # Get the file type, mime type and md5sum hash of the source file
         try:
             file_type = call([['file', '-b', source]]).strip()
-        except CalledProcessError:
+        except Exception:
             file_type = ""
         try:
             mime_type = call([['file', '-bi', source]]).strip()
-        except CalledProcessError:
+        except Exception:
             mime_type = ""
         try:
             md5sum = call([['md5sum', source]]).strip().split()[0]
-        except CalledProcessError:
+        except Exception:
             md5sum = ""
 
         grep_string_data_match_list = []
@@ -1040,7 +1117,7 @@ class MalwareDetectionClient:
             else:
                 return []
 
-        # Parse scan_since, can be either an int or a string (ie 'last')
+        # Parse *_scan_since, can be either an int or a string (ie 'last')
         if env_var in ENV_VAR_TYPES['int_or_str']:
             return int(value) if value.isdigit() else value
 
@@ -1336,38 +1413,38 @@ def process_include_exclude_items(include_items=[], exclude_items=[], exclude_mo
     return scan_dict
 
 
-def get_scan_since_timestamp(since):
+def get_scan_since_timestamp(scan_since_option, since):
     """
-    Return a unix timestamp corresponding to how long ago to scan for files created/modified since this timestamp.
+    Return a unix timestamp corresponding to how long ago to scan for files or processes (depending on scan_since_option)
     Valid values of 'since' are integers > 0 meaning the number of days back in time from now,
                              or 'last' meaning get the timestamp of the last scan
     If 'since' is not one of these valid values, then terminate
     """
     now = time.time()
+    timestamp_file = LAST_FILESYSTEM_SCAN_FILE if scan_since_option == 'filesystem_scan_since' else LAST_PROCESSES_SCAN_FILE
 
-    def get_lastscan_timestamp(lastscan):
+    def get_lastscan_timestamp(scan_since_option, lastscan):
         try:
             # Convert the datetime string into a unix timestamp
             lastscan_seconds = float(datetime.strptime(lastscan, '%Y-%m-%dT%H:%M:%S.%f').strftime('%s'))
             if lastscan_seconds > now:
                 raise RuntimeError("Last scan time is in the future.")
         except Exception as err:
-            logger.error("Error getting time of last malware scan: %s.  Ignoring 'scan_since: last' option ...", str(err))
+            logger.error("Error getting time of last malware scan: %s.  Ignoring '%s: last' option ...", str(err), scan_since_option)
             return None
         return lastscan_seconds
 
     if isinstance(since, str) and since.lower().startswith('l'):
         # Get the timestamp of the last scan
-        if os.path.isfile(LAST_SCAN_FILE):
-            with open(LAST_SCAN_FILE) as f:
+        if os.path.isfile(timestamp_file):
+            with open(timestamp_file) as f:
                 lastscan = f.readline().strip()
-            return get_lastscan_timestamp(lastscan)
+            return get_lastscan_timestamp(scan_since_option, lastscan)
         else:
-            logger.info("File %s doesn't exist for 'scan_since: last' option.  Continuing ...",
-                        LAST_SCAN_FILE)
+            logger.info("File %s doesn't exist for '%s: last' option.  Continuing ...", timestamp_file, scan_since_option)
             return None
     elif isinstance(since, str):
-        logger.error("Unknown value '%s' for scan_since option.  Valid values are integers >= 1 and 'last'", since)
+        logger.error("Unknown value '%s' for %s option.  Valid values are integers >= 1 and 'last'", since, scan_since_option)
         exit(constants.sig_kill_bad)
 
     try:
@@ -1375,7 +1452,7 @@ def get_scan_since_timestamp(since):
         if since_int >= 1:
             return now - (since_int * 86400)  # 86400 seconds in a day
         else:
-            raise ValueError("Invalid scan_since value %s.  Valid values are integers >= 1 and 'last'" % since)
+            raise ValueError("Invalid %s value %s.  Valid values are integers >= 1 and 'last'" % (scan_since_option, since))
     except ValueError as e:
         logger.error(str(e))
         exit(constants.sig_kill_bad)

--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -36,7 +36,8 @@ DEFAULT_MALWARE_CONFIG = """
 scan_filesystem: true
 
 # Scan the running processes?
-# Disabled by default due to its potential performance impact on the host when scanning numerous or large processes
+# Disabled by default due to an existing issue in Yara that can impact system performance
+# when scanning numerous or large processes.  Option will be enabled by default when Yara issue is fixed.
 scan_processes: false
 
 # Perform a simple test scan of the insights-client config directory and process to verify installation and scanning
@@ -44,20 +45,19 @@ scan_processes: false
 # Once verified, disable this option to perform actual malware scans.
 test_scan: true
 
-# scan_only: a single or list of files/directories/process IDs to scan, for example:
-# scan_only:
+# filesystem_scan_only: a single or list of files/directories to be scanned and no others, for example:
+# filesystem_scan_only:
 # - /var/www
 # - /home
-# ... means scan only files in /var/www and /home.  May also be written as scan_only: [/var/www, /home]
-# scan_only: 12345
-#... means scan only process ID 12345
-# No value means scan all files/directories/PIDs
-scan_only:
+# ... means only scan files in /var/www and /home.  May also be written as filesystem_scan_only: [/var/www, /home]
+# No value means scan all files and directories
+filesystem_scan_only:
 
-# scan_exclude: a single or list of files/directories to be excluded from filesystem scanning
-# If an item appears in both scan_only and scan_exclude, scan_exclude takes precedence and the item will be excluded
-# scan_exclude is pre-populated with a list of top level directories that are recommended to be excluded
-scan_exclude:
+# filesystem_scan_exclude: a single or list of files/directories to be excluded from filesystem scanning
+# If an item appears in both filesystem_scan_only and filesystem_scan_exclude, filesystem_scan_exclude takes precedence
+# and the item will be excluded
+# filesystem_scan_exclude is pre-populated with a list of top level directories that are recommended to be excluded
+filesystem_scan_exclude:
 - /proc
 - /sys
 - /cgroup
@@ -66,6 +66,19 @@ scan_exclude:
 - /mnt
 - /media
 - /dev
+
+# processes_scan_only: a single or list of process IDs to be scanned and no others, for example:
+# processes_scan_only:
+# - 123
+# - 456
+#... means only scan process IDs 123 and 456
+# No value means scan all processes
+processes_scan_only:
+
+# processes_scan_exclude: a single or list of process IDs to be excluded from processes scanning
+# If an item appears in both processes_scan_only and processes_scan_exclude, processes_scan_exclude takes precedence
+# and the item will be excluded
+processes_scan_exclude:
 
 # scan_since: scan files created or modified since X days ago or since the 'last' scan.
 # Valid values are integers >= 1 or the string 'last'.  For example:
@@ -106,7 +119,8 @@ cpu_thread_limit: # 2
 ENV_VAR_TYPES = {
     'boolean': ['SCAN_FILESYSTEM', 'SCAN_PROCESSES', 'TEST_SCAN', 'ADD_METADATA',
                 'EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'],
-    'list': ['SCAN_ONLY', 'SCAN_EXCLUDE', 'NETWORK_FILESYSTEM_TYPES'],
+    'list': ['FILESYSTEM_SCAN_ONLY', 'FILESYSTEM_SCAN_EXCLUDE', 'PROCESSES_SCAN_ONLY', 'PROCESSES_SCAN_EXCLUDE',
+             'NETWORK_FILESYSTEM_TYPES'],
     'integer': ['SCAN_TIMEOUT', 'NICE_VALUE', 'CPU_THREAD_LIMIT', 'STRING_MATCH_LIMIT'],
     'int_or_str': ['SCAN_SINCE']
 }
@@ -135,8 +149,8 @@ class MalwareDetectionClient:
                 exit(constants.sig_kill_bad)
 
         # If doing a test scan, then ignore the other scan_* options because test scan sets its own values for them
-        if not self._process_test_scan_option():
-            self._process_scan_options()
+        if not self._parse_test_scan_option():
+            self._parse_scan_options()
 
         # Obtain the rules to be used by yara
         self.rules_file = self._get_rules()
@@ -245,31 +259,59 @@ class MalwareDetectionClient:
         logger.error("Couldn't find yara.  Please ensure the yara package is installed")
         exit(constants.sig_kill_bad)
 
-    def _process_scan_options(self):
+    def _parse_scan_options(self):
         """
         Initialize the various scan flags and lists and run methods that may change/populate them
         """
         self.do_filesystem_scan = self._get_config_option('scan_filesystem', True)
         self.do_process_scan = self._get_config_option('scan_processes', False)
-        if not (self.do_filesystem_scan or self.do_process_scan):
-            logger.error("Both filesystem and process scans are disabled.  Nothing to do.")
-            exit(constants.sig_kill_bad)
-
         self.scan_fsobjects = []
         self.scan_pids = []
 
-        self._process_scan_only_option()
-        self._process_scan_exclude_option()
-        self._process_scan_since_option()
-        self._process_exclude_network_filesystem_mountpoints_option()
+        if not (self.do_filesystem_scan or self.do_process_scan):
+            logger.error("Both scan_filesystem and scan_processes are disabled.  Nothing to scan.")
+            exit(constants.sig_kill_bad)
 
-    def _process_test_scan_option(self):
+        # Check if old options are still in use and inform the user of their replacements
+        if self._get_config_option('scan_only'):
+            logger.error("The scan_only option has been replaced with the filesystem_scan_only and processes_scan_only options")
+            exit(constants.sig_kill_bad)
+        if self._get_config_option('scan_exclude'):
+            logger.error("The scan_exclude option has been replaced with the filesystem_scan_exclude and processes_scan_exclude options")
+            exit(constants.sig_kill_bad)
+
+        # Try parsing the filesystem and processes scan_only options and exit under certain conditions
+        parse_filesystem_scan_only = self._parse_filesystem_scan_only_option()
+        parse_processes_scan_only = self._parse_processes_scan_only_option()
+        if not (parse_filesystem_scan_only or parse_processes_scan_only):
+            logger.error("Nothing to scan with the filesystem_scan_only and processes_scan_only options")
+            exit(constants.sig_kill_bad)
+        if not (parse_filesystem_scan_only or self.do_process_scan):
+            logger.error("Nothing to scan with filesystem_scan_only option and scan_processes is disabled")
+            exit(constants.sig_kill_bad)
+        if not (self.do_filesystem_scan or parse_processes_scan_only):
+            logger.error("Nothing to scan with processes_scan_only option and scan_filesystem is disabled")
+            exit(constants.sig_kill_bad)
+
+        # If we've made it here we are still doing scans, but disable scans if there were problems with scan_only
+        if not parse_filesystem_scan_only:
+            self.do_filesystem_scan = False
+        if not parse_processes_scan_only:
+            self.do_process_scan = False
+
+        self._parse_filesystem_scan_exclude_option()
+        self._parse_processes_scan_exclude_option()
+        self._parse_scan_since_option()
+        self._parse_exclude_network_filesystem_mountpoints_option()
+
+    def _parse_test_scan_option(self):
         self.test_scan = self._get_config_option('test_scan', False)
         if not self.test_scan:
             return False
 
         self.scan_since_dict = {'timestamp': None}
-        self.scan_exclude_list = []
+        self.filesystem_scan_exclude_list = []
+        self.processes_scan_exclude_list = []
         self.network_filesystem_mountpoints = []
 
         # For matching the test rule, scan the insights config file and the currently running process
@@ -288,46 +330,110 @@ class MalwareDetectionClient:
                     "%s and " % self.scan_fsobjects[0] if self.do_filesystem_scan else "", self.scan_pids[0])
         return True
 
-    def _process_scan_only_option(self):
+    def _parse_filesystem_scan_only_option(self):
         """
-        Parse the scan_only option, if specified, to get a list of things to scan
+        Parse the filesystem_scan_only option, if specified, to get a list of files/dirs to scan
         """
-        scan_only = self._get_config_option('scan_only')
-        if scan_only:
-            # Process the scan_only option as a list of items to scan
-            # There may be both files/directories and PIDs all together
-            # Strings are assumed to be files/directories and ints are assumed to be process IDs
-            if not isinstance(scan_only, list):
-                scan_only = [scan_only]
-            for item in scan_only:
-                if isinstance(item, str) and self.do_filesystem_scan:
-                    # Remove extras slashes (/) in the file name and leading double slashes too (normpath doesn't)
-                    item = os.path.normpath(item).replace('//', '/')
-                    # Assume the item represents a filesystem item
-                    if os.path.exists(item):
-                        self.scan_fsobjects.append(item)
-                    else:
-                        logger.info("Skipping missing scan_only filesystem item: '%s'", item)
-                elif isinstance(item, int) and self.do_process_scan:
-                    # Assume the item represents a process ID
-                    if os.path.exists('/proc/%s' % item):
-                        self.scan_pids.append(str(item))
-                    else:
-                        logger.info("Skipping missing scan_only PID: %s", item)
+        filesystem_scan_only = self._get_config_option('filesystem_scan_only')
+        if filesystem_scan_only:
+            if not self.do_filesystem_scan:
+                logger.error("Skipping filesystems_scan_only option because scan_filesystem is false")
+                return False
+            # Process the filesystem_scan_only option as a list of files/dirs
+            if not isinstance(filesystem_scan_only, list):
+                filesystem_scan_only = [filesystem_scan_only]
+            for item in filesystem_scan_only:
+                # Remove extras slashes (/) in the file name and leading double slashes too (normpath doesn't)
+                item = os.path.normpath(item).replace('//', '/')
+                # Assume the item represents a filesystem item
+                if os.path.exists(item):
+                    self.scan_fsobjects.append(item)
                 else:
-                    logger.info("Skipping scan_only item: %s", item)
+                    logger.info("Skipping missing filesystem_scan_only item: '%s'", item)
 
             if self.scan_fsobjects:
                 logger.info("Scan only the specified filesystem item%s: %s", "s" if len(self.scan_fsobjects) > 1 else "",
                             self.scan_fsobjects)
+                return True
+            else:
+                logger.error("Unable to find the items specified for the filesystem_scan_only option.  Skipping ...")
+                return False
+        return True
+
+    def _parse_processes_scan_only_option(self):
+        """
+        Parse the processes_scan_only option, if specified, to get a list of processes to scan
+        """
+        processes_scan_only = self._get_config_option('processes_scan_only')
+        if processes_scan_only:
+            if not self.do_process_scan:
+                logger.error("Skipping processes_scan_only option because scan_processes is false")
+                return False
+            # Process the processes_scan_only option as a list of processes to scan
+            if not isinstance(processes_scan_only, list):
+                processes_scan_only = [str(processes_scan_only)]
+            for item in processes_scan_only:
+                # Assume the item represents a process ID
+                if os.path.exists('/proc/%s' % item):
+                    self.scan_pids.append(str(item))
+                else:
+                    logger.info("Skipping missing processes_scan_only PID: %s", item)
+
             if self.scan_pids:
                 logger.info("Scan only the specified process ID%s: %s", "s" if len(self.scan_pids) > 1 else "",
                             self.scan_pids)
-            if not (self.scan_fsobjects or self.scan_pids):
-                logger.error("Unable to scan the items specified for the scan_only option")
-                exit(constants.sig_kill_bad)
+                return True
+            else:
+                logger.error("Unable to find the items specified for the processes_scan_only option.  Skipping ...")
+                return False
+        return True
 
-    def _process_scan_since_option(self):
+    def _parse_filesystem_scan_exclude_option(self):
+        """
+        Simple parse of the filesystem_scan_exclude option (if specified) to get a list of valid items to exclude
+        """
+        if not self.do_filesystem_scan:
+            return
+
+        self.filesystem_scan_exclude_list = []
+        filesystem_scan_exclude = self._get_config_option('filesystem_scan_exclude')
+        if filesystem_scan_exclude:
+            if not isinstance(filesystem_scan_exclude, list):
+                # Convert filesystem_scan_exclude to a list if only a single non-list item was specified
+                filesystem_scan_exclude = [filesystem_scan_exclude]
+            for item in filesystem_scan_exclude:
+                item = os.path.normpath(item).replace('//', '/')
+                if os.path.exists(item):
+                    self.filesystem_scan_exclude_list.append(item)
+                else:
+                    logger.debug("Skipping missing filesystem_scan_exclude item: '%s'", item)
+            logger.info("Excluding specified filesystem item%s: %s", "s" if len(self.filesystem_scan_exclude_list) > 1 else "",
+                        self.filesystem_scan_exclude_list)
+
+    def _parse_processes_scan_exclude_option(self):
+        """
+        Simple parse of the processes_scan_exclude option (if specified) to get a list of processes to exclude
+        """
+        if not self.do_process_scan:
+            return
+
+        self.processes_scan_exclude_list = []
+        processes_scan_exclude = self._get_config_option('processes_scan_exclude')
+        if processes_scan_exclude:
+            if not isinstance(processes_scan_exclude, list):
+                # Convert processes_scan_exclude to a list if only a single non-list item was specified
+                processes_scan_exclude = [str(processes_scan_exclude)]
+            for item in processes_scan_exclude:
+                # Assume the item represents a process ID
+                if os.path.exists('/proc/%s' % item):
+                    self.processes_scan_exclude_list.append(str(item))
+                else:
+                    logger.info("Skipping missing processes_scan_only PID: %s", item)
+
+            logger.info("Excluding specified process ID%s: %s", "s" if len(self.processes_scan_exclude_list) > 1 else "",
+                        self.processes_scan_exclude_list)
+
+    def _parse_scan_since_option(self):
         """
         scan_since is specified as an integer representing the number of days ago to scan for modified files
         If the option was specified and valid, then get the corresponding unix timestamp for the specified
@@ -347,29 +453,7 @@ class MalwareDetectionClient:
                     submessage = '%s day%s ago on ' % (scan_since, "s" if scan_since > 1 else "")
                 logger.info(message, submessage, self.scan_since_dict['datetime'])
 
-    def _process_scan_exclude_option(self):
-        """
-        Simple parse of the scan_exclude option (if specified) to get a list of valid items to exclude
-        """
-        if not self.do_filesystem_scan:
-            return
-
-        self.scan_exclude_list = []
-        scan_exclude = self._get_config_option('scan_exclude')
-        if scan_exclude:
-            if not isinstance(scan_exclude, list):
-                # Convert scan_exclude to a list if only a single non-list item was specified
-                scan_exclude = [str(scan_exclude)]
-            for item in scan_exclude:
-                item = os.path.normpath(item).replace('//', '/')
-                if os.path.exists(item):
-                    self.scan_exclude_list.append(item)
-                else:
-                    logger.debug("Skipping missing scan_exclude item: '%s'", item)
-            logger.info("Excluding specified filesystem item%s: %s", "s" if len(self.scan_exclude_list) > 1 else "",
-                        self.scan_exclude_list)
-
-    def _process_exclude_network_filesystem_mountpoints_option(self):
+    def _parse_exclude_network_filesystem_mountpoints_option(self):
         """
         If exclude_network_filesystem_mountpoints is true, get a list of mountpoints of mounted network filesystems.
         The network_filesystem_types option has the list of network filesystems types to look for mountpoints for,
@@ -530,13 +614,17 @@ class MalwareDetectionClient:
 
         # Exclude the rules file and insights-client log files, unless they are things we specifically want to scan
         if self.rules_file not in self.scan_fsobjects:
-            self.scan_exclude_list.append(self.rules_file)
+            self.filesystem_scan_exclude_list.append(self.rules_file)
         insights_log_files = glob(constants.default_log_file + '*')
-        self.scan_exclude_list.extend(list(set(insights_log_files) - set(self.scan_fsobjects)))
+        self.filesystem_scan_exclude_list.extend(list(set(insights_log_files) - set(self.scan_fsobjects)))
 
         scan_dict = process_include_exclude_items(include_items=self.scan_fsobjects,
-                                                  exclude_items=self.scan_exclude_list,
+                                                  exclude_items=self.filesystem_scan_exclude_list,
                                                   exclude_mountpoints=self.network_filesystem_mountpoints)
+        if not scan_dict:
+            self.do_filesystem_scan = False
+            return False
+
         logger.debug("Filesystem objects to be scanned in: %s", sorted(scan_dict.keys()))
 
         logger.info("Starting filesystem scan ...")
@@ -592,14 +680,23 @@ class MalwareDetectionClient:
         if not self.do_process_scan:
             return False
 
-        logger.info("Starting processes scan ...")
-        pids_scan_start = time.time()
+        # Get a list of all PIDs to scan if none were specified with scan only option
+        if not self.scan_pids:
+            self.scan_pids = [entry for entry in os.listdir('/proc') if entry.isdigit()]
+
+        # Add this currently running process' PID to the list of processes to exclude (unless its a test_scan)
+        # Then remove the excluded processes from the list of PIDs to scan
+        if not self.test_scan:
+            self.processes_scan_exclude_list.append(str(os.getpid()))  # make sure to exclude our script's pid
+        self.scan_pids = sorted(list(set(self.scan_pids) - set(self.processes_scan_exclude_list)), key=lambda pid: int(pid))
 
         if not self.scan_pids:
-            # Get list of process ids to scan
-            all_pids = [entry for entry in os.listdir('/proc') if entry.isdigit()]
-            exclude_pids = [str(os.getpid())]  # exclude our script's pid at least
-            self.scan_pids = sorted(list(set(all_pids) - set(exclude_pids)), key=lambda pid: int(pid))
+            logger.error("No processes to scan because the specified exclude items cancel them out")
+            self.do_process_scan = False
+            return False
+
+        logger.info("Starting processes scan ...")
+        pids_scan_start = time.time()
 
         for scan_pid in self.scan_pids:
             pid_scan_start = time.time()
@@ -894,11 +991,10 @@ class MalwareDetectionClient:
         if env_var in ENV_VAR_TYPES['boolean']:
             return value.lower() in ('true', 'yes', 't', 'y')
 
-        # Parse these as lists and convert any numeric values into ints
+        # Parse these as lists by splitting at the commas
         if env_var in ENV_VAR_TYPES['list']:
             if value:
-                value_list = value.split(',') if ',' in value else [value]
-                return list(map(lambda x: int(x) if str.isdigit(x) else x, value_list))
+                return value.split(',') if ',' in value else [value]
             else:
                 return []
 
@@ -1094,13 +1190,13 @@ def process_include_exclude_items(include_items=[], exclude_items=[], exclude_mo
     # Get a list of included items from the include file, minus the excluded items
     initial_include_list = process_include_items(include_items)
     if not initial_include_list:
-        logger.error("No items to scan because the include items doesn't contain any valid items")
-        exit(constants.sig_kill_bad)
+        logger.error("No filesystem items to scan because the include items doesn't contain any valid items")
+        return {}
     final_include_list = remove_included_excluded_items(initial_include_list, final_exclude_list)
     logger.debug("Final include items after removing exclude items: %s", final_include_list)
     if not final_include_list:
-        logger.error("No items to scan because the specified exclude items cancel them out")
-        exit(constants.sig_kill_bad)
+        logger.error("No filesystem items to scan because the specified exclude items cancel them out")
+        return {}
 
     # This is the dictionary that will hold all the items to scan (after processing the include and exclude items)
     # It will be keyed by each of the toplevel directories containing items to scan

--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -32,18 +32,14 @@ DEFAULT_MALWARE_CONFIG = """
 # Configuration file for the Red Hat Insights Malware Detection Client app
 # File format is YAML
 ---
-# Scan the filesystem?
-scan_filesystem: true
-
-# Scan the running processes?
-# Disabled by default due to an existing issue in Yara that can impact system performance
-# when scanning numerous or large processes.  Option will be enabled by default when Yara issue is fixed.
-scan_processes: false
-
 # Perform a simple test scan of the insights-client config directory and process to verify installation and scanning
 # are working correctly.  The results from this scan do not show up in the webUI.
 # Once verified, disable this option to perform actual malware scans.
 test_scan: true
+
+# Scan the filesystem?
+# When it is false, the filesystem isn't scanned and the filesystem_* options that follow are ignored
+scan_filesystem: true
 
 # filesystem_scan_only: a single or list of files/directories to be scanned and no others, for example:
 # filesystem_scan_only:
@@ -67,19 +63,6 @@ filesystem_scan_exclude:
 - /media
 - /dev
 
-# processes_scan_only: a single or list of process IDs to be scanned and no others, for example:
-# processes_scan_only:
-# - 123
-# - 456
-#... means only scan process IDs 123 and 456
-# No value means scan all processes
-processes_scan_only:
-
-# processes_scan_exclude: a single or list of process IDs to be excluded from processes scanning
-# If an item appears in both processes_scan_only and processes_scan_exclude, processes_scan_exclude takes precedence
-# and the item will be excluded
-processes_scan_exclude:
-
 # scan_since: scan files created or modified since X days ago or since the 'last' scan.
 # Valid values are integers >= 1 or the string 'last'.  For example:
 # scan_since: 1
@@ -99,6 +82,30 @@ exclude_network_filesystem_mountpoints: true
 # If any mountpoints are found for these filesystem types, the value of the exclude_network_filesystem_mountpoints
 # option will determine if files within the mountpoints are scanned or not.
 network_filesystem_types: [nfs, nfs4, cifs, smbfs, fuse.sshfs, ceph, glusterfs, gfs, gfs2]
+
+# Scan the running processes?
+# Disabled by default due to an existing issue in Yara that can impact system performance
+# when scanning numerous or large processes.  Option will be enabled by default when the Yara fix is available.
+# When it is false, no processes are scanned and the processes_scan_* options that follow are ignored
+scan_processes: false
+
+# processes_scan_only: process IDs to be scanned and no others, for example:
+# processes_scan_only:
+# - 123
+# - 1..100
+# - 10000..
+# - docker
+# - chrome
+#... means only scan PID 123, PIDs from 1 to 100 inclusive, PIDs >= 10000 and PIDs for process names containing the
+#    strings docker or chrome
+# No value means scan all processes
+processes_scan_only:
+
+# processes_scan_exclude: process ID(s) to be excluded from processes scanning
+# If an item appears in both processes_scan_only and processes_scan_exclude, processes_scan_exclude takes precedence
+# and the item will be excluded
+# No value means don't exclude any processes
+processes_scan_exclude:
 
 # Add extra metadata about each scan match (if possible), eg file type & md5sum, matching line numbers, process name
 # The extra metadata will display in the webUI along with the scan matches
@@ -360,34 +367,6 @@ class MalwareDetectionClient:
                 return False
         return True
 
-    def _parse_processes_scan_only_option(self):
-        """
-        Parse the processes_scan_only option, if specified, to get a list of processes to scan
-        """
-        processes_scan_only = self._get_config_option('processes_scan_only')
-        if processes_scan_only:
-            if not self.do_process_scan:
-                logger.error("Skipping processes_scan_only option because scan_processes is false")
-                return False
-            # Process the processes_scan_only option as a list of processes to scan
-            if not isinstance(processes_scan_only, list):
-                processes_scan_only = [str(processes_scan_only)]
-            for item in processes_scan_only:
-                # Assume the item represents a process ID
-                if os.path.exists('/proc/%s' % item):
-                    self.scan_pids.append(str(item))
-                else:
-                    logger.info("Skipping missing processes_scan_only PID: %s", item)
-
-            if self.scan_pids:
-                logger.info("Scan only the specified process ID%s: %s", "s" if len(self.scan_pids) > 1 else "",
-                            self.scan_pids)
-                return True
-            else:
-                logger.error("Unable to find the items specified for the processes_scan_only option.  Skipping ...")
-                return False
-        return True
-
     def _parse_filesystem_scan_exclude_option(self):
         """
         Simple parse of the filesystem_scan_exclude option (if specified) to get a list of valid items to exclude
@@ -410,28 +389,91 @@ class MalwareDetectionClient:
             logger.info("Excluding specified filesystem item%s: %s", "s" if len(self.filesystem_scan_exclude_list) > 1 else "",
                         self.filesystem_scan_exclude_list)
 
+    @staticmethod
+    def _parse_processes_scan_options(option):
+        # Process the processes option as a list of processes to scan or exclude
+        pids = []
+        ps_output = call([['ps', '-eo', 'pid=,comm=']]).splitlines()
+        proc_names = list(map(lambda x: (int(x[0]), str(x[1])), map(lambda x: tuple(x.split()), ps_output)))
+        proc_pids = list(map(lambda x: x[0], proc_names))
+        if not isinstance(option, list):
+            option = [str(option)]
+        for item in option:
+            if isinstance(item, float):
+                # Handle floats so they don't cause exceptions
+                item = str(item)
+            if isinstance(item, int) or item.isdigit():
+                # If it's digit, assume it represents a process ID
+                if int(item) in proc_pids:
+                    logger.debug("Found PID %s", item)
+                    pids.append(str(item))
+                else:
+                    logger.info("Skipping missing PID: %s", item)
+            elif '..' in item:
+                # Assume the item represents a range of process IDs
+                try:
+                    start, end = item.split('..', 1)
+                    start = 1 if not start else int(start.strip('.'))
+                    end = int(open('/proc/sys/kernel/pid_max').read()) if not end else int(end.strip('.'))
+                    pid_matches = [str(proc) for proc in proc_pids if start <= proc <= end]
+                except Exception as err:
+                    logger.error("Unable to parse '%s' in to a range of PIDs: %s", item, str(err))
+                    continue
+                logger.info("Found PID(s) in range '%s': %s", item, pid_matches)
+                if pid_matches:
+                    pids.extend(pid_matches)
+                else:
+                    logger.info("No PIDs found in process range '%s'", item)
+            else:
+                # Assume the item is a string representing the name of one or multiple processes
+                pid_matches = [str(proc[0]) for proc in proc_names if item in proc[1]]
+                if pid_matches:
+                    pids.extend(pid_matches)
+                    logger.info("Found PID(s) for string '%s': %s", item, pid_matches)
+                else:
+                    logger.info("No PID matches found for process name '%s'", item)
+
+        return pids
+
+    def _parse_processes_scan_only_option(self):
+        """
+        Parse the processes_scan_only option, if specified, to get a list of processes to scan
+        """
+        processes_scan_only = self._get_config_option('processes_scan_only')
+        if processes_scan_only:
+            if not self.do_process_scan:
+                logger.error("Skipping processes_scan_only option because scan_processes is false")
+                return False
+
+            pids = self._parse_processes_scan_options(processes_scan_only)
+            if pids:
+                self.scan_pids = sorted(set(pids), key=lambda pid: int(pid))
+                logger.info("Scan only the specified process ID%s: %s", "s" if len(self.scan_pids) > 1 else "",
+                            self.scan_pids)
+                return True
+            else:
+                logger.error("Unable to find the items specified for the processes_scan_only option.  Skipping ...")
+                return False
+        return True
+
     def _parse_processes_scan_exclude_option(self):
         """
         Simple parse of the processes_scan_exclude option (if specified) to get a list of processes to exclude
         """
-        if not self.do_process_scan:
-            return
-
         self.processes_scan_exclude_list = []
         processes_scan_exclude = self._get_config_option('processes_scan_exclude')
         if processes_scan_exclude:
-            if not isinstance(processes_scan_exclude, list):
-                # Convert processes_scan_exclude to a list if only a single non-list item was specified
-                processes_scan_exclude = [str(processes_scan_exclude)]
-            for item in processes_scan_exclude:
-                # Assume the item represents a process ID
-                if os.path.exists('/proc/%s' % item):
-                    self.processes_scan_exclude_list.append(str(item))
-                else:
-                    logger.info("Skipping missing processes_scan_only PID: %s", item)
+            if not self.do_process_scan:
+                logger.error("Skipping processes_scan_exclude option because scan_processes is false")
+                return
 
-            logger.info("Excluding specified process ID%s: %s", "s" if len(self.processes_scan_exclude_list) > 1 else "",
-                        self.processes_scan_exclude_list)
+            pids = self._parse_processes_scan_options(processes_scan_exclude)
+            if pids:
+                self.processes_scan_exclude_list = sorted(set(pids), key=lambda pid: int(pid))
+                logger.info("Excluding specified process ID%s: %s", "s" if len(self.processes_scan_exclude_list) > 1 else "",
+                            self.processes_scan_exclude_list)
+            else:
+                logger.error("Unable to find the items specified for the processes_scan_exclude option.  Skipping ...")
 
     def _parse_scan_since_option(self):
         """
@@ -1000,7 +1042,7 @@ class MalwareDetectionClient:
 
         # Parse scan_since, can be either an int or a string (ie 'last')
         if env_var in ENV_VAR_TYPES['int_or_str']:
-            return int(value) if str.isdigit(value) else value
+            return int(value) if value.isdigit() else value
 
         # Parse these as ints
         if env_var in ENV_VAR_TYPES['integer']:

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -15,7 +15,6 @@ except ImportError:
     from urllib.parse import quote as urlencode  # python 3
 
 from insights.client.apps.manifests import manifests, content_types
-from insights.client.constants import InsightsConstants as constants
 from insights.util.subproc import call, CalledProcessError
 from insights.client.config import InsightsConfig
 
@@ -34,6 +33,7 @@ RULES_FILE = os.path.join(TEMP_TEST_DIR, 'rules.yar')
 TEST_RULE_FILE = os.path.join(TEMP_TEST_DIR, 'test-rule.yar')
 CONFIG = yaml.safe_load(DEFAULT_MALWARE_CONFIG)  # Config 'returned' from _load_config
 TEMP_CONFIG_FILE = os.path.join(TEMP_TEST_DIR, 'malware-detection-config.yml')
+TEST_PID = str(os.getpid())  # This running processes ID
 
 # Get the number of CPU threads to run yara
 CPUS = 1 if int(call('nproc').strip()) <= 2 else 2
@@ -99,10 +99,12 @@ class TestDefaultValues:
         assert CONFIG['test_scan'] is True
         assert CONFIG['scan_filesystem'] is True
         assert CONFIG['scan_processes'] is False
-        assert CONFIG['scan_only'] is None
+        assert CONFIG['filesystem_scan_only'] is None
+        assert CONFIG['processes_scan_only'] is None
         assert CONFIG['scan_since'] is None
-        assert all([x in CONFIG['scan_exclude']
+        assert all([x in CONFIG['filesystem_scan_exclude']
                     for x in ['/proc', '/sys', '/cgroup', '/selinux', '/net', '/mnt', '/media', '/dev']])
+        assert CONFIG['processes_scan_exclude'] is None
         assert CONFIG['exclude_network_filesystem_mountpoints'] is True
 
     @patch(BUILD_YARA_COMMAND_TARGET)
@@ -114,7 +116,6 @@ class TestDefaultValues:
         # With the default options, test_scan is true, so some of the option values will be changed for that and
         # will be different from those in the default config file.
         # For example, do_filesystem_scan AND do_process_scan are both True when doing a test scan
-        test_pid = str(os.getpid())
         # Use a real config file so scan_fsobjects will be populated properly
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             mdc = MalwareDetectionClient(None)
@@ -123,9 +124,10 @@ class TestDefaultValues:
         assert mdc.do_filesystem_scan is True
         assert mdc.do_process_scan is True
         assert mdc.scan_fsobjects == [TEMP_CONFIG_FILE]
-        assert mdc.scan_pids == [test_pid]
+        assert mdc.scan_pids == [TEST_PID]
         assert mdc.scan_since_dict == {'timestamp': None}
-        assert mdc.scan_exclude_list == []
+        assert mdc.filesystem_scan_exclude_list == []
+        assert mdc.processes_scan_exclude_list == []
         assert mdc.network_filesystem_mountpoints == []
         assert mdc.scan_timeout == 3600
         assert mdc.nice_value == 19
@@ -138,13 +140,13 @@ class TestDefaultValues:
                                      "ASCII text", "text/plain; charset=us-ascii", "d5b0aeb3e18df68f47287e14ef144489",
                                      "2:74:Malware Detection Client",
                                      "// Verifies the Red Hat Insights Malware Detection Client app is present on the system",
-                                     "TEST_RedHatInsightsMalwareDetection %s\n0x4a:$re1: Malware Detection Client" % test_pid,
+                                     "TEST_RedHatInsightsMalwareDetection %s\n0x4a:$re1: Malware Detection Client" % TEST_PID,
                                      "python insights_client/run.py --collector malware-detection"]
             mutation = mdc.run()
         log_mock.info.assert_any_call("Found %d rule match%s.", 2, "es")
         assert 'ruleName: "TEST_RedHatInsightsMalwareDetection"' in mutation
         assert 'source: "%s"' % TEST_RULE_FILE in mutation
-        assert 'source: "%s"' % test_pid in mutation
+        assert 'source: "%s"' % TEST_PID in mutation
         assert re.search('metadata:.*line_number', mutation)
         assert re.search('metadata:.*process_name', mutation)
 
@@ -423,45 +425,85 @@ class TestMalwareDetectionOptions:
         assert mdc.scan_fsobjects == []
         assert mdc.scan_pids == []
         assert mdc.scan_since_dict == {'timestamp': None, 'datetime': None}
-        assert all([d in mdc.scan_exclude_list for d in ['/proc', '/sys', '/mnt', '/media', '/dev']])
+        assert all([d in mdc.filesystem_scan_exclude_list for d in ['/proc', '/sys', '/mnt', '/media', '/dev']])
 
     @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
-    def test_scan_only_option(self, conf, yara, rules, cmd):
-        # Test various combinations of scan_only and the scan_filesystem and scan_processes options
+    @patch(LOGGER_TARGET)
+    def test_scan_only_options(self, log_mock, conf, yara, rules, cmd):
+        # Test various combinations of filesystem_scan_only, process_scan_only, scan_filesystem & scan_processes
         # Firstly, test the default option values
         mdc = MalwareDetectionClient(None)
         assert mdc.do_filesystem_scan is True
-        assert mdc.do_process_scan is False
         assert mdc.scan_fsobjects == []
+        assert mdc.do_process_scan is False
         assert mdc.scan_pids == []
 
-        # Add scan_only for a process - expect to exit because we can't scan processes because do_process_scan is false
-        os.environ['SCAN_ONLY'] = '1'
+        # Add some directories
+        os.environ['FILESYSTEM_SCAN_ONLY'] = '/tmp,/var'
+        mdc = MalwareDetectionClient(None)
+        assert mdc.scan_fsobjects == ['/tmp', '/var']
+
+        # Disable filesystem scanning and only expect the process to be scanned
+        os.environ['SCAN_FILESYSTEM'] = 'false'
         with pytest.raises(SystemExit):
             MalwareDetectionClient(None)
+        log_mock.error.assert_called_with("Both scan_filesystem and scan_processes are disabled.  Nothing to scan.")
+
+        # Add scan_only for a process
+        os.environ['PROCESSES_SCAN_ONLY'] = '1'
+        with pytest.raises(SystemExit):
+            MalwareDetectionClient(None)
+        log_mock.error.assert_called_with("Both scan_filesystem and scan_processes are disabled.  Nothing to scan.")
 
         # Enable process scanning and now the scan_only value should be used
         os.environ['SCAN_PROCESSES'] = 'true'
         mdc = MalwareDetectionClient(None)
-        assert mdc.scan_fsobjects == []
+        assert mdc.do_filesystem_scan is False
+        assert mdc.do_process_scan is True
         assert mdc.scan_pids == ['1']
 
-        # Add directories and processes and expect all to be scanned
-        os.environ['SCAN_ONLY'] = '1,/tmp'
-        mdc = MalwareDetectionClient(None)
+    @patch(LOGGER_TARGET)
+    @patch.dict(os.environ)
+    def test_removed_config_values(self, log_mock, yara, rules, cmd, create_test_files):
+        # If the user uses old config items, eg scan_only and scan_exclude, then notify them
+        with open(TEMP_CONFIG_FILE, 'a') as f:
+            f.write('scan_only: /tmp\nscan_exclude: /home\n')
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            with pytest.raises(SystemExit):
+                MalwareDetectionClient(None)
+        log_mock.error.assert_called_with("The scan_only option has been replaced with the filesystem_scan_only and processes_scan_only options")
+
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "#scan_only: /tmp" if line.startswith("scan_only: ") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            with pytest.raises(SystemExit):
+                MalwareDetectionClient(None)
+        log_mock.error.assert_called_with("The scan_exclude option has been replaced with the filesystem_scan_exclude and processes_scan_exclude options")
+
+        os.environ['SCAN_ONLY'] = '/tmp'
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "#scan_exclude: /home" if line.startswith("scan_exclude: ") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            with pytest.raises(SystemExit):
+                MalwareDetectionClient(None)
+        log_mock.error.assert_called_with("The scan_only option has been replaced with the filesystem_scan_only and processes_scan_only options")
+
+        del os.environ['SCAN_ONLY']
+        os.environ['FILESYSTEM_SCAN_ONLY'] = '/tmp'
+        os.environ['SCAN_EXCLUDE'] = '/home'
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            with pytest.raises(SystemExit):
+                MalwareDetectionClient(None)
+        log_mock.error.assert_called_with("The scan_exclude option has been replaced with the filesystem_scan_exclude and processes_scan_exclude options")
+
+        del os.environ['SCAN_EXCLUDE']
+        os.environ['FILESYSTEM_SCAN_EXCLUDE'] = '/home'
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
         assert mdc.scan_fsobjects == ['/tmp']
-        assert mdc.scan_pids == ['1']
-
-        # Disable filesystem scanning and only expect the process to be scanned
-        os.environ['SCAN_FILESYSTEM'] = 'FALSE'
-        mdc = MalwareDetectionClient(None)
-        assert mdc.scan_fsobjects == []
-        assert mdc.scan_pids == ['1']
-
-        # Disable both filesystem and process scanning and expect an error as there is nothing to scan
-        os.environ['SCAN_PROCESSES'] = 'FALSE'
-        with pytest.raises(SystemExit):
-            MalwareDetectionClient(None)
+        assert mdc.filesystem_scan_exclude_list == ['/home']
 
     @patch(LOGGER_TARGET)
     def test_invalid_config_values(self, log_mock, yara, rules, cmd, create_test_files):
@@ -492,7 +534,7 @@ class TestMalwareDetectionOptions:
         # Bad list items for scan_only, mixing single item and list items - fails yaml parsing
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
             line = "nice_value: 19\n" if line.startswith("nice_value") else line
-            line = "scan_only: /bad\n- /bad" if line.startswith("scan_only:") else line
+            line = "filesystem_scan_only: /bad\n- /bad" if line.startswith("filesystem_scan_only:") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             with pytest.raises(SystemExit):
@@ -502,7 +544,7 @@ class TestMalwareDetectionOptions:
 
         # Bad list items for scan_only, not a list item -  fails yaml parsing
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-            line = "scan_only:" if line.startswith("scan_only:") else line
+            line = "filesystem_scan_only:" if line.startswith("filesystem_scan_only:") else line
             line = "/bad" if line.startswith("- /bad") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
@@ -536,9 +578,10 @@ class TestMalwareDetectionOptions:
     @patch.dict(os.environ)
     def test_using_env_vars(self, conf, yara, rules, cmd):
         # Set certain option values via environment variables
-        env_var_list = [('RULES_LOCATION', RULES_FILE), ('TEST_SCAN', 'false'),
-                        ('SCAN_FILESYSTEM', 'YES'), ('SCAN_PROCESSES', 'hello'),  # will be interpreted as false
-                        ('SCAN_ONLY', '/tmp'), ('SCAN_EXCLUDE', '/tmp'),
+        env_var_list = [('RULES_LOCATION', RULES_FILE), ('TEST_SCAN', 'hello'),  # will be interpreted as false
+                        ('SCAN_FILESYSTEM', 'YES'), ('SCAN_PROCESSES', 'T'),
+                        ('FILESYSTEM_SCAN_ONLY', '/tmp'), ('FILESYSTEM_SCAN_EXCLUDE', '/tmp'),
+                        ('PROCESSES_SCAN_ONLY', '1,2'), ('PROCESSES_SCAN_EXCLUDE', '2,1'),
                         ('SCAN_SINCE', '2'), ('SCAN_TIMEOUT', '1800'), ('CPU_THREAD_LIMIT', '1')]
         for key, value in env_var_list:
             os.environ[key] = value
@@ -548,9 +591,11 @@ class TestMalwareDetectionOptions:
         assert mdc.rules_file == RULES_FILE
         assert mdc.test_scan is False
         assert mdc.do_filesystem_scan is True
-        assert mdc.do_process_scan is False
+        assert mdc.do_process_scan is True
         assert mdc.scan_fsobjects == ['/tmp']
-        assert mdc.scan_exclude_list == ['/tmp']
+        assert mdc.filesystem_scan_exclude_list == ['/tmp']
+        assert mdc.scan_pids == ['1', '2']
+        assert mdc.processes_scan_exclude_list == ['2', '1']
         assert mdc.scan_since_dict['timestamp'] < time.time() - (2 * 86400)
         assert mdc.scan_timeout == 1800
         # Not env vars, but just checking they have the expected values
@@ -558,30 +603,39 @@ class TestMalwareDetectionOptions:
         assert mdc.cpu_thread_limit == 1
 
         # Start a filesystem scan and expect scan_only and scan_exclude to cancel each other out
-        with pytest.raises(SystemExit) as exc_info:
-            mdc.scan_filesystem()
-        assert exc_info.value.code == constants.sig_kill_bad
+        mdc.scan_filesystem()
+        assert mdc.do_filesystem_scan is False
+
+        # Start a process scan and expect scan_only and scan_exclude to cancel each other out
+        mdc.scan_processes()
+        assert mdc.do_process_scan is False
 
         # Test when SCAN_ONLY and SCAN_EXCLUDE values are comma separated
-        for key, value in [('SCAN_ONLY', '/tmp,/,/var/tmp'),
-                           ('SCAN_EXCLUDE', '/home,/,/fred,barney')]:
+        # No items will be scanned because '/' is to be excluded
+        for key, value in [('FILESYSTEM_SCAN_ONLY', '/tmp,/,/var/tmp'),
+                           ('FILESYSTEM_SCAN_EXCLUDE', '/home,/,/fred,barney')]:
             os.environ[key] = value
         mdc = MalwareDetectionClient(None)
+        assert mdc.do_filesystem_scan is True
         assert mdc.scan_fsobjects == ['/tmp', '/', '/var/tmp']
-        assert mdc.scan_exclude_list == ['/home', '/']
-        assert mdc.test_scan is False
+        assert mdc.filesystem_scan_exclude_list == ['/home', '/']
+        mdc.scan_filesystem()
+        assert mdc.do_filesystem_scan is False
 
-        # Test when SCAN_ONLY is empty
-        os.environ['SCAN_ONLY'] = ''
+        # Test when FILESYSTEM_SCAN_ONLY is empty, so no items will be scanned because '/' is to be excluded
+        os.environ['FILESYSTEM_SCAN_ONLY'] = ''
+        mdc = MalwareDetectionClient(None)
+        assert mdc.do_filesystem_scan is True
+        assert mdc.scan_fsobjects == []
+        assert mdc.filesystem_scan_exclude_list == ['/home', '/']
+        mdc.scan_filesystem()
+        assert mdc.do_filesystem_scan is False
+
+        # Test when FILESYSTEM_SCAN_EXCLUDE is empty
+        os.environ['FILESYSTEM_SCAN_EXCLUDE'] = ''
         mdc = MalwareDetectionClient(None)
         assert mdc.scan_fsobjects == []
-        assert mdc.scan_exclude_list == ['/home', '/']
-
-        # Test when SCAN_EXCLUDE is empty
-        os.environ['SCAN_EXCLUDE'] = ''
-        mdc = MalwareDetectionClient(None)
-        assert mdc.scan_fsobjects == []
-        assert mdc.scan_exclude_list == []
+        assert mdc.filesystem_scan_exclude_list == []
 
         # Further testing of list type env vars
         os.environ['NETWORK_FILESYSTEM_TYPES'] = ''
@@ -609,83 +663,85 @@ class TestMalwareDetectionOptions:
         log_mock.error.assert_called_with("Unknown value '%s' for scan_since option.  "
                                           "Valid values are integers >= 1 and 'last'", "blast")
 
-    def test_scan_only_root(self, yara, rules, cmd, create_test_files):
-        # Nothing special about root when parsing the scan_only option
+    def test_filesystem_scan_only_root(self, yara, rules, cmd, create_test_files):
+        # Nothing special about root when parsing the filesystem_scan_only option
         # There is no parsing of root to individual toplevel directories until running scan_filesystem
-        scan_only = '/'
+        filesystem_scan_only = '/'
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
             line = "test_scan: false" if line.startswith("test_scan:") else line
-            line = "scan_only: %s" % scan_only if line.startswith("scan_only:") else line
+            line = "filesystem_scan_only: %s" % filesystem_scan_only if line.startswith("filesystem_scan_only:") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             mdc = MalwareDetectionClient(None)
-        assert mdc.scan_fsobjects == [scan_only]
+        assert mdc.scan_fsobjects == [filesystem_scan_only]
         # This is called by scan_filesystem to convert '/' into its top level subdirectories
         scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                                  exclude_items=mdc.scan_exclude_list)
+                                                  exclude_items=mdc.filesystem_scan_exclude_list)
         assert all([x in list(scan_dict.keys()) for x in INCLUDED_TLDS])
         assert '/' not in list(scan_dict.keys())
 
         # Multiple directories aren't consolidated until later
-        scan_only = ['/', '/tmp', '/home']
+        filesystem_scan_only = ['/', '/tmp', '/home']
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-            line = "scan_only: %s" % scan_only if line.startswith("scan_only:") else line
+            line = "filesystem_scan_only: %s" % filesystem_scan_only if line.startswith("filesystem_scan_only:") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             mdc = MalwareDetectionClient(None)
-        assert mdc.scan_fsobjects == scan_only
+        assert mdc.scan_fsobjects == filesystem_scan_only
         scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                                  exclude_items=mdc.scan_exclude_list)
+                                                  exclude_items=mdc.filesystem_scan_exclude_list)
         assert all([x in list(scan_dict.keys()) for x in INCLUDED_TLDS])
         assert '/' not in list(scan_dict.keys())
 
-    def test_scan_exclude_root(self, yara, rules, cmd, create_test_files):
-        # Nothing special about root when parsing the scan_exclude option
+    @patch(LOGGER_TARGET)
+    def test_filesystem_scan_exclude_root(self, log_mock, yara, rules, cmd, create_test_files):
+        # Nothing special about root when parsing the filesystem_scan_exclude option
         # There is no parsing of root to individual toplevel directories until running scan_filesystem
-        # Add '/' to the list of scan_exclude items.  Add it directly after the scan_exclude: line
+        # Add '/' to the list of filesystem_scan_exclude items.  Add it directly after the filesystem_scan_exclude: line
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
             line = "test_scan: false" if line.startswith("test_scan:") else line
-            line = line + "\n- /" if line.startswith("scan_exclude:") else line
+            line = line + "\n- /" if line.startswith("filesystem_scan_exclude:") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             mdc = MalwareDetectionClient(None)
-        assert '/' in mdc.scan_exclude_list
+        assert '/' in mdc.filesystem_scan_exclude_list
         # When scan_filesystem is run, '/' will be expanded into toplevel directories that cancel out everything
-        with pytest.raises(SystemExit) as exc_info:
-            process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                          exclude_items=mdc.scan_exclude_list)
-        assert exc_info.value.code == constants.sig_kill_bad
+        scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
+                                                  exclude_items=mdc.filesystem_scan_exclude_list)
+        assert scan_dict == {}
+        log_mock.error.assert_called_with("No filesystem items to scan because the specified exclude items cancel them out")
 
-    def test_scan_only_scan_exclude_nullify(self, yara, rules, cmd, create_test_files):
-        # Testing scan_only and scan_exclude items such that the exclude items nullify all the scan_only items
+    @patch(LOGGER_TARGET)
+    def test_filesystem_scan_only_exclude_nullify(self, log_mock, yara, rules, cmd, create_test_files):
+        # Testing filesystem scan_only and scan_exclude items such that the exclude items nullify the scan_only items
         # In which case there will be nothing to scan
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
             line = "test_scan: false" if line.startswith("test_scan:") else line
-            line = line + "\n- /var/log\n- /usr/lib/systemd\n- /tmp" if line.startswith("scan_only:") else line
-            line = line + "\n- /tmp/\n- /usr/lib/\n- /var/log" if line.startswith("scan_exclude:") else line
+            line = line + "\n- /var/log\n- /usr/lib/systemd\n- /tmp" if line.startswith("filesystem_scan_only:") else line
+            line = line + "\n- /tmp/\n- /usr/lib/\n- /var/log" if line.startswith("filesystem_scan_exclude:") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             mdc = MalwareDetectionClient(None)
         assert mdc.scan_fsobjects == ['/var/log', '/usr/lib/systemd', '/tmp']
-        assert all([x in mdc.scan_exclude_list for x in ['/tmp', '/usr/lib', '/var/log']])
+        assert all([x in mdc.filesystem_scan_exclude_list for x in ['/tmp', '/usr/lib', '/var/log']])
         # The exclude list covers all the items to be scanned, thus there is nothing to scan
-        with pytest.raises(SystemExit) as exc_info:
-            mdc.scan_filesystem()
-        assert exc_info.value.code == constants.sig_kill_bad
+        mdc.scan_filesystem()
+        assert mdc.do_filesystem_scan is False
+        log_mock.error.assert_called_with("No filesystem items to scan because the specified exclude items cancel them out")
 
-        # Both scan_only and scan_exclude contain root
+        # Both filesystem scan_only and scan_exclude contain root
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-            line = line + "\n- /" if line.startswith("scan_only:") else line
-            line = line + "\n- /" if line.startswith("scan_exclude:") else line
+            line = line + "\n- /" if line.startswith("filesystem_scan_only:") else line
+            line = line + "\n- /" if line.startswith("filesystem_scan_exclude:") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             mdc = MalwareDetectionClient(None)
         assert mdc.scan_fsobjects == ['/', '/var/log', '/usr/lib/systemd', '/tmp']
-        assert all([x in mdc.scan_exclude_list for x in ['/', '/tmp', '/usr/lib', '/var/log']])
+        assert all([x in mdc.filesystem_scan_exclude_list for x in ['/', '/tmp', '/usr/lib', '/var/log']])
         # Because both lists contain /, they will cancel each other out and there is nothing to scan
-        with pytest.raises(SystemExit) as exc_info:
-            mdc.scan_filesystem()
-        assert exc_info.value.code == constants.sig_kill_bad
+        mdc.scan_filesystem()
+        assert mdc.do_filesystem_scan is False
+        log_mock.error.assert_called_with("No filesystem items to scan because the specified exclude items cancel them out")
 
     @patch("insights.client.apps.malware_detection.call")
     @patch(LOGGER_TARGET)
@@ -699,7 +755,7 @@ class TestMalwareDetectionOptions:
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
             line = "test_scan: false" if line.startswith("test_scan:") else line
             line = line + "rules_location: %s\n" % TEST_RULE_FILE if line.startswith('---') else line
-            line = "scan_only: %s" % TEMP_TEST_DIR if line.startswith("scan_only:") else line
+            line = "filesystem_scan_only: %s" % TEMP_TEST_DIR if line.startswith("filesystem_scan_only:") else line
             print(line)
 
         # This is the mocked output returned from the findmnt command
@@ -717,7 +773,7 @@ class TestMalwareDetectionOptions:
         del os.environ['EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS']
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             with pytest.raises(SystemExit):
-                mdc = MalwareDetectionClient(None)
+                MalwareDetectionClient(None)
         log_mock.error.assert_called_with("No value specified for 'network_filesystem_types' option")
 
         # Ok, now with exclude mountpoints true and a value for types we will produce a list of mountpoints
@@ -728,7 +784,7 @@ class TestMalwareDetectionOptions:
 
         # Now we can process all the include and exclude items to build the scan_dict of things to scan
         scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                                  exclude_items=mdc.scan_exclude_list,
+                                                  exclude_items=mdc.filesystem_scan_exclude_list,
                                                   exclude_mountpoints=mdc.network_filesystem_mountpoints)
 
         # The exclude_mountpoints will be added to the list of items to exclude
@@ -743,18 +799,75 @@ class TestMalwareDetectionOptions:
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             mdc = MalwareDetectionClient(None)
         assert mdc.network_filesystem_mountpoints == [TEMP_TEST_DIR]
-        with pytest.raises(SystemExit):
-            process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                          exclude_items=mdc.scan_exclude_list,
-                                          exclude_mountpoints=mdc.network_filesystem_mountpoints)
-        log_mock.error.assert_called_with("No items to scan because the specified exclude items cancel them out")
+        scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
+                                                  exclude_items=mdc.filesystem_scan_exclude_list,
+                                                  exclude_mountpoints=mdc.network_filesystem_mountpoints)
+        assert scan_dict == {}
+        log_mock.error.assert_called_with("No filesystem items to scan because the specified exclude items cancel them out")
+
+
+@patch(BUILD_YARA_COMMAND_TARGET)
+@patch(GET_RULES_TARGET, return_value=TEST_RULE_FILE)
+@patch(FIND_YARA_TARGET, return_value=YARA)
+@patch(LOGGER_TARGET)
+@patch.dict(os.environ)
+class TestProcessScanning:
+
+    def test_scan_processes(self, log_mock, yara, rules, cmd, create_test_files):
+        # Test scanning processes to test which processes are going to be scanned
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "test_scan: false" if line.startswith("test_scan:") else line
+            line = "scan_processes: true" if line.startswith("scan_processes:") else line
+            line = "add_metadata: false" if line.startswith("add_metadata:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert mdc.rules_file == TEST_RULE_FILE
+        assert mdc.do_filesystem_scan is True
+        assert mdc.do_process_scan is True
+        assert mdc.scan_pids == []
+        assert mdc.processes_scan_exclude_list == []
+
+        # Patch the calls to yara so it doesn't actually try to scan any processes
+        with patch("insights.client.apps.malware_detection.call", return_value=""):
+            mdc.scan_processes()
+        assert mdc.processes_scan_exclude_list == [TEST_PID]
+        assert len(mdc.scan_pids) > 1
+        assert '1' in mdc.scan_pids
+        assert TEST_PID not in mdc.scan_pids
+
+        # Exclude some processes via the config file
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "processes_scan_exclude: 1\n" if line.startswith("processes_scan_exclude:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert mdc.processes_scan_exclude_list == ['1']
+        # Patch the calls to yara so it doesn't actually try to scan any processes
+        with patch("insights.client.apps.malware_detection.call", return_value=""):
+            mdc.scan_processes()
+        assert mdc.processes_scan_exclude_list == ['1', TEST_PID]
+        assert len(mdc.scan_pids) > 1
+        assert all([x not in mdc.scan_pids for x in ['1', TEST_PID]])
+
+        # Exclude some processes via env vars
+        os.environ['PROCESSES_SCAN_EXCLUDE'] = '3,2,1'
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert mdc.processes_scan_exclude_list == ['3', '2', '1']
+        # Patch the calls to yara so it doesn't actually try to scan any processes
+        with patch("insights.client.apps.malware_detection.call", return_value=""):
+            mdc.scan_processes()
+        assert mdc.processes_scan_exclude_list == ['3', '2', '1', TEST_PID]
+        assert len(mdc.scan_pids) > 1
+        assert all([x not in mdc.scan_pids for x in [3, 2, 1, TEST_PID]])
 
 
 @patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
 @patch(BUILD_YARA_COMMAND_TARGET)
 @patch(FIND_YARA_TARGET, return_value=YARA)
 @patch(LOGGER_TARGET)
-class TestScanning:
+class TestFilesystemScanning:
 
     def test_scan_rules_file_with_extra_slashes(self, log_mock, yara, cmd, remove, create_test_files):
         # Test scanning RULES_FILE with an extra slash only in the rules_location one
@@ -763,7 +876,7 @@ class TestScanning:
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
             line = "test_scan: false" if line.startswith("test_scan:") else line
             line = line + "rules_location: %s\n" % TEST_RULE_FILE.replace('/', '//') if line.startswith('---') else line
-            line = "scan_only: %s" % TEST_RULE_FILE if line.startswith("scan_only:") else line
+            line = "filesystem_scan_only: %s" % TEST_RULE_FILE if line.startswith("filesystem_scan_only:") else line
             line = "add_metadata: false" if line.startswith("add_metadata:") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
@@ -783,51 +896,50 @@ class TestScanning:
         log_mock.info.assert_any_call("Matched rule %s in %s %s", "TEST_RedHatInsightsMalwareDetection", "file", TEST_RULE_FILE)
 
     def test_scan_root_with_extra_slashes(self, log_mock, yara, cmd, remove, create_test_files):
-        # Testing we handle the situation where items in scan_only & scan_exclude contain multiple slashes
+        # Testing we handle the situation where items in filesystem_scan_only & scan_exclude contain multiple slashes
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
             line = "test_scan: false" if line.startswith("test_scan:") else line
             line = line + "rules_location: %s\n" % TEST_RULE_FILE if line.startswith('---') else line
-            line = line + "- //\n" if line.startswith("scan_only:") else line
-            line = line + "- //\n" if line.startswith("scan_exclude:") else line
+            line = line + "- //\n" if line.startswith("filesystem_scan_only:") else line
+            line = line + "- //\n" if line.startswith("filesystem_scan_exclude:") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             mdc = MalwareDetectionClient(None)
         assert mdc.scan_fsobjects == ['/']
-        assert '/' in mdc.scan_exclude_list
-        # Chaos monkey - modify scan_fsobjects and scan_exclude_list AFTER they have been verified
+        assert '/' in mdc.filesystem_scan_exclude_list
+        # Chaos monkey - modify scan_fsobjects and filesystem_scan_exclude_list AFTER they have been verified
         # Assert that they still work and cancel each other out
         mdc.scan_fsobjects = ['//']
-        mdc.scan_exclude_list = ['//']
-        with pytest.raises(SystemExit) as exc_info:
-            mdc.scan_filesystem()
-        log_mock.error.assert_called_with("No items to scan because the specified exclude items cancel them out")
-        assert exc_info.value.code == constants.sig_kill_bad
+        mdc.filesystem_scan_exclude_list = ['//']
+        mdc.scan_filesystem()
+        assert mdc.do_filesystem_scan is False
+        log_mock.error.assert_called_with("No filesystem items to scan because the specified exclude items cancel them out")
 
     @patch('insights.client.apps.malware_detection.NamedTemporaryFile')
     @patch("insights.client.apps.malware_detection.call", return_value="")
     def test_scan_since_tmp_files(self, call_mock, tmp_file_mock, log_mock, yara, cmd, remove, extract_tmp_files, create_test_files):
-        # Set scan_only, scan_exclude options to some of the tmp files and then 'scan' them
+        # Set filesystem_scan_only, filesystem_scan_exclude options to some of the tmp files and then 'scan' them
         # Then touch files to test the scan_since option and make sure that only the touched files will be scanned
         yara_file_list = os.path.join(TEMP_TEST_DIR, 'yara_file_list')
         scan_me_file = os.path.join(TEMP_TEST_DIR, 'scan_me/scan_me_file')
         scan_me_too_file = os.path.join(TEMP_TEST_DIR, 'scan_me_too/scan_me_too_file')
-        scan_only = tuple(map(lambda x: os.path.join(TEMP_TEST_DIR, x), ['scan_me', 'scan_me_too']))
-        scan_exclude = tuple(map(lambda x: os.path.join(TEMP_TEST_DIR, x),
-                                 ['scan_me_not', 'scan_me/dont_scan_me', 'scan_me_too/dont_scan_me_too']))
+        filesystem_scan_only = tuple(map(lambda x: os.path.join(TEMP_TEST_DIR, x), ['scan_me', 'scan_me_too']))
+        filesystem_scan_exclude = tuple(map(lambda x: os.path.join(TEMP_TEST_DIR, x),
+                                            ['scan_me_not', 'scan_me/dont_scan_me', 'scan_me_too/dont_scan_me_too']))
 
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
             line = "test_scan: false" if line.startswith("test_scan:") else line
             line = line + "rules_location: %s\n" % TEST_RULE_FILE if line.startswith('---') else line
-            line = line + '- %s\n- %s' % scan_only if line.startswith("scan_only:") else line
-            line = line + "- %s\n- %s\n- %s" % scan_exclude if line.startswith("scan_exclude:") else line
+            line = line + '- %s\n- %s' % filesystem_scan_only if line.startswith("filesystem_scan_only:") else line
+            line = line + "- %s\n- %s\n- %s" % filesystem_scan_exclude if line.startswith("filesystem_scan_exclude:") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             mdc = MalwareDetectionClient(None)
         scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                                  exclude_items=mdc.scan_exclude_list)
+                                                  exclude_items=mdc.filesystem_scan_exclude_list)
         # Ensure the correct scan include and exclude values are set
         assert list(scan_dict.keys()) == ['/tmp']
-        assert sorted(list(scan_dict['/tmp']['exclude']['items'])) == sorted(scan_exclude)
+        assert sorted(list(scan_dict['/tmp']['exclude']['items'])) == sorted(filesystem_scan_exclude)
 
         # Run scan_filesystem, but mock out NamedTemporaryFile so we can use our own file and inspect its contents after
         # Also mock out the call to yara but we don't return anything since we aren't testing it
@@ -840,8 +952,8 @@ class TestScanning:
         assert len(contents) > 2
         assert all([x in contents for x in [scan_me_file, scan_me_too_file]])
 
-        # With the same scan_only and scan_exclude values, add scan_since: last into the mix and set the last scan
-        # time to now.  There should be no matches because no files have been modified since now
+        # With the same filesystem scan_only and scan_exclude values, add scan_since: last into the mix and set
+        # the last scan time to now.  There should be no matches because no files have been modified since now
         last_scan = time.time()
         last_scan_fmt = datetime.fromtimestamp(last_scan).strftime('%Y-%m-%d %H:%M:%S')
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
@@ -855,7 +967,7 @@ class TestScanning:
         log_mock.info.assert_called_with("Scan for files created/modified since %s%s", ANY, ANY)
 
         # Run scan_filesystem, but mock out NamedTemporaryFile so we can use our own file and inspect its contents after
-        # Also mock out the call to yara but we don't return anything since we aren't testing it
+        # Also mock out the call to yara, but we don't return anything since we aren't testing it
         with open(yara_file_list, 'w') as f:
             tmp_file_mock.return_value = f
             mdc.scan_filesystem()
@@ -907,7 +1019,7 @@ class TestScanning:
         glob_files = [os.path.join(TEMP_TEST_DIR, 'scan_me', f) for f in ['new_file', 'old_file']]
         os.environ['TEST_SCAN'] = 'false'
         os.environ['RULES_LOCATION'] = TEST_RULE_FILE
-        os.environ['SCAN_ONLY'] = "%s,%s" % (TEMP_TEST_DIR, glob_files[1])  # we actually want to scan glob_files[1]
+        os.environ['FILESYSTEM_SCAN_ONLY'] = "%s,%s" % (TEMP_TEST_DIR, glob_files[1])  # we actually want to scan glob_files[1]
         mdc = MalwareDetectionClient(None)
         assert mdc.rules_file == TEST_RULE_FILE
         assert mdc.scan_fsobjects == [TEMP_TEST_DIR, glob_files[1]]
@@ -917,22 +1029,22 @@ class TestScanning:
         with patch("insights.client.apps.malware_detection.glob", return_value=glob_files):
             with patch("insights.client.apps.malware_detection.call", return_value=""):
                 mdc.scan_filesystem()
-        assert mdc.rules_file in mdc.scan_exclude_list
-        assert glob_files[0] in mdc.scan_exclude_list
+        assert mdc.rules_file in mdc.filesystem_scan_exclude_list
+        assert glob_files[0] in mdc.filesystem_scan_exclude_list
         # Make sure glob_files[1] isn't excluded because we actually want to scan that file
-        assert glob_files[1] not in mdc.scan_exclude_list
+        assert glob_files[1] not in mdc.filesystem_scan_exclude_list
 
         # This time patch glob so it returns an empty list, ie simulating no extra files to exclude
         mdc = MalwareDetectionClient(None)
         with patch("insights.client.apps.malware_detection.glob", return_value=[]):
             with patch("insights.client.apps.malware_detection.call", return_value=""):
                 mdc.scan_filesystem()
-        assert mdc.rules_file in mdc.scan_exclude_list
+        assert mdc.rules_file in mdc.filesystem_scan_exclude_list
         # None of the glob files should be excluded this time
-        assert all([f not in mdc.scan_exclude_list for f in glob_files])
+        assert all([f not in mdc.filesystem_scan_exclude_list for f in glob_files])
 
 
-class TestIncludeExcludeMethods:
+class TestFilesystemIncludeExcludeMethods:
 
     def test_toplevel_dirs(self):
         tlds = get_toplevel_dirs()
@@ -1070,7 +1182,7 @@ class TestIncludeExcludeMethods:
 @patch(FIND_YARA_TARGET, return_value=YARA)
 @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
 @patch.dict(os.environ, {'TEST_SCAN': 'false'})
-class TestIncludeExcludeProcessing:
+class TestFilesystemIncludeExcludeProcessing:
 
     def test_process_include_exclude_items_simple(self, conf, yara, rules, cmd):
         # Test the process_include_exclude_items function with simple modified include and exclude items
@@ -1079,9 +1191,9 @@ class TestIncludeExcludeProcessing:
         # Add a single toplevel directory to the include file - expect only a single directory to scan
         mdc = MalwareDetectionClient(None)
         mdc.scan_fsobjects = ['/etc']
-        mdc.scan_exclude_list = []
+        mdc.filesystem_scan_exclude_list = []
         scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                                  exclude_items=mdc.scan_exclude_list)
+                                                  exclude_items=mdc.filesystem_scan_exclude_list)
         assert list(scan_dict.keys()) == ['/etc']
         assert 'include' not in scan_dict['/etc']
         assert 'exclude' not in scan_dict['/etc']
@@ -1089,31 +1201,30 @@ class TestIncludeExcludeProcessing:
         # Add some extra subdirectories to scan
         mdc.scan_fsobjects.extend(['/var/lib', '/var/log'])
         scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                                  exclude_items=mdc.scan_exclude_list)
+                                                  exclude_items=mdc.filesystem_scan_exclude_list)
         assert sorted(scan_dict.keys()) == ['/etc', '/var']
         assert sorted(list(scan_dict['/var']['include'])) == ['/var/lib', '/var/log']
         assert 'exclude' not in scan_dict['/var']
 
         # Add some extra directories to exclude that won't impact the already included directories
-        mdc.scan_exclude_list.extend(['/tmp', '/var/run'])
+        mdc.filesystem_scan_exclude_list.extend(['/tmp', '/var/run'])
         scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                                  exclude_items=mdc.scan_exclude_list)
+                                                  exclude_items=mdc.filesystem_scan_exclude_list)
         assert sorted(scan_dict.keys()) == ['/etc', '/var']
         assert sorted(scan_dict['/var']['include']) == ['/var/lib', '/var/log']
         assert scan_dict['/var']['exclude']['items'] == ['/var/run']
 
         # Exclude /var which will remove it from the list of directories to scan
-        mdc.scan_exclude_list.append('/var')
+        mdc.filesystem_scan_exclude_list.append('/var')
         scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                                  exclude_items=mdc.scan_exclude_list)
+                                                  exclude_items=mdc.filesystem_scan_exclude_list)
         assert list(scan_dict.keys()) == ['/etc']
 
         # Exclude /etc which means there will be no directories to scan
-        mdc.scan_exclude_list.append('/etc')
-        with pytest.raises(SystemExit) as exc_info:
-            process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                          exclude_items=mdc.scan_exclude_list)
-        assert exc_info.value.code == constants.sig_kill_bad
+        mdc.filesystem_scan_exclude_list.append('/etc')
+        scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
+                                                  exclude_items=mdc.filesystem_scan_exclude_list)
+        assert scan_dict == {}
 
     def test_process_include_exclude_items_complex(self, conf, yara, rules, cmd):
         # Test the process function with modified include and exclude files that will require more complex
@@ -1122,10 +1233,10 @@ class TestIncludeExcludeProcessing:
         # We don't need to list the contents of the /var directory
         mdc = MalwareDetectionClient(None)
         mdc.scan_fsobjects = ['/var/lib', '/var/log']
-        mdc.scan_exclude_list = ['/var/lib/systemd', '/var/lib/misc/', '/var/log/wtmp']
+        mdc.filesystem_scan_exclude_list = ['/var/lib/systemd', '/var/lib/misc/', '/var/log/wtmp']
 
         scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                                  exclude_items=mdc.scan_exclude_list)
+                                                  exclude_items=mdc.filesystem_scan_exclude_list)
         assert list(scan_dict.keys()) == ['/var']
         assert sorted(scan_dict['/var']['exclude']['items']) == ['/var/lib/misc', '/var/lib/systemd', '/var/log/wtmp']
         # The exclude items shouldn't be in the include items
@@ -1142,7 +1253,7 @@ class TestIncludeExcludeProcessing:
         # Because now we have to list the contents of the /var and /var/lib directories
         mdc.scan_fsobjects.append('/var')
         scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                                  exclude_items=mdc.scan_exclude_list)
+                                                  exclude_items=mdc.filesystem_scan_exclude_list)
         assert list(scan_dict.keys()) == ['/var']
         assert sorted(scan_dict['/var']['exclude']['items']) == ['/var/lib/misc', '/var/lib/systemd', '/var/log/wtmp']
         assert all([x not in scan_dict['/var']['include']

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 import pytest
 import yaml
 import time
@@ -17,6 +16,7 @@ except ImportError:
 from insights.client.apps.manifests import manifests, content_types
 from insights.util.subproc import call, CalledProcessError
 from insights.client.config import InsightsConfig
+from insights.tests.helpers import getenv_bool
 
 from insights.client.apps.malware_detection import (
     DEFAULT_MALWARE_CONFIG, MalwareDetectionClient, InsightsConnection,
@@ -31,6 +31,7 @@ TEMP_TEST_DIR = "/tmp/malware-detection_test_dir_%s" % RANDOM_STRING
 YARA = '/bin/yara'  # Fake yara executable
 RULES_FILE = os.path.join(TEMP_TEST_DIR, 'rules.yar')
 TEST_RULE_FILE = os.path.join(TEMP_TEST_DIR, 'test-rule.yar')
+TEST_RULE_SCRIPT = os.path.join(TEMP_TEST_DIR, 'test-rule_process_match.sh')
 CONFIG = yaml.safe_load(DEFAULT_MALWARE_CONFIG)  # Config 'returned' from _load_config
 TEMP_CONFIG_FILE = os.path.join(TEMP_TEST_DIR, 'malware-detection-config.yml')
 TEST_PID = str(os.getpid())  # This running processes ID
@@ -43,16 +44,15 @@ TLDS = ['/boot', '/dev', '/etc', '/home', '/opt', '/proc', '/root', '/sys', '/tm
 INCLUDED_TLDS = ['/boot', '/etc', '/home', '/opt', '/root', '/tmp', '/usr', '/var']  # after removing exclude items
 DEFAULT_SCAN_EXCLUDE = ['/cgroup', '/dev', '/media', '/mnt', '/net', '/proc', '/selinux', '/sys']
 
-# Tests using the caplog fixture fail with python 2.6
-IS_PY26 = sys.version_info < (2, 7)
-PY26_SKIP_TEST_REASON = "pytest caplog fixture doesn't work in python 2.6"
-
 # Various patch targets
 LOGGER_TARGET = "insights.client.apps.malware_detection.logger"
 LOAD_CONFIG_TARGET = "insights.client.apps.malware_detection.MalwareDetectionClient._load_config"
 FIND_YARA_TARGET = "insights.client.apps.malware_detection.MalwareDetectionClient._find_yara"
 GET_RULES_TARGET = "insights.client.apps.malware_detection.MalwareDetectionClient._get_rules"
 BUILD_YARA_COMMAND_TARGET = "insights.client.apps.malware_detection.MalwareDetectionClient._build_yara_command"
+
+# Run the test_processes_scan_since test?
+TEST_PROCESSES_SCAN_SINCE = getenv_bool("TEST_PROCESSES_SCAN_SINCE", False)
 
 
 @pytest.fixture
@@ -64,11 +64,13 @@ def create_test_files():
         tcf.write(DEFAULT_MALWARE_CONFIG)
     test_files = [(MATCHING_ENTITY_FILE, MATCHING_ENTITY_FILE_CONTENTS),
                   (ANOTHER_MATCHING_ENTITY_FILE, ANOTHER_MATCHING_ENTITY_FILE_CONTENTS),
-                  (TEST_RULE_FILE, TEST_RULE_FILE_CONTENTS)]
+                  (TEST_RULE_FILE, TEST_RULE_FILE_CONTENTS),
+                  (TEST_RULE_SCRIPT, TEST_RULE_SCRIPT_CONTENTS)]
     for test_file, contents in test_files:
         if not os.path.exists(test_file):
             with open(test_file, 'w') as f:
                 f.write(contents)
+    os.chmod(TEST_RULE_SCRIPT, 0o755)
     yield
     os.system('rm -rf %s' % TEMP_TEST_DIR)
 
@@ -101,7 +103,8 @@ class TestDefaultValues:
         assert CONFIG['scan_processes'] is False
         assert CONFIG['filesystem_scan_only'] is None
         assert CONFIG['processes_scan_only'] is None
-        assert CONFIG['scan_since'] is None
+        assert CONFIG['filesystem_scan_since'] is None
+        assert CONFIG['processes_scan_since'] is None
         assert all([x in CONFIG['filesystem_scan_exclude']
                     for x in ['/proc', '/sys', '/cgroup', '/selinux', '/net', '/mnt', '/media', '/dev']])
         assert CONFIG['processes_scan_exclude'] is None
@@ -125,9 +128,10 @@ class TestDefaultValues:
         assert mdc.do_process_scan is True
         assert mdc.scan_fsobjects == [TEMP_CONFIG_FILE]
         assert mdc.scan_pids == [TEST_PID]
-        assert mdc.scan_since_dict == {'timestamp': None}
+        assert mdc.filesystem_scan_since_dict == {'timestamp': None}
         assert mdc.filesystem_scan_exclude_list == []
         assert mdc.processes_scan_exclude_list == []
+        assert mdc.processes_scan_since_dict == {'timestamp': None}
         assert mdc.network_filesystem_mountpoints == []
         assert mdc.scan_timeout == 3600
         assert mdc.nice_value == 19
@@ -424,8 +428,11 @@ class TestMalwareDetectionOptions:
         assert mdc.do_process_scan is False
         assert mdc.scan_fsobjects == []
         assert mdc.scan_pids == []
-        assert mdc.scan_since_dict == {'timestamp': None, 'datetime': None}
+        assert mdc.filesystem_scan_since_dict == {'timestamp': None, 'datetime': None}
         assert all([d in mdc.filesystem_scan_exclude_list for d in ['/proc', '/sys', '/mnt', '/media', '/dev']])
+        # filesystem_scan_* attributes will exist whereas processes_scan_* will not
+        assert all([hasattr(mdc, 'filesystem_scan_' + attr) is True and hasattr(mdc, 'processes_scan_' + attr) is False
+                    for attr in ('exclude_list', 'since_dict')])
 
     @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
     @patch(LOGGER_TARGET)
@@ -471,7 +478,8 @@ class TestMalwareDetectionOptions:
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             with pytest.raises(SystemExit):
                 MalwareDetectionClient(None)
-        log_mock.error.assert_called_with("The scan_only option has been replaced with the filesystem_scan_only and processes_scan_only options")
+        log_mock.error.assert_any_call("The 'scan_only' option has been replaced with the 'filesystem_scan_only' and 'processes_scan_only' options in " + TEMP_CONFIG_FILE)
+        log_mock.error.assert_called_with("Please remove the %s file and a new config file will be written with the new options", TEMP_CONFIG_FILE)
 
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
             line = "#scan_only: /tmp" if line.startswith("scan_only: ") else line
@@ -479,7 +487,7 @@ class TestMalwareDetectionOptions:
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             with pytest.raises(SystemExit):
                 MalwareDetectionClient(None)
-        log_mock.error.assert_called_with("The scan_exclude option has been replaced with the filesystem_scan_exclude and processes_scan_exclude options")
+        log_mock.error.assert_any_call("The 'scan_exclude' option has been replaced with the 'filesystem_scan_exclude' and 'processes_scan_exclude' options in " + TEMP_CONFIG_FILE)
 
         os.environ['SCAN_ONLY'] = '/tmp'
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
@@ -488,7 +496,7 @@ class TestMalwareDetectionOptions:
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             with pytest.raises(SystemExit):
                 MalwareDetectionClient(None)
-        log_mock.error.assert_called_with("The scan_only option has been replaced with the filesystem_scan_only and processes_scan_only options")
+        log_mock.error.assert_any_call("The 'scan_only' option has been replaced with the 'filesystem_scan_only' and 'processes_scan_only' options in " + TEMP_CONFIG_FILE)
 
         del os.environ['SCAN_ONLY']
         os.environ['FILESYSTEM_SCAN_ONLY'] = '/tmp'
@@ -496,7 +504,7 @@ class TestMalwareDetectionOptions:
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             with pytest.raises(SystemExit):
                 MalwareDetectionClient(None)
-        log_mock.error.assert_called_with("The scan_exclude option has been replaced with the filesystem_scan_exclude and processes_scan_exclude options")
+        log_mock.error.assert_any_call("The 'scan_exclude' option has been replaced with the 'filesystem_scan_exclude' and 'processes_scan_exclude' options in " + TEMP_CONFIG_FILE)
 
         del os.environ['SCAN_EXCLUDE']
         os.environ['FILESYSTEM_SCAN_EXCLUDE'] = '/home'
@@ -582,7 +590,8 @@ class TestMalwareDetectionOptions:
                         ('SCAN_FILESYSTEM', 'YES'), ('SCAN_PROCESSES', 'T'),
                         ('FILESYSTEM_SCAN_ONLY', '/tmp'), ('FILESYSTEM_SCAN_EXCLUDE', '/tmp'),
                         ('PROCESSES_SCAN_ONLY', '1,2'), ('PROCESSES_SCAN_EXCLUDE', '2,1'),
-                        ('SCAN_SINCE', '2'), ('SCAN_TIMEOUT', '1800'), ('CPU_THREAD_LIMIT', '1')]
+                        ('FILESYSTEM_SCAN_SINCE', '2'), ('PROCESSES_SCAN_SINCE', '10'),
+                        ('SCAN_TIMEOUT', '1800'), ('CPU_THREAD_LIMIT', '1')]
         for key, value in env_var_list:
             os.environ[key] = value
 
@@ -596,7 +605,8 @@ class TestMalwareDetectionOptions:
         assert mdc.filesystem_scan_exclude_list == ['/tmp']
         assert mdc.scan_pids == ['1', '2']
         assert mdc.processes_scan_exclude_list == ['1', '2']
-        assert mdc.scan_since_dict['timestamp'] < time.time() - (2 * 86400)
+        assert mdc.filesystem_scan_since_dict['timestamp'] < time.time() - (2 * 86400)
+        assert mdc.processes_scan_since_dict['timestamp'] < time.time() - (10 * 86400)
         assert mdc.scan_timeout == 1800
         # Not env vars, but just checking they have the expected values
         assert mdc.nice_value == 19
@@ -654,21 +664,36 @@ class TestMalwareDetectionOptions:
 
     @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
     @patch(LOGGER_TARGET)
-    @patch.dict(os.environ, {'TEST_SCAN': 'false', 'NICE_VALUE': 'nineteen', 'SCAN_SINCE': 'blast'})
+    @patch.dict(os.environ, {'TEST_SCAN': 'false', 'NICE_VALUE': 'nineteen', 'FILESYSTEM_SCAN_SINCE': 'blast'})
     def test_invalid_env_vars(self, log_mock, conf, yara, rules, cmd):
-        # NICE_VALUE and SCAN_SINCE have invalid values
+        # NICE_VALUE and FILESYSTEM_SCAN_SINCE have invalid values
         # First time through the NICE_VALUE should generate an error
         with pytest.raises(SystemExit):
             MalwareDetectionClient(None)
         log_mock.error.assert_called_with("Problem parsing environment variable %s: %s", "NICE_VALUE", ANY)
 
         # Set NICE_VALUE to proper value to avoid it giving an error this time.
-        # Only SCAN_SINCE should generate an error
+        # Only FILESYSTEM_SCAN_SINCE should generate an error
         os.environ['NICE_VALUE'] = '19'
         with pytest.raises(SystemExit):
             MalwareDetectionClient(None)
-        log_mock.error.assert_called_with("Unknown value '%s' for scan_since option.  "
-                                          "Valid values are integers >= 1 and 'last'", "blast")
+        log_mock.error.assert_called_with("Unknown value '%s' for %s option.  "
+                                          "Valid values are integers >= 1 and 'last'", "blast", "filesystem_scan_since")
+
+        # Fix FILESYSTEM_SCAN_SINCE to proper value to avoid it giving an error this time.
+        # Give an invalid value for PROCESSES_SCAN_SINCE, but need to enable SCAN_PROCESSES too
+        os.environ['FILESYSTEM_SCAN_SINCE'] = 'last'
+        os.environ['SCAN_PROCESSES'] = 'true'
+        os.environ['PROCESSES_SCAN_SINCE'] = '0'
+        with pytest.raises(SystemExit):
+            MalwareDetectionClient(None)
+        log_mock.error.assert_called_with("Invalid processes_scan_since value 0.  Valid values are integers >= 1 and 'last'")
+
+        # Disable SCAN_PROCESSES and the invalid PROCESSES_SCAN_SINCE doesn't raise an error anymore
+        # because it isn't even parsed
+        os.environ['SCAN_PROCESSES'] = 'false'
+        mdc = MalwareDetectionClient(None)
+        assert hasattr(mdc, 'processes_scan_since_dict') is False
 
     def test_filesystem_scan_only_root(self, yara, rules, cmd, create_test_files):
         # Nothing special about root when parsing the filesystem_scan_only option
@@ -981,6 +1006,82 @@ class TestProcessScanning:
         assert all([x not in mdc.scan_pids for x in ['1', '3', TEST_PID]])
         assert '2' in mdc.scan_pids
 
+    @pytest.mark.skipif(not TEST_PROCESSES_SCAN_SINCE, reason='test_processes_scan_since is slowish and could potentially fail')
+    def test_processes_scan_since(self, log_mock, yara, rules, cmd, create_test_files):
+        # Firstly, start the TEST_RULE_SCRIPT process then scan_only that process
+        # Expect that we'll find it
+        os.system(TEST_RULE_SCRIPT + " &")  # Run the script in the background
+        ps_call_output = call([['ps', '-eo', 'pid=', '-o', 'lstart=']])
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "test_scan: false" if line.startswith("test_scan:") else line
+            line = "scan_filesystem: false" if line.startswith("scan_filesystem:") else line
+            line = "scan_processes: true" if line.startswith("scan_processes:") else line
+            line = "processes_scan_only: test-rule" if line.startswith("processes_scan_only:") else line
+            line = "add_metadata: false" if line.startswith("add_metadata:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert mdc.rules_file == TEST_RULE_FILE
+        assert mdc.do_filesystem_scan is False
+        assert mdc.do_process_scan is True
+        # Match TEST_RULE_SCRIPT process from processes_scan_only
+        assert len(mdc.scan_pids) == 1
+
+        # Now find processes started since the last scan, specifically the TEST_RULE_SCRIPT process
+        # However expect to not find it because it wasn't started since the last_scan date
+        last_scan = time.time()
+        last_scan_fmt = datetime.fromtimestamp(last_scan).strftime('%Y-%m-%d %H:%M:%S')
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "processes_scan_since: last" if line.startswith("processes_scan_since:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            with patch("insights.client.apps.malware_detection.get_scan_since_timestamp", return_value=last_scan):
+                mdc = MalwareDetectionClient(None)
+        assert mdc.processes_scan_since_dict['timestamp'] == last_scan
+        assert mdc.processes_scan_since_dict['datetime'] == last_scan_fmt
+        # Still match the TEST_RULE_SCRIPT process from processes_scan_only
+        assert len(mdc.scan_pids) == 1
+        # But when we run scan_processes() it won't be found because it wasn't started since the last scan
+        # Patch the calls to yara so it doesn't actually try to scan any processes
+        with patch("insights.client.apps.malware_detection.call", return_value=ps_call_output):
+            mdc.scan_processes()
+        assert len(mdc.scan_pids) == 0
+        log_mock.error.assert_called_with("No processes to scan because none were started since %s", last_scan_fmt)
+
+        # Now find processes started since one day ago, specifically the TEST_RULE_SCRIPT process
+        # Expect to find it this time it was started since a day ago
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "processes_scan_since: 1" if line.startswith("processes_scan_since:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        # Still match the TEST_RULE_SCRIPT process from processes_scan_only
+        assert len(mdc.scan_pids) == 1
+        with patch("insights.client.apps.malware_detection.call") as call_mock:
+            # Patch calls to 'call' within the scan_processes function
+            # The first call is to ps to get the process list, which is what we want
+            # The second call is to yara, which we want to ignore since yara may not be installed
+            call_mock.side_effect = [ps_call_output, ""]
+            mdc.scan_processes()
+        # Expect to find the TEST_RULE_SCRIPT process because it was started since a day ago
+        assert len(mdc.scan_pids) == 1
+
+        # Start another process and this time there will be a TEST_RULE_SCRIPT process started since last_scan date
+        time.sleep(2)  # Wait a second to ensure the last_scan time is greater than the process start time
+        os.system(TEST_RULE_SCRIPT + " &")  # Run the script in the background
+        ps_call_output = call([['ps', '-eo', 'pid=', '-o', 'lstart=']])
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            with patch("insights.client.apps.malware_detection.get_scan_since_timestamp", return_value=last_scan):
+                mdc = MalwareDetectionClient(None)
+        # Match 2 TEST_RULE_SCRIPT processes from processes_scan_only
+        assert len(mdc.scan_pids) == 2
+        # But when we run scan_processes() only the latest one will be found
+        with patch("insights.client.apps.malware_detection.call") as call_mock:
+            call_mock.side_effect = [ps_call_output, ""]
+            mdc.scan_processes()
+        # Only find the latest TEST_RULE_SCRIPT process
+        assert len(mdc.scan_pids) == 1
+
 
 @patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
 @patch(BUILD_YARA_COMMAND_TARGET)
@@ -1036,9 +1137,9 @@ class TestFilesystemScanning:
 
     @patch('insights.client.apps.malware_detection.NamedTemporaryFile')
     @patch("insights.client.apps.malware_detection.call", return_value="")
-    def test_scan_since_tmp_files(self, call_mock, tmp_file_mock, log_mock, yara, cmd, remove, extract_tmp_files, create_test_files):
+    def test_filesystem_scan_since_tmp_files(self, call_mock, tmp_file_mock, log_mock, yara, cmd, remove, extract_tmp_files, create_test_files):
         # Set filesystem_scan_only, filesystem_scan_exclude options to some of the tmp files and then 'scan' them
-        # Then touch files to test the scan_since option and make sure that only the touched files will be scanned
+        # Then touch files to test the filesystem_scan_since option and make sure that only the touched files will be scanned
         yara_file_list = os.path.join(TEMP_TEST_DIR, 'yara_file_list')
         scan_me_file = os.path.join(TEMP_TEST_DIR, 'scan_me/scan_me_file')
         scan_me_too_file = os.path.join(TEMP_TEST_DIR, 'scan_me_too/scan_me_too_file')
@@ -1071,18 +1172,18 @@ class TestFilesystemScanning:
         assert len(contents) > 2
         assert all([x in contents for x in [scan_me_file, scan_me_too_file]])
 
-        # With the same filesystem scan_only and scan_exclude values, add scan_since: last into the mix and set
+        # With the same filesystem scan_only and scan_exclude values, add filesystem_scan_since: last into the mix and set
         # the last scan time to now.  There should be no matches because no files have been modified since now
         last_scan = time.time()
         last_scan_fmt = datetime.fromtimestamp(last_scan).strftime('%Y-%m-%d %H:%M:%S')
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-            line = "scan_since: last" if line.startswith("scan_since:") else line
+            line = "filesystem_scan_since: last" if line.startswith("filesystem_scan_since:") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             with patch("insights.client.apps.malware_detection.get_scan_since_timestamp", return_value=last_scan):
                 mdc = MalwareDetectionClient(None)
-        assert mdc.scan_since_dict['timestamp'] == last_scan
-        assert mdc.scan_since_dict['datetime'] == last_scan_fmt
+        assert mdc.filesystem_scan_since_dict['timestamp'] == last_scan
+        assert mdc.filesystem_scan_since_dict['datetime'] == last_scan_fmt
         log_mock.info.assert_called_with("Scan for files created/modified since %s%s", ANY, ANY)
 
         # Run scan_filesystem, but mock out NamedTemporaryFile so we can use our own file and inspect its contents after
@@ -1695,6 +1796,13 @@ rule TEST_RedHatInsightsMalwareDetection
     condition:
         $re1
 }
+""".lstrip()
+
+TEST_RULE_SCRIPT_CONTENTS = """
+#!/bin/sh
+# As a process this will match the TEST_RedHatInsightsMalwareDetection rule
+echo "Malware Detection Client"
+sleep 3
 """.lstrip()
 
 CONTRIVED_SCAN_OUTPUT = """

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -595,7 +595,7 @@ class TestMalwareDetectionOptions:
         assert mdc.scan_fsobjects == ['/tmp']
         assert mdc.filesystem_scan_exclude_list == ['/tmp']
         assert mdc.scan_pids == ['1', '2']
-        assert mdc.processes_scan_exclude_list == ['2', '1']
+        assert mdc.processes_scan_exclude_list == ['1', '2']
         assert mdc.scan_since_dict['timestamp'] < time.time() - (2 * 86400)
         assert mdc.scan_timeout == 1800
         # Not env vars, but just checking they have the expected values
@@ -636,6 +636,13 @@ class TestMalwareDetectionOptions:
         mdc = MalwareDetectionClient(None)
         assert mdc.scan_fsobjects == []
         assert mdc.filesystem_scan_exclude_list == []
+
+        # Test when FILESYSTEM_SCAN_EXCLUDE is empty
+        os.environ['PROCESSES_SCAN_ONLY'] = 'systemd,2,3..10'
+        os.environ['PROCESSES_SCAN_EXCLUDE'] = '3..100,systemd,2'
+        mdc = MalwareDetectionClient(None)
+        assert all([pid in mdc.scan_pids for pid in ['1', '2', '3']])
+        assert all([pid in mdc.processes_scan_exclude_list for pid in ['1', '2', '3']])
 
         # Further testing of list type env vars
         os.environ['NETWORK_FILESYSTEM_TYPES'] = ''
@@ -805,6 +812,116 @@ class TestMalwareDetectionOptions:
         assert scan_dict == {}
         log_mock.error.assert_called_with("No filesystem items to scan because the specified exclude items cancel them out")
 
+    def test_processes_scan_options(self, yara, rules, cmd, create_test_files):
+        # Test the processes scan options
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "test_scan: false" if line.startswith("test_scan:") else line
+            line = "scan_filesystem: false" if line.startswith("scan_filesystem:") else line
+            line = "scan_processes: true" if line.startswith("scan_processes:") else line
+            line = "processes_scan_only: 1\n" if line.startswith("processes_scan_only:") else line
+            line = "processes_scan_exclude: 1\n" if line.startswith("processes_scan_exclude:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert mdc.scan_pids == ['1']
+        assert mdc.processes_scan_exclude_list == ['1']
+
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "processes_scan_only: 1..10\n" if line.startswith("processes_scan_only:") else line
+            line = "processes_scan_exclude: 1..10\n" if line.startswith("processes_scan_exclude:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert len(mdc.scan_pids) > 1
+        assert all([pid in mdc.scan_pids for pid in ['1', '2']])
+        assert len(mdc.processes_scan_exclude_list) > 1
+        assert all([pid in mdc.processes_scan_exclude_list for pid in ['1', '2']])
+
+        # Test an open ended range, but really just saves typing '1' - scan all processes from 1 to 10
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "processes_scan_only: ..10\n" if line.startswith("processes_scan_only:") else line
+            line = "processes_scan_exclude: ..10\n" if line.startswith("processes_scan_exclude:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert len(mdc.scan_pids) > 1
+        assert all([int(pid) <= 10 for pid in mdc.scan_pids])
+        assert len(mdc.processes_scan_exclude_list) > 1
+        assert all([int(pid) <= 10 for pid in mdc.processes_scan_exclude_list])
+
+        # Testing an open ended range - scan all processes from 101 to the max_pid value
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "processes_scan_only: 101..\n" if line.startswith("processes_scan_only:") else line
+            line = "processes_scan_exclude: 101..\n" if line.startswith("processes_scan_exclude:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert len(mdc.scan_pids) > 1
+        assert all([int(pid) > 100 for pid in mdc.scan_pids])
+        assert len(mdc.processes_scan_exclude_list) > 1
+        assert all([int(pid) > 100 for pid in mdc.processes_scan_exclude_list])
+
+        # Not invalid ranges, just testing them to confirm they are handled gracefully
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "processes_scan_only: 1...10\n" if line.startswith("processes_scan_only:") else line
+            line = "processes_scan_exclude: .1.....10.\n" if line.startswith("processes_scan_exclude:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert len(mdc.scan_pids) > 1
+        assert all([int(pid) <= 10 for pid in mdc.scan_pids])
+        assert len(mdc.processes_scan_exclude_list) > 1
+        assert all([int(pid) <= 10 for pid in mdc.processes_scan_exclude_list])
+
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "processes_scan_only: systemd\n" if line.startswith("processes_scan_only:") else line
+            line = "processes_scan_exclude: systemd\n" if line.startswith("processes_scan_exclude:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert len(mdc.scan_pids) > 1
+        assert '1' in mdc.scan_pids
+        assert len(mdc.processes_scan_exclude_list) > 1
+        assert '1' in mdc.processes_scan_exclude_list
+
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "processes_scan_only:\n- 2\n- 3..10\n- systemd" if line.startswith("processes_scan_only:") else line
+            line = "processes_scan_exclude:\n- systemd\n- 2\n- 3..10" if line.startswith("processes_scan_exclude:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert len(mdc.scan_pids) > 1
+        assert all([pid in mdc.scan_pids for pid in ['1', '2', '3']])
+        assert len(mdc.processes_scan_exclude_list) > 1
+        assert all([pid in mdc.processes_scan_exclude_list for pid in ['1', '2', '3']])
+
+    @patch(LOGGER_TARGET)
+    def test_processes_scan_options_invalid_or_missing_values(self, log_mock, yara, rules, cmd, create_test_files):
+        # Test the processes scan options
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = "test_scan: false" if line.startswith("test_scan:") else line
+            line = "scan_filesystem: false" if line.startswith("scan_filesystem:") else line
+            line = "scan_processes: true" if line.startswith("scan_processes:") else line
+            line = line + "\n- pid2\n- three..10\n- 20.50\n- notsystemd" if line.startswith("processes_scan_only:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            with pytest.raises(SystemExit):
+                MalwareDetectionClient(None)
+        log_mock.error.assert_any_call("Unable to parse '%s' in to a range of PIDs: %s", 'three..10', ANY)
+        log_mock.error.assert_any_call("Unable to find the items specified for the processes_scan_only option.  Skipping ...")
+        log_mock.error.assert_any_call("Nothing to scan with processes_scan_only option and scan_filesystem is disabled")
+
+        for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
+            line = line + "\n- 1" if line.startswith("processes_scan_only:") else line
+            line = line + "\n- -1\n- 3..ten\n- 123 systemd" if line.startswith("processes_scan_exclude:") else line
+            print(line)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert mdc.scan_pids == ['1']
+        assert mdc.processes_scan_exclude_list == []
+        log_mock.error.assert_any_call("Unable to parse '%s' in to a range of PIDs: %s", '3..ten', ANY)
+        log_mock.error.assert_any_call("Unable to find the items specified for the processes_scan_exclude option.  Skipping ...")
+
 
 @patch(BUILD_YARA_COMMAND_TARGET)
 @patch(GET_RULES_TARGET, return_value=TEST_RULE_FILE)
@@ -851,16 +968,18 @@ class TestProcessScanning:
         assert all([x not in mdc.scan_pids for x in ['1', TEST_PID]])
 
         # Exclude some processes via env vars
-        os.environ['PROCESSES_SCAN_EXCLUDE'] = '3,2,1'
+        os.environ['PROCESSES_SCAN_EXCLUDE'] = 'systemd,3..10'
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             mdc = MalwareDetectionClient(None)
-        assert mdc.processes_scan_exclude_list == ['3', '2', '1']
+        assert all([pid in mdc.processes_scan_exclude_list for pid in ['1', '3']])
+        assert '2' not in mdc.processes_scan_exclude_list
         # Patch the calls to yara so it doesn't actually try to scan any processes
         with patch("insights.client.apps.malware_detection.call", return_value=""):
             mdc.scan_processes()
-        assert mdc.processes_scan_exclude_list == ['3', '2', '1', TEST_PID]
+        assert all([pid in mdc.processes_scan_exclude_list for pid in ['1', '3', TEST_PID]])
         assert len(mdc.scan_pids) > 1
-        assert all([x not in mdc.scan_pids for x in [3, 2, 1, TEST_PID]])
+        assert all([x not in mdc.scan_pids for x in ['1', '3', TEST_PID]])
+        assert '2' in mdc.scan_pids
 
 
 @patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files


### PR DESCRIPTION
* https://issues.redhat.com/browse/YARA-258

Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
The scan_only option applied to both the filesystem and processes but it was a little confusing to parse the items and decide whether to scan the filesystem and/or processes.  Also, there was  a scan_exclude option but it only applied to the filesystem.  To clear this up and make the filesystem and processes options separate, this PR creates the following options: filesystem_scan_only, filesystem_scan_exclude, processes_scan_only and processes_scan_exclude.  This makes them more explicit and less confusing.  I hope so anyway.

