### PR TITLE
fix: strip the '\x00' from the ibm_fw_vernum_encoded before parsing

### DIFF
--- a/insights/parsers/ibm_proc.py
+++ b/insights/parsers/ibm_proc.py
@@ -55,7 +55,7 @@ class IBMFirmwareLevel(Parser):
 
     Typical content looks like::
 
-        FW950.30 (VL950_092)
+        FW950.30 (VL950_092)\x00
 
     Attributes:
         firmware_level (str): The firmware level required by FLRT.
@@ -77,4 +77,4 @@ class IBMFirmwareLevel(Parser):
         if not fwl:
             raise SkipException("Nothing to parse.")
 
-        self.firmware_level = fwl.strip('()')
+        self.firmware_level = fwl.strip('()\x00')

--- a/insights/parsers/ibm_proc.py
+++ b/insights/parsers/ibm_proc.py
@@ -58,7 +58,7 @@ class IBMFirmwareLevel(Parser):
         FW950.30 (VL950_092)\x00
 
     Attributes:
-        raw (str): The RAW value of the `ibm,fw-vernum_encoded` file.
+        raw (str): The RAW content of the `ibm,fw-vernum_encoded` file.
         firmware_level (str): The firmware level required by FLRT.
 
     Examples:
@@ -78,4 +78,4 @@ class IBMFirmwareLevel(Parser):
         if "(" not in self.raw or ")" not in self.raw:
             raise SkipException("Nothing to parse.")
 
-        self.firmware_level = self.raw[self.raw.index('(')+1:self.raw.index(')')]
+        self.firmware_level = self.raw[self.raw.index('(') + 1:self.raw.index(')')]

--- a/insights/parsers/ibm_proc.py
+++ b/insights/parsers/ibm_proc.py
@@ -58,6 +58,7 @@ class IBMFirmwareLevel(Parser):
         FW950.30 (VL950_092)\x00
 
     Attributes:
+        raw (str): The RAW value of the `ibm,fw-vernum_encoded` file.
         firmware_level (str): The firmware level required by FLRT.
 
     Examples:
@@ -72,9 +73,9 @@ class IBMFirmwareLevel(Parser):
         if not content:
             raise SkipException("Empty output.")
 
-        _, fwl = content[0].split(None, 1)
+        self.raw = content[0]
 
-        if not fwl:
+        if "(" not in self.raw or ")" not in self.raw:
             raise SkipException("Nothing to parse.")
 
-        self.firmware_level = fwl.strip('()\x00')
+        self.firmware_level = self.raw[self.raw.index('(')+1:self.raw.index(')')]

--- a/insights/parsers/tests/test_ibm_proc.py
+++ b/insights/parsers/tests/test_ibm_proc.py
@@ -14,6 +14,10 @@ PROC_IBM_FWL = """
 FW950.30 (VL950_092)\x00
 """.strip()
 
+PROC_IBM_FWL_NG = """
+FW950.30 VL950_092\x00
+""".strip()
+
 
 def test_ibm_proc():
     results = IBMPpcLparCfg(context_wrap(PROC_PPC_LPARCFG))
@@ -30,6 +34,9 @@ def test_ibm_proc_empty():
 
     with pytest.raises(SkipException):
         IBMFirmwareLevel(context_wrap(''))
+
+    with pytest.raises(SkipException):
+        IBMFirmwareLevel(context_wrap(PROC_IBM_FWL_NG))
 
 
 def test_ibm_proc_doc_examples():

--- a/insights/parsers/tests/test_ibm_proc.py
+++ b/insights/parsers/tests/test_ibm_proc.py
@@ -11,7 +11,7 @@ system_type=IBM,8247-22L
 """.strip()
 
 PROC_IBM_FWL = """
-FW950.30 (VL950_092)
+FW950.30 (VL950_092)\x00
 """.strip()
 
 


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
According to the collected `ibm_fw_vernum_encoded` file, there is a `\x00` invisible symbol at the EOL. This PR removed this invisible symbol.