### PR TITLE
feat: Add new sos ps spec and fix ValueError caused by it

### DIFF
--- a/insights/combiners/ps.py
+++ b/insights/combiners/ps.py
@@ -225,9 +225,9 @@ class Ps(object):
     def __update_data(self, ps_parser, mapping=None):
         """
         Updates internal dictionary with the processes data from the parser.
-        New PIDs will be add added to the dictionary and existing ones
-        will be updated. ``mapping`` needs to specify attribute mapping
-        metadata for proper consolidation of data.
+        New PIDs will be added to the dictionary and existing ones will be
+        updated. ``mapping`` needs to specify attribute mapping metadata
+        for proper consolidation of data.
 
         Args:
             ps_parser (insights.parsers.ps.Ps): Ps parser implementation instance.
@@ -243,8 +243,7 @@ class Ps(object):
             temp_row = self.__map_row(pid, input_row, mapping)
             pid_row.update(temp_row)
 
-        [update_row(row, mapping)
-        for row in ps_parser.data]
+        [update_row(row, mapping) for row in ps_parser.data if row['PID'].isdigit()]
 
     def __convert_data_types(self):
         """
@@ -260,9 +259,9 @@ class Ps(object):
                 row[attr_name] = type_ctor(row[attr_name])
 
         [convert_attr(attr_name, row)
-        for attr_name in self.__CONVERSION_MAP
-        for row in self._pid_data.values()
-        if attr_name in row]
+         for attr_name in self.__CONVERSION_MAP
+         for row in self._pid_data.values()
+         if attr_name in row]
 
     def __map_row(self, pid, row, mapping):
         """

--- a/insights/combiners/tests/test_ps.py
+++ b/insights/combiners/tests/test_ps.py
@@ -73,6 +73,18 @@ F   UID   PID  PPID PRI  NI    VSZ   RSS WCHAN  STAT TTY        TIME COMMAND
 1     0     9     2  20   0      0     0 rcu_gp S    ?          0:00 [rcu_bh]
 """
 
+PS_AUXWWWM_LINES = """
+USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root           1  1.8  0.8  24228 15660 ?        -    09:56   0:00 /usr/lib/systemd/systemd rhgb --switched-root --system --deserialize 31
+root           -  1.8    -      -     - -        Ss   09:56   0:00 -
+root           2  0.0  0.0      0     0 ?        -    09:56   0:00 [kthreadd]
+root           -  0.0    -      -     - -        S    09:56   0:00 -
+root           3  0.0  0.0      0     0 ?        -    09:56   0:00 [rcu_gp]
+root           -  0.0    -      -     - -        I<   09:56   0:00 -
+root           4  0.0  0.0      0     0 ?        -    09:56   0:00 [rcu_par_gp]
+root           -  0.0    -      -     - -        I<   09:56   0:00 -
+"""
+
 
 def test_pseo_parser():
     ps_eo = PsEo(context_wrap(PS_EO_LINES, strip=False))
@@ -165,6 +177,41 @@ def test_psalxwww_and_psauxww_and_psaux_parsers():
     assert ps['PRI'] == 20
     assert ps['NI'] == '0'
     assert ps['WCHAN'] == 'ep_pol'
+
+
+def test_psauxwwwm_parser():
+    ps_auxwwwm = PsAuxww(context_wrap(PS_AUXWWWM_LINES))
+    ps = Ps(None, ps_auxwwwm, None, None, None, None, None)
+
+    assert len(ps.processes) == 4
+
+    ps_1 = ps[1]
+    assert ps_1['PID'] == 1
+    assert ps_1['USER'] == 'root'
+    assert ps_1['%CPU'] == 1.8
+    assert ps_1['%MEM'] == 0.8
+    assert ps_1['VSZ'] == 24228.0
+    assert ps_1['RSS'] == 15660.0
+    assert ps_1['STAT'] == 'Ss'
+    assert ps_1['TTY'] == '?'
+    assert ps_1['START'] == '09:56'
+    assert ps_1['TIME'] == '0:00'
+    assert ps_1['COMMAND'] == '/usr/lib/systemd/systemd rhgb --switched-root --system --deserialize 31'
+    assert ps_1['COMMAND_NAME'] == 'systemd'
+
+    ps_4 = ps[4]
+    assert ps_4['PID'] == 4
+    assert ps_4['USER'] == 'root'
+    assert ps_4['%CPU'] == 0.0
+    assert ps_4['%MEM'] == 0.0
+    assert ps_4['VSZ'] == 0.0
+    assert ps_4['RSS'] == 0.0
+    assert ps_4['STAT'] == 'I<'
+    assert ps_4['TTY'] == '?'
+    assert ps_4['START'] == '09:56'
+    assert ps_4['TIME'] == '0:00'
+    assert ps_4['COMMAND'] == '[rcu_par_gp]'
+    assert ps_4['COMMAND_NAME'] == '[rcu_par_gp]'
 
 
 def test_psalxwww_and_psauxww_and_psaux_and_psef_and_psauxcww_and_ps_eo_parsers():

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -203,8 +203,8 @@ class SosSpecs(Specs):
     )
     ps_alxwww = simple_file("sos_commands/process/ps_alxwww")
     ps_aux = first_file(["sos_commands/process/ps_aux", "sos_commands/process/ps_auxwww", "sos_commands/process/ps_auxcww"])
-    ps_auxcww = first_file(["sos_commands/process/ps_auxcww", "sos_commands/process/ps_auxwww", "sos_commands/process/ps_aux"])
-    ps_auxww = first_file(["sos_commands/process/ps_auxww", "sos_commands/process/ps_auxwww", "sos_commands/process/ps_aux", "sos_commands/process/ps_auxcww"])
+    ps_auxcww = first_file(["sos_commands/process/ps_auxcww", "sos_commands/process/ps_auxwww", "sos_commands/process/ps_aux", "sos_commands/process/ps_auxwwwm"])
+    ps_auxww = first_file(["sos_commands/process/ps_auxww", "sos_commands/process/ps_auxwww", "sos_commands/process/ps_aux", "sos_commands/process/ps_auxwwwm", "sos_commands/process/ps_auxcww"])
     puppet_ssl_cert_ca_pem = first_file([
         "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
         "sos_commands/foreman/foreman-debug/var/lib/puppet/ssl/certs/ca.pem"


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
SOS Report no longer collects ps auxwww and ps auxwwwm, it removed the  auxwww since auxwwwm basically shows the same thing with threads added. Adding this spec caused a ValueError in the ps combiner due to the thread entries containing a - in the pid column. So I updated the combiner to check to make sure the pid column entry is a digit before  continuing.