### PR TITLE
fix: Move _LogRotateConf parser out of combiner

### DIFF
--- a/insights/combiners/tests/test_logrotate_conf_tree.py
+++ b/insights/combiners/tests/test_logrotate_conf_tree.py
@@ -1,8 +1,9 @@
 # coding=utf-8
 import pytest
 
+from insights.combiners.logrotate_conf import LogRotateConfTree
+from insights.parsers import logrotate_conf
 from insights.parsr.query import first
-from insights.combiners.logrotate_conf import _LogRotateConf, LogRotateConfTree
 from insights.tests import context_wrap
 
 
@@ -85,7 +86,7 @@ LOGROTATE_MISSING_ENDSCRIPT = """
 
 
 def test_logrotate_tree():
-    p = _LogRotateConf(context_wrap(CONF, path="/etc/logrotate.conf"))
+    p = logrotate_conf.LogRotateConfPEG(context_wrap(CONF, path="/etc/logrotate.conf"))
     conf = LogRotateConfTree([p])
     assert len(conf["weekly"]) == 1
     assert len(conf["/var/log/wtmp"]["missingok"]) == 1
@@ -97,12 +98,11 @@ def test_logrotate_tree():
 
 
 def test_junk_space():
-    p = _LogRotateConf(context_wrap(JUNK_SPACE, path="/etc/logrotate.conf"))
+    p = logrotate_conf.LogRotateConfPEG(context_wrap(JUNK_SPACE, path="/etc/logrotate.conf"))
     conf = LogRotateConfTree([p])
     assert "compress" in conf["/var/log/spooler"]
 
 
 def test_logrotate_conf_combiner_missing_endscript():
     with pytest.raises(Exception):
-        p = _LogRotateConf(context_wrap(LOGROTATE_MISSING_ENDSCRIPT, path='/etc/logrotate.conf')),
-        print(p)
+        logrotate_conf.LogRotateConfPEG(context_wrap(LOGROTATE_MISSING_ENDSCRIPT, path='/etc/logrotate.conf')),

--- a/insights/parsers/tests/test_logrotate_conf.py
+++ b/insights/parsers/tests/test_logrotate_conf.py
@@ -124,8 +124,9 @@ LOGROTATE_CONF_4 = """
 
 def test_web_xml_doc_examples():
     env = {
-            'log_rt': LogrotateConf(context_wrap(LOGROTATE_MAN_PAGE_DOC, path='/etc/logrotate.conf')),
-          }
+        'log_rt': logrotate_conf.LogrotateConf(context_wrap(LOGROTATE_MAN_PAGE_DOC, path='/etc/logrotate.conf')),
+        'log_rt_peg': logrotate_conf.LogRotateConfPEG(context_wrap(LOGROTATE_MAN_PAGE_DOC, path='/etc/logrotate.conf')),
+    }
     failed, total = doctest.testmod(logrotate_conf, globs=env)
     assert failed == 0
 


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
Due to an issue found with the httpdconf parser that was in the combiner I'm moving the newer logrotate parser out of it's combiner as well. Added docstring to the moved parser, and added doctest.