### PR TITLE
Add os major version 9 for Compliance

### DIFF
--- a/insights/client/apps/compliance/__init__.py
+++ b/insights/client/apps/compliance/__init__.py
@@ -145,7 +145,7 @@ class ComplianceClient:
         return version
 
     def os_major_version(self):
-        return findall("^[6-8]", self.os_release())[0]
+        return findall("^[6-9]", self.os_release())[0]
 
     def os_minor_version(self):
         return findall("\d+$", self.os_release())[0]


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

`insights-client --compliance` currently does not upload reports for RHEL 9 systems. For more information on the exact error message, please see the Jira ticket: RHICOMPL-2975 
