### PR TITLE
Fix parsing problem in cloud_cfg datasource

### DIFF
--- a/insights/specs/datasources/cloud_init.py
+++ b/insights/specs/datasources/cloud_init.py
@@ -106,9 +106,8 @@ def cloud_cfg(broker):
                 content.pop('system_info', None)
                 # apply filters
                 for item in filters:
-                    val = content.get(item, None)
-                    if val:
-                        result[item] = val
+                    if item in content:
+                        result[item] = content[item]
 
                 if result:
                     result = dict(sorted(result.items(), key=lambda x: x[0]))


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The current implementation does not parse the `0` value correctly. The value is evaluated as `False` and is ignored.
This PR solves mentioned problem.