### PR TITLE
Add a new spec and parser for /etc/insights-client/tags.yaml

### DIFF
--- a/docs/shared_parsers_catalog/insights_client_tags.rst
+++ b/docs/shared_parsers_catalog/insights_client_tags.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.insights_client_tags
+   :members:
+   :show-inheritance:

--- a/insights/parsers/insights_client_tags.py
+++ b/insights/parsers/insights_client_tags.py
@@ -1,0 +1,52 @@
+"""
+InsightsClientTags - file ``/etc/insights-client/tags.yaml``
+=======================================================================
+"""
+
+from insights import parser
+from insights.core import YAMLParser
+from insights.specs import Specs
+
+
+@parser(Specs.insights_client_tags)
+class InsightsClientTags(YAMLParser):
+    """
+    This class parses the YAML-formatted file `/etc/insights-client/tags.yaml`.
+    The file is created by the user after running this command:
+
+    `insights-client --group=<group-name>`
+
+    The command above creates the file and adds an initial group tag
+    as defined by the `--group` option.
+    Other tags are added manually by the user.
+
+    Sample input data:
+
+        group: eastern-sap
+        location: Boston
+        description:
+        - RHEL8
+        - SAP
+        key 4: value
+
+    Examples:
+        >>> type(tags)
+        <class 'insights.parsers.insights_client_tags.InsightsClientTags'>
+        >>> tags.data
+        {'group': 'eastern-sap', 'location': 'Boston', 'description': ['RHEL8', 'SAP'], 'key 4': 'value'}
+        >>> tags.group
+        'eastern-sap'
+        >>> tags.get('location')
+        'Boston'
+        >>> tags.get('key 1', 'not defined')
+        'not defined'
+    """
+
+    @property
+    def group(self):
+        """
+        Return value of the group tag or None if the group tag is missing.
+        Missing group tag indicates that the `tags.yaml` file was not created
+        by the `insights-client` command.
+        """
+        return self.get('group')

--- a/insights/parsers/insights_client_tags.py
+++ b/insights/parsers/insights_client_tags.py
@@ -1,6 +1,6 @@
 """
 InsightsClientTags - file ``/etc/insights-client/tags.yaml``
-=======================================================================
+============================================================
 """
 
 from insights import parser
@@ -20,7 +20,7 @@ class InsightsClientTags(YAMLParser):
     as defined by the `--group` option.
     Other tags are added manually by the user.
 
-    Sample input data:
+    Sample input data::
 
         group: eastern-sap
         location: Boston

--- a/insights/parsers/tests/test_insights_client_tags.py
+++ b/insights/parsers/tests/test_insights_client_tags.py
@@ -39,7 +39,7 @@ def test_insights_client_tags():
     name = ".".join([cls.__module__, cls.__name__])
     with pytest.raises(ParseException) as e:
         InsightsClientTags(context_wrap(TAGS_UNPARSABLE))
-    assert f"{name} couldn't parse yaml." in str(e.value)
+    assert "{0} couldn't parse yaml.".format(name) in str(e.value)
 
     tags = InsightsClientTags(context_wrap(TAGS_WITHOUT_GROUP))
     assert tags.group is None

--- a/insights/parsers/tests/test_insights_client_tags.py
+++ b/insights/parsers/tests/test_insights_client_tags.py
@@ -1,0 +1,48 @@
+import pytest
+
+from insights.parsers import ParseException
+from insights.parsers.insights_client_tags import InsightsClientTags
+from insights.tests import context_wrap
+
+TAGS = '''
+group: eastern-sap
+location: Boston
+description:
+- RHEL8
+- SAP
+key 4: value
+'''.strip()
+
+TAGS_UNPARSABLE = '''
+group: eastern-sap
+location=Boston
+'''.strip()
+
+TAGS_WITHOUT_GROUP = '''
+location: Boston
+description:
+- RHEL8
+- SAP
+key 4: value
+'''.strip()
+
+
+def test_insights_client_tags():
+
+    tags = InsightsClientTags(context_wrap(TAGS))
+    assert tags.group == 'eastern-sap'
+    assert tags.get('location') == 'Boston'
+    assert tags.get('description') == ['RHEL8', 'SAP']
+    assert tags.get('key 1') is None
+
+    cls = tags.__class__
+    name = ".".join([cls.__module__, cls.__name__])
+    with pytest.raises(ParseException) as e:
+        InsightsClientTags(context_wrap(TAGS_UNPARSABLE))
+    assert f"{name} couldn't parse yaml." in str(e.value)
+
+    tags = InsightsClientTags(context_wrap(TAGS_WITHOUT_GROUP))
+    assert tags.group is None
+    assert tags.get('location') == 'Boston'
+    assert tags.get('description') == ['RHEL8', 'SAP']
+    assert tags.get('key 1') is None

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -250,6 +250,7 @@ class Specs(SpecSet):
     initscript = RegistryPoint(multi_output=True)
     init_process_cgroup = RegistryPoint()
     insights_client_conf = RegistryPoint(filterable=True)
+    insights_client_tags = RegistryPoint()
     installed_rpms = RegistryPoint()
     interrupts = RegistryPoint()
     ip6tables_permanent = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -324,6 +324,7 @@ class DefaultSpecs(Specs):
     initctl_lst = simple_command("/sbin/initctl --system list")
     init_process_cgroup = simple_file("/proc/1/cgroup")
     insights_client_conf = simple_file('/etc/insights-client/insights-client.conf')
+    insights_client_tags = simple_file('/etc/insights-client/tags.yaml')
     interrupts = simple_file("/proc/interrupts")
     ip_addr = simple_command("/sbin/ip addr")
     ip_addresses = simple_command("/bin/hostname -I")


### PR DESCRIPTION
Signed-off-by: Tamara Ciernikova <tciernik@redhat.com>

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Description of Additions:

New spec `insights_client_tags` and its parser was added to collect data from `/etc/insights-client/tags.yaml`. 
