### PR TITLE
fix(client): Return valid machine-id UUID4 object

### DIFF
--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -149,11 +149,8 @@ def generate_machine_id(new=False,
         logger.debug("Creating %s", destination_file)
         write_to_disk(destination_file, content=machine_id)
 
-    machine_id = str(machine_id).strip()
-
     try:
-        uuid.UUID(machine_id, version=4)
-        return machine_id
+        return str(uuid.UUID(str(machine_id).strip(), version=4))
     except ValueError as e:
         logger.error("Invalid machine ID: %s", machine_id)
         logger.error("Error details: %s", str(e))

--- a/insights/tests/client/test_utilities.py
+++ b/insights/tests/client/test_utilities.py
@@ -61,6 +61,17 @@ def test_generate_machine_id():
     os.remove('/tmp/testmachineid')
 
 
+def test_generate_machine_id_with_non_hyphen_id():
+    content = '86f6f5fad8284730b708a2e44ba5c14a'
+    filename = '/tmp/testmachineid'
+    util.write_to_disk(filename, content=content)
+
+    returned_uuid = str(uuid.UUID(content, version=4))
+
+    assert util.generate_machine_id(destination_file=filename) == returned_uuid
+    os.remove(filename)
+
+
 def test_bad_machine_id():
     with mock.patch.object(util.sys, "exit") as mock_exit:
         with open('/tmp/testmachineid', 'w') as _file:


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

In old version of the client, the machine-id could be a non-hyphen
UUID. Upload still works but `insights-client-results.service` fails with
a `Error: failed to download advisor report.` error message.

This patch fixes this issue by actually returning a `UUID4` object with
hyphens. Moreover, it also adds a unit test to check non-hyphen `UUID`
from old client.

Resolves: rhbz#1998560

Signed-off-by: Gael Chamoulaud (Strider) <gchamoul@redhat.com>

