### PR TITLE
malware-detection feature: handle different yara versions

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -257,7 +257,8 @@ class MalwareDetectionClient:
             # Check the installed yara version >= MIN_YARA_VERSION
             installed_yara_version = call([[yara, '--version']]).strip()
             try:
-                if float(installed_yara_version[:3]) < float(MIN_YARA_VERSION[:3]):
+                self.yara_version = '.'.join(installed_yara_version.split('.')[:2])  # Eg 4.2.0 becomes 4.2
+                if float(self.yara_version) < float(MIN_YARA_VERSION[:3]):
                     raise RuntimeError("Found %s with version %s, but malware-detection requires version >= %s\n"
                                        "Please install a later version of yara."
                                        % (yara, installed_yara_version, MIN_YARA_VERSION))
@@ -619,11 +620,14 @@ class MalwareDetectionClient:
             logger.error("Couldn't access the insights-client configuration")
             exit(constants.sig_kill_bad)
 
+        signatures_file = default_signatures_file = 'signatures.yar'
+        if hasattr(self, 'yara_version'):
+            signatures_file = 'signatures-%s.yar' % self.yara_version
         if not self.rules_location:
-            self.rules_location = "https://console.redhat.com/api/malware-detection/v1/signatures.yar"
+            self.rules_location = "https://console.redhat.com/api/malware-detection/v1/" + signatures_file
             if '/redhat_access/' in self.insights_config.base_url:
                 # Satellite URLs have '/redhat_access/' in the base_url config option
-                self.rules_location = self.insights_config.base_url + '/malware-detection/v1/signatures.yar'
+                self.rules_location = self.insights_config.base_url + '/malware-detection/v1/' + signatures_file
 
         # Make sure the rules_location starts with https://
         if not re.match('^https?://', self.rules_location):
@@ -651,6 +655,11 @@ class MalwareDetectionClient:
             self.insights_config.cert_verify = True
             conn = InsightsConnection(self.insights_config)
             response = conn.get(self.rules_location, log_response_text=log_rule_contents)
+            if response.status_code == 404 and not (self.test_scan or signatures_file == default_signatures_file):
+                # Got a 404 with the 'signatures-X.Y.yar' file, so try with just 'signatures.yar' instead
+                logger.debug("Couldn't find %s file, trying %s instead", signatures_file, default_signatures_file)
+                self.rules_location = self.rules_location.replace(signatures_file, default_signatures_file)
+                response = conn.get(self.rules_location, log_response_text=log_rule_contents)
             if response.status_code != 200:
                 logger.error("%s %s: %s", response.status_code, response.reason, response.text)
                 exit(constants.sig_kill_bad)
@@ -688,7 +697,8 @@ class MalwareDetectionClient:
         try:
             call([cmd])
         except CalledProcessError as err:
-            logger.error("Unable to use rules file %s: %s", self.rules_file, err.output.strip())
+            err_str = str(err.output.strip().decode())
+            logger.error("Unable to use rules file %s: %s", self.rules_file, err_str)
             exit(constants.sig_kill_bad)
 
         # Limit the number of threads used by yara to limit the CPU load of the scans
@@ -1161,13 +1171,26 @@ def get_toplevel_dirs():
     return toplevel_dirs
 
 
+def is_same_file_or_root(file1, file2):
+    # Catch possible permission denied error with fuse mounted filesystems. Yes, even for root!
+    try:
+        if os.path.samefile(file1, file2) or os.path.samefile(file1, '/'):
+            return True
+    except Exception as err:
+        logger.debug("Encountered exception running os.path.samefile('%s', '%s'): %s.  Trying string comparison ...",
+                     file1, file2, str(err))
+        if file1 == file2 or file1 == '/':
+            return True
+    return False
+
+
 def get_parent_dirs(item, parent_dir_list, base_case='/'):
     """
     Get a list of parent directories of a particular filesystem item, stopping at base_case (root by default)
     Eg for get_parent_dirs('/path/to/some/item', parent_dir_list) ->
         parent_dir_list = ['/path', '/path/to', '/path/to/some', '/path/to/some/item']
     """
-    if os.path.samefile(item, base_case) or os.path.samefile(item, '/'):
+    if is_same_file_or_root(item, base_case):
         return
     get_parent_dirs(os.path.dirname(item), parent_dir_list, base_case)
     parent_dir_list.append(item)
@@ -1196,7 +1219,7 @@ def process_include_items(include_items=[]):
             elif os.path.islink(include_item):
                 logger.debug("Skipping link '%s' ...", include_item)
                 continue
-            elif os.path.samefile(include_item, '/'):
+            elif include_item == '/':
                 # Found / in include item list.  No need to get the other items because / trumps all
                 logger.debug("Found root directory in list of items to scan.  Ignoring the other items ...")
                 parsed_list = default_values
@@ -1231,7 +1254,7 @@ def process_exclude_items(exclude_items=[]):
         exclude_item = os.path.normpath(item).replace('//', '/')
         if os.path.exists(exclude_item):
             # ignore the exclude_item if its not a full directory path
-            if os.path.samefile(exclude_item, '/'):
+            if exclude_item == '/':
                 # Found / in exclude list.  No need to get the other items because / trumps all
                 logger.debug("Found root directory in the exclude list.  Expanding it to all toplevel directories ...")
                 parsed_list = get_toplevel_dirs()

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -176,6 +176,7 @@ class TestFindYara:
             with patch("insights.client.apps.malware_detection.call", return_value='4.1'):
                 mdc = MalwareDetectionClient(None)
         assert mdc.yara_binary == '/bin/yara'
+        assert mdc.yara_version == '4.1'
         cmd.assert_called()
 
         # 'Find' yara in /usr/local/bin/yara (fails to 'find' /bin/yara and /usr/bin/yara)
@@ -183,6 +184,7 @@ class TestFindYara:
             with patch("insights.client.apps.malware_detection.call", return_value='4.1'):
                 mdc = MalwareDetectionClient(None)
         assert mdc.yara_binary == '/usr/local/bin/yara'
+        assert mdc.yara_version == '4.1'
         cmd.assert_called()
 
     def test_find_unsupported_yara(self, log_mock, conf, rules, cmd):
@@ -190,7 +192,8 @@ class TestFindYara:
         with patch('os.path.exists', return_value=True):
             with patch("insights.client.apps.malware_detection.call", return_value='3.10'):
                 with pytest.raises(SystemExit):
-                    MalwareDetectionClient(None)
+                    mdc = MalwareDetectionClient(None)
+                    assert mdc.yara_version == '3.10'
         log_mock.error.assert_called_with("Found /bin/yara with version 3.10, but malware-detection requires version >= 4.1.0\n"
                                           "Please install a later version of yara.")
         cmd.assert_not_called()
@@ -214,7 +217,7 @@ class TestFindYara:
 
     @patch("os.path.exists", return_value=True)
     @patch("insights.client.apps.malware_detection.call")  # mock call to 'yara --version'
-    def test_invalid_yara_versions(self, version_mock, exists_mock, log_mock, conf, rules, cmd):
+    def test_yara_versions(self, version_mock, exists_mock, log_mock, conf, rules, cmd):
         # Test checking the version of yara
         # Invalid versions of yara
         for version in ['4.0.99', '4']:
@@ -224,10 +227,11 @@ class TestFindYara:
         cmd.assert_not_called()  # We won't get to the build_yara_cmd method because we exit before its called
 
         # Valid versions of yara
-        for version in ['4.1', '10.0.0']:
+        for version in ['4.1', '4.10.10', '10.100.1000.0', '5']:
             version_mock.return_value = version
             mdc = MalwareDetectionClient(None)
             assert mdc.yara_binary == '/bin/yara'
+            assert mdc.yara_version in ['4.1', '4.10', '10.100', '5']
         cmd.assert_called()
 
 
@@ -239,13 +243,13 @@ class TestFindYara:
 @patch.object(InsightsConnection, 'get_proxies')
 @patch.object(InsightsConnection, '_init_session', return_value=Mock())
 @patch.object(MalwareDetectionClient, '_build_yara_command')
-@patch.object(MalwareDetectionClient, '_find_yara', return_value=YARA)
 @patch.object(MalwareDetectionClient, '_load_config', return_value=CONFIG)
 class TestGetRules:
     """ Testing the _get_rules method """
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true'})
-    def test_download_rules_cert_auth(self, conf, yara, cmd, session, proxies, get, findmnt, remove):
+    @patch(FIND_YARA_TARGET, return_value=YARA)
+    def test_download_rules_cert_auth(self, yara, conf, cmd, session, proxies, get, findmnt, remove):
         # Test the standard rules_location urls, but will result in cert auth being used to download the rules
         # Test with insights-config None, expect an error when trying to use the insights-config object
         with pytest.raises(SystemExit):
@@ -257,27 +261,32 @@ class TestGetRules:
         mdc = MalwareDetectionClient(InsightsConfig())
         assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
         assert mdc.rules_file.startswith('/tmp')  # rules will be saved into a temp file
-        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar",
+                               log_response_text=True)
 
         # With authmethod=CERT, expect 'cert.' to be prefixed to the url
         mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
         assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
-        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar",
+                               log_response_text=True)
 
         # With authmethod=BASIC and test scan false ...
         # Expect to still use cert auth because no username or password specified
         os.environ['TEST_SCAN'] = 'false'
         mdc = MalwareDetectionClient(InsightsConfig(authmethod='BASIC'))
         assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
-        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar", log_response_text=False)
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar",
+                               log_response_text=False)
 
         mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
         assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
-        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar", log_response_text=False)
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar",
+                               log_response_text=False)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true'})
+    @patch(FIND_YARA_TARGET, return_value=YARA)
     @patch(LOGGER_TARGET)
-    def test_download_rules_basic_auth(self, log_mock, conf, yara, cmd, session, proxies, get, findmnt, remove):
+    def test_download_rules_basic_auth(self, log_mock, yara, conf, cmd, session, proxies, get, findmnt, remove):
         # Test the standard rules_location urls, with basic auth attempting to be used to download the rules
         # Basic auth is used by default, but needs to have a valid username and password for it to work
         # Without a username and password, then cert auth will be used
@@ -286,29 +295,65 @@ class TestGetRules:
         get.return_value = Mock(status_code=401, reason="Unauthorized", text="No can do")
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(username='user'))
-        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
+        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar",
+                               log_response_text=True)
         log_mock.error.assert_called_with("%s %s: %s", 401, "Unauthorized", ANY)
 
         # Test with just a password specified - expect basic auth to be used but fails
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(password='pass'))
-        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
+        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar",
+                               log_response_text=True)
         log_mock.error.assert_called_with("%s %s: %s", 401, "Unauthorized", ANY)
 
         # Test with 'incorrect' username and/or password - expect basic auth failure
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(username='user', password='badpass'))
-        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
+        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar",
+                               log_response_text=True)
         log_mock.error.assert_called_with("%s %s: %s", 401, "Unauthorized", ANY)
 
         # Test with 'correct' username and password - expect basic auth success
         get.return_value = Mock(status_code=200, content=b"Rule Content")
         mdc = MalwareDetectionClient(InsightsConfig(username='user', password='goodpass'))
         assert mdc.rules_location == "https://console.redhat.com/api/malware-detection/v1/test-rule.yar"
-        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar", log_response_text=True)
+        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar",
+                               log_response_text=True)
+
+    @patch.dict(os.environ, {'TEST_SCAN': 'false'})
+    @patch("os.path.exists", return_value=True)  # mock call to os.path.exists in _find_yara
+    @patch("insights.client.apps.malware_detection.call", return_value='4.2')  # mock call to 'yara --version'
+    def test_download_rules_versioned_files(self, version_mock, exists_mock, conf, cmd, session, proxies, get, findmnt, remove):
+        # Test downloading different signatures files depending on the yara version found on the system
+        mdc = MalwareDetectionClient(InsightsConfig())
+        assert mdc.yara_version == '4.2'
+        assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures-4.2.yar"
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures-4.2.yar",
+                               log_response_text=False)
+
+        version_mock.return_value = '4.1'
+        mdc = MalwareDetectionClient(InsightsConfig())
+        assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures-4.1.yar"
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures-4.1.yar",
+                               log_response_text=False)
+
+        version_mock.return_value = '10.100'
+        mdc = MalwareDetectionClient(InsightsConfig())
+        assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures-10.100.yar"
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures-10.100.yar",
+                               log_response_text=False)
+
+        # Bypass the _find_yara method so self.yara_version isn't set
+        with patch(FIND_YARA_TARGET, return_value=YARA):
+            mdc = MalwareDetectionClient(InsightsConfig())
+        assert not hasattr(mdc, 'yara_version')
+        assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar",
+                               log_response_text=False)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': 'console.redhat.com/rules.yar'})
-    def test_get_rules_missing_protocol(self, conf, yara, cmd, session, proxies, get, findmnt, remove):
+    @patch(FIND_YARA_TARGET, return_value=YARA)
+    def test_get_rules_missing_protocol(self, yara, conf, cmd, session, proxies, get, findmnt, remove):
         # Non-standard rules URLS - without https:// at the start and not signatures.yar
         # test-scan true and BASIC auth by default expect test-rule.yar and no 'cert.' in URL
         mdc = MalwareDetectionClient(InsightsConfig(username='user', password='pass'))
@@ -322,8 +367,9 @@ class TestGetRules:
         get.assert_called_with("https://cert.console.redhat.com/rules.yar", log_response_text=False)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'http://localhost/rules.yar'})
+    @patch(FIND_YARA_TARGET, return_value=YARA)
     @patch(LOGGER_TARGET)
-    def test_download_failures(self, log_mock, conf, yara, cmd, session, proxies, get, findmnt, remove):
+    def test_download_failures(self, log_mock, yara, conf, cmd, session, proxies, get, findmnt, remove):
         from requests.exceptions import ConnectionError, Timeout
         # Test various problems downloading rules
         # 404 error - unlikely to occur unless an incorrect rules_location was manually specified
@@ -351,8 +397,9 @@ class TestGetRules:
         assert get.call_count == 3
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': '//console.redhat.com/rules.yar'})
+    @patch(FIND_YARA_TARGET, return_value=YARA)
     @patch("os.path.isfile", return_value=True)
-    def test_get_rules_location_as_file(self, isfile, conf, yara, cmd, session, proxies, get, findmnt, remove):
+    def test_get_rules_location_as_file(self, isfile, yara, conf, cmd, session, proxies, get, findmnt, remove):
         # Test using files for rules_location, esp irregular file names
         # rules_location that starts with a '/' is assumed to be a file, even if its a double '//'
         # Re-writing the rule to be test-rule.yar doesn't apply to local files
@@ -370,24 +417,35 @@ class TestGetRules:
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true'})
     @patch(LOGGER_TARGET)
-    def test_via_satellite_proxy(self, log_mock, conf, yara, cmd, session, proxies, get, findmnt, remove):
+    def test_via_satellite_proxy(self, log_mock, conf, cmd, session, proxies, get, findmnt, remove):
         # Test recognizing and handling of Satellite URLs.
         # Satellite URLs have '/redhat_access/' in their path (which is how the Satellite knows to redirect the
         # query to C.R.C).
         # For malware-detection requests through a Satellite we append the malware-detection path and add https://
         satellite_url = 'satellite.example.com:443/redhat_access/r/insights/platform'
+        replaced_url_prefix = "https://satellite.example.com:443/redhat_access/r/insights/platform/malware-detection/v1/"
 
         # Firstly try with test-rule
-        replaced_url = "https://satellite.example.com:443/redhat_access/r/insights/platform/malware-detection/v1/test-rule.yar"
-        mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
+        replaced_url = replaced_url_prefix + "test-rule.yar"
+        with patch(FIND_YARA_TARGET, return_value=YARA):
+            mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
         assert mdc.rules_location == replaced_url
         get.assert_called_with(replaced_url, log_response_text=True)
         log_mock.debug.assert_called_with("Downloading rules from: %s", replaced_url)
 
         # Then with the actual rules file
         os.environ['TEST_SCAN'] = 'false'
-        replaced_url = "https://satellite.example.com:443/redhat_access/r/insights/platform/malware-detection/v1/signatures.yar"
-        mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
+        replaced_url = replaced_url_prefix + "signatures.yar"
+        with patch(FIND_YARA_TARGET, return_value=YARA):
+            mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
+        assert mdc.rules_location == replaced_url
+        get.assert_called_with(replaced_url, log_response_text=False)
+        log_mock.debug.assert_called_with("Downloading rules from: %s", replaced_url)
+
+        replaced_url = replaced_url_prefix + "signatures-4.1.yar"
+        with patch('os.path.exists', return_value=True):
+            with patch("insights.client.apps.malware_detection.call", return_value='4.1'):
+                mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
         assert mdc.rules_location == replaced_url
         get.assert_called_with(replaced_url, log_response_text=False)
         log_mock.debug.assert_called_with("Downloading rules from: %s", replaced_url)
@@ -444,7 +502,7 @@ class TestBuildYaraCmd:
 
         # Test with 'invalid' rules file - raise CalledProcessError when running command
         with patch("insights.client.apps.malware_detection.call") as call_mock:
-            call_mock.side_effect = ['yara', CalledProcessError(1, 'cmd', 'invalid'), '2']
+            call_mock.side_effect = ['yara', CalledProcessError(1, 'cmd', b'invalid\n'), '2']
             with pytest.raises(SystemExit):
                 MalwareDetectionClient(None)
             assert call_mock.call_count == 2  # 2 calls to 'call' before we exit
@@ -878,6 +936,31 @@ class TestMalwareDetectionOptions:
         assert scan_dict == {}
         log_mock.error.assert_called_with("No filesystem items to scan because the specified exclude items cancel them out")
 
+    @patch("insights.client.apps.malware_detection.call")
+    @patch('os.path.samefile', side_effect=OSError(13, "Permission denied"))
+    @patch(LOGGER_TARGET)
+    @patch.dict(os.environ, {'EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS': 'true', 'TEST_SCAN': 'false',
+                             'RULES_LOCATION': TEST_RULE_FILE, 'FILESYSTEM_SCAN_ONLY': TEMP_TEST_DIR})
+    def test_network_filesystem_permission_denied(self, log_mock, samefile_mock, call_mock, yara, rules, cmd,
+                                                  extract_tmp_files, create_test_files):
+        # Test accessing network filesystem mountpoints that result in permission denied errors
+        # Yes, even root can get permission denied trying to access fuse filesystems
+        # Should produce the same results as the corresponding test in test_network_filesystem_mountpoints
+        scan_me_not_mnt = os.path.join(TEMP_TEST_DIR, 'scan_me_not')
+        dont_scan_me_mnt = os.path.join(TEMP_TEST_DIR, 'scan_me/dont_scan_me')
+        # This is the mocked output returned from the findmnt command
+        call_mock.return_value = '%s\n%s\n' % (scan_me_not_mnt, dont_scan_me_mnt)
+
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert mdc.network_filesystem_mountpoints == [scan_me_not_mnt, dont_scan_me_mnt]
+
+        # process_include_exclude_items uses os.path.samefile, but should gracefully handle the permission denied errors
+        scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
+                                                  exclude_items=mdc.filesystem_scan_exclude_list,
+                                                  exclude_mountpoints=mdc.network_filesystem_mountpoints)
+        assert sorted(list(scan_dict['/tmp']['exclude']['items'])) == sorted([scan_me_not_mnt, dont_scan_me_mnt])
+
     def test_processes_scan_options(self, yara, rules, cmd, create_test_files):
         # Test the processes scan options
         for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
@@ -1049,7 +1132,9 @@ class TestProcessScanning:
         assert all([x not in mdc.scan_pids for x in ['1', '3', TEST_PID]])
         assert '2' in mdc.scan_pids
 
-    @pytest.mark.skipif(not TEST_PROCESSES_SCAN_SINCE, reason='test_processes_scan_since is slowish and could potentially fail')
+    @pytest.mark.skipif(not TEST_PROCESSES_SCAN_SINCE,
+                        reason='test_processes_scan_since is slowish and could potentially fail. '
+                               'Use TEST_PROCESSES_SCAN_SINCE=True to enable test')
     def test_processes_scan_since(self, log_mock, yara, rules, cmd, create_test_files):
         # Firstly, start the TEST_RULE_SCRIPT process then scan_only that process
         # Expect that we'll find it


### PR DESCRIPTION
* Download versioned signatures file corresponding to installed version of yara
* Also fixes permission denied bug from fuse mounted filesystems

Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
https://issues.redhat.com/browse/YARA-320
Make the malware detection client aware of the version of yara installed on the machine and to select the appropriate signature file for scanning.

Also piggybacks a bug fix whereby os.path.samefile() may raise a permission denied exception when trying to access Fuse filesystem mountpoints, yes even as root!