### PR TITLE
Fix: Update the unitfiles parser for RHEL9 output

### DIFF
--- a/insights/parsers/systemd/unitfiles.py
+++ b/insights/parsers/systemd/unitfiles.py
@@ -89,9 +89,15 @@ class UnitFiles(Parser):
         on_states = set(['enabled', 'enabled-runtime', 'static', 'indirect', 'generated', 'transient'])
 
         for line in get_active_lines(content):
-            parts = line.split(None)  # AWK like split, strips whitespaces
-            if len(parts) == 2 and any(part in valid_states for part in parts):
+            service = state = None
+            parts = line.split()
+            if len(parts) == 2:
                 service, state = parts
+            elif len(parts) == 3:
+                # rhel 9 has an extra vendor preset column
+                service, state, vender_preset = parts
+
+            if service and state and state in valid_states:
                 enabled = state in on_states
                 self.services[service] = enabled
                 self.parsed_lines[service] = line

--- a/insights/parsers/tests/test_unitfiles.py
+++ b/insights/parsers/tests/test_unitfiles.py
@@ -17,6 +17,16 @@ UNIT FILE                                   STATE
 kdump.service                               enabled
 """.strip()
 
+KDUMP_DISABLED_RHEL9 = """
+UNIT FILE                                   STATE           VENDOR PRESET
+kdump.service                               disabled        disabled
+""".strip()
+
+KDUMP_ENABLED_RHEL9 = """
+UNIT FILE                                   STATE           VENDOR PRESET
+kdump.service                               enabled         enabled
+""".strip()
+
 KDUMP_ENABLED_FOOTER_RHEL7 = """
 UNIT FILE                                   STATE
 kdump.service                               enabled
@@ -55,7 +65,13 @@ def test_unitfiles():
     assert len(unitfiles.services) == 1
     assert len(unitfiles.parsed_lines) == 1
 
-    context = context_wrap(KDUMP_ENABLED_RHEL7)
+    context = context_wrap(KDUMP_DISABLED_RHEL9)
+    unitfiles = UnitFiles(context)
+    assert not unitfiles.is_on('kdump.service')
+    assert len(unitfiles.services) == 1
+    assert len(unitfiles.parsed_lines) == 1
+
+    context = context_wrap(KDUMP_ENABLED_RHEL9)
     unitfiles = UnitFiles(context)
     assert unitfiles.is_on('kdump.service')
     assert len(unitfiles.services) == 1


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
In RHEL9 there is an additional column in the list-unit-files output for the vendor preset, so updated the parser to handle the old and new output.