### PR TITLE
fix: Fix deprecation warning for using ET.getiterator

### DIFF
--- a/insights/specs/datasources/candlepin_broker.py
+++ b/insights/specs/datasources/candlepin_broker.py
@@ -56,7 +56,7 @@ def candlepin_broker(broker):
         if content:
             root = ET.fromstring('\n'.join(content))
             # remove namespace before save to avoid urgly search
-            for node in root.getiterator():
+            for node in list(root.iter()):
                 prefix, has_namespace, postfix = node.tag.rpartition('}')
                 if has_namespace:
                     node.tag = postfix


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
Using the xml element tree getiterator function has been deprecated for a while it seems. To get rid of the warning I updated to using iter wrapped in a list which is all the getiterator function did.