### PR TITLE
Add new system_user_dirs datasource and parser

### DIFF
--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -131,6 +131,14 @@ insights.specs.datasources.ssl_certificate
     :show-inheritance:
     :undoc-members:
 
+insights.specs.datasources.system_user_dirs
+-------------------------------------------
+
+.. automodule:: insights.specs.datasources.system_user_dirs
+    :members: system_user_dirs
+    :show-inheritance:
+    :undoc-members:
+
 insights.specs.datasources.user_group
 -------------------------------------
 

--- a/docs/shared_parsers_catalog/system_user_dirs.rst
+++ b/docs/shared_parsers_catalog/system_user_dirs.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.system_user_dirs
+   :members:
+   :show-inheritance:

--- a/insights/parsers/system_user_dirs.py
+++ b/insights/parsers/system_user_dirs.py
@@ -23,9 +23,9 @@ class SystemUserDirs(Parser):
 
         >>> type(system_user_dirs)
         <class 'insights.parsers.system_user_dirs.SystemUserDirs'>
-        >>> system_user_dirs.data
+        >>> system_user_dirs.packages
         ['ca-certificates', 'kmod', 'sssd-ldap']
     """
 
     def parse_content(self, content):
-        self.data = content
+        self.packages = content

--- a/insights/parsers/system_user_dirs.py
+++ b/insights/parsers/system_user_dirs.py
@@ -1,26 +1,31 @@
 """
 SystemUserDirs - datasource ``system_user_dirs``
 ================================================
+
+Parser for CVE-2021-35937, CVE-2021-35938, and CVE-2021-35939.
+For more information, see the ``system_user_dirs`` datasource.
 """
 
-from insights import JSONParser, parser
+from insights import Parser, parser
 from insights.specs import Specs
 
 
 @parser(Specs.system_user_dirs)
-class SystemUserDirs(JSONParser):
+class SystemUserDirs(Parser):
     """
-    Class for parsing the ``system_user_dirs`` datasource.
+    Class for enabling the data from the ``system_user_dirs`` datasource.
 
     Sample output of this datasource is::
 
-        '{"pcp-testsuite-5.3.3-1.fc33.x86_64": ["/var/lib/pcp/testsuite"]}'
+        ["ca-certificates", "kmod", "sssd-ldap"]
 
     Examples:
 
         >>> type(system_user_dirs)
         <class 'insights.parsers.system_user_dirs.SystemUserDirs'>
         >>> system_user_dirs.data
-        {'pcp-testsuite-5.3.3-1.fc33.x86_64': ['/var/lib/pcp/testsuite']}
+        ['ca-certificates', 'kmod', 'sssd-ldap']
     """
-    pass
+
+    def parse_content(self, content):
+        self.data = content

--- a/insights/parsers/system_user_dirs.py
+++ b/insights/parsers/system_user_dirs.py
@@ -1,0 +1,26 @@
+"""
+SystemUserDirs - datasource ``system_user_dirs``
+================================================
+"""
+
+from insights import JSONParser, parser
+from insights.specs import Specs
+
+
+@parser(Specs.system_user_dirs)
+class SystemUserDirs(JSONParser):
+    """
+    Class for parsing the ``system_user_dirs`` datasource.
+
+    Sample output of this datasource is::
+
+        '{"pcp-testsuite-5.3.3-1.fc33.x86_64": ["/var/lib/pcp/testsuite"]}'
+
+    Examples:
+
+        >>> type(system_user_dirs)
+        <class 'insights.parsers.system_user_dirs.SystemUserDirs'>
+        >>> system_user_dirs.data
+        {'pcp-testsuite-5.3.3-1.fc33.x86_64': ['/var/lib/pcp/testsuite']}
+    """
+    pass

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -685,6 +685,7 @@ class Specs(SpecSet):
     sysctl_conf_initramfs = RegistryPoint(multi_output=True)
     sysctl_d_conf_etc = RegistryPoint(multi_output=True)
     sysctl_d_conf_usr = RegistryPoint(multi_output=True)
+    system_user_dirs = RegistryPoint()
     systemctl_cat_dnsmasq_service = RegistryPoint()
     systemctl_cat_rpcbind_socket = RegistryPoint()
     systemctl_cinder_volume = RegistryPoint()

--- a/insights/specs/datasources/system_user_dirs.py
+++ b/insights/specs/datasources/system_user_dirs.py
@@ -1,7 +1,5 @@
 """
 Custom datasource for CVE-2021-35937, CVE-2021-35938, and CVE-2021-35939.
