### PR TITLE
Add parser for /proc/self/mountinfo and new combiner mounts

### DIFF
--- a/docs/shared_combiners_catalog/mounts.rst
+++ b/docs/shared_combiners_catalog/mounts.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.combiners.mounts
+   :members:
+   :show-inheritance:

--- a/insights/combiners/mounts.py
+++ b/insights/combiners/mounts.py
@@ -1,0 +1,204 @@
+"""
+Mounts
+======
+
+This combiner provides information about mount entries.
+More specifically this consolidates data from
+:py:class:`insights.parsers.mount.Mount`,
+:py:class:`insights.parsers.mount.ProcMounts` and
+:py:class:`insights.parsers.mount.MountInfo`.
+
+Examples:
+
+    >>> type(mounts)
+    <class 'insights.combiners.mounts.Mounts'>
+    >>> len(mounts)
+    19
+    >>> '/boot' in mounts
+    True
+    >>> mounts['/boot'].mount_source
+    '/dev/sda1'
+    >>> mounts['/boot'].mount_options
+    {'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'}
+    >>> mounts['/boot'].mount_addtlinfo.major_minor
+    '8:1'
+"""
+
+import os
+from collections import namedtuple
+from insights.core.plugins import combiner
+from insights.parsers import keyword_search
+from insights.parsers.mount import Mount, ProcMounts, MountInfo
+
+MOUNTADDTLINFO_FIELD_NAMES = [
+    "mount_label",  # (str): Optional label of this mount entry, an empty string by default
+    "fs_freq",  # (str): Optional label of this mount entry, an empty string by default
+    "fs_passno",  # (str): Optional label of this mount entry, an empty string by default
+    "mount_id",  # (str): Unique identifier of the mount
+    "parent_id",  # (str): Unique identifier of the mount
+    "major_minor",  # (str): Value of st_dev for files on filesystem
+    "root",  # (str): Root of the mount within the filesystem
+    "optional_fields",  # (str): Zero or more fields of the form "tag[:value]"
+    "mount_clause_binmount",   # (str): Full raw string from /bin/mount command output
+    "mount_clause_procmounts",   # (str): Full raw string from /proc/mounts
+    "mount_clause_mountinfo",   # (str): Full raw string from /proc/self/mountinfo
+]
+MountAddtlInfo = namedtuple("MountAddtlInfo", field_names=MOUNTADDTLINFO_FIELD_NAMES)
+
+MOUNTENTRY_FIELD_NAMES = [
+    "mount_source", # (str): Name of filesystem of mounted device
+    "mount_point",  # (str): Name of mount point for filesystem
+    "mount_type",   # (str): Name of filesystem type
+    "mount_options",  # (dict): Mount options
+    "mount_addtlinfo", # (MountAddtlInfo): Additional mount information as namedtuple `MountAddtlInfo`
+]
+MountEntry = namedtuple("MountEntry", field_names=MOUNTENTRY_FIELD_NAMES)
+"""
+    An object representing an mount entry of ``mount`` command or
+    ``/proc/mounts`` file.  Each entry contains below fixed attributes:
+
+    Attributes:
+        mount_source(str): Name of filesystem of mounted device
+        mount_point (str): Name of mount point for filesystem
+        mount_type (str): Name of filesystem type
+        mount_options (MountOpts): Mount options as :class:`MountOpts`
+        mount_addtlinfo (MountAddtlInfo): Additional mount information as :class:`MountAddtlInfo`
+"""
+
+
+@combiner([Mount, ProcMounts, MountInfo])
+class Mounts(object):
+    """
+    ``Mounts`` combiner consolidates data from the parsers in
+    ``insights.parsers.mounts`` module.
+
+    Attributes:
+        rows (list): list of :class:`MountEntry` objects for each mount entry
+    """
+
+    def __init__(self, binmount, procmounts, mountinfo):
+        self._mounts = {}
+
+        all_mount_points = set().union(
+                    binmount.mounts.keys() if binmount else [],
+                    procmounts.mounts.keys() if procmounts else [],
+                    mountinfo.mounts.keys() if mountinfo else [])
+        for mount_point in all_mount_points:
+            this_binmount = binmount.get_dir(mount_point) if binmount else None
+            this_procmounts = procmounts.get_dir(mount_point) if procmounts else None
+            this_mountinfo = mountinfo.get_dir(mount_point) if mountinfo else None
+
+            # create MountAddtlInfo
+            addtlinfo = self.__init_a_addtlinfo()
+            if this_binmount:
+                if 'mount_label' in this_binmount:
+                    addtlinfo['mount_label'] = this_binmount['mount_label']
+                addtlinfo['mount_clause_binmount'] = this_binmount['mount_clause']
+            if this_procmounts:
+                addtlinfo['fs_freq'], addtlinfo['fs_passno'] = this_procmounts['mount_label']
+                addtlinfo['mount_clause_procmounts'] = this_procmounts['mount_clause']
+            if this_mountinfo:
+                this_addtlinfo = this_mountinfo.get('mount_addtlinfo')
+                for k in MOUNTADDTLINFO_FIELD_NAMES[3:8]:
+                    addtlinfo[k] = this_addtlinfo.__getattribute__(k)
+                addtlinfo['mount_clause_mountinfo'] = this_mountinfo['mount_clause']
+            entry_addtlinfo = MountAddtlInfo(**addtlinfo)
+
+            # create MountEntry
+            source_mount = this_mountinfo if this_mountinfo else (
+                            this_procmounts if this_procmounts else this_binmount)
+            basicinfo = {}
+            basicinfo['mount_point'] = mount_point
+            basicinfo['mount_source'] = source_mount.get('mount_source') or source_mount.get('filesystem')
+            basicinfo['mount_type'] = source_mount.get('mount_type')
+            # covert `mount_options` into a real dict instead of MountOpts(AttributeAsDict)
+            mount_ops = source_mount.get('mount_options')
+            basicinfo['mount_options'] = dict([k, v] for k, v in mount_ops.items())
+            basicinfo['mount_addtlinfo'] = entry_addtlinfo
+            entry_info = MountEntry(**basicinfo)
+
+            self._mounts[mount_point] = entry_info
+            self.rows = sorted(self._mounts.values(), key=lambda r: (r.mount_addtlinfo[3], r.mount_point))
+
+    @property
+    def mount_points(self):
+        """
+        Returns:
+            list: list of :str:`mount_point` for each mount entry
+        """
+        return list(self._mounts.keys())
+
+    def get_dir(self, path):
+        """
+        This finds the most specific mount path that contains the given path,
+        by successively removing the directory or file name on the end of
+        the path and seeing if that is a mount point.  This will always
+        terminate since / is always a mount point.  Strings that are not
+        absolute paths will return None.
+
+        Arguments:
+            path (str): The path to check.
+        Returns:
+            MountEntry: The mount point that contains the given path.
+        """
+        while path != '':
+            if path in self._mounts:
+                return self._mounts[path]
+            path = os.path.split(path)[0]
+        return None
+
+    def search(self, **kwargs):
+        """
+        Returns a list of the mounts matching the given criteria.
+        Keys are searched for directly - see the
+        :py:func:`insights.parsers.keyword_search` utility function for more
+        details.  If no search parameters are given, no rows are returned.
+
+        Arguments:
+            **kwargs (dict): Dictionary of key-value pairs to search for.
+
+        Returns:
+            (list): The list of mount points matching the given criteria.
+
+        Examples:
+
+            >>> mounts.search(mount_point='/proc')[0]['mount_source']
+            'proc'
+            >>> mounts.search(mount_type__contains='nfs')[0]['mount_point']
+            '/shared/dir1'
+        """
+        return keyword_search([r._asdict() for r in self.rows], **kwargs)
+
+    def __contains__(self, mount_point):
+        """
+        Check if a specific mount_point is mounted.
+
+        Args:
+            mount_point (str): a mount_point string
+
+        Returns:
+            bool: True if mount_point is mounted, otherwise False
+        """
+        return mount_point in self._mounts
+
+    def __getitem__(self, mount_point):
+        """
+        Retrieve a specific mount entry by its mount_point.
+
+        Args:
+            mount_point (str): a mount_point string
+
+        Returns:
+            MountEntry: a namedtuple that represents a mount entry
+        """
+        return self._mounts.get(mount_point)
+
+    def __len__(self):
+        return len(self._mounts)
+
+    def __iter__(self):
+        for row in self.rows:
+            yield row
+
+    def __init_a_addtlinfo(self):
+        return dict([k, ''] for k in MOUNTADDTLINFO_FIELD_NAMES)

--- a/insights/combiners/mounts.py
+++ b/insights/combiners/mounts.py
@@ -31,38 +31,54 @@ from insights.parsers import keyword_search
 from insights.parsers.mount import Mount, ProcMounts, MountInfo
 
 MOUNTADDTLINFO_FIELD_NAMES = [
-    "mount_label",  # (str): Optional label of this mount entry, an empty string by default
-    "fs_freq",  # (str): Optional label of this mount entry, an empty string by default
-    "fs_passno",  # (str): Optional label of this mount entry, an empty string by default
-    "mount_id",  # (str): Unique identifier of the mount
-    "parent_id",  # (str): Unique identifier of the mount
-    "major_minor",  # (str): Value of st_dev for files on filesystem
-    "root",  # (str): Root of the mount within the filesystem
-    "optional_fields",  # (str): Zero or more fields of the form "tag[:value]"
-    "mount_clause_binmount",   # (str): Full raw string from /bin/mount command output
-    "mount_clause_procmounts",   # (str): Full raw string from /proc/mounts
-    "mount_clause_mountinfo",   # (str): Full raw string from /proc/self/mountinfo
+    "mount_label",
+    "fs_freq",
+    "fs_passno",
+    "mount_id",
+    "parent_id",
+    "major_minor",
+    "root",
+    "optional_fields",
+    "mount_clause_binmount",
+    "mount_clause_procmounts",
+    "mount_clause_mountinfo",
 ]
 MountAddtlInfo = namedtuple("MountAddtlInfo", field_names=MOUNTADDTLINFO_FIELD_NAMES)
+"""
+A namedtuple object representing the additional infomation for a mount entry.
+For a missing field, default to an empty string
+
+Attributes:
+    mount_label (str): Label of this mount entry from command ``/bin/mount``
+    fs_freq (str): fs_freq of this mount entry from file ``/proc/mounts``
+    fs_passno (str): fs_passno of this mount entry from file ``/proc/mounts``
+    mount_id (str): Unique identifier of the mount
+    parent_id (str): Unique identifier of the parent mount
+    major_minor (str): Value of st_dev for files on filesystem
+    root (str): Root of the mount within the filesystem
+    optional_fields (str): Zero or more fields of the form "tag[:value]"
+    mount_clause_binmount (str): Full raw string from command ``/bin/mount``
+    mount_clause_procmounts (str): Full raw string from file ``/proc/mounts``
+    mount_clause_mountinfo (str): Full raw string from file ``/proc/self/mountinfo``
+"""
 
 MOUNTENTRY_FIELD_NAMES = [
-    "mount_source", # (str): Name of filesystem of mounted device
-    "mount_point",  # (str): Name of mount point for filesystem
-    "mount_type",   # (str): Name of filesystem type
-    "mount_options",  # (dict): Mount options
-    "mount_addtlinfo", # (MountAddtlInfo): Additional mount information as namedtuple `MountAddtlInfo`
+    "mount_source",
+    "mount_point",
+    "mount_type",
+    "mount_options",
+    "mount_addtlinfo",
 ]
 MountEntry = namedtuple("MountEntry", field_names=MOUNTENTRY_FIELD_NAMES)
 """
-    An object representing an mount entry of ``mount`` command or
-    ``/proc/mounts`` file.  Each entry contains below fixed attributes:
+A namedtuple object representing a mount entry.
 
-    Attributes:
-        mount_source(str): Name of filesystem of mounted device
-        mount_point (str): Name of mount point for filesystem
-        mount_type (str): Name of filesystem type
-        mount_options (MountOpts): Mount options as :class:`MountOpts`
-        mount_addtlinfo (MountAddtlInfo): Additional mount information as :class:`MountAddtlInfo`
+Attributes:
+    mount_source (str): Name of mounted device for filesystem
+    mount_point (str): Name of mount point for filesystem
+    mount_type (str): Name of filesystem type
+    mount_options (dict): Mount options
+    mount_addtlinfo (MountAddtlInfo): Additional mount information as namedtuple `MountAddtlInfo`
 """
 
 

--- a/insights/combiners/mounts.py
+++ b/insights/combiners/mounts.py
@@ -18,8 +18,8 @@ Examples:
     True
     >>> mounts['/boot'].mount_source
     '/dev/sda1'
-    >>> mounts['/boot'].mount_options
-    {'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'}
+    >>> mounts['/boot'].mount_options.get('data')
+    'ordered'
     >>> mounts['/boot'].mount_addtlinfo.major_minor
     '8:1'
 """

--- a/insights/combiners/mounts.py
+++ b/insights/combiners/mounts.py
@@ -87,7 +87,7 @@ class Mounts(object):
     def mount_points(self):
         """
         Returns:
-            list: list of :str:`mount_point` for each mount entry
+            (list): list of `mount_point` for each mount entry
         """
         return list(self._mounts.keys())
 

--- a/insights/combiners/tests/test_mounts.py
+++ b/insights/combiners/tests/test_mounts.py
@@ -1,6 +1,7 @@
 import doctest
 from insights.parsers.mount import Mount, ProcMounts, MountInfo
-from insights.combiners.mounts import Mounts, MountAddtlInfo
+from insights.parsers.mount import MountOpts, MountAddtlInfo
+from insights.combiners.mounts import Mounts
 from insights.combiners import mounts as module_mounts
 from insights.tests import context_wrap
 
@@ -79,14 +80,18 @@ def test_combiner_mounts_all():
     assert '/' in mounts
     root_entry = mounts['/']
     assert root_entry.mount_type == 'ext4'
-    assert root_entry.mount_options == {'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'}
-    root_entry_addtlinfo = MountAddtlInfo(mount_label='', fs_freq='0', fs_passno='0',
+    assert len(root_entry.mount_options) == 5
+    assert root_entry.mount_options.data == 'ordered'
+    root_entry_opts = MountOpts({'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'})
+    for k, v in root_entry_opts.items():
+        assert root_entry.mount_options[k] == v
+    root_entry_addtlinfo = MountAddtlInfo(dict(fs_freq='0', fs_passno='0',
                 mount_id='21', parent_id='1', major_minor='253:1', root='/', optional_fields='',
                 mount_clause_binmount='/dev/mapper/vgsys-root on / type ext4 (rw)',
                 mount_clause_procmounts='/dev/mapper/vgsys-root / ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0',
-                mount_clause_mountinfo='21 1 253:1 / / rw,relatime - ext4 /dev/mapper/vgsys-root rw,barrier=1,stripe=64,data=ordered')
-    for idx in range(len(root_entry_addtlinfo)):
-        assert root_entry.mount_addtlinfo[idx] == root_entry_addtlinfo[idx]
+                mount_clause_mountinfo='21 1 253:1 / / rw,relatime - ext4 /dev/mapper/vgsys-root rw,barrier=1,stripe=64,data=ordered'))
+    for k, v in root_entry_addtlinfo.items():
+        assert root_entry.mount_addtlinfo[k] == v
 
     assert mounts.search(mount_source="/dev/mapper/vgsys-root")[0]['mount_point'] == '/'
 
@@ -106,14 +111,14 @@ def test_combiner_wo_mountinfo():
     assert '/' in mounts
     root_entry = mounts['/']
     assert root_entry.mount_type == 'ext4'
-    assert root_entry.mount_options == {'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'}
-    root_entry_addtlinfo = MountAddtlInfo(mount_label='', fs_freq='0', fs_passno='0',
-                mount_id='', parent_id='', major_minor='', root='', optional_fields='',
+    root_entry_opts = MountOpts({'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'})
+    for k, v in root_entry_opts.items():
+        assert root_entry.mount_options[k] == v
+    root_entry_addtlinfo = MountAddtlInfo(dict(fs_freq='0', fs_passno='0',
                 mount_clause_binmount='/dev/mapper/vgsys-root on / type ext4 (rw)',
-                mount_clause_procmounts='/dev/mapper/vgsys-root / ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0',
-                mount_clause_mountinfo='')
-    for idx in range(len(root_entry_addtlinfo)):
-        assert root_entry.mount_addtlinfo[idx] == root_entry_addtlinfo[idx]
+                mount_clause_procmounts='/dev/mapper/vgsys-root / ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0'))
+    for k, v in root_entry_addtlinfo.items():
+        assert root_entry.mount_addtlinfo[k] == v
 
     assert mounts.search(mount_source="/dev/mapper/vgsys-root")[0]['mount_point'] == '/'
     assert mounts.rows[0] == mounts['/']
@@ -128,14 +133,15 @@ def test_combiner_wo_binmount():
     assert '/' in mounts
     root_entry = mounts['/']
     assert root_entry.mount_type == 'ext4'
-    assert root_entry.mount_options == {'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'}
-    root_entry_addtlinfo = MountAddtlInfo(mount_label='', fs_freq='0', fs_passno='0',
+    root_entry_opts = MountOpts({'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'})
+    for k, v in root_entry_opts.items():
+        assert root_entry.mount_options[k] == v
+    root_entry_addtlinfo = MountAddtlInfo(dict(fs_freq='0', fs_passno='0',
                 mount_id='21', parent_id='1', major_minor='253:1', root='/', optional_fields='',
-                mount_clause_binmount='',
                 mount_clause_procmounts='/dev/mapper/vgsys-root / ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0',
-                mount_clause_mountinfo='21 1 253:1 / / rw,relatime - ext4 /dev/mapper/vgsys-root rw,barrier=1,stripe=64,data=ordered')
-    for idx in range(len(root_entry_addtlinfo)):
-        assert root_entry.mount_addtlinfo[idx] == root_entry_addtlinfo[idx]
+                mount_clause_mountinfo='21 1 253:1 / / rw,relatime - ext4 /dev/mapper/vgsys-root rw,barrier=1,stripe=64,data=ordered'))
+    for k, v in root_entry_addtlinfo.items():
+        assert root_entry.mount_addtlinfo[k] == v
 
     assert mounts.search(mount_source="/dev/mapper/vgsys-root")[0]['mount_point'] == '/'
     assert mounts.rows[0] == mounts['/proc']
@@ -150,14 +156,15 @@ def test_combiner_wo_procmount():
     assert '/' in mounts
     root_entry = mounts['/']
     assert root_entry.mount_type == 'ext4'
-    assert root_entry.mount_options == {'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'}
-    root_entry_addtlinfo = MountAddtlInfo(mount_label='', fs_freq='', fs_passno='',
+    root_entry_opts = MountOpts({'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'})
+    for k, v in root_entry_opts.items():
+        assert root_entry.mount_options[k] == v
+    root_entry_addtlinfo = MountAddtlInfo(dict(
                 mount_id='21', parent_id='1', major_minor='253:1', root='/', optional_fields='',
                 mount_clause_binmount='/dev/mapper/vgsys-root on / type ext4 (rw)',
-                mount_clause_procmounts='',
-                mount_clause_mountinfo='21 1 253:1 / / rw,relatime - ext4 /dev/mapper/vgsys-root rw,barrier=1,stripe=64,data=ordered')
-    for idx in range(len(root_entry_addtlinfo)):
-        assert root_entry.mount_addtlinfo[idx] == root_entry_addtlinfo[idx]
+                mount_clause_mountinfo='21 1 253:1 / / rw,relatime - ext4 /dev/mapper/vgsys-root rw,barrier=1,stripe=64,data=ordered'))
+    for k, v in root_entry_addtlinfo.items():
+        assert root_entry.mount_addtlinfo[k] == v
 
     assert mounts.search(mount_source="/dev/mapper/vgsys-root")[0]['mount_point'] == '/'
     assert mounts.rows[0] == mounts['/proc']
@@ -171,14 +178,13 @@ def test_combiner_only_binmount():
     assert '/' in mounts
     root_entry = mounts['/']
     assert root_entry.mount_type == 'ext4'
-    assert root_entry.mount_options == {'rw': True}
-    root_entry_addtlinfo = MountAddtlInfo(mount_label='', fs_freq='', fs_passno='',
-                mount_id='', parent_id='', major_minor='', root='', optional_fields='',
-                mount_clause_binmount='/dev/mapper/vgsys-root on / type ext4 (rw)',
-                mount_clause_procmounts='',
-                mount_clause_mountinfo='')
-    for idx in range(len(root_entry_addtlinfo)):
-        assert root_entry.mount_addtlinfo[idx] == root_entry_addtlinfo[idx]
+    root_entry_opts = MountOpts({'rw': True})
+    for k, v in root_entry_opts.items():
+        assert root_entry.mount_options[k] == v
+    root_entry_addtlinfo = MountAddtlInfo(dict(
+                mount_clause_binmount='/dev/mapper/vgsys-root on / type ext4 (rw)'))
+    for k, v in root_entry_addtlinfo.items():
+        assert root_entry.mount_addtlinfo[k] == v
 
     assert mounts.search(mount_source="/dev/mapper/vgsys-root")[0]['mount_point'] == '/'
     assert mounts.rows[0] == mounts['/']

--- a/insights/combiners/tests/test_mounts.py
+++ b/insights/combiners/tests/test_mounts.py
@@ -1,0 +1,196 @@
+import doctest
+from insights.parsers.mount import Mount, ProcMounts, MountInfo
+from insights.combiners.mounts import Mounts, MountAddtlInfo
+from insights.combiners import mounts as module_mounts
+from insights.tests import context_wrap
+
+
+MOUNT_DATA = """
+/dev/mapper/vgsys-root on / type ext4 (rw)
+proc on /proc type proc (rw)
+sysfs on /sys type sysfs (rw)
+devpts on /dev/pts type devpts (rw,gid=5,mode=620)
+tmpfs on /dev/shm type tmpfs (rw,noexec,nosuid,nodev)
+/dev/sda1 on /boot type ext4 (rw)
+/dev/mapper/vgsys-diskdump on /diskdump type ext4 (rw)
+/dev/mapper/vgsys-tmp on /tmp type ext4 (rw)
+/dev/mapper/vgsys-var on /var type ext4 (rw)
+/dev/mapper/vgsys-var_log on /var/log type ext4 (rw) [cluster7:lv_gfs]
+/dev/mapper/vgsys-var_tmp on /var/tmp type ext4 (rw) [VMware Tools]
+none on /proc/sys/fs/binfmt_misc type binfmt_misc (rw)
+sunrpc on /var/lib/nfs/rpc_pipefs type rpc_pipefs (rw)
+hostname1:/shared_dir1 on /shared/dir1 type nfs (rw,nosuid,sync,hard,intr,bg,tcp,timeo=600,rsize=32768,nolock,wsize=32768,noacl,vers=4,addr=10.72.36.91,clientaddr=10.72.32.16)
+hostname2:/shared/some/dir2 on /shared/dir2 type nfs (rw,nosuid,sync,hard,intr,bg,tcp,timeo=600,rsize=32768,nolock,wsize=32768,noacl,addr=10.73.32.202)
+""".strip()
+
+PROCMOUNTS_DATA = """
+rootfs / rootfs rw 0 0
+proc /proc proc rw,relatime 0 0
+sysfs /sys sysfs rw,relatime 0 0
+devtmpfs /dev devtmpfs rw,relatime,size=66002212k,nr_inodes=16500553,mode=755 0 0
+devpts /dev/pts devpts rw,relatime,gid=5,mode=620,ptmxmode=000 0 0
+tmpfs /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime 0 0
+/dev/mapper/vgsys-root / ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0
+/proc/bus/usb /proc/bus/usb usbfs rw,relatime 0 0
+/dev/sda1 /boot ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0
+/dev/mapper/vgsys-diskdump /diskdump ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0
+/dev/mapper/vgsys-tmp /tmp ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0
+/dev/mapper/vgsys-var /var ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0
+/dev/mapper/vgsys-var_log /var/log ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0
+/dev/mapper/vgsys-var_tmp /var/tmp ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0
+none /proc/sys/fs/binfmt_misc binfmt_misc rw,relatime 0 0
+sunrpc /var/lib/nfs/rpc_pipefs rpc_pipefs rw,relatime 0 0
+hostname1:/shared_dir1 /shared/dir1 nfs4 rw,sync,nosuid,relatime,vers=4,rsize=32768,wsize=32768,namlen=255,hard,proto=tcp,port=0,timeo=600,retrans=2,sec=sys,clientaddr=10.72.32.16,minorversion=0,local_lock=none,addr=10.72.36.91 0 0
+hostname2:/shared/some/dir2 /shared/dir2 nfs rw,sync,nosuid,relatime,vers=3,rsize=32768,wsize=32768,namlen=255,hard,nolock,noacl,proto=tcp,timeo=600,retrans=2,sec=sys,mountaddr=10.73.32.108,mountvers=3,mountport=300,mountproto=tcp,local_lock=all,addr=10.73.32.202 0 0
+/etc/auto.misc /misc autofs rw,relatime,fd=7,pgrp=4826,timeout=300,minproto=5,maxproto=5,indirect 0 0
+-hosts /autofsmp autofs rw,relatime,fd=13,pgrp=4826,timeout=300,minproto=5,maxproto=5,indirect 0 0
+""".strip()
+
+MOUNTINFO_DATA = """
+16 21 0:3 / /proc rw,relatime - proc proc rw
+17 21 0:0 / /sys rw,relatime - sysfs sysfs rw
+18 21 0:5 / /dev rw,relatime - devtmpfs devtmpfs rw,size=66002212k,nr_inodes=16500553,mode=755
+19 18 0:11 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+20 18 0:16 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw
+21 1 253:1 / / rw,relatime - ext4 /dev/mapper/vgsys-root rw,barrier=1,stripe=64,data=ordered
+22 16 0:15 / /proc/bus/usb rw,relatime - usbfs /proc/bus/usb rw
+23 21 8:1 / /boot rw,relatime - ext4 /dev/sda1 rw,barrier=1,stripe=64,data=ordered
+25 21 253:32 / /diskdump rw,relatime - ext4 /dev/mapper/vgsys-diskdump rw,barrier=1,stripe=64,data=ordered
+33 21 253:33 / /tmp rw,relatime - ext4 /dev/mapper/vgsys-tmp rw,barrier=1,stripe=64,data=ordered
+36 21 253:34 / /var rw,relatime - ext4 /dev/mapper/vgsys-var rw,barrier=1,stripe=64,data=ordered
+37 36 253:36 / /var/log rw,relatime - ext4 /dev/mapper/vgsys-var_log rw,barrier=1,stripe=64,data=ordered
+40 36 253:35 / /var/tmp rw,relatime - ext4 /dev/mapper/vgsys-var_tmp rw,barrier=1,stripe=64,data=ordered
+52 16 0:17 / /proc/sys/fs/binfmt_misc rw,relatime - binfmt_misc none rw
+53 36 0:18 / /var/lib/nfs/rpc_pipefs rw,relatime - rpc_pipefs sunrpc rw
+55 21 0:20 / /shared/dir1 rw,nosuid,relatime - nfs4 hostname1:/shared_dir1 rw,sync,vers=4,rsize=32768,wsize=32768,namlen=255,hard,proto=tcp,port=0,timeo=600,retrans=2,sec=sys,clientaddr=10.72.32.16,minorversion=0,local_lock=none,addr=10.72.36.91
+56 21 0:19 / /shared/dir2 rw,nosuid,relatime - nfs hostname2:/shared/some/dir2 rw,sync,vers=3,rsize=32768,wsize=32768,namlen=255,hard,nolock,noacl,proto=tcp,timeo=600,retrans=2,sec=sys,mountaddr=10.73.32.108,mountvers=3,mountport=300,mountproto=tcp,local_lock=all,addr=10.73.32.202
+57 21 0:21 / /misc rw,relatime - autofs /etc/auto.misc rw,fd=7,pgrp=4826,timeout=300,minproto=5,maxproto=5,indirect
+58 21 0:22 / /autofsmp rw,relatime - autofs -hosts rw,fd=13,pgrp=4826,timeout=300,minproto=5,maxproto=5,indirect
+""".strip()
+
+
+def test_combiner_mounts_all():
+    mount = Mount(context_wrap(MOUNT_DATA))
+    procmounts = ProcMounts(context_wrap(PROCMOUNTS_DATA))
+    mountinfo = MountInfo(context_wrap(MOUNTINFO_DATA))
+    mounts = Mounts(mount, procmounts, mountinfo)
+    assert len(mounts) == 19
+
+    assert '/' in mounts
+    root_entry = mounts['/']
+    assert root_entry.mount_type == 'ext4'
+    assert root_entry.mount_options == {'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'}
+    root_entry_addtlinfo = MountAddtlInfo(mount_label='', fs_freq='0', fs_passno='0',
+                mount_id='21', parent_id='1', major_minor='253:1', root='/', optional_fields='',
+                mount_clause_binmount='/dev/mapper/vgsys-root on / type ext4 (rw)',
+                mount_clause_procmounts='/dev/mapper/vgsys-root / ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0',
+                mount_clause_mountinfo='21 1 253:1 / / rw,relatime - ext4 /dev/mapper/vgsys-root rw,barrier=1,stripe=64,data=ordered')
+    for idx in range(len(root_entry_addtlinfo)):
+        assert root_entry.mount_addtlinfo[idx] == root_entry_addtlinfo[idx]
+
+    assert mounts.search(mount_source="/dev/mapper/vgsys-root")[0]['mount_point'] == '/'
+
+    assert mounts.rows[0] == mounts['/proc']
+    assert len([row for row in mounts]) == 19
+    assert len(mounts.mount_points) == 19
+    assert mounts.get_dir('/var/somedir') == mounts['/var']
+    assert mounts.get_dir('not/absolute/path') is None
+
+
+def test_combiner_wo_mountinfo():
+    mount = Mount(context_wrap(MOUNT_DATA))
+    procmounts = ProcMounts(context_wrap(PROCMOUNTS_DATA))
+    mounts = Mounts(mount, procmounts, None)
+    assert len(mounts) == 19
+
+    assert '/' in mounts
+    root_entry = mounts['/']
+    assert root_entry.mount_type == 'ext4'
+    assert root_entry.mount_options == {'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'}
+    root_entry_addtlinfo = MountAddtlInfo(mount_label='', fs_freq='0', fs_passno='0',
+                mount_id='', parent_id='', major_minor='', root='', optional_fields='',
+                mount_clause_binmount='/dev/mapper/vgsys-root on / type ext4 (rw)',
+                mount_clause_procmounts='/dev/mapper/vgsys-root / ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0',
+                mount_clause_mountinfo='')
+    for idx in range(len(root_entry_addtlinfo)):
+        assert root_entry.mount_addtlinfo[idx] == root_entry_addtlinfo[idx]
+
+    assert mounts.search(mount_source="/dev/mapper/vgsys-root")[0]['mount_point'] == '/'
+    assert mounts.rows[0] == mounts['/']
+
+
+def test_combiner_wo_binmount():
+    procmounts = ProcMounts(context_wrap(PROCMOUNTS_DATA))
+    mountinfo = MountInfo(context_wrap(MOUNTINFO_DATA))
+    mounts = Mounts(None, procmounts, mountinfo)
+    assert len(mounts) == 19
+
+    assert '/' in mounts
+    root_entry = mounts['/']
+    assert root_entry.mount_type == 'ext4'
+    assert root_entry.mount_options == {'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'}
+    root_entry_addtlinfo = MountAddtlInfo(mount_label='', fs_freq='0', fs_passno='0',
+                mount_id='21', parent_id='1', major_minor='253:1', root='/', optional_fields='',
+                mount_clause_binmount='',
+                mount_clause_procmounts='/dev/mapper/vgsys-root / ext4 rw,relatime,barrier=1,stripe=64,data=ordered 0 0',
+                mount_clause_mountinfo='21 1 253:1 / / rw,relatime - ext4 /dev/mapper/vgsys-root rw,barrier=1,stripe=64,data=ordered')
+    for idx in range(len(root_entry_addtlinfo)):
+        assert root_entry.mount_addtlinfo[idx] == root_entry_addtlinfo[idx]
+
+    assert mounts.search(mount_source="/dev/mapper/vgsys-root")[0]['mount_point'] == '/'
+    assert mounts.rows[0] == mounts['/proc']
+
+
+def test_combiner_wo_procmount():
+    mount = Mount(context_wrap(MOUNT_DATA))
+    mountinfo = MountInfo(context_wrap(MOUNTINFO_DATA))
+    mounts = Mounts(mount, None, mountinfo)
+    assert len(mounts) == 19
+
+    assert '/' in mounts
+    root_entry = mounts['/']
+    assert root_entry.mount_type == 'ext4'
+    assert root_entry.mount_options == {'rw': True, 'relatime': True, 'barrier': '1', 'stripe': '64', 'data': 'ordered'}
+    root_entry_addtlinfo = MountAddtlInfo(mount_label='', fs_freq='', fs_passno='',
+                mount_id='21', parent_id='1', major_minor='253:1', root='/', optional_fields='',
+                mount_clause_binmount='/dev/mapper/vgsys-root on / type ext4 (rw)',
+                mount_clause_procmounts='',
+                mount_clause_mountinfo='21 1 253:1 / / rw,relatime - ext4 /dev/mapper/vgsys-root rw,barrier=1,stripe=64,data=ordered')
+    for idx in range(len(root_entry_addtlinfo)):
+        assert root_entry.mount_addtlinfo[idx] == root_entry_addtlinfo[idx]
+
+    assert mounts.search(mount_source="/dev/mapper/vgsys-root")[0]['mount_point'] == '/'
+    assert mounts.rows[0] == mounts['/proc']
+
+
+def test_combiner_only_binmount():
+    mount = Mount(context_wrap(MOUNT_DATA))
+    mounts = Mounts(mount, None, None)
+    assert len(mounts) == 15
+
+    assert '/' in mounts
+    root_entry = mounts['/']
+    assert root_entry.mount_type == 'ext4'
+    assert root_entry.mount_options == {'rw': True}
+    root_entry_addtlinfo = MountAddtlInfo(mount_label='', fs_freq='', fs_passno='',
+                mount_id='', parent_id='', major_minor='', root='', optional_fields='',
+                mount_clause_binmount='/dev/mapper/vgsys-root on / type ext4 (rw)',
+                mount_clause_procmounts='',
+                mount_clause_mountinfo='')
+    for idx in range(len(root_entry_addtlinfo)):
+        assert root_entry.mount_addtlinfo[idx] == root_entry_addtlinfo[idx]
+
+    assert mounts.search(mount_source="/dev/mapper/vgsys-root")[0]['mount_point'] == '/'
+    assert mounts.rows[0] == mounts['/']
+
+
+def test_docs():
+    mount = Mount(context_wrap(MOUNT_DATA))
+    procmounts = ProcMounts(context_wrap(PROCMOUNTS_DATA))
+    mountinfo = MountInfo(context_wrap(MOUNTINFO_DATA))
+    mounts = Mounts(mount, procmounts, mountinfo)
+    env = {
+        'mounts': mounts
+    }
+    failed, total = doctest.testmod(module_mounts, globs=env)
+    assert failed == 0

--- a/insights/parsers/fstab.py
+++ b/insights/parsers/fstab.py
@@ -57,11 +57,7 @@ class FSTabEntry(AttributeAsDict):
         raw_fs_mntops (str): the mount options as a string
         raw (str): the RAW line which is useful to front-end
     """
-
-    def __init__(self, data=None):
-        data = {} if data is None else data
-        for k, v in data.items():
-            setattr(self, k, v)
+    pass
 
 
 @parser(Specs.fstab)

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -85,7 +85,7 @@ class MountAddtlInfo(AttributeAsDict):
         mount_id (str): Unique identifier of the mount
         parent_id (str): Unique identifier of the mount
         major_minor (str): Value of st_dev for files on filesystem
-        root（str): Root of the mount within the filesystem
+        root (str): Root of the mount within the filesystem
         optional_fields (str): Zero or more fields of the form "tag[:value]"
         # super_options (str): Per super block options
 

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -45,21 +45,20 @@ from insights.specs import Specs
 from insights.parsers import optlist_to_dict, keyword_search, ParseException, SkipException
 from insights import parser, get_active_lines, CommandParser
 
-
 MOUNTADDTLINFO_FIELD_NAMES = [
-    "mount_id",  # (str): Unique identifier of the mount
-    "parent_id",  # (str): Unique identifier of the mount
-    "major_minor",  # (str): Value of st_dev for files on filesystem
-    "root",  # (str): Root of the mount within the filesystem
-    "optional_fields",  # (str): Zero or more fields of the form "tag[:value]"
+    "mount_id",
+    "parent_id",
+    "major_minor",
+    "root",
+    "optional_fields",
 ]
 MountAddtlInfo = namedtuple("MountAddtlInfo", field_names=MOUNTADDTLINFO_FIELD_NAMES)
 """
-An namedtuple object representing the additional information for an mount entry.
+A namedtuple object representing the additional infomation for a mount entry.
 
-Attributes
+Attributes:
     mount_id (str): Unique identifier of the mount
-    parent_id (str): Unique identifier of the mount
+    parent_id (str): Unique identifier of the parent mount
     major_minor (str): Value of st_dev for files on filesystem
     root (str): Root of the mount within the filesystem
     optional_fields (str): Zero or more fields of the form "tag[:value]"

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -10,6 +10,9 @@ Mount - command ``/bin/mount``
 ProcMounts - file ``/proc/mounts``
 ----------------------------------
 
+MountInfo - file ``/proc/self/mountinfo``
+-----------------------------------------
+
 The ``Mount`` class implements parsing for the ``mount`` command output which looks like::
 
     /dev/mapper/rootvg-rootlv on / type ext4 (rw,relatime,barrier=1,data=ordered)
@@ -21,18 +24,16 @@ The information is stored as a list of :class:`MountEntry` objects.  Each
 :class:`MountEntry` object contains attributes for the following information that
 are listed in the same order as in the command output:
 
- * ``filesystem`` - Name of filesystem or the mounted device
+ * ``mount_source`` - Name of filesystem or the mounted device
  * ``mount_point`` - Name of mount point for filesystem
  * ``mount_type`` - Name of filesystem type
  * ``mount_options`` -  Mount options as ``MountOpts`` object
  * ``mount_label`` - Optional label of this mount entry, empty string by default
+ * ``mount_addtlinfo`` - Additional mount information as ``MountAddtlInfo`` object
  * ``mount_clause`` - Full raw string from command output
+ * ``filesystem`` - Name of filesystem or the mounted device (Deprecated)
 
-The :class:`MountOpts` class contains the mount options as attributes accessible
-via the attribute name as it appears in the command output.  For instance the
-options ``(rw,dmode=0500)`` may be accessed as ''mnt_row_info.rw`` with the
-value ``True`` and ``mnt_row_info.dmode`` with the value "0500".  The ``in``
-operator may be used to determine if an option is present.
+``ProcMounts`` and ``MountInfo`` classes have the similar style as ``mount``.
 
 MountEntry lines are also available in a ``mounts`` property, keyed on the
 mount point.
@@ -75,18 +76,44 @@ class MountOpts(AttributeAsDict):
             setattr(self, k, v)
 
 
+class MountAddtlInfo(AttributeAsDict):
+    """
+    An object representing the additional information for an mount entry as
+    attributes accessible via the attribute name.
+
+    Attributes
+        mount_id (str): Unique identifier of the mount
+        parent_id (str): Unique identifier of the mount
+        major_minor (str): Value of st_dev for files on filesystem
+        root（str): Root of the mount within the filesystem
+        optional_fields (str): Zero or more fields of the form "tag[:value]"
+        # super_options (str): Per super block options
+
+    For instance, the major:minor number ``253:4`` could be accessed as
+    ``mnt_row_info.major_minor`` with the value ``253:4``.
+
+    The ``in`` operator could be used to determine if an option is present before direct accessing.
+    """
+    def __init__(self, data=None):
+        data = {} if data is None else data
+        for k, v in data.items():
+            setattr(self, k, v)
+
+
 class MountEntry(AttributeAsDict):
     """
     An object representing an mount entry of ``mount`` command or
     ``/proc/mounts`` file.  Each entry contains below fixed attributes:
 
     Attributes:
-        filesystem (str): Name of filesystem of mounted device
+        mount_source(str): Name of filesystem of mounted device
         mount_point (str): Name of mount point for filesystem
         mount_type (str): Name of filesystem type
         mount_options (MountOpts): Mount options as :class:`MountOpts`
         mount_label (str): Optional label of this mount entry, an empty string by default
+        mount_addtlinfo (MountAddtlInfo): Additional mount information as :class:`MountAddtlInfo`
         mount_clause (str): Full raw string from command output
+        filesystem (str): Name of filesystem of mounted device (Deprecated)
     """
 
     def __init__(self, data=None):
@@ -302,6 +329,76 @@ class ProcMounts(MountedFileSystems):
             entry = MountEntry(mount)
             self.rows.append(entry)
             self.mounts[mount['mount_point']] = entry
+
+
+@parser(Specs.mountinfo)
+class MountInfo(MountedFileSystems):
+    """
+    Class to parse the content of ``/proc/self/mountinfo`` file.
+
+    .. note::
+        Please refer to its super-class :class:`MountedFileSystems` for more details.
+
+    The typical content of ``/proc/self/mountinfo`` file looks like::
+
+        39 0 253:0 / / rw,relatime shared:1 - xfs /dev/mapper/rootvg-lvlocroot rw,attr2,inode64,noquota
+        47 39 8:1 / /boot rw,relatime shared:30 - xfs /dev/sda1 rw,attr2,inode64,noquota
+        65 39 253:19 / /data rw,relatime shared:44 - ext4 /dev/mapper/vgdata-lvdata rw,data=ordered
+        58 39 253:15 / /opt rw,relatime shared:45 - xfs /dev/mapper/rootvg-lvlocopt rw,attr2,inode64,noquota
+        61 39 253:17 / /home rw,nosuid,relatime shared:46 - xfs /dev/mapper/rootvg-lvlochome rw,attr2,inode64,noquotao
+
+    Examples:
+
+        >>> type(proc_mountinfo)
+        <class 'insights.parsers.mount.MountInfo'>
+        >>> len(proc_mountinfo)
+        5
+        >>> proc_mountinfo[2].mount_source
+        '/dev/mapper/vgdata-lvdata'
+        >>> proc_mountinfo[2].mount_type
+        'ext4'
+        >>> proc_mountinfo[2].mount_point
+        '/data'
+        >>> 'data' in proc_mountinfo[2].mount_options
+        True
+        >>> proc_mountinfo[2].mount_options.data
+        'ordered'
+        >>> 'major_minor' in proc_mountinfo[4]
+        False
+        >>> 'major_minor' in proc_mountinfo[4].mount_addtlinfo
+        True
+        >>> proc_mountinfo[4].mount_addtlinfo.major_minor
+        '253:17'
+        >>> proc_mountinfo['/boot'].mount_source
+        '/dev/sda1'
+    """
+
+    def _parse_mounts(self, content):
+        rows = []
+        for line in get_active_lines(content):
+            mount = {}
+            mount['mount_clause'] = line
+            line_own_sp = _customized_split(line, line, sep=' - ')
+            line_left_sp = _customized_split(line, line_own_sp[0], num=7)
+            mount['mount_point'] = line_left_sp[4]
+            line_right_sp = _customized_split(line, line_own_sp[1], num=3)
+            mount['mount_type'] = line_right_sp[0]
+            mount['mount_source'] = line_right_sp[1]
+            mount['filesystem'] = mount['mount_source']  # compatible for deprecation
+            unioned_options = ','.join(line_left_sp[5], line_right_sp[2])
+            mount['mount_options'] = MountOpts(optlist_to_dict(unioned_options))
+            mount['mount_addtlinfo'] = MountAddtlInfo({
+                    'mount_id': line_left_sp[0],
+                    'parent_id': line_left_sp[1],
+                    'major_minor': line_left_sp[2],
+                    'root': line_left_sp[3],
+                    'optional_fields': line_left_sp[6],
+            })
+            mount['mount_label'] = ''  # compatible for MountEntry init
+            entry = MountEntry(mount)
+            rows.append(entry)
+        self.rows = rows
+        self.mounts = {mnt['mount_point']: rows[idx] for idx, mnt in enumerate(rows)}
 
 
 def _customized_split(raw, l, sep=None, num=2, reverse=False, check=True):

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -46,6 +46,15 @@ from insights import parser, get_active_lines, CommandParser
 
 
 class AttributeAsDict(object):
+    """
+    Set the given key, value pair data as attribute of object.
+    """
+
+    def __init__(self, data=None):
+        data = {} if data is None else data
+        for k, v in data.items():
+            setattr(self, k, v)
+
     def __contains__(self, item):
         return item in self.__dict__
 
@@ -70,10 +79,7 @@ class MountOpts(AttributeAsDict):
 
     The ``in`` operator may be used to determine if an option is present.
     """
-    def __init__(self, data=None):
-        data = {} if data is None else data
-        for k, v in data.items():
-            setattr(self, k, v)
+    pass
 
 
 class MountAddtlInfo(AttributeAsDict):
@@ -87,17 +93,13 @@ class MountAddtlInfo(AttributeAsDict):
         major_minor (str): Value of st_dev for files on filesystem
         root (str): Root of the mount within the filesystem
         optional_fields (str): Zero or more fields of the form "tag[:value]"
-        # super_options (str): Per super block options
 
     For instance, the major:minor number ``253:4`` could be accessed as
     ``mnt_row_info.major_minor`` with the value ``253:4``.
 
     The ``in`` operator could be used to determine if an option is present before direct accessing.
     """
-    def __init__(self, data=None):
-        data = {} if data is None else data
-        for k, v in data.items():
-            setattr(self, k, v)
+    pass
 
 
 class MountEntry(AttributeAsDict):

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -379,22 +379,23 @@ class MountInfo(MountedFileSystems):
             mount = {}
             mount['mount_clause'] = line
             line_own_sp = _customized_split(line, line, sep=' - ')
-            line_left_sp = _customized_split(line, line_own_sp[0], num=7)
+            line_left_sp = _customized_split(line, line_own_sp[0], num=6)
             mount['mount_point'] = line_left_sp[4]
             line_right_sp = _customized_split(line, line_own_sp[1], num=3)
             mount['mount_type'] = line_right_sp[0]
             mount['mount_source'] = line_right_sp[1]
             mount['filesystem'] = mount['mount_source']  # compatible for deprecation
-            unioned_options = ','.join(line_left_sp[5], line_right_sp[2])
+            optional_fields = line_left_sp[5].split()[1] if ' ' in line_left_sp[5] else ''
+            mntopt = line_left_sp[5].split()[0] if ' ' in line_left_sp[5] else line_left_sp[5]
+            unioned_options = ','.join([mntopt, line_right_sp[2]])
             mount['mount_options'] = MountOpts(optlist_to_dict(unioned_options))
             mount['mount_addtlinfo'] = MountAddtlInfo({
                     'mount_id': line_left_sp[0],
                     'parent_id': line_left_sp[1],
                     'major_minor': line_left_sp[2],
                     'root': line_left_sp[3],
-                    'optional_fields': line_left_sp[6],
+                    'optional_fields': optional_fields,
             })
-            mount['mount_label'] = ''  # compatible for MountEntry init
             entry = MountEntry(mount)
             rows.append(entry)
         self.rows = rows

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -40,29 +40,9 @@ mount point.
 """
 
 import os
-from collections import namedtuple
 from insights.specs import Specs
 from insights.parsers import optlist_to_dict, keyword_search, ParseException, SkipException
 from insights import parser, get_active_lines, CommandParser
-
-MOUNTADDTLINFO_FIELD_NAMES = [
-    "mount_id",
-    "parent_id",
-    "major_minor",
-    "root",
-    "optional_fields",
-]
-MountAddtlInfo = namedtuple("MountAddtlInfo", field_names=MOUNTADDTLINFO_FIELD_NAMES)
-"""
-A namedtuple object representing the additional infomation for a mount entry.
-
-Attributes:
-    mount_id (str): Unique identifier of the mount
-    parent_id (str): Unique identifier of the parent mount
-    major_minor (str): Value of st_dev for files on filesystem
-    root (str): Root of the mount within the filesystem
-    optional_fields (str): Zero or more fields of the form "tag[:value]"
-"""
 
 
 class AttributeAsDict(object):
@@ -89,6 +69,30 @@ class MountOpts(AttributeAsDict):
     with the value "0500".
 
     The ``in`` operator may be used to determine if an option is present.
+    """
+    def __init__(self, data=None):
+        data = {} if data is None else data
+        for k, v in data.items():
+            setattr(self, k, v)
+
+
+class MountAddtlInfo(AttributeAsDict):
+    """
+    An object representing the additional information for an mount entry as
+    attributes accessible via the attribute name.
+
+    Attributes
+        mount_id (str): Unique identifier of the mount
+        parent_id (str): Unique identifier of the parent mount
+        major_minor (str): Value of st_dev for files on filesystem
+        root (str): Root of the mount within the filesystem
+        optional_fields (str): Zero or more fields of the form "tag[:value]"
+        # super_options (str): Per super block options
+
+    For instance, the major:minor number ``253:4`` could be accessed as
+    ``mnt_row_info.major_minor`` with the value ``253:4``.
+
+    The ``in`` operator could be used to determine if an option is present before direct accessing.
     """
     def __init__(self, data=None):
         data = {} if data is None else data
@@ -361,6 +365,8 @@ class MountInfo(MountedFileSystems):
         'ordered'
         >>> 'major_minor' in proc_mountinfo[4]
         False
+        >>> 'major_minor' in proc_mountinfo[4].mount_addtlinfo
+        True
         >>> proc_mountinfo[4].mount_addtlinfo.major_minor
         '253:17'
         >>> proc_mountinfo['/boot'].mount_source
@@ -383,7 +389,7 @@ class MountInfo(MountedFileSystems):
             mntopt = line_left_sp[5].split()[0] if ' ' in line_left_sp[5] else line_left_sp[5]
             unioned_options = ','.join([mntopt, line_right_sp[2]])
             mount['mount_options'] = MountOpts(optlist_to_dict(unioned_options))
-            mount['mount_addtlinfo'] = MountAddtlInfo(**{
+            mount['mount_addtlinfo'] = MountAddtlInfo({
                     'mount_id': line_left_sp[0],
                     'parent_id': line_left_sp[1],
                     'major_minor': line_left_sp[2],

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -313,7 +313,6 @@ def test_mountinfo():
     assert dir1['mount_options']['vers'] == '4'
     assert dir1['mount_addtlinfo'].major_minor == '0:20'
     assert dir1.mount_addtlinfo.mount_id == '55'
-    assert len(dir1['mount_addtlinfo']) == 5
 
     # Test iteration
     for mnt in results:

--- a/insights/parsers/tests/test_mount.py
+++ b/insights/parsers/tests/test_mount.py
@@ -311,6 +311,9 @@ def test_mountinfo():
     assert dir1['mount_type'] == 'nfs4'
     assert 'vers' in dir1['mount_options']
     assert dir1['mount_options']['vers'] == '4'
+    assert dir1['mount_addtlinfo'].major_minor == '0:20'
+    assert dir1.mount_addtlinfo.mount_id == '55'
+    assert len(dir1['mount_addtlinfo']) == 5
 
     # Test iteration
     for mnt in results:

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -388,6 +388,7 @@ class Specs(SpecSet):
     mokutil_sbstate = RegistryPoint()
     mongod_conf = RegistryPoint(multi_output=True, filterable=True)
     mount = RegistryPoint()
+    mountinfo = RegistryPoint()
     mounts = RegistryPoint()
     mssql_conf = RegistryPoint()
     mssql_api_assessment = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -436,6 +436,7 @@ class DefaultSpecs(Specs):
         "/etc/opt/rh/rh-mongodb34/mongod.conf"
     ])
     mount = simple_command("/bin/mount")
+    mountinfo = simple_file("/proc/self/mountinfo")
     mounts = simple_file("/proc/mounts")
     mssql_api_assessment = simple_file("/var/opt/mssql/log/assessments/assessment-latest")
     mssql_conf = simple_file("/var/opt/mssql/mssql.conf")

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -159,6 +159,7 @@ class SosSpecs(Specs):
     modinfo_all = glob_file("sos_commands/kernel/modinfo_*")
     mokutil_sbstate = simple_file("sos_commands/boot/mokutil_--sb-state")
     mount = simple_file("sos_commands/filesys/mount_-l")
+    mountinfo = simple_file("proc/self/mountinfo")
     mounts = simple_file("/proc/mounts")
     mlx4_port = glob_file("/sys/bus/pci/devices/*/mlx4_port[0-9]")
     multipath__v4__ll = first_file(["sos_commands/multipath/multipath_-v4_-ll", "sos_commands/devicemapper/multipath_-v4_-ll"])


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
This `/proc/self/mountinfo` can provide additional info that `/bin/mount` and `/proc/mounts` don't collect. 