### PR TITLE
Exclude some Specs from IP address obfuscation

### DIFF
--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -87,4 +87,3 @@ class InsightsConstants(object):
     rhsm_facts_file = os.path.join(os.sep, 'etc', 'rhsm', 'facts', 'insights-client.facts')
     # In MB
     archive_filesize_max = 100
-    obfuscation_excluded_specs = ("insights.specs.Specs.installed_rpms",)

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -87,3 +87,4 @@ class InsightsConstants(object):
     rhsm_facts_file = os.path.join(os.sep, 'etc', 'rhsm', 'facts', 'insights-client.facts')
     # In MB
     archive_filesize_max = 100
+    obfuscation_excluded_specs = ("insights.specs.Specs.installed_rpms",)

--- a/insights/contrib/soscleaner.py
+++ b/insights/contrib/soscleaner.py
@@ -79,13 +79,13 @@ class SOSCleaner:
         self.kw_db = dict() #keyword database
         self.kw_count = 0
 
-        self.excluded_specs = (
+        self.excluded_specs = [
             "insights.specs.Specs.installed_rpms",
             "insights.specs.Specs.dnf_modules",
             "insights.specs.Specs.yum_list_available",
             "insights.specs.Specs.yum_updateinfo",
             "insights.specs.Specs.yum_updates"
-        )
+        ]
 
     def _skip_file(self, d, files):
         '''

--- a/insights/contrib/soscleaner.py
+++ b/insights/contrib/soscleaner.py
@@ -79,9 +79,7 @@ class SOSCleaner:
         self.kw_db = dict() #keyword database
         self.kw_count = 0
 
-        # Doing so here to avoid cyclic imports.
-        from insights.client.constants import InsightsConstants as constants
-        self.excluded_specs = constants.obfuscation_excluded_specs
+        self.excluded_specs = ("insights.specs.Specs.installed_rpms",)
 
     def _skip_file(self, d, files):
         '''

--- a/insights/contrib/soscleaner.py
+++ b/insights/contrib/soscleaner.py
@@ -79,7 +79,13 @@ class SOSCleaner:
         self.kw_db = dict() #keyword database
         self.kw_count = 0
 