-
-Authors: ffesti@redhat.com, jobselko@redhat.com
 """
 
 import grp

--- a/insights/specs/datasources/system_user_dirs.py
+++ b/insights/specs/datasources/system_user_dirs.py
@@ -1,0 +1,75 @@
+"""
+Custom datasource for checking non-root owned packaged directories
+
+Author: Florian Festi <ffesti@redhat.com>
+"""
+import grp
+import json
+import pwd
+import stat
+
+from insights import datasource
+from insights.core.dr import SkipComponent
+from insights.core.spec_factory import DatasourceProvider
+
+
+def get_shells():
+    with open('/etc/shells') as f:
+        return set((line.strip() for line in f))
+
+
+def get_users():
+    shells = get_shells()
+    users = set()
+
+    for user in pwd.getpwall():
+        shell = user[6].strip()
+        if shell not in shells or shell in ('/sbin/nologin', '/bin/nologin'):
+            continue
+        users.add(user[0])
+    users.discard("root")
+    return users
+
+
+def get_groups(users):
+    groups = set()
+
+    for group in grp.getgrall():
+        name = group[0]
+        if name in users:
+            groups.add(name)  # group for an user of interest
+        for u in group[3]:
+            u = u.strip()
+            if u in users:
+                groups.add(name)  # add groups containing a user
+    return groups
+
+
+@datasource()
+def system_user_dirs(_broker):
+    try:
+        import rpm
+    except ImportError:
+        raise SkipComponent
+
+    users = get_users()
+    groups = get_groups(users)
+
+    ts = rpm.TransactionSet()
+
+    directories = {}
+    for hdr in ts.dbMatch(rpm.RPMTAG_NAME):
+        for f in rpm.files(hdr):
+            if stat.S_ISDIR(f.mode):
+                if ((f.user in users) and (f.mode & stat.S_IWUSR) or
+                        (f.group in groups) and (f.mode & stat.S_IWGRP) or
+                        (f.mode & stat.S_IWOTH)):
+                    directories[f.name] = (hdr.NEVRA,)
+
+    packages = {}
+    for dirname, data in directories.items():
+        mi = ts.dbMatch(rpm.RPMTAG_DIRNAMES, dirname + '/')
+        for hdr in mi:
+            packages.setdefault(hdr.NEVRA, []).append(dirname)
+
+    return DatasourceProvider(content=json.dumps(packages), relative_path='insights_commands/system_user_dirs')

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -26,7 +26,7 @@ from insights.specs.datasources import (
     awx_manage, cloud_init, candlepin_broker, corosync as corosync_ds,
     dir_list, ethernet, httpd, ipcs, kernel_module_list, lpstat, md5chk,
     package_provides, ps as ps_datasource, sap, satellite_missed_queues,
-    ssl_certificate, user_group, yum_updates)
+    ssl_certificate, system_user_dirs, user_group, yum_updates)
 from insights.specs.datasources.sap import sap_hana_sid, sap_hana_sid_SID_nr
 from insights.specs.datasources.pcp import pcp_enabled, pmlog_summary_args
 
@@ -632,6 +632,7 @@ class DefaultSpecs(Specs):
     sysctl_conf = simple_file("/etc/sysctl.conf")
     sysctl_d_conf_etc = glob_file("/etc/sysctl.d/*.conf")
     sysctl_d_conf_usr = glob_file("/usr/lib/sysctl.d/*.conf")
+    system_user_dirs = system_user_dirs.system_user_dirs
     systemctl_cat_dnsmasq_service = simple_command("/bin/systemctl cat dnsmasq.service")
     systemctl_cat_rpcbind_socket = simple_command("/bin/systemctl cat rpcbind.socket")
     systemctl_cinder_volume = simple_command("/bin/systemctl show openstack-cinder-volume")

--- a/insights/tests/datasources/test_system_user_dirs.py
+++ b/insights/tests/datasources/test_system_user_dirs.py
@@ -1,0 +1,53 @@
+"""
+Tests for custom datasource for checking non-root owned packaged directories
+
+Author: Florian Festi <ffesti@redhat.com>
+"""
+import mock
+
+from insights.core.dr import SkipComponent
+from insights.specs.datasources import system_user_dirs
+
+try:
+    import rpm
+except ImportError:
+    raise SkipComponent
+
+
+def get_users():
+    return set(["danger", "close"])
+
+
+def get_groups(users):
+    return set(["danger", "close"])
+
+
+class TransactionSet:
+
+    def _create_hdr(self):
+        hdr = rpm.hdr()
+        hdr["name"] = "testpkg"
+        hdr["version"] = "1.0"
+        hdr["release"] = "42"
+        hdr["basenames"] = ["foo", "bar"]
+        hdr["dirnames"] = ["/opt/", "/opt/foo/"]
+        hdr["dirindexes"] = [0, 1]
+        hdr["fileusername"] = ["danger", "danger"]
+        hdr["filegroupname"] = ["danger", "danger"]
+        hdr["filemodes"] = [0o040775, 0o100775]
+
+        return hdr
+
+    def __init__(self):
+        self.hdrs = [self._create_hdr()]
+
+    def dbMatch(self, *l):
+        return self.hdrs
+
+
+@mock.patch("insights.specs.datasources.system_user_dirs.get_users", get_users)
+@mock.patch("insights.specs.datasources.system_user_dirs.get_groups", get_groups)
+@mock.patch("rpm.TransactionSet", TransactionSet)
+def test_system_user_dirs():
+    result = system_user_dirs.system_user_dirs(None)
+    assert result.content == ['{"testpkg-1.0-42.src": ["/opt/foo"]}']

--- a/insights/tests/parsers/test_system_user_dirs.py
+++ b/insights/tests/parsers/test_system_user_dirs.py
@@ -1,34 +1,20 @@
 import doctest
-import pytest
 
 from insights.parsers import system_user_dirs
 from insights.parsers.system_user_dirs import SystemUserDirs
 from insights.tests import context_wrap
 
-
-TEST_CASES = [
-    (
-        '{"pcp-testsuite-5.3.3-1.fc33.x86_64": ["/var/lib/pcp/testsuite"]}',
-        {
-            "pcp-testsuite-5.3.3-1.fc33.x86_64": ["/var/lib/pcp/testsuite"]
-        }
-    ),
-    (
-        '{}',
-        {}
-    )
-]
+DATA = ["ca-certificates", "kmod", "sssd-ldap"]
 
 
-@pytest.mark.parametrize("output, expected", TEST_CASES)
-def test_system_user_dirs(output, expected):
-    test = SystemUserDirs(context_wrap(output))
-    assert test.data == expected
+def test_system_user_dirs():
+    test = SystemUserDirs(context_wrap(DATA))
+    assert test.data == DATA
 
 
 def test_doc_examples():
     env = {
-        "system_user_dirs": SystemUserDirs(context_wrap(TEST_CASES[0][0]))
+        "system_user_dirs": SystemUserDirs(context_wrap(DATA))
     }
     failed, total = doctest.testmod(system_user_dirs, globs=env)
     assert failed == 0

--- a/insights/tests/parsers/test_system_user_dirs.py
+++ b/insights/tests/parsers/test_system_user_dirs.py
@@ -4,17 +4,17 @@ from insights.parsers import system_user_dirs
 from insights.parsers.system_user_dirs import SystemUserDirs
 from insights.tests import context_wrap
 
-DATA = ["ca-certificates", "kmod", "sssd-ldap"]
+PACKAGES = ["ca-certificates", "kmod", "sssd-ldap"]
 
 
 def test_system_user_dirs():
-    test = SystemUserDirs(context_wrap(DATA))
-    assert test.data == DATA
+    test = SystemUserDirs(context_wrap(PACKAGES))
+    assert test.packages == PACKAGES
 
 
 def test_doc_examples():
     env = {
-        "system_user_dirs": SystemUserDirs(context_wrap(DATA))
+        "system_user_dirs": SystemUserDirs(context_wrap(PACKAGES))
     }
     failed, total = doctest.testmod(system_user_dirs, globs=env)
     assert failed == 0

--- a/insights/tests/parsers/test_system_user_dirs.py
+++ b/insights/tests/parsers/test_system_user_dirs.py
@@ -1,0 +1,34 @@
+import doctest
+import pytest
+
+from insights.parsers import system_user_dirs
+from insights.parsers.system_user_dirs import SystemUserDirs
+from insights.tests import context_wrap
+
+
+TEST_CASES = [
+    (
+        '{"pcp-testsuite-5.3.3-1.fc33.x86_64": ["/var/lib/pcp/testsuite"]}',
+        {
+            "pcp-testsuite-5.3.3-1.fc33.x86_64": ["/var/lib/pcp/testsuite"]
+        }
+    ),
+    (
+        '{}',
+        {}
+    )
+]
+
+
+@pytest.mark.parametrize("output, expected", TEST_CASES)
+def test_system_user_dirs(output, expected):
+    test = SystemUserDirs(context_wrap(output))
+    assert test.data == expected
+
+
+def test_doc_examples():
+    env = {
+        "system_user_dirs": SystemUserDirs(context_wrap(TEST_CASES[0][0]))
+    }
+    failed, total = doctest.testmod(system_user_dirs, globs=env)
+    assert failed == 0


### PR DESCRIPTION
Signed-off-by: Jitka Obselkova <jobselko@redhat.com>

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
We are working on new rules (CVE-2021-35937, CVE-2021-35938, CVE-2021-35939), which need a new parser and data source for checking non-root owned packaged directories.

CI is failing because the datasource uses the rpm module, which is the system package and the current virtual environment does not have it.