### PR TITLE
Draft: Parse SSSD group listings

### DIFF
--- a/insights/core/ls_parser.py
+++ b/insights/core/ls_parser.py
@@ -140,12 +140,12 @@ def parse_rhel8_selinux(parts):
 
 
 def parse_sssd(parts):
-    links, owner, group1, group2, last = parts
+    links, owner, group, domain, last = parts
     size, rest = last.split(None, 1)
     result = {
         "links": int(links),
         "owner": owner,
-        "group": group1 + " " + group2,
+        "group": group + " " + domain,
         "size": int(size),
         "date": rest[:12],
         "name": rest[13:]
@@ -210,7 +210,7 @@ class Directory(dict):
                 # always have at least two pieces separated by ':'.
                 if ":" in line.split()[4]:
                     rest = parse_rhel8_selinux(parts[1:])
-                elif "@" in line.split()[4]:
+                elif line.split()[4].startswith("users") or "@" in line.split()[4]:
                     parts = line.split(None, 5)
                     rest = parse_sssd(parts[1:])
                 else:

--- a/insights/core/ls_parser.py
+++ b/insights/core/ls_parser.py
@@ -139,6 +139,21 @@ def parse_rhel8_selinux(parts):
     return result
 
 
+def parse_sssd(parts):
+    links, owner, group1, group2, last = parts
+    size, rest = last.split(None, 1)
+    result = {
+        "links": int(links),
+        "owner": owner,
+        "group": group1 + " " + group2,
+        "size": int(size),
+        "date": rest[:12],
+        "name": rest[13:]
+    }
+
+    return result
+
+
 PASS_KEYS = set(["name", "total"])
 DELAYED_KEYS = ["entries", "files", "dirs", "specials"]
 
@@ -195,6 +210,9 @@ class Directory(dict):
                 # always have at least two pieces separated by ':'.
                 if ":" in line.split()[4]:
                     rest = parse_rhel8_selinux(parts[1:])
+                elif "@" in line.split()[4]:
+                    parts = line.split(None, 5)
+                    rest = parse_sssd(parts[1:])
                 else:
                     rest = parse_non_selinux(parts[1:])
             else:

--- a/insights/tests/test_ls_parser.py
+++ b/insights/tests/test_ls_parser.py
@@ -168,6 +168,14 @@ No such file or directory
 adsf
 """
 
+SSSD_LISTINGS = """
+/var/log:
+total 20
+-rw-r--r--.  1 root   domain users@CR.LOCAL        36548 Jan 13 10:43 Xorg.1.log
+-rw-r--r--.  1 root   domain users@CR.LOCAL        28245 Jan 13 10:38 Xorg.1.log.old
+-rw-------.  1 root   root                         52756 Jun 28 10:26 X.log
+"""
+
 
 def test_parse_selinux():
     results = parse(SELINUX_DIRECTORY.splitlines(), "/boot")
@@ -312,3 +320,10 @@ def test_rhel8_selinux():
     assert res["date"] == "Apr  8 16:41"
     assert res["name"] == "abcd-efgh-ijkl-mnop"
     assert res["dir"] == "/var/lib/nova/instances"
+
+
+def test_sssd_listing():
+    results = parse(SSSD_LISTINGS.splitlines(), "/var/log")
+    assert len(results) == 1
+    assert results["/var/log"]["entries"]['Xorg.1.log']['group'] == "domain users@CR.LOCAL"
+    assert len(results["/var/log"]["entries"]) == 3

--- a/insights/tests/test_ls_parser.py
+++ b/insights/tests/test_ls_parser.py
@@ -168,12 +168,19 @@ No such file or directory
 adsf
 """
 
-SSSD_LISTINGS = """
+SSSD_LISTINGS_1 = """
 /var/log:
 total 20
 -rw-r--r--.  1 root   domain users@CR.LOCAL        36548 Jan 13 10:43 Xorg.1.log
 -rw-r--r--.  1 root   domain users@CR.LOCAL        28245 Jan 13 10:38 Xorg.1.log.old
 -rw-------.  1 root   root                         52756 Jun 28 10:26 X.log
+"""
+
+SSSD_LISTINGS_2 = """
+/var/log:
+total 20
+-rw-r--r--.  1 root   domain users                 40893 Jan 31 16:34 Xorg.1.log
+-rw-r--r--.  1 root   domain users                 36911 Dec 20 09:49 Xorg.1.log.old
 """
 
 
@@ -323,7 +330,12 @@ def test_rhel8_selinux():
 
 
 def test_sssd_listing():
-    results = parse(SSSD_LISTINGS.splitlines(), "/var/log")
+    results = parse(SSSD_LISTINGS_1.splitlines(), "/var/log")
     assert len(results) == 1
     assert results["/var/log"]["entries"]['Xorg.1.log']['group'] == "domain users@CR.LOCAL"
     assert len(results["/var/log"]["entries"]) == 3
+
+    results = parse(SSSD_LISTINGS_2.splitlines(), "/var/log")
+    assert len(results) == 1
+    assert results["/var/log"]["entries"]['Xorg.1.log']['group'] == "domain users"
+    assert len(results["/var/log"]["entries"]) == 2


### PR DESCRIPTION
The SSSD group listings breaks the present implementation by parsing the domain
group as the file-size.

Resolves: #3395

Signed-off-by: Sachin Patil <psachin@redhat.com>

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