-        self.excluded_specs = ("insights.specs.Specs.installed_rpms",)
+        self.excluded_specs = (
+            "insights.specs.Specs.installed_rpms",
+            "insights.specs.Specs.dnf_modules",
+            "insights.specs.Specs.yum_list_available",
+            "insights.specs.Specs.yum_updateinfo",
+            "insights.specs.Specs.yum_updates"
+        )
 
     def _skip_file(self, d, files):
         '''

--- a/insights/tests/test_soscleaner.py
+++ b/insights/tests/test_soscleaner.py
@@ -12,7 +12,6 @@ from mock.mock import patch
 from pytest import mark
 
 from insights.client.config import InsightsConfig
-from insights.client.constants import InsightsConstants as constants
 from insights.client.data_collector import CleanOptions
 from insights.contrib.soscleaner import SOSCleaner
 

--- a/insights/tests/test_soscleaner.py
+++ b/insights/tests/test_soscleaner.py
@@ -166,9 +166,11 @@ def test_sub_ip_no_match(line):
     assert actual == line
 
 
-def test_obfuscation_excluded_specs():
+def test_excluded_specs():
     soscleaner = SOSCleaner()
-    assert soscleaner.excluded_specs == constants.obfuscation_excluded_specs
+    assert len(soscleaner.excluded_specs) > 0
+    for spec in soscleaner.excluded_specs:
+        assert spec.find("insights.specs.Specs.") == 0
 
 
 def test_excluded_files():

--- a/insights/tests/test_soscleaner.py
+++ b/insights/tests/test_soscleaner.py
@@ -194,7 +194,7 @@ def test_excluded_files():
     expected = [
         report_item.relative_path
         for report_item in report_items
-        if report_item.name in constants.obfuscation_excluded_specs
+        if report_item.name in soscleaner.excluded_specs
     ]
     assert actual == expected
 

--- a/insights/tests/test_soscleaner.py
+++ b/insights/tests/test_soscleaner.py
@@ -1,13 +1,76 @@
+from collections import namedtuple
+from contextlib import contextmanager
+from json import dump
+from os import mkdir
+from os.path import join
+from shutil import rmtree
+from tempfile import mkdtemp
+
+from mock.mock import call
+from mock.mock import Mock
+from mock.mock import patch
+from pytest import mark
+
+from insights.client.config import InsightsConfig
+from insights.client.constants import InsightsConstants as constants
+from insights.client.data_collector import CleanOptions
 from insights.contrib.soscleaner import SOSCleaner
 
-from mock.mock import Mock
-from pytest import mark
+ReportItem = namedtuple("ReportItem", ("name", "relative_path"))
+
+RPM_OUTPUT_SHADOW_UTILS =\
+    "{\"name\":\"shadow-utils\","\
+    "\"epoch\":\"2\","\
+    "\"version\":\"4.1.5.1\","\
+    "\"release\":\"5.el6\","\
+    "\"arch\":\"x86_64\","\
+    "\"installtime\":\"Wed 13 Jan 2021 10:04:18 AM CET\","\
+    "\"buildtime\":\"1455012203\","\
+    "\"vendor\":\"Red Hat, Inc.\","\
+    "\"buildhost\":\"x86-027.build.eng.bos.redhat.com\","\
+    "\"sigpgp\":"\
+    "\"RSA/8, "\
+    "Tue 08 Mar 2016 11:15:08 AM CET, "\
+    "Key ID 199e2f91fd431d51\"}"
 
 
 def _soscleaner():
     soscleaner = SOSCleaner()
     soscleaner.logger = Mock()
     return soscleaner
+
+
+@contextmanager
+def _mock_report_dir(report_items):
+    tmpdir = mkdtemp()
+    try:
+        hostname_path = join(tmpdir, "hostname")
+        with open(hostname_path, "w") as hostname_file:
+            hostname_file.write("test-hostname")
+
+        data_path = join(tmpdir, "data")
+        meta_data_path = join(tmpdir, "meta_data")
+        for path in [data_path, meta_data_path]:
+            mkdir(path)
+
+        for report_item in report_items:
+            json_path = join(
+                meta_data_path, "%s.json" % report_item.name
+            )
+            with open(json_path, "w") as json_file:
+                meta_data_obj = {
+                    "name": report_item.name,
+                    "results": {
+                        "object": {
+                            "relative_path": report_item.relative_path
+                        }
+                    }
+                }
+                dump(meta_data_obj, json_file)
+
+        yield tmpdir
+    finally:
+        rmtree(tmpdir)
 
 
 @mark.parametrize(("line", "expected"), [
@@ -101,3 +164,86 @@ def test_sub_ip_no_match(line):
     soscleaner = _soscleaner()
     actual = soscleaner._sub_ip(line)
     assert actual == line
+
+
+def test_obfuscation_excluded_specs():
+    soscleaner = SOSCleaner()
+    assert soscleaner.excluded_specs == constants.obfuscation_excluded_specs
+
+
+def test_excluded_files():
+    report_items = [
+        ReportItem(
+            "insights.specs.Specs.installed_rpms",
+            "insights_commands/rpm_-qa_--qf_name_NAME_epoch_EPOCH_"
+            "version_VERSION_release_RELEASE_arch_ARCH_"
+            "installtime_INSTALLTIME_date_buildtime_BUILDTIME_"
+            "vendor_VENDOR_buildhost_BUILDHOST_sigpgp_SIGPGP_pgpsig"
+        ),
+        ReportItem(
+            "insights.specs.Specs.ip_addr",
+            "insights_commands/ip_addr"
+        )
+    ]
+
+    soscleaner = _soscleaner()
+    with _mock_report_dir(report_items) as tmpdir:
+        soscleaner.dir_path = tmpdir
+        actual = soscleaner._excluded_files()
+
+    expected = [
+        report_item.relative_path
+        for report_item in report_items
+        if report_item.name in constants.obfuscation_excluded_specs
+    ]
+    assert actual == expected
+
+
+@patch("insights.contrib.soscleaner.SOSCleaner._clean_file")
+@patch("insights.contrib.soscleaner.SOSCleaner._excluded_files")
+@patch("insights.contrib.soscleaner.SOSCleaner._extract_sosreport")
+@patch("insights.contrib.soscleaner.SOSCleaner._make_dest_env")
+@patch("insights.contrib.soscleaner.SOSCleaner._start_logging")
+def test_clean_report(
+    _start_logging,
+    _make_dest_env,
+    _extract_sosreport,
+    excluded_files,
+    clean_file
+):
+    class FileList:
+        def __init__(self, soscleaner):
+            self.soscleaner = soscleaner
+
+        def __call__(self, data_path):
+            self.soscleaner.file_count = len(file_list_files)
+
+            paths = []
+            for file in file_list_files:
+                path = join(self.soscleaner.dir_path, data_path, file)
+                paths.append(path)
+            self.return_value = paths
+            return paths
+
+    file_list_files = [
+        "insights_commands/rpm_-qa_--qf_name_NAME_version_VERSION",
+        "insights_commands/ip_addr"
+    ]
+
+    file_list_exempt = file_list_files[0:1]
+    excluded_files.configure_mock(return_value=file_list_exempt)
+
+    config = InsightsConfig()
+    options = CleanOptions(config, None, None, None)
+    options.no_tar_file = "."
+
+    soscleaner = _soscleaner()
+    with patch(
+        "insights.contrib.soscleaner.SOSCleaner._file_list",
+        FileList(soscleaner)
+    ) as file_list:
+        soscleaner.clean_report(options, ".")
+
+    file_list_whitelisted = file_list.return_value[1:2]
+    calls_whitelisted = map(call, file_list_whitelisted)
+    assert clean_file.mock_calls == list(calls_whitelisted)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This Pull Request is a fix for [ESSNTL-444](https://issues.redhat.com/browse/ESSNTL-444) / [Bug 2026141](https://bugzilla.redhat.com/show_bug.cgi?id=2026141), introducing a list of Specs excluded from the IP obfuscation by the SOSCleaner. The files generated by some Specs contain package versions consisting of four numeric parts. Those strings are indistinguishable from IPv4 addresses and the SOSCleaner incorrectly obfuscates them. The now invalid package versions case false rule hits further down in the cloud console.

As a hotfix, a hardcoded list of Specs excluded from the IP address obfuscation is introduced. A more proper way would be to have a flag in the Spec that would allow it to exclude itself from the obfuscation, or to provide a custom obfuscation pattern. This solution would however require a change to the Spec architecture.