### PR TITLE
Add type check for the context root in ContentProvider

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -109,10 +109,11 @@ class ContentProvider(object):
 
     @property
     def path(self):
-        if not isinstance(self.root, str):
-            log.warning("WARNING: root is not a string %s", "root=" + str(self.root))
+        try:
+            return os.path.join(self.root, self.relative_path)
+        except Exception as ex:
+            log.warning("WARNING: %s", str(ex))
             raise dr.SkipComponent()
-        return os.path.join(self.root, self.relative_path)
 
     @property
     def content(self):

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -109,6 +109,9 @@ class ContentProvider(object):
 
     @property
     def path(self):
+        if not isinstance(self.root, str):
+            log.warning("WARNING: root is not a string %s", "root=" + str(self.root))
+            raise dr.SkipComponent()
         return os.path.join(self.root, self.relative_path)
 
     @property


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
ccx-ocp-core added a new execution context recently and the context root is not a string but a dictionary. This pull request adds type checks for the context root in class ContentProvider to avoid the TypeError exceptions.
