### PR TITLE
Improved yum/dnf updates datasource to work on RHEL 8.5+

### DIFF
--- a/insights/specs/datasources/yum_updates.py
+++ b/insights/specs/datasources/yum_updates.py
@@ -5,24 +5,102 @@ import json
 import time
 
 from insights import datasource, HostContext, SkipComponent
-from insights.components.rhel_version import IsRhel7
+from insights.components.rhel_version import IsRhel7, IsRhel8, IsRhel9
 from insights.core.spec_factory import DatasourceProvider
 
-sorted_cmp = None
 try:
+    from functools import cmp_to_key
+
     # cmp_to_key is not available in python 2.6, but it has sorted function which accepts cmp function
     def sorted_cmp(it, cmp):
-        from functools import cmp_to_key
         return sorted(it, key=cmp_to_key(cmp))
 except ImportError:
     sorted_cmp = sorted
 
 
-class UpdatesManager:
+class DnfManager:
+    """ Performs package resolution on dnf based systems """
+    def __init__(self):
+        self.base = dnf.base.Base()
+        self.releasever = dnf.rpm.detect_releasever("/")
+        self.basearch = dnf.rpm.basearch(hawkey.detect_arch())
+        self.packages = []
+        self.repos = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    @staticmethod
+    def pkg_cmp(a, b):
+        if a.name != b.name:
+            return -1 if a.name < b.name else 1
+        vercmp = rpm.labelCompare((str(a.e), a.v, a.r), (str(b.e), b.v, b.r))
+        if vercmp != 0:
+            return vercmp
+        if a.reponame != b.reponame:
+            return -1 if a.reponame < b.reponame else 1
+        return 0
+
+    def sorted_pkgs(self, pkgs):
+        # if package is installed more than once (e.g. kernel)
+        # don't report other installed (i.e. with @System repo) as updates
+        return sorted_cmp([pkg for pkg in pkgs if pkg.reponame != "@System"], self.pkg_cmp)
+
+    def load(self):
+        self.base.conf.read()
+        self.base.conf.cacheonly = True
+        self.base.read_all_repos()
+        try:
+            # do not use standard self.base.fill_sack() it does not respect cacheonly
+            self.base.fill_sack_from_repos_in_cache(load_system_repo=True)
+            self.packages = self.base.sack.query()
+        except (dnf.exceptions.RepoError, AttributeError):
+            # RepoError is raised when cache is empty
+            # AttributeError is raised in dnf < 4.4 which can't handle cacheonly correctly
+            self.packages = hawkey.Query(hawkey.Sack())
+        self.repos = self.base.repos
+
+    def installed_packages(self):
+        return self.packages.installed().run()
+
+    def updates(self, pkg):
+        name = pkg.name
+        evr = "{0}:{1}-{2}".format(pkg.epoch, pkg.version, pkg.release)
+        arch = pkg.arch
+        nevra = "{0}-{1}.{2}".format(name, evr, arch)
+        updates_list = []
+        for upd in self.packages.filter(name=name, arch=arch, evr__gt=evr):
+            updates_list.append(upd)
+        return nevra, updates_list
+
+    @staticmethod
+    def pkg_nevra(pkg):
+        return "{0}-{1}:{2}-{3}.{4}".format(pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch)
+
+    @staticmethod
+    def pkg_repo(pkg):
+        return pkg.reponame
+
+    @staticmethod
+    def advisory(pkg):
+        errata = pkg.get_advisories(hawkey.EQ)
+        return errata[0].id if len(errata) > 0 else None
+
+    def last_update(self):
+        last_ts = 0
+        for repo in self.base.repos.iter_enabled():
+            repo_ts = repo._repo.getTimestamp()
+            if repo_ts > last_ts:
+                last_ts = repo_ts
+        return last_ts
+
+
+class YumManager(DnfManager):
     """ Performs package resolution on yum based systems """
     def __init__(self):
-        import yum
-
         self.base = yum.YumBase()
         self.base.doGenericSetup(cache=1)
         self.releasever = self.base.conf.yumvar['releasever']
@@ -30,12 +108,6 @@ class UpdatesManager:
         self.packages = []
         self.repos = []
         self.updict = {}
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        pass
 
     @staticmethod
     def pkg_cmp(a, b):
@@ -51,8 +123,12 @@ class UpdatesManager:
 
     def load(self):
         self.base.doRepoSetup()
-        self.base.doSackSetup()
-        self.packages = self.base.pkgSack.returnPackages()
+        try:
+            self.base.doSackSetup()
+            self.packages = self.base.pkgSack.returnPackages()
+        except yum.Errors.RepoError:
+            # RepoError is raised when cache is empty
+            pass
         self.repos = self.base.repos.repos
         self._build_updict()
 
