### PR TITLE
fix: correctly obfuscate IP addresses at EOL

### DIFF
--- a/insights/contrib/soscleaner.py
+++ b/insights/contrib/soscleaner.py
@@ -240,6 +240,9 @@ class SOSCleaner:
                             c = line[idx]
                             while c != " ":
                                 idx += 1
+                                if idx == len(line):
+                                    idx = len(line) - 1
+                                    break
                                 c = line[idx]
                             line = line[0:idx] + numspaces * " " + line[idx:]
 
@@ -252,6 +255,8 @@ class SOSCleaner:
                             c = line[idx]
                             while c != " ":
                                 idx += 1
+                                if idx == len(line):
+                                    break
                                 c = line[idx]
                             line = line[0:idx] + line[(idx+numspaces):]
 

--- a/insights/tests/test_soscleaner.py
+++ b/insights/tests/test_soscleaner.py
@@ -64,6 +64,14 @@ def test_sub_ip_match_IP_overlap(line, expected):
         "tcp6  10.0.0.11    0 10.0.0.1:23       10.0.0.111:63564    ESTABLISHED 0",
         "tcp6  10.230.230.2 0 10.230.230.3:23   10.230.230.1:63564  ESTABLISHED 0"
     ),
+    (
+        "unix  2      [ ACC ]     STREAM     LISTENING     43279    2070/snmpd         172.31.0.1\n",
+        "unix  2      [ ACC ]     STREAM     LISTENING     43279    2070/snmpd         10.230.230.1\n"
+    ),
+    (
+        "unix  2      [ ACC ]     STREAM     LISTENING     43279    2070/snmpd         172.31.111.11\n",
+        "unix  2      [ ACC ]     STREAM     LISTENING     43279    2070/snmpd         10.230.230.1 \n"
+    ),
 ])
 def test_sub_ip_match_IP_overlap_netstat(line, expected):
     soscleaner = _soscleaner()


### PR DESCRIPTION
Account for cases where IP addresses can appear at the end of a line in
the space-preserving netstat obfuscation function _sub_ip_netstat.

Resolves: RHBZ#2029997
Signed-off-by: Link Dupont <link@sub-pop.net>