### PR TITLE
Fix failing malware-detection tests

### DIFF
--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -52,6 +52,7 @@ LOAD_CONFIG_TARGET = "insights.client.apps.malware_detection.MalwareDetectionCli
 FIND_YARA_TARGET = "insights.client.apps.malware_detection.MalwareDetectionClient._find_yara"
 GET_RULES_TARGET = "insights.client.apps.malware_detection.MalwareDetectionClient._get_rules"
 BUILD_YARA_COMMAND_TARGET = "insights.client.apps.malware_detection.MalwareDetectionClient._build_yara_command"
+FINDMNT_TARGET = "insights.client.apps.malware_detection.MalwareDetectionClient._parse_exclude_network_filesystem_mountpoints_option"
 
 # Run the test_processes_scan_since test?
 TEST_PROCESSES_SCAN_SINCE = getenv_bool("TEST_PROCESSES_SCAN_SINCE", False)
@@ -233,6 +234,7 @@ class TestFindYara:
 # Use patch.object, just because I wanted to try using patch.object instead of using patch all the time :shrug:
 @pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
 @patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
+@patch.object(MalwareDetectionClient, '_parse_exclude_network_filesystem_mountpoints_option')
 @patch.object(InsightsConnection, 'get', return_value=Mock(status_code=200, content=b"Rule Content"))
 @patch.object(InsightsConnection, 'get_proxies')
 @patch.object(InsightsConnection, '_init_session', return_value=Mock())
@@ -243,7 +245,7 @@ class TestGetRules:
     """ Testing the _get_rules method """
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true'})
-    def test_download_rules_cert_auth(self, conf, yara, cmd, session, proxies, get, remove):
+    def test_download_rules_cert_auth(self, conf, yara, cmd, session, proxies, get, findmnt, remove):
         # Test the standard rules_location urls, but will result in cert auth being used to download the rules
         # Test with insights-config None, expect an error when trying to use the insights-config object
         with pytest.raises(SystemExit):
@@ -275,7 +277,7 @@ class TestGetRules:
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true'})
     @patch(LOGGER_TARGET)
-    def test_download_rules_basic_auth(self, log_mock, conf, yara, cmd, session, proxies, get, remove):
+    def test_download_rules_basic_auth(self, log_mock, conf, yara, cmd, session, proxies, get, findmnt, remove):
         # Test the standard rules_location urls, with basic auth attempting to be used to download the rules
         # Basic auth is used by default, but needs to have a valid username and password for it to work
         # Without a username and password, then cert auth will be used
@@ -306,7 +308,7 @@ class TestGetRules:
         get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': 'console.redhat.com/rules.yar'})
-    def test_get_rules_missing_protocol(self, conf, yara, cmd, session, proxies, get, remove):
+    def test_get_rules_missing_protocol(self, conf, yara, cmd, session, proxies, get, findmnt, remove):
         # Non-standard rules URLS - without https:// at the start and not signatures.yar
         # test-scan true and BASIC auth by default expect test-rule.yar and no 'cert.' in URL
         mdc = MalwareDetectionClient(InsightsConfig(username='user', password='pass'))
@@ -321,7 +323,7 @@ class TestGetRules:
 
     @patch.dict(os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'http://localhost/rules.yar'})
     @patch(LOGGER_TARGET)
-    def test_download_failures(self, log_mock, conf, yara, cmd, session, proxies, get, remove):
+    def test_download_failures(self, log_mock, conf, yara, cmd, session, proxies, get, findmnt, remove):
         from requests.exceptions import ConnectionError, Timeout
         # Test various problems downloading rules
         # 404 error - unlikely to occur unless an incorrect rules_location was manually specified
@@ -350,7 +352,7 @@ class TestGetRules:
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': '//console.redhat.com/rules.yar'})
     @patch("os.path.isfile", return_value=True)
-    def test_get_rules_location_as_file(self, isfile, conf, yara, cmd, session, proxies, get, remove):
+    def test_get_rules_location_as_file(self, isfile, conf, yara, cmd, session, proxies, get, findmnt, remove):
         # Test using files for rules_location, esp irregular file names
         # rules_location that starts with a '/' is assumed to be a file, even if its a double '//'
         # Re-writing the rule to be test-rule.yar doesn't apply to local files
@@ -368,7 +370,7 @@ class TestGetRules:
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true'})
     @patch(LOGGER_TARGET)
-    def test_via_satellite_proxy(self, log_mock, conf, yara, cmd, session, proxies, get, remove):
+    def test_via_satellite_proxy(self, log_mock, conf, yara, cmd, session, proxies, get, findmnt, remove):
         # Test recognizing and handling of Satellite URLs.
         # Satellite URLs have '/redhat_access/' in their path (which is how the Satellite knows to redirect the
         # query to C.R.C).
@@ -453,7 +455,7 @@ class TestBuildYaraCmd:
 @patch(BUILD_YARA_COMMAND_TARGET)
 @patch(GET_RULES_TARGET, return_value=RULES_FILE)
 @patch(FIND_YARA_TARGET, return_value=YARA)
-@patch.dict(os.environ, {'TEST_SCAN': 'false'})
+@patch.dict(os.environ, {'TEST_SCAN': 'false', 'EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS': 'false'})
 class TestMalwareDetectionOptions:
 
     @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
@@ -817,6 +819,7 @@ class TestMalwareDetectionOptions:
     @patch(LOGGER_TARGET)
     def test_network_filesystem_mountpoints(self, log_mock, call_mock, yara, rules, cmd, extract_tmp_files, create_test_files):
         # Test the exclude_network_filesystem_mountpoints option by 'creating' various mountpoints to exclude
+        os.environ['EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'] = 'true'  # Override the default setting for this test class
         scan_me_scan_me = os.path.join(TEMP_TEST_DIR, 'scan_me/scan_me')
         scan_me_too = os.path.join(TEMP_TEST_DIR, 'scan_me_too')
         scan_me_not_mnt = os.path.join(TEMP_TEST_DIR, 'scan_me_not')
@@ -996,6 +999,7 @@ class TestProcessScanning:
 
     def test_scan_processes(self, log_mock, yara, rules, cmd, create_test_files):
         # Test scanning processes to test which processes are going to be scanned
+        os.environ['EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'] = 'false'
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
             line = "test_scan: false" if line.startswith("test_scan:") else line
             line = "scan_processes: true" if line.startswith("scan_processes:") else line
@@ -1051,6 +1055,7 @@ class TestProcessScanning:
         # Expect that we'll find it
         os.system(TEST_RULE_SCRIPT + " &")  # Run the script in the background
         ps_call_output = call([['ps', '-eo', 'pid=', '-o', 'lstart=']])
+        os.environ['EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'] = 'false'
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
             line = "test_scan: false" if line.startswith("test_scan:") else line
             line = "scan_filesystem: false" if line.startswith("scan_filesystem:") else line
@@ -1138,6 +1143,7 @@ class TestFilesystemScanning:
             line = line + "rules_location: %s\n" % TEST_RULE_FILE.replace('/', '//') if line.startswith('---') else line
             line = "filesystem_scan_only: %s" % TEST_RULE_FILE if line.startswith("filesystem_scan_only:") else line
             line = "add_metadata: false" if line.startswith("add_metadata:") else line
+            line = "exclude_network_filesystem_mountpoints: false" if line.startswith("exclude_network_filesystem_mountpoints:") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             mdc = MalwareDetectionClient(None)
@@ -1162,6 +1168,7 @@ class TestFilesystemScanning:
             line = line + "rules_location: %s\n" % TEST_RULE_FILE if line.startswith('---') else line
             line = line + "- //\n" if line.startswith("filesystem_scan_only:") else line
             line = line + "- //\n" if line.startswith("filesystem_scan_exclude:") else line
+            line = "exclude_network_filesystem_mountpoints: false" if line.startswith("exclude_network_filesystem_mountpoints:") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             mdc = MalwareDetectionClient(None)
@@ -1192,6 +1199,7 @@ class TestFilesystemScanning:
             line = line + "rules_location: %s\n" % TEST_RULE_FILE if line.startswith('---') else line
             line = line + '- %s\n- %s' % filesystem_scan_only if line.startswith("filesystem_scan_only:") else line
             line = line + "- %s\n- %s\n- %s" % filesystem_scan_exclude if line.startswith("filesystem_scan_exclude:") else line
+            line = "exclude_network_filesystem_mountpoints: false" if line.startswith("exclude_network_filesystem_mountpoints:") else line
             print(line)
         with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
             mdc = MalwareDetectionClient(None)
@@ -1278,6 +1286,7 @@ class TestFilesystemScanning:
         # Also test we are not excluding ones we actually want to scan
         glob_files = [os.path.join(TEMP_TEST_DIR, 'scan_me', f) for f in ['new_file', 'old_file']]
         os.environ['TEST_SCAN'] = 'false'
+        os.environ['EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'] = 'false'
         os.environ['RULES_LOCATION'] = TEST_RULE_FILE
         os.environ['FILESYSTEM_SCAN_ONLY'] = "%s,%s" % (TEMP_TEST_DIR, glob_files[1])  # we actually want to scan glob_files[1]
         mdc = MalwareDetectionClient(None)
@@ -1386,9 +1395,9 @@ class TestFilesystemIncludeExcludeMethods:
         assert processed_items == ['/etc/pam.d', '/tmp', '/var/log']
 
         # Add some more subdirectories
-        include_items.extend(['/etc/cron.d', '/tmp', '/var/lib/'])
+        include_items.extend(['/etc/alternatives', '/tmp', '/var/lib/'])
         processed_items = process_include_items(include_items)
-        assert processed_items == ['/etc/cron.d', '/etc/pam.d', '/tmp', '/var/lib', '/var/log']
+        assert processed_items == ['/etc/alternatives', '/etc/pam.d', '/tmp', '/var/lib', '/var/log']
 
         # Add some top level directories to override the subdirectories
         include_items.extend(['/etc', '/var'])
@@ -1418,9 +1427,9 @@ class TestFilesystemIncludeExcludeMethods:
         assert processed_items == ['/etc/ssh', '/tmp', '/var/run']
 
         # Add some more subdirectories
