### PR TITLE
Feat: Add spec and parser for 'containers_policy'

### DIFF
--- a/docs/shared_parsers_catalog/containers_policy.rst
+++ b/docs/shared_parsers_catalog/containers_policy.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.containers_policy
+   :members:
+   :show-inheritance:

--- a/insights/parsers/containers_policy.py
+++ b/insights/parsers/containers_policy.py
@@ -55,7 +55,5 @@ class ContainersPolicy(JSONParser):
     Examples:
         >>> len(containers_policy["default"])
         1
-        >>> containers_policy["default"][0]["type"]
-        'insecureAcceptAnything'
     """
     pass

--- a/insights/parsers/containers_policy.py
+++ b/insights/parsers/containers_policy.py
@@ -1,0 +1,61 @@
+"""
+ContainersPolicy - file ``/etc/containers/policy.json``
+=======================================================
+"""
+from insights import JSONParser, parser
+from insights.specs import Specs
+
+
+@parser(Specs.containers_policy)
+class ContainersPolicy(JSONParser):
+    """
+    Class for converting file ``/etc/containers/policy.json``
+    into a dictionary that matches the JSON string in the file.
+
+    Sample file content::
+
+        {
+          "default": [
+            {
+              "type": "insecureAcceptAnything"
+            }
+          ],
+          "transports": {
+            "docker": {
+              "registry.access.redhat.com": [
+                {
+                  "type": "signedBy",
+                  "keyType": "GPGKeys",
+                  "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+                }
+              ],
+              "registry.redhat.io/redhat/redhat-operator-index": [
+                {
+                  "type": "insecureAcceptAnything"
+                }
+              ],
+              "registry.redhat.io": [
+                {
+                  "type": "signedBy",
+                  "keyType": "GPGKeys",
+                  "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+                }
+              ]
+            },
+            "docker-daemon": {
+              "": [
+                {
+                  "type": "insecureAcceptAnything"
+                }
+              ]
+            }
+          }
+        }
+
+    Examples:
+        >>> len(containers_policy["default"])
+        1
+        >>> containers_policy["default"][0]["type"]
+        'insecureAcceptAnything'
+    """
+    pass

--- a/insights/parsers/tests/test_containers_policy.py
+++ b/insights/parsers/tests/test_containers_policy.py
@@ -1,0 +1,64 @@
+import doctest
+
+from insights.parsers import containers_policy
+from insights.parsers.containers_policy import ContainersPolicy
+from insights.parsers.tests import skip_exception_check
+from insights.tests import context_wrap
+
+CONTAINERS_POLICY_FILE = '''
+{
+  "default": [
+    {
+      "type": "insecureAcceptAnything"
+    }
+  ],
+  "transports": {
+    "docker": {
+      "registry.access.redhat.com": [
+        {
+          "type": "signedBy",
+          "keyType": "GPGKeys",
+          "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+        }
+      ],
+      "registry.redhat.io/redhat/redhat-operator-index": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ],
+      "registry.redhat.io": [
+        {
+          "type": "signedBy",
+          "keyType": "GPGKeys",
+          "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+        }
+      ]
+    },
+    "docker-daemon": {
+      "": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ]
+    }
+  }
+}
+'''.strip()
+
+
+def test_doc_examples():
+    env = {
+        'containers_policy': ContainersPolicy(context_wrap(CONTAINERS_POLICY_FILE)),
+    }
+    failed, total = doctest.testmod(containers_policy, globs=env)
+    assert failed == 0
+
+
+def test_containers_policy():
+    conf = ContainersPolicy(context_wrap(CONTAINERS_POLICY_FILE))
+    assert len(conf["default"]) == 1
+    assert conf["default"][0]["type"] == "insecureAcceptAnything"
+
+
+def test_containers_policy_empty():
+    assert 'Empty output.' in skip_exception_check(ContainersPolicy)

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -73,6 +73,7 @@ class Specs(SpecSet):
     cni_podman_bridge_conf = RegistryPoint()
     cobbler_modules_conf = RegistryPoint()
     cobbler_settings = RegistryPoint()
+    containers_policy = RegistryPoint()
     corosync = RegistryPoint()
     corosync_cmapctl = RegistryPoint(multi_output=True)
     corosync_conf = RegistryPoint()

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -43,6 +43,7 @@ class SosSpecs(Specs):
     cni_podman_bridge_conf = simple_file("/etc/cni/net.d/87-podman-bridge.conflist")
     cobbler_settings = first_file(["/etc/cobbler/settings", "/conf/cobbler/settings"])
     cobbler_modules_conf = first_file(["/etc/cobbler/modules.conf", "/conf/cobbler/modules.conf"])
+    containers_policy = simple_file("/etc/containers/policy.json")
     corosync_cmapctl = glob_file("sos_commands/corosync/corosync-cmapctl*")
     cpe = simple_file("/etc/system-release-cpe")
     cpu_smt_control = simple_file("sys/devices/system/cpu/smt/control")


### PR DESCRIPTION
Signed-off-by: shlao <shlao@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->


CRI-O crashes with "_gpgme_ath_mutex_lock" on worker nodes when signature verification is enabled. The signature verification policy, `/etc/containers/policy.json`, specifies the policy. For the Detail info, please see: INSIGHTOCP-695 card.
