### PR TITLE
feat: RHICOMPL-2450 implemented OpenSCAP result obfuscation

### DIFF
--- a/MANIFEST.in.client
+++ b/MANIFEST.in.client
@@ -1,5 +1,6 @@
 include insights/defaults.yaml
 include insights/revoked_playbooks.yaml
+include insights/compliance_obfuscations.yaml
 include insights/NAME
 include insights/VERSION
 include insights/COMMIT

--- a/insights/client/archive.py
+++ b/insights/client/archive.py
@@ -44,8 +44,14 @@ class InsightsArchive(object):
         # we don't really need this anymore...
         self.archive_tmp_dir = tempfile.mkdtemp(prefix='/var/tmp/')
 
+        # We should not hint the hostname in the archive if it has to be obfuscated
+        if config.obfuscate_hostname:
+            hostname = "localhost"
+        else:
+            hostname = determine_hostname()
+
         self.archive_name = ("insights-%s-%s" %
-                             (determine_hostname(),
+                             (hostname,
                               time.strftime("%Y%m%d%H%M%S")))
 
         # lazy create these, only if needed when certain

--- a/insights/compliance_obfuscations.yaml
+++ b/insights/compliance_obfuscations.yaml
@@ -1,0 +1,16 @@
+# This file contains a structure of xpaths for obfuscations in compliance
+obfuscate:
+  - './/{http://checklists.nist.gov/xccdf/1.2}target-address'
+  - './/{http://checklists.nist.gov/xccdf/1.2}target-facts/{http://checklists.nist.gov/xccdf/1.2}fact[@name="urn:xccdf:fact:asset:identifier:ipv4"]'
+  - './/{http://checklists.nist.gov/xccdf/1.2}target-facts/{http://checklists.nist.gov/xccdf/1.2}fact[@name="urn:xccdf:fact:asset:identifier:ipv6"]'
+  - './/{http://scap.nist.gov/schema/asset-identification/1.1}ip-address/{http://scap.nist.gov/schema/asset-identification/1.1}ip-v4'
+  - './/{http://scap.nist.gov/schema/asset-identification/1.1}ip-address/{http://scap.nist.gov/schema/asset-identification/1.1}ip-v6'
+  - './/{http://oval.mitre.org/XMLSchema/oval-system-characteristics-5}system_info/{http://oval.mitre.org/XMLSchema/oval-system-characteristics-5}interfaces/{http://oval.mitre.org/XMLSchema/oval-system-characteristics-5}interface/{http://oval.mitre.org/XMLSchema/oval-system-characteristics-5}ip_address'
+obfuscate_hostname:
+  - './/{http://scap.nist.gov/schema/asset-identification/1.1}fqdn'
+  - './/{http://scap.nist.gov/schema/asset-identification/1.1}hostname'
+  - './/{http://checklists.nist.gov/xccdf/1.2}target'
+  - './/{http://checklists.nist.gov/xccdf/1.2}target-facts/{http://checklists.nist.gov/xccdf/1.2}fact[@name="urn:xccdf:fact:asset:identifier:fqdn"]'
+  - './/{http://checklists.nist.gov/xccdf/1.2}target-facts/{http://checklists.nist.gov/xccdf/1.2}fact[@name="urn:xccdf:fact:asset:identifier:host_name"]'
+  - './/{http://oval.mitre.org/XMLSchema/oval-system-characteristics-5}system_info/{http://oval.mitre.org/XMLSchema/oval-system-characteristics-5}primary_host_name'
+  - './/{http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix}uname_item/{http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix}node_name'


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
As compliance relies on the external OpenSCAP tool, it was ignoring the `--obfuscate` and `--obfuscate-hostname` parameters. This proposed solution goes through the OpenSCAP result XML file and removes the sensitive information based on the predefined xpaths stored in a YAML file.