### PR TITLE
Fix BZ#2071058

### DIFF
--- a/insights/specs/datasources/ipcs.py
+++ b/insights/specs/datasources/ipcs.py
@@ -27,13 +27,14 @@ def semid(broker):
     Returns:
         list: A list of the semid of all the inter-processes.
     """
+    allowed_owners = ['root', 'apache', 'oracle']
     content = broker[Specs.ipcs_s].content
     results = set()
     for s in content:
         s_splits = s.split()
         # key        semid      owner      perms      nsems
         # 0x00000000 65536      apache     600        1
-        if len(s_splits) == 5 and s_splits[1].isdigit():
+        if len(s_splits) == 5 and s_splits[1].isdigit() and s_splits[2] in allowed_owners:
             results.add(s_splits[1])
     if results:
         return list(results)

--- a/insights/tests/datasources/test_ipcs.py
+++ b/insights/tests/datasources/test_ipcs.py
@@ -12,6 +12,8 @@ IPCS_OUTPUT1 = """
 key        semid      owner      perms      nsems
 0x00000000 65570      apache     600        1
 0x00000000 98353      apache     600        1
+0x00000000 28         fxadmin    0          1
+0x0052e2c1 89998      oracle     600        26
 0x00000000 98354      apache     600        1
 0x00000000 98355      apache     600        1
 0x00000000 98356      apache     600        1
@@ -34,7 +36,9 @@ def test_semid():
     assert isinstance(result, list)
     assert '65570' in result
     assert '98357' in result
-    assert len(result) == 6
+    assert '89998' in result
+    assert '28' not in result
+    assert len(result) == 7
 
 
 def test_exception():


### PR DESCRIPTION
Due to application workload or misbehavior the semaphores count might increase
significantly. Additionally, the current rules expects semids from selected
owners namely 'root', 'apache', and 'oracle'.

Closes-Bug: RHBZ#2071058

Signed-off-by: Sachin Patil <psachin@redhat.com>

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