@@ -60,9 +136,6 @@ class UpdatesManager:
         self.updict = {}
         for pkg in self.packages:
             self.updict.setdefault(pkg.na, []).append(pkg)
-
-    def enabled_repos(self):
-        return [repo.id for repo in self.base.repos.listEnabled()]
 
     def installed_packages(self):
         return self.base.rpmdb.returnPackages()
@@ -74,10 +147,6 @@ class UpdatesManager:
             if upg.verGT(pkg):
                 updates_list.append(upg)
         return nevra, updates_list
-
-    @staticmethod
-    def pkg_nevra(pkg):
-        return "{}-{}:{}-{}.{}".format(pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch)
 
     @staticmethod
     def pkg_repo(pkg):
@@ -94,7 +163,21 @@ class UpdatesManager:
         return 0
 
 
-@datasource(HostContext, [IsRhel7])
+# Select which manager to use based on the available system libraries.
+try:
+    import dnf
+    import hawkey
+    import rpm
+    UpdatesManager = DnfManager
+except ImportError:
+    try:
+        import yum
+        UpdatesManager = YumManager
+    except ImportError:
+        UpdatesManager = None
+
+
+@datasource(HostContext, [IsRhel7, IsRhel8, IsRhel9])
 def yum_updates(_broker):
     """
     This datasource provides a list of available updates on the system.
@@ -125,11 +208,11 @@ def yum_updates(_broker):
     Returns:
         list: List of available updates
     Raises:
-        SkipComponent: Raised on systems different than RHEL 7
+        SkipComponent: Raised when neither dnf nor yum is found
     """
 
-    if not _broker.get(IsRhel7):
-        raise SkipComponent("Yum updates currently only works on RHEL 7")
+    if UpdatesManager is None:
+        raise SkipComponent()
 
     with UpdatesManager() as umgr:
         umgr.load()

--- a/insights/tests/datasources/test_yum_updates.py
+++ b/insights/tests/datasources/test_yum_updates.py
@@ -1,0 +1,49 @@
+import json
+
+from insights.core.spec_factory import DatasourceProvider
+from insights.specs.datasources import yum_updates
+from mock.mock import MagicMock, patch
+
+
+# Verify that the yum_updates broker correctly executes.
+def test_yum_updates_runs_correctly():
+    expected_json = json.dumps({
+            "releasever": "8",
+            "basearch": "x86_64",
+            "update_list": {
+                "NetworkManager-1:1.22.8-4.el8.x86_64": {
+                    "available_updates": [
+                        {
+                            "package": "NetworkManager-1:1.22.8-5.el8_2.x86_64",
+                            "repository": "rhel-8-for-x86_64-baseos-rpms",
+                            "basearch": "x86_64",
+                            "releasever": "8",
+                            "erratum": "RHSA-2020:3011"
+                        }
+                    ]
+                }
+            },
+            "metadata_time": "2021-01-01T09:39:45Z"
+    })
+    # setup dnf mock
+    with patch("insights.specs.datasources.yum_updates.UpdatesManager", yum_updates.DnfManager):
+        yum_updates.dnf = MagicMock()
+        yum_updates.hawkey = MagicMock()
+        yum_updates.dnf.rpm.detect_releasever.return_value = "8"
+        yum_updates.dnf.rpm.basearch.return_value = "x86_64"
+        repo = MagicMock()
+        repo._repo.getTimestamp.return_value = 1609493985
+        yum_updates.dnf.base.Base().repos.iter_enabled.return_value = [repo]
+        pkg = MagicMock(epoch=1, version="1.22.8", release="4.el8", arch="x86_64")
+        pkg.name = "NetworkManager"
+        yum_updates.dnf.base.Base().sack.query().installed().run.return_value = [pkg]
+        update = MagicMock(epoch=1, version="1.22.8", release="5.el8_2", arch="x86_64",
+                    reponame="rhel-8-for-x86_64-baseos-rpms", basearch="x86_64", releasever="8")
+        update.name = "NetworkManager"
+        update.get_advisories.return_value = [MagicMock(id="RHSA-2020:3011")]
+        yum_updates.dnf.base.Base().sack.query().filter.return_value = [update]
+
+        result = yum_updates.yum_updates({})
+        assert result is not None
+        assert isinstance(result, DatasourceProvider)
+        assert expected_json == ''.join(result.content)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Current `yum updates` datasource is limited to work on RHEL7.
This PR extends functionality to RHEL 8.5+ systems.
When run on RHEL 8 prior RHEL 8.5 it skips data collection (a bug in dnf ignores cacheonly flag and may cause downloading data over network ).
