### PR TITLE
Support downloading malware-detection rules via Satellite

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -601,9 +601,7 @@ class MalwareDetectionClient:
             logger.debug("Removing old rules file %s", old_rules_file)
             os.remove(old_rules_file)
 
-        self.rules_location = self._get_config_option(
-            'rules_location', "https://console.redhat.com/api/malware-detection/v1/signatures.yar"
-        )
+        self.rules_location = self._get_config_option('rules_location', '')
 
         # If rules_location starts with a /, assume its a file rather than a URL
         if self.rules_location.startswith('/'):
@@ -621,19 +619,26 @@ class MalwareDetectionClient:
             logger.error("Couldn't access the insights-client configuration")
             exit(constants.sig_kill_bad)
 
+        if not self.rules_location:
+            self.rules_location = "https://console.redhat.com/api/malware-detection/v1/signatures.yar"
+            if '/redhat_access/' in self.insights_config.base_url:
+                # Satellite URLs have '/redhat_access/' in the base_url config option
+                self.rules_location = self.insights_config.base_url + '/malware-detection/v1/signatures.yar'
+
         # Make sure the rules_location starts with https://
         if not re.match('^https?://', self.rules_location):
             self.rules_location = 'https://' + self.rules_location
 
-        # if insights-client is using cert auth or basic auth without a username and password, append 'cert.' to the url
-        authmethod = self.insights_config.authmethod if hasattr(self.insights_config, 'authmethod') else 'CERT'
-        username = self.insights_config.username if hasattr(self.insights_config, 'username') else ''
-        password = self.insights_config.password if hasattr(self.insights_config, 'password') else ''
-        if authmethod == 'CERT' or (authmethod == 'BASIC' and not (username or password)):
-            self.insights_config.authmethod = 'CERT'
-            parsed_url = urlparse(self.rules_location)
-            if not parsed_url.netloc.startswith('cert.'):
-                self.rules_location = urlunparse(parsed_url._replace(netloc='cert.' + parsed_url.netloc))
+        # If talking direct to C.R.C with cert auth or basic auth without a username/password, append 'cert.' to the url
+        if self.rules_location.startswith('https://console.redhat.com'):
+            authmethod = self.insights_config.authmethod if hasattr(self.insights_config, 'authmethod') else 'CERT'
+            username = self.insights_config.username if hasattr(self.insights_config, 'username') else ''
+            password = self.insights_config.password if hasattr(self.insights_config, 'password') else ''
+            if authmethod == 'CERT' or (authmethod == 'BASIC' and not (username or password)):
+                self.insights_config.authmethod = 'CERT'
+                parsed_url = urlparse(self.rules_location)
+                if not parsed_url.netloc.startswith('cert.'):
+                    self.rules_location = urlunparse(parsed_url._replace(netloc='cert.' + parsed_url.netloc))
 
         # If doing a test scan, replace signatures.yar (or any other file suffix) with test-rule.yar
         log_rule_contents = False

--- a/insights/specs/datasources/malware_detection.py
+++ b/insights/specs/datasources/malware_detection.py
@@ -5,6 +5,7 @@ from insights.core.plugins import datasource
 from insights.core.spec_factory import DatasourceProvider
 from insights.client.apps.malware_detection import MalwareDetectionClient
 from insights.client.config import InsightsConfig
+from insights.client import auto_config
 
 
 class MalwareDetectionSpecs(Specs):
@@ -17,6 +18,7 @@ class MalwareDetectionSpecs(Specs):
         try:
             # Only run malware-detection if it was passed as an option to insights-client
             insights_config = InsightsConfig().load_all()
+            auto_config.try_auto_configuration(insights_config)
             if not (insights_config and hasattr(insights_config, 'app') and insights_config.app == 'malware-detection'):
                 raise SkipComponent
             mdc = MalwareDetectionClient(insights_config)

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -323,22 +323,25 @@ class TestGetRules:
         assert get.call_count == 1
 
         # Test other errors downloading rules from the backend - these are more likely to occur
+        # Firstly handling an error like connection refused (Couldn't connect)
         get.side_effect = [ConnectionError("Couldn't connect"), Timeout("Timeout")]
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(username='user', password='pass'))
         log_mock.error.assert_called_with("Unable to download rules from %s: %s",
-                                        os.environ['RULES_LOCATION'], "Couldn't connect")
+                                          os.environ['RULES_LOCATION'], "Couldn't connect")
         assert get.call_count == 2
 
+        # Then handling a Timeout error
+        # Note, because we aren't downloading from console.redhat.com, there won't be 'cert.*' appended to the URL
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig())
         log_mock.error.assert_called_with("Unable to download rules from %s: %s",
-                                        'http://cert.localhost/rules.yar', "Timeout")
+                                          os.environ['RULES_LOCATION'], "Timeout")
         assert get.call_count == 3
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': '//console.redhat.com/rules.yar'})
     @patch("os.path.isfile", return_value=True)
-    def test_get_rules_location_files(self, isfile, conf, yara, cmd, session, proxies, get, remove):
+    def test_get_rules_location_as_file(self, isfile, conf, yara, cmd, session, proxies, get, remove):
         # Test using files for rules_location, esp irregular file names
         # rules_location that starts with a '/' is assumed to be a file, even if its a double '//'
         # Re-writing the rule to be test-rule.yar doesn't apply to local files
@@ -353,6 +356,30 @@ class TestGetRules:
         assert mdc.rules_location == "//console.redhat.com/rules.yar"
         assert mdc.rules_file == "/console.redhat.com/rules.yar"
         get.assert_not_called()
+
+    @patch.dict(os.environ, {'TEST_SCAN': 'true'})
+    @patch(LOGGER_TARGET)
+    def test_via_satellite_proxy(self, log_mock, conf, yara, cmd, session, proxies, get, remove):
+        # Test recognizing and handling of Satellite URLs.
+        # Satellite URLs have '/redhat_access/' in their path (which is how the Satellite knows to redirect the
+        # query to C.R.C).
+        # For malware-detection requests through a Satellite we append the malware-detection path and add https://
+        satellite_url = 'satellite.example.com:443/redhat_access/r/insights/platform'
+
+        # Firstly try with test-rule
+        replaced_url = "https://satellite.example.com:443/redhat_access/r/insights/platform/malware-detection/v1/test-rule.yar"
+        mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
+        assert mdc.rules_location == replaced_url
+        get.assert_called_with(replaced_url, log_response_text=True)
+        log_mock.debug.assert_called_with("Downloading rules from: %s", replaced_url)
+
+        # Then with the actual rules file
+        os.environ['TEST_SCAN'] = 'false'
+        replaced_url = "https://satellite.example.com:443/redhat_access/r/insights/platform/malware-detection/v1/signatures.yar"
+        mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
+        assert mdc.rules_location == replaced_url
+        get.assert_called_with(replaced_url, log_response_text=False)
+        log_mock.debug.assert_called_with("Downloading rules from: %s", replaced_url)
 
 
 @patch(GET_RULES_TARGET, return_value=RULES_FILE)


### PR DESCRIPTION
Check all that apply:

* [ x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
This PR allows the malware-detection app to download rules via a Satellite proxy.  The malware-detection rules are on C.R.C but if the system is using a Satellite, then malware-detection needs to use the Satellite URL (and hence its certificates) to initiate the request, which the Satellite will then forward onto C.R.C.

The malware-detection app runs insights-client auto_config to determine if a Satellite is being used by checking the base_url.

