### PR TITLE
Skip malware-detection tests on RHEL6/python2.6 (not supported)

### DIFF
--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -1,5 +1,7 @@
 import os
 import re
+import sys
+
 import pytest
 import yaml
 import time
@@ -54,6 +56,10 @@ BUILD_YARA_COMMAND_TARGET = "insights.client.apps.malware_detection.MalwareDetec
 # Run the test_processes_scan_since test?
 TEST_PROCESSES_SCAN_SINCE = getenv_bool("TEST_PROCESSES_SCAN_SINCE", False)
 
+# Are we running on RHEL6? (well actually, with python 2.6)
+IS_RHEL6 = sys.version_info < (2, 7)
+SKIP_IF_RHEL6_REASON = "The malware-detection client isn't supported on RHEL6 / python 2.6"
+
 
 @pytest.fixture
 def create_test_files():
@@ -84,6 +90,7 @@ def extract_tmp_files():
     os.system('rm -rf %s' % TEMP_TEST_DIR)
 
 
+@pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
 class TestDefaultValues:
     def test_default_spec(self):
         # Read in the default malware spec and check its values
@@ -155,6 +162,7 @@ class TestDefaultValues:
         assert re.search('metadata:.*process_name', mutation)
 
 
+@pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
 @patch(BUILD_YARA_COMMAND_TARGET)
 @patch(GET_RULES_TARGET, return_value=RULES_FILE)
 @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
@@ -223,6 +231,7 @@ class TestFindYara:
 
 
 # Use patch.object, just because I wanted to try using patch.object instead of using patch all the time :shrug:
+@pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
 @patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
 @patch.object(InsightsConnection, 'get', return_value=Mock(status_code=200, content=b"Rule Content"))
 @patch.object(InsightsConnection, 'get_proxies')
@@ -382,6 +391,7 @@ class TestGetRules:
         log_mock.debug.assert_called_with("Downloading rules from: %s", replaced_url)
 
 
+@pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
 @patch(GET_RULES_TARGET, return_value=RULES_FILE)
 @patch(FIND_YARA_TARGET, return_value=YARA)
 @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
@@ -439,6 +449,7 @@ class TestBuildYaraCmd:
         log_mock.error.assert_called_with("Unable to use rules file %s: %s", RULES_FILE, "invalid")
 
 
+@pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
 @patch(BUILD_YARA_COMMAND_TARGET)
 @patch(GET_RULES_TARGET, return_value=RULES_FILE)
 @patch(FIND_YARA_TARGET, return_value=YARA)
@@ -975,6 +986,7 @@ class TestMalwareDetectionOptions:
         log_mock.error.assert_any_call("Unable to find the items specified for the processes_scan_exclude option.  Skipping ...")
 
 
+@pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
 @patch(BUILD_YARA_COMMAND_TARGET)
 @patch(GET_RULES_TARGET, return_value=TEST_RULE_FILE)
 @patch(FIND_YARA_TARGET, return_value=YARA)
@@ -1110,6 +1122,7 @@ class TestProcessScanning:
         assert len(mdc.scan_pids) == 1
 
 
+@pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
 @patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
 @patch(BUILD_YARA_COMMAND_TARGET)
 @patch(FIND_YARA_TARGET, return_value=YARA)
@@ -1291,6 +1304,7 @@ class TestFilesystemScanning:
         assert all([f not in mdc.filesystem_scan_exclude_list for f in glob_files])
 
 
+@pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
 class TestFilesystemIncludeExcludeMethods:
 
     def test_toplevel_dirs(self):
@@ -1424,6 +1438,7 @@ class TestFilesystemIncludeExcludeMethods:
         assert processed_items == get_toplevel_dirs()
 
 
+@pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
 @patch(BUILD_YARA_COMMAND_TARGET)
 @patch(GET_RULES_TARGET, return_value=RULES_FILE)
 @patch(FIND_YARA_TARGET, return_value=YARA)
@@ -1543,6 +1558,7 @@ class TestFilesystemIncludeExcludeProcessing:
         assert all([x not in scan_dict['/tmp']['include'] for x in dont_include_files])
 
 
+@pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
 @patch(BUILD_YARA_COMMAND_TARGET)
 @patch(GET_RULES_TARGET, return_value=RULES_FILE)
 @patch(FIND_YARA_TARGET, return_value=YARA)


### PR DESCRIPTION
* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

This is to correct problems encountered when running the malware-detection tests on RHEL6 systems outside the automated PR check environment. Malware detection won't be supported on RHEL6 so no need to check it works in that environment anyway.