### PR TITLE
Parameters checked when offline is active

### DIFF
--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -701,9 +701,13 @@ class InsightsConfig(object):
             if self.test_connection:
                 raise ValueError('Cannot run connection test in offline mode.')
             if self.checkin:
-                raise ValueError('Cannot check in in offline mode.')
+                raise ValueError('Cannot check-in in offline mode.')
             if self.unregister:
                 raise ValueError('Cannot unregister in offline mode.')
+            if self.check_results:
+                raise ValueError('Cannot check results in offline mode')
+            if self.diagnosis:
+                raise ValueError('Cannot diagnosis in offline mode')
         if self.output_dir and self.output_file:
             raise ValueError('Specify only one: --output-dir or --output-file.')
         if self.output_dir == '':


### PR DESCRIPTION
Signed-off-by: ahitacat <ahitacat@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
[ESSNTL-943](https://issues.redhat.com/browse/ESSNTL-943) reports the lack of exception when both parameters `--offline` and `--check-results` are passing to insights-client.

This PR adds the parameters that need a connection as `--check-results` and `--diagnosis` to be checked if `--offline` parameter is active in the validation of parameters. This will prevent trying to continue with the execution and not being able to finish the request because of the lack of connection.
