### PR TITLE
chore: remove the unused get_owner from specs.default

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -12,10 +12,6 @@ import logging
 import os
 import signal
 
-from grp import getgrgid
-from os import stat
-from pwd import getpwuid
-
 from insights.components.virtualization import IsBareMetal
 from insights.core.context import HostContext
 from insights.core.dr import SkipComponent
@@ -40,14 +36,6 @@ from insights.specs.datasources.pcp import pcp_enabled, pmlog_summary_args
 
 
 logger = logging.getLogger(__name__)
-
-
-def get_owner(filename):
-    """ tuple: Return tuple containing uid and gid of file filename """
-    st = stat(filename)
-    name = getpwuid(st.st_uid).pw_name
-    group = getgrgid(st.st_gid).gr_name
-    return (name, group)
 
 
 def _make_rpm_formatter(fmt=None):


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
the `specs.default.get_owner` is not used, this PR removed it from the code.