-        exclude_items.extend(['/etc/cron.d', '/tmp', '/var/lock/'])
+        exclude_items.extend(['/etc/alternatives', '/tmp', '/var/lock/'])
         processed_items = process_exclude_items(exclude_items)
-        assert processed_items == ['/etc/cron.d', '/etc/ssh', '/tmp', '/var/lock', '/var/run']
+        assert processed_items == ['/etc/alternatives', '/etc/ssh', '/tmp', '/var/lock', '/var/run']
 
         # Add some top level directories to override the subdirectories
         exclude_items.extend(['/etc', '/var'])
@@ -1439,6 +1448,7 @@ class TestFilesystemIncludeExcludeMethods:
 
 
 @pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
+@patch(FINDMNT_TARGET)
 @patch(BUILD_YARA_COMMAND_TARGET)
 @patch(GET_RULES_TARGET, return_value=RULES_FILE)
 @patch(FIND_YARA_TARGET, return_value=YARA)
@@ -1446,7 +1456,7 @@ class TestFilesystemIncludeExcludeMethods:
 @patch.dict(os.environ, {'TEST_SCAN': 'false'})
 class TestFilesystemIncludeExcludeProcessing:
 
-    def test_process_include_exclude_items_simple(self, conf, yara, rules, cmd):
+    def test_process_include_exclude_items_simple(self, conf, yara, rules, cmd, findmnt):
         # Test the process_include_exclude_items function with simple modified include and exclude items
         # Simple in that the include and exclude files are modified in such a way that
         # directory listings aren't required get the list of included files
@@ -1488,7 +1498,7 @@ class TestFilesystemIncludeExcludeProcessing:
                                                   exclude_items=mdc.filesystem_scan_exclude_list)
         assert scan_dict == {}
 
-    def test_process_include_exclude_items_complex(self, conf, yara, rules, cmd):
+    def test_process_include_exclude_items_complex(self, conf, yara, rules, cmd, findmnt):
         # Test the process function with modified include and exclude files that will require more complex
         # processing to generate the list of items to be scanned
         # Because we are including items in /var/lib, we only need to list the contents of the /var/lib directory
@@ -1523,7 +1533,7 @@ class TestFilesystemIncludeExcludeProcessing:
         assert all([x in scan_dict['/var']['include']
                     for x in ['/var/cache', '/var/tmp', '/var/lib/dbus', '/var/log/lastlog']])
 
-    def test_process_include_exclude_tmp_files(self, conf, yara, rules, cmd, extract_tmp_files):
+    def test_process_include_exclude_tmp_files(self, conf, yara, rules, cmd, findmnt, extract_tmp_files):
         # Test the including/excluding some of the files in the tmp archive
         # Specifically tests excluding link files (good or broken) and pipe files (as well as explicit exclude items)
 
@@ -1559,6 +1569,7 @@ class TestFilesystemIncludeExcludeProcessing:
 
 
 @pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
+@patch(FINDMNT_TARGET)
 @patch(BUILD_YARA_COMMAND_TARGET)
 @patch(GET_RULES_TARGET, return_value=RULES_FILE)
 @patch(FIND_YARA_TARGET, return_value=YARA)
@@ -1566,7 +1577,7 @@ class TestFilesystemIncludeExcludeProcessing:
 @patch.dict(os.environ, {'TEST_SCAN': 'false'})
 class TestParseScanOutput:
 
-    def test_contrived_scan_output(self, conf, yara, rules, cmd):
+    def test_contrived_scan_output(self, conf, yara, rules, cmd, findmnt):
         # Parse the CONTRIVED_SCAN_OUTPUT to find actual rule matches amongst malformed output lines
         mdc = MalwareDetectionClient(None)
         mdc.add_metadata = False
@@ -1664,7 +1675,7 @@ class TestParseScanOutput:
         assert rule_match[0]['string_identifier'] == ''
         assert rule_match[0]['string_offset'] == -1
 
-    def test_contrived_scan_output_metadata(self, conf, yara, rules, cmd, create_test_files):
+    def test_contrived_scan_output_metadata(self, conf, yara, rules, cmd, findmnt, create_test_files):
         # Again, parse the CONTRIVED_SCAN_OUTPUT to find actual rule matches amongst malformed output lines,
         # but this time check the expected metadata values too
 
@@ -1785,7 +1796,7 @@ class TestParseScanOutput:
         assert metadata['source_type'] == 'process'
         assert all([key not in ['process_name', 'file_type', 'md5sum', 'line_number'] for key in metadata.keys()])
 
-    def test_random_output(self, conf, yara, rules, cmd):
+    def test_random_output(self, conf, yara, rules, cmd, findmnt):
         mdc = MalwareDetectionClient(None)
         mdc.parse_scan_output(RANDOM_OUTPUT)
         assert mdc.matches == 2


### PR DESCRIPTION
- Patch findmnt command to return consistent output
- Fix missing directories on Fedora 35

Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

Fixes https://github.com/RedHatInsights/insights-core/issues/3397 and other problems identified due to running the actual findmnt command on test machines.