### PR TITLE
fix: Deprecation warnings and removal of collections

### DIFF
--- a/insights/combiners/nfs_exports.py
+++ b/insights/combiners/nfs_exports.py
@@ -29,11 +29,13 @@ Examples:
     True
 
 """
-
 from insights.core.plugins import combiner
 from insights.parsers.nfs_exports import NFSExports, NFSExportsD
 
-import collections
+try:
+    from six.moves import collections_abc
+except ImportError:
+    import collections as collections_abc
 
 
 @combiner(NFSExports, optional=[NFSExportsD])
@@ -70,7 +72,7 @@ class AllNFSExports(object):
         sources = [nfsexports]
         # Make sure exports are stored in the order they're parsed -
         # alphabetically by file name.  Ignore it if nfsexportsd isn't valid.
-        if isinstance(nfsexportsd, collections.Iterable):
+        if isinstance(nfsexportsd, collections_abc.Iterable):
             sources.extend(sorted(nfsexportsd, key=lambda f: f.file_path))
 
         def add_paths_to_dict(src_path, src_dict, dest_dict):

--- a/insights/contrib/pyparsing.py
+++ b/insights/contrib/pyparsing.py
@@ -62,18 +62,21 @@ __version__ = "2.1.4"
 __versionTime__ = "13 May 2016 18:25 UTC"
 __author__ = "Paul McGuire <ptmcg@users.sourceforge.net>"
 
-import string
-from weakref import ref as wkref
 import copy
-import sys
-import warnings
+import pprint
 import re
 import sre_constants
-import collections
-import pprint
-import functools
-import itertools
+import string
+import sys
 import traceback
+import warnings
+
+from weakref import ref as wkref
+
+try:
+    from six.moves import collections_abc
+except ImportError:
+    import collections as collections_abc
 
 #~ sys.stderr.write( "testing pyparsing module, version %s, %s\n" % (__version__,__versionTime__ ) )
 
@@ -711,7 +714,7 @@ class ParseResults(object):
     def __dir__(self):
         return (dir(type(self)) + list(self.keys()))
 
-collections.MutableMapping.register(ParseResults)
+collections_abc.MutableMapping.register(ParseResults)
 
 def col (loc,strg):
     """Returns current column within a string, counting newlines as line separators.
@@ -2403,7 +2406,7 @@ class ParseExpression(ParserElement):
 
         if isinstance( exprs, basestring ):
             self.exprs = [ Literal( exprs ) ]
-        elif isinstance( exprs, collections.Sequence ):
+        elif isinstance(exprs, collections_abc.Sequence):
             # if sequence of strings provided, wrap with Literal
             if all(isinstance(expr, basestring) for expr in exprs):
                 exprs = map(Literal, exprs)
@@ -3437,7 +3440,7 @@ def oneOf( strs, caseless=False, useRegex=True ):
     symbols = []
     if isinstance(strs,basestring):
         symbols = strs.split()
-    elif isinstance(strs, collections.Sequence):
+    elif isinstance(strs, collections_abc.Sequence):
         symbols = list(strs[:])
     elif isinstance(strs, _generatorType):
         symbols = list(strs)


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
The collections module was moved to collections.abc in py3.3 it looks like, and collections was deprecated completely in py3.10. This causes specs to not load in py3.10 environments. Switched to using six.moves compatibility layer for this issue. Also reordered the imports in the pyparsing module.

Fixes #3405