### PR TITLE
feat: flexibility in specifying expiration times for cachecontrol

### DIFF
--- a/insights/core/remote_resource.py
+++ b/insights/core/remote_resource.py
@@ -62,8 +62,6 @@ class CachedRemoteResource(RemoteResource):
 
     """
 
-    expire_after = 180
-    """ float: Amount of time in seconds that the cache will expire """
     backend = "DictCache"
     """ str: Type of storage for cache `DictCache1`, `FileCache` or `RedisCache` """
     redis_port = 6379
@@ -75,7 +73,7 @@ class CachedRemoteResource(RemoteResource):
     file_cache_path = '.web_cache'
     """ str: Path to where file cache will be stored if `FileCache` backend is specified """
 
-    def __init__(self):
+    def __init__(self, expire_after=180):
 
         session = requests.Session()
 
@@ -89,7 +87,7 @@ class CachedRemoteResource(RemoteResource):
             else:
                 self.__class__._cache = DictCache()
 
-        session = CacheControl(session, heuristic=DefaultHeuristic(self.expire_after), cache=self.__class__._cache)
+        session = CacheControl(session, heuristic=DefaultHeuristic(expire_after), cache=self.__class__._cache)
 
         super(CachedRemoteResource, self).__init__(session)
 

--- a/insights/tests/test_remote_resource.py
+++ b/insights/tests/test_remote_resource.py
@@ -1,14 +1,41 @@
+import sys
+import time
+import pytest
 from cachecontrol.cache import DictCache
 from insights.core.remote_resource import RemoteResource, CachedRemoteResource
 from insights.tests.mock_web_server import TestMockServer
-import sys
-import pytest
 
 GOOD_PAYLOAD = b'Successful return from Mock Service'
 NOT_FOUND = b'{"error":{"code": "404", "message": "Not Found"}}'
 
 
 class TestRemoteResource(TestMockServer):
+
+    # Test CachedRemoteResource returns cached response with specified expire_after
+    # - To avoid the `expire_after` is set to the default 180 seconds, this case
+    #   should be tested at first
+    @pytest.mark.skipif(sys.version_info < (2, 7), reason="CacheControl requires python 2.7 or higher")
+    def test_get_cached_remote_resource_cached_expire_after(self):
+        url = 'http://localhost:{port}/mock/'.format(port=self.server_port)
+        crr = CachedRemoteResource(expire_after=1)
+        rtn = crr.get(url)
+        exp_1 = rtn.headers['expires']
+        time.sleep(2)
+        rtn = crr.get(url)
+        exp_2 = rtn.headers['expires']
+        assert exp_1 != exp_2
+
+        crr = CachedRemoteResource(expire_after=10)
+        # Refresh the cache
+        crr.get(url)
+        time.sleep(1)
+        # Use the new expire_after
+        rtn = crr.get(url)
+        exp_1 = rtn.headers['expires']
+        time.sleep(1)
+        rtn = crr.get(url)
+        exp_2 = rtn.headers['expires']
+        assert exp_1 == exp_2
 
     # Test RemoteResource
     def test_get_remote_resource(self):
@@ -38,18 +65,6 @@ class TestRemoteResource(TestMockServer):
     @pytest.mark.skipif(sys.version_info < (2, 7), reason="CacheControl requires python 2.7 or higher")
     def test_get_cached_remote_resource_cached(self):
         crr = CachedRemoteResource()
-
-        url = 'http://localhost:{port}/mock/'.format(port=self.server_port)
-        rtn = crr.get(url)
-        cont_1 = rtn.content
-        rtn = crr.get(url)
-        cont_2 = rtn.content
-        assert cont_1 == cont_2
-
-    # Test CachedRemoteResource returns cached response with specified expire_after
-    @pytest.mark.skipif(sys.version_info < (2, 7), reason="CacheControl requires python 2.7 or higher")
-    def test_get_cached_remote_resource_cached_1_min(self):
-        crr = CachedRemoteResource(3600)
 
         url = 'http://localhost:{port}/mock/'.format(port=self.server_port)
         rtn = crr.get(url)

--- a/insights/tests/test_remote_resource.py
+++ b/insights/tests/test_remote_resource.py
@@ -46,6 +46,18 @@ class TestRemoteResource(TestMockServer):
         cont_2 = rtn.content
         assert cont_1 == cont_2
 
+    # Test CachedRemoteResource returns cached response with specified expire_after
+    @pytest.mark.skipif(sys.version_info < (2, 7), reason="CacheControl requires python 2.7 or higher")
+    def test_get_cached_remote_resource_cached_1_min(self):
+        crr = CachedRemoteResource(3600)
+
+        url = 'http://localhost:{port}/mock/'.format(port=self.server_port)
+        rtn = crr.get(url)
+        cont_1 = rtn.content
+        rtn = crr.get(url)
+        cont_2 = rtn.content
+        assert cont_1 == cont_2
+
     # Test CachedRemoteResource not found
     def test_get_cached_remote_resource_not_found(self):
         crr = CachedRemoteResource()


### PR DESCRIPTION

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The default `180` seconds is too short, by applying this change it's more flexible to specify the expiration time when using the CacheControl.

