### PR TITLE
fix: Enhance parser Grub2Config

### DIFF
--- a/insights/combiners/grub_conf.py
+++ b/insights/combiners/grub_conf.py
@@ -92,11 +92,11 @@ class BootLoaderEntries(object):
             raise SkipComponent()
 
 
-@combiner([Grub1Config, Grub2Config, Grub1EFIConfig, Grub2EFIConfig, BootLoaderEntries],
+@combiner([Grub1Config, Grub2Config, Grub1EFIConfig, Grub2EFIConfig],
           optional=[InstalledRpms, CmdLine, LsSysFirmware, RedHatRelease])
 class GrubConf(object):
     """
-    Process Grub configuration v1, v2, and BLS based on which type is passed in.
+    Process Grub configuration v1, v2 based on which type is passed in.
 
     Attributes:
         version (int): returns 1 or 2, version of the GRUB configuration
@@ -124,37 +124,34 @@ class GrubConf(object):
         >>> grub_conf.get_grub_cmdlines('')
         []
     """
-    def __init__(self, grub1, grub2, grub1_efi, grub2_efi, grub_bles,
+    def __init__(self, grub1, grub2, grub1_efi, grub2_efi,
                  rpms, cmdline, sys_firmware, rh_rel):
         self.version = self.is_kdump_iommu_enabled = None
         self.grub = self.kernel_initrds = None
         self.is_efi = '/sys/firmware/efi' in sys_firmware if sys_firmware else False
-        _grubs = list(filter(None, [grub1, grub2, grub1_efi, grub2_efi, grub_bles]))
+        _grubs = list(filter(None, [grub1, grub2, grub1_efi, grub2_efi]))
 
         if len(_grubs) == 1:
             self.grub = _grubs[0]
             self.is_efi = self.is_efi if sys_firmware else self.grub._efi
         else:
             _grub1, _grub2 = (grub1_efi, grub2_efi) if self.is_efi else (grub1, grub2)
-            if rh_rel and rh_rel.rhel8:
-                self.grub = grub_bles
             # Check grub version via installed-rpms
-            else:
-                if rpms:
-                    # grub1
-                    if 'grub2' not in rpms and 'grub' in rpms and _grub1 is not None:
-                        self.grub = _grub1
-                    # grub2
-                    if 'grub' not in rpms and 'grub2' in rpms and _grub2 is not None:
-                        self.grub = _grub2
-                # Check grub version via the booted CmdLine
-                if self.grub is None and cmdline:
-                    # grub1
-                    if "BOOT_IMAGE" not in cmdline or 'rd_LVM_LV' in cmdline:
-                        self.grub = _grub1
-                    # grub2
-                    if "BOOT_IMAGE" in cmdline or 'rd.lvm.lv' in cmdline:
-                        self.grub = _grub2
+            if rpms:
+                # grub1
+                if 'grub2' not in rpms and 'grub' in rpms and _grub1 is not None:
+                    self.grub = _grub1
+                # grub2
+                if 'grub' not in rpms and 'grub2' in rpms and _grub2 is not None:
+                    self.grub = _grub2
+            # Check grub version via the booted CmdLine
+            if self.grub is None and cmdline:
+                # grub1
+                if "BOOT_IMAGE" not in cmdline or 'rd_LVM_LV' in cmdline:
+                    self.grub = _grub1
+                # grub2
+                if "BOOT_IMAGE" in cmdline or 'rd.lvm.lv' in cmdline:
+                    self.grub = _grub2
 
         if self.grub:
             self.version = self.grub._version

--- a/insights/combiners/tests/test_selinux.py
+++ b/insights/combiners/tests/test_selinux.py
@@ -382,7 +382,7 @@ def test_integration():
         sestatus = SEStatus(context_wrap(inputs[0]))
         selinux_config = SelinuxConfig(context_wrap(inputs[1]))
         grub_config = Grub1Config(context_wrap(inputs[2]))
-        grub_conf = GrubConf(grub_config, None, None, None, None, None, None, None, None)
+        grub_conf = GrubConf(grub_config, None, None, None, None, None, None, None)
         selinux = SELinux(sestatus, selinux_config, grub_conf)
         assert selinux.ok() == outputs[0]
         assert selinux.problems == outputs[1]
@@ -392,7 +392,7 @@ def test_integration():
         sestatus = SEStatus(context_wrap(inputs[0]))
         selinux_config = SelinuxConfig(context_wrap(inputs[1]))
         grub_config = Grub2Config(context_wrap(inputs[2]))
-        grub_conf = GrubConf(None, grub_config, None, None, None, None, None, None, None)
+        grub_conf = GrubConf(None, grub_config, None, None, None, None, None, None)
         selinux = SELinux(sestatus, selinux_config, grub_conf)
         assert selinux.ok() == outputs[0]
         assert selinux.problems == outputs[1]

--- a/insights/parsers/grub_conf.py
+++ b/insights/parsers/grub_conf.py
@@ -287,7 +287,7 @@ class Grub1EFIConfig(Grub1Config):
         self._efi = True
 
 
-@parser(Specs.grub2_cfg, [IsRhel6, IsRhel7])
+@parser(Specs.grub2_cfg, [IsRhel6, IsRhel7, IsRhel8])
 class Grub2Config(GrubConfig):
     """
     Parser for configuration for GRUB version 2.


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Spec `grub2_cfg` can also exist on RHEL8, so update to make it can be used for RHEL8 systems.
