### PR TITLE
fix(Compliance): Find policy correctly when there is one datasteam file

### DIFF
--- a/insights/client/apps/compliance/__init__.py
+++ b/insights/client/apps/compliance/__init__.py
@@ -31,6 +31,7 @@ else:
 NONCOMPLIANT_STATUS = 2
 COMPLIANCE_CONTENT_TYPE = 'application/vnd.redhat.compliance.something+tgz'
 POLICY_FILE_LOCATION = '/usr/share/xml/scap/ssg/content/'
+SCAP_DATASTREAMS_PATH = '/usr/share/xml/scap/'
 SSG_PACKAGE = 'scap-security-guide'
 REQUIRED_PACKAGES = [SSG_PACKAGE, 'openscap-scanner', 'openscap']
 
@@ -154,14 +155,14 @@ class ComplianceClient:
         return glob("{0}*rhel{1}*.xml".format(POLICY_FILE_LOCATION, self.os_major_version()))
 
     def find_scap_policy(self, profile_ref_id):
-        grepcmd = 'grep ' + profile_ref_id + ' ' + ' '.join(self.profile_files())
+        grepcmd = 'grep -H ' + profile_ref_id + ' ' + ' '.join(self.profile_files())
         if not six.PY3:
             grepcmd = grepcmd.encode()
         rc, grep = call(grepcmd, keep_rc=True)
         if rc:
             logger.error('XML profile file not found matching ref_id {0}\n{1}\n'.format(profile_ref_id, grep))
             return None
-        filenames = findall('/usr/share/xml/scap/.+xml', grep)
+        filenames = findall(SCAP_DATASTREAMS_PATH + '.+xml', grep)
         if not filenames:
             logger.error('No XML profile files found matching ref_id {0}\n{1}\n'.format(profile_ref_id, ' '.join(filenames)))
             exit(constants.sig_kill_bad)

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -305,6 +305,39 @@ def test_find_scap_policy(config, call):
     assert compliance_client.find_scap_policy('ref_id') == PATH
 
 
+@patch("insights.client.config.InsightsConfig")
+def test_find_scap_policy_with_one_datastream_file(config, tmpdir):
+    compliance_client = ComplianceClient(config)
+    dir1 = tmpdir.mkdir('scap')
+    file = dir1.join('test_file.xml')
+    file.write("""
+    <xccdf-1.2:Profile id="xccdf_org.ssgproject.content_profile_anssi_bp28_high">
+    </xccdf-1.2:Profile>
+        """)
+    compliance_client.profile_files = lambda: [str(file)]
+    with patch("insights.client.apps.compliance.SCAP_DATASTREAMS_PATH", str(dir1) + "/"):
+        assert compliance_client.find_scap_policy('content_profile_anssi_bp28_high') == file
+
+
+@patch("insights.client.config.InsightsConfig")
+def test_find_scap_policy_with_two_datastream_file(config, tmpdir):
+    compliance_client = ComplianceClient(config)
+    dir1 = tmpdir.mkdir('scap')
+    file1 = dir1.join('test_file1.xml')
+    file1.write("""
+    <xccdf-1.2:Profile id="xccdf_org.ssgproject.content_profile_anssi_bp28_high">
+    </xccdf-1.2:Profile>
+        """)
+    file2 = dir1.join('test_file2.xml')
+    file2.write("""
+    <xccdf-1.2:Profile id="xccdf_org.ssgproject.content_profile_anssi_bp28_high">
+    </xccdf-1.2:Profile>
+        """)
+    compliance_client.profile_files = lambda: [str(file1), str(file2)]
+    with patch("insights.client.apps.compliance.SCAP_DATASTREAMS_PATH", str(dir1) + "/"):
+        assert compliance_client.find_scap_policy('content_profile_anssi_bp28_high') == file1
+
+
 @patch("insights.client.apps.compliance.call", return_value=(1, 'bad things happened'.encode('utf-8')))
 @patch("insights.client.config.InsightsConfig")
 def test_find_scap_policy_not_found(config, call):


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

`grep` behaves differently when searching for a string in a single file. The issue is that it doesn't include the filename in the output so for example `grep xccdf_org.ssgproject.content_profile_anssi_bp28_high /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml` would return `<xccdf-1.2:Profile id="xccdf_org.ssgproject.content_profile_anssi_bp28_high">` but `/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml:  <xccdf-1.2:Profile id="xccdf_org.ssgproject.content_profile_anssi_bp28_high">` is needed for `insights-client --compliance` to work correctly. This can be fixed by passing the `-H` switch.


