### PR TITLE
Don't log the insights-core egg in verbose mode

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -202,10 +202,10 @@ class InsightsClient(object):
             if current_etag and not force:
                 logger.debug('Requesting new file with etag %s', current_etag)
                 etag_headers = {'If-None-Match': current_etag}
-                response = self.connection.get(url, headers=etag_headers)
+                response = self.connection.get(url, headers=etag_headers, log_response_text=False)
             else:
                 logger.debug('Found no etag or forcing fetch')
-                response = self.connection.get(url)
+                response = self.connection.get(url, log_response_text=False)
         except ConnectionError as e:
             logger.error(e)
             logger.error('The Insights API could not be reached.')

--- a/insights/tests/client/init/test_fetch.py
+++ b/insights/tests/client/init/test_fetch.py
@@ -30,7 +30,7 @@ def test_request_with_etag(insights_client):
 
     url = "{0}{1}".format(insights_client.connection.base_url, source_path)
     headers = {'If-None-Match': etag_value}
-    insights_client.connection.get.assert_called_once_with(url, headers=headers)
+    insights_client.connection.get.assert_called_once_with(url, headers=headers, log_response_text=False)
 
 
 def test_request_forced(insights_client):
@@ -41,7 +41,7 @@ def test_request_forced(insights_client):
     insights_client._fetch(source_path, "", "", force=False)
 
     url = "{0}{1}".format(insights_client.connection.base_url, source_path)
-    insights_client.connection.get.assert_called_once_with(url)
+    insights_client.connection.get.assert_called_once_with(url, log_response_text=False)
 
 
 @patch('insights.client.InsightsClient._fetch', Mock())


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?

### Complete Description of Additions/Changes:
https://bugzilla.redhat.com/show_bug.cgi?id=2045995

From the BZ: "If there is a new Egg available to download the whole binary content of the new Egg (zip) file is dumped to the terminal. This binary content has also terminal control characters and PuTTy and responds also to them".  This only happens when verbose mode is enabled, and only under certain conditions (eg after deleting the etag file).
