### PR TITLE
Fix: [insights-client] insights-client --status returns 1 when it is unregistered ESSNTL-2001

### DIFF
--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -233,10 +233,9 @@ def post_update(client, config):
     if config.status:
         if reg_check:
             logger.info('This host is registered.')
-            sys.exit(constants.sig_kill_ok)
         else:
             logger.info('This host is unregistered.')
-            sys.exit(constants.sig_kill_bad)
+        sys.exit(constants.sig_kill_ok)
 
     # put this first to avoid conflicts with register
     if config.unregister:

--- a/insights/tests/client/phase/test_post_update.py
+++ b/insights/tests/client/phase/test_post_update.py
@@ -103,13 +103,13 @@ def test_post_update_check_status_registered(insights_config, insights_client):
 def test_post_update_check_status_unregistered(insights_config, insights_client):
     """
     Just check status.
-        If unregistered, exit with 101 exit code (kill parent)
+        If unregistered, exit with 100 exit code (kill parent)
     """
     insights_config.return_value.load_all.return_value.status = True
     insights_client.return_value.get_registration_status = MagicMock(return_value=False)
     with raises(SystemExit) as exc_info:
         post_update()
-    assert exc_info.value.code == 101
+    assert exc_info.value.code == 100
     insights_client.return_value.get_machine_id.assert_called_once()
     insights_client.return_value.get_registration_status.assert_called_once()
     insights_client.return_value.clear_local_registration.assert_not_called()


### PR DESCRIPTION
Signed-off-by: ahitacat <ahitacat@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

`insights-client --status` was exiting good if it was registered, and otherwise. But the correct exit should be bad if a problem happened and good whether it is registered and unregistered.

Follow discussion in [ESSNTL-2001](https://issues.redhat.com/browse/ESSNTL-2001)

Clarification Edit (I copied here @subpop 's comment ):
To clarify, this PR is changing the behavior of insights-client so that regardless of the output of the --status command, the process will exit with a 0 if the process executed successfully. Prior to this change, the process would exit with a 1 if the output was "unregistered" and a 0 if the output was "registered". This change brings the client in more compliance with normal command line utility behaviors.