### PR TITLE
Feat: Add spec and parser for 'crictl_logs'

### DIFF
--- a/docs/shared_parsers_catalog/crictl_logs.rst
+++ b/docs/shared_parsers_catalog/crictl_logs.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.crictl_logs
+   :members:
+   :show-inheritance:

--- a/insights/parsers/crictl_logs.py
+++ b/insights/parsers/crictl_logs.py
@@ -1,0 +1,30 @@
+"""
+CrictlLogs - files ``sos_commands/crio/containers/crictl_logs_-t*``
+===================================================================
+"""
+
+from insights.core import LogFileOutput
+from insights.core.plugins import parser
+from insights.specs import Specs
+
+
+@parser(Specs.crictl_logs)
+class CrictlLogs(LogFileOutput):
+    """
+    Class for parsing ``sos_commands/crio/containers/crictl_logs_-t*`` files.
+
+    Sample input data looks like::
+
+        2021-12-21T11:12:45.854971114+01:00 Successfully copied files in /usr/src/multus-cni/rhel7/bin/ to /host/opt/cni/bin/
+        2021-12-21T11:12:45.995998017+01:00 2021-12-21T10:12:45+00:00 WARN: {unknown parameter "-"}
+        2021-12-21T11:12:46.008998978+01:00 2021-12-21T10:12:46+00:00 Entrypoint skipped copying Multus binary.
+        2021-12-21T11:12:46.081427544+01:00 2021-12-21T10:12:46+00:00 Attempting to find master plugin configuration, attempt 0
+
+    Note:
+        Please refer to its super-class :class:`insights.core.LogFileOutput`.
+
+    Examples:
+        >>> len(logs.get('skipped copying Multus binary'))
+        1
+    """
+    pass

--- a/insights/parsers/tests/test_crictl_logs.py
+++ b/insights/parsers/tests/test_crictl_logs.py
@@ -1,0 +1,28 @@
+from insights.parsers import crictl_logs
+from insights.parsers.crictl_logs import CrictlLogs
+from insights.tests import context_wrap
+import doctest
+
+CRICTL_LOGS = """
+2021-12-21T11:12:45.854971114+01:00 Successfully copied files in /usr/src/multus-cni/rhel7/bin/ to /host/opt/cni/bin/
+2021-12-21T11:12:45.995998017+01:00 2021-12-21T10:12:45+00:00 WARN: {unknown parameter "-"}
+2021-12-21T11:12:46.008998978+01:00 2021-12-21T10:12:46+00:00 Entrypoint skipped copying Multus binary.
+2021-12-21T11:12:46.081427544+01:00 2021-12-21T10:12:46+00:00 Attempting to find master plugin configuration, attempt 0
+""".strip()
+
+
+def test_crictl_logs():
+    logs = CrictlLogs(context_wrap(CRICTL_LOGS))
+    test_1 = logs.get('skipped copying Multus binary')
+    assert 1 == len(test_1)
+    test_2 = logs.get('Attempting to find master plugin configuration')
+    assert 1 == len(test_2)
+    assert test_2[0]['raw_message'] == '2021-12-21T11:12:46.081427544+01:00 2021-12-21T10:12:46+00:00 Attempting to find master plugin configuration, attempt 0'
+
+
+def test_crictl_logs_documentation():
+    failed_count, tests = doctest.testmod(
+        crictl_logs,
+        globs={'logs': CrictlLogs(context_wrap(CRICTL_LOGS))}
+    )
+    assert failed_count == 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -90,6 +90,7 @@ class Specs(SpecSet):
     cpuinfo = RegistryPoint()
     cpupower_frequency_info = RegistryPoint()
     cpuset_cpus = RegistryPoint()
+    crictl_logs = RegistryPoint(multi_output=True, filterable=True)
     crio_conf = RegistryPoint(multi_output=True)
     cron_daily_rhsmd = RegistryPoint(filterable=True)
     crypto_policies_config = RegistryPoint()

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -52,6 +52,7 @@ class SosSpecs(Specs):
     cpu_vulns_spec_store_bypass = simple_file("sys/devices/system/cpu/vulnerabilities/spec_store_bypass")
     cpuinfo_max_freq = simple_file("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq")
     cpupower_frequency_info = simple_file("sos_commands/processor/cpupower_frequency-info")
+    crictl_logs = glob_file("sos_commands/crio/containers/crictl_logs_-t*")
     crio_conf = glob_file([r"etc/crio/crio.conf", r"etc/crio/crio.conf.d/*"])
     date = first_of([simple_file("sos_commands/general/date"), simple_file("sos_commands/date/date")])
     df__al = first_file(["sos_commands/filesys/df_-al", "sos_commands/filesys/df_-al_-x_autofs"])


### PR DESCRIPTION
Signed-off-by: shlao <shlao@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

The buildah and its related libraries set incorrect options for the overlayfs storage driver on RHEL 7 hosts. That makes OpenShift builds are failing and sends error info to the container's log.  Detail info please see: INSIGHTOCP-595 card.
