### PR TITLE
feat: Add spec and parser for systemctl_status_-all

### DIFF
--- a/docs/shared_parsers_catalog/systemctl_status_all.rst
+++ b/docs/shared_parsers_catalog/systemctl_status_all.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.systemctl_status_all
+   :members:
+   :show-inheritance:

--- a/insights/parsers/systemctl_status_all.py
+++ b/insights/parsers/systemctl_status_all.py
@@ -1,0 +1,45 @@
+"""
+SystemctlStatusAll command ``systemctl status --all``
+=====================================================
+"""
+
+from insights.core import LogFileOutput
+from insights.core.plugins import parser
+from insights.specs import Specs
+
+
+@parser(Specs.systemctl_status_all)
+class SystemctlStatusAll(LogFileOutput):
+    """
+    Class for parsing the output from command ``systemctl status --all``.
+
+    .. note::
+        Please refer to its super-class :class:`insights.core.LogFileOutput`
+
+    Sample log lines::
+
+        * redhat.test.com
+            State: degraded
+             Jobs: 0 queued
+           Failed: 2 units
+            Since: Thu 2021-09-23 12:03:43 UTC; 3h 7min ago
+           CGroup: /
+                   |-user.slice
+                   | `-user-1000.slice
+                   |   |-user@1000.service
+
+        * proc-sys-fs-binfmt_misc.automount - Arbitrary Executable File Formats File System Automount Point
+           Loaded: loaded (/usr/lib/systemd/system/proc-sys-fs-binfmt_misc.automount; static; vendor preset: disabled)
+           Active: active (running) since Thu 2021-09-23 12:03:43 UTC; 3h 7min ago
+            Where: /proc/sys/fs/binfmt_misc
+             Docs: https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
+                   https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems
+
+        Sep 23 15:11:07 redhat.test.com systemd[1]: proc-sys-fs-binfmt_misc.automount: Automount point already active?
+        Sep 23 15:11:07 redhat.test.com systemd[1]: proc-sys-fs-binfmt_misc.automount: Got automount request for /proc/sys/fs/binfmt_mis
+
+    Examples:
+        >>> "Automount point already active?" in log
+        True
+    """
+    pass

--- a/insights/parsers/tests/test_systemctl_status_all.py
+++ b/insights/parsers/tests/test_systemctl_status_all.py
@@ -1,0 +1,41 @@
+import doctest
+
+from insights.parsers import systemctl_status_all
+from insights.parsers.systemctl_status_all import SystemctlStatusAll
+from insights.tests import context_wrap
+
+SYSTEMCTLSTATUSALL_ERROR_LOG = """
+* redhat.test.com
+    State: degraded
+     Jobs: 0 queued
+   Failed: 2 units
+    Since: Thu 2021-09-23 12:03:43 UTC; 3h 7min ago
+   CGroup: /
+           |-user.slice
+           | `-user-1000.slice
+           |   |-user@1000.service
+
+* proc-sys-fs-binfmt_misc.automount - Arbitrary Executable File Formats File System Automount Point
+   Loaded: loaded (/usr/lib/systemd/system/proc-sys-fs-binfmt_misc.automount; static; vendor preset: disabled)
+   Active: active (running) since Thu 2021-09-23 12:03:43 UTC; 3h 7min ago
+    Where: /proc/sys/fs/binfmt_misc
+     Docs: https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
+           https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems
+
+Sep 23 15:11:07 redhat.test.com systemd[1]: proc-sys-fs-binfmt_misc.automount: Automount point already active?
+Sep 23 15:11:07 redhat.test.com systemd[1]: proc-sys-fs-binfmt_misc.automount: Got automount request for /proc/sys/fs/binfmt_mis
+""".strip()
+
+
+def test_error_log():
+    log = SystemctlStatusAll(context_wrap(SYSTEMCTLSTATUSALL_ERROR_LOG))
+    assert 19 == len(log.lines)
+    assert "Automount point already active?" in log
+
+
+def test_crio_conf_documentation():
+    failed_count, tests = doctest.testmod(
+        systemctl_status_all,
+        globs={'log': SystemctlStatusAll(context_wrap(SYSTEMCTLSTATUSALL_ERROR_LOG))}
+    )
+    assert failed_count == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -674,6 +674,7 @@ class Specs(SpecSet):
     systemctl_show_all_services = RegistryPoint()
     systemctl_show_target = RegistryPoint()
     systemctl_smartpdc = RegistryPoint()
+    systemctl_status_all = RegistryPoint(filterable=True)
     systemd_analyze_blame = RegistryPoint()
     systemd_docker = RegistryPoint()
     systemd_logind_conf = RegistryPoint()

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -288,6 +288,7 @@ class SosSpecs(Specs):
     systemctl_list_unit_files = simple_file("sos_commands/systemd/systemctl_list-unit-files")
     systemctl_list_units = first_file(["sos_commands/systemd/systemctl_list-units", "sos_commands/systemd/systemctl_list-units_--all"])
     systemctl_show_all_services = simple_file("sos_commands/systemd/systemctl_show_service_--all")
+    systemctl_status_all = simple_file("sos_commands/systemd/systemctl_status_--all")
     systemd_system_origin_accounting = simple_file("/etc/systemd/system.conf.d/origin-accounting.conf")
     teamdctl_config_dump = glob_file("sos_commands/teamd/teamdctl_*_config_dump")
     teamdctl_state_dump = glob_file("sos_commands/teamd/teamdctl_*_state_dump")


### PR DESCRIPTION
Signed-off-by: shlao <shlao@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
The Open Shift Node will fail to start the `cri-o` service with the error messages showing in the command `systemctl status --all`.  Detail info please see: INSIGHTOCP-525 card.