### PR TITLE
malware-detection: implement yara version handling differently

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -255,13 +255,13 @@ class MalwareDetectionClient:
         """
         def yara_version_ok(yara):
             # Check the installed yara version >= MIN_YARA_VERSION
-            installed_yara_version = call([[yara, '--version']]).strip()
+            self.yara_version = call([[yara, '--version']]).strip()
             try:
-                self.yara_version = '.'.join(installed_yara_version.split('.')[:2])  # Eg 4.2.0 becomes 4.2
-                if float(self.yara_version) < float(MIN_YARA_VERSION[:3]):
+                # Check the installed yara X.Y version > the minimal recommended yara version
+                if float('.'.join(self.yara_version.split('.')[:2])) < float(MIN_YARA_VERSION[:3]):
                     raise RuntimeError("Found %s with version %s, but malware-detection requires version >= %s\n"
                                        "Please install a later version of yara."
-                                       % (yara, installed_yara_version, MIN_YARA_VERSION))
+                                       % (yara, self.yara_version, MIN_YARA_VERSION))
             except RuntimeError as e:
                 logger.error(str(e))
                 exit(constants.sig_kill_bad)
@@ -620,11 +620,10 @@ class MalwareDetectionClient:
             logger.error("Couldn't access the insights-client configuration")
             exit(constants.sig_kill_bad)
 
-        signatures_file = default_signatures_file = 'signatures.yar'
-        if hasattr(self, 'yara_version'):
-            signatures_file = 'signatures-%s.yar' % self.yara_version
+        signatures_file = 'signatures.yar'
+        signatures_file += '?yara_version=' + self.yara_version if hasattr(self, 'yara_version') else ''
         if not self.rules_location:
-            self.rules_location = "https://console.redhat.com/api/malware-detection/v1/" + signatures_file
+            self.rules_location = 'https://console.redhat.com/api/malware-detection/v1/' + signatures_file
             if '/redhat_access/' in self.insights_config.base_url:
                 # Satellite URLs have '/redhat_access/' in the base_url config option
                 self.rules_location = self.insights_config.base_url + '/malware-detection/v1/' + signatures_file
@@ -655,11 +654,6 @@ class MalwareDetectionClient:
             self.insights_config.cert_verify = True
             conn = InsightsConnection(self.insights_config)
             response = conn.get(self.rules_location, log_response_text=log_rule_contents)
-            if response.status_code == 404 and not (self.test_scan or signatures_file == default_signatures_file):
-                # Got a 404 with the 'signatures-X.Y.yar' file, so try with just 'signatures.yar' instead
-                logger.debug("Couldn't find %s file, trying %s instead", signatures_file, default_signatures_file)
-                self.rules_location = self.rules_location.replace(signatures_file, default_signatures_file)
-                response = conn.get(self.rules_location, log_response_text=log_rule_contents)
             if response.status_code != 200:
                 logger.error("%s %s: %s", response.status_code, response.reason, response.text)
                 exit(constants.sig_kill_bad)

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -231,7 +231,7 @@ class TestFindYara:
             version_mock.return_value = version
             mdc = MalwareDetectionClient(None)
             assert mdc.yara_binary == '/bin/yara'
-            assert mdc.yara_version in ['4.1', '4.10', '10.100', '5']
+            assert mdc.yara_version in ['4.1', '4.10.10', '10.100.1000.0', '5']
         cmd.assert_called()
 
 
@@ -322,25 +322,25 @@ class TestGetRules:
 
     @patch.dict(os.environ, {'TEST_SCAN': 'false'})
     @patch("os.path.exists", return_value=True)  # mock call to os.path.exists in _find_yara
-    @patch("insights.client.apps.malware_detection.call", return_value='4.2')  # mock call to 'yara --version'
+    @patch("insights.client.apps.malware_detection.call", return_value='4.2.1')  # mock call to 'yara --version'
     def test_download_rules_versioned_files(self, version_mock, exists_mock, conf, cmd, session, proxies, get, findmnt, remove):
         # Test downloading different signatures files depending on the yara version found on the system
         mdc = MalwareDetectionClient(InsightsConfig())
-        assert mdc.yara_version == '4.2'
-        assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures-4.2.yar"
-        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures-4.2.yar",
+        assert mdc.yara_version == '4.2.1'
+        assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar?yara_version=4.2.1"
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar?yara_version=4.2.1",
                                log_response_text=False)
 
-        version_mock.return_value = '4.1'
+        version_mock.return_value = '4.1.0'
         mdc = MalwareDetectionClient(InsightsConfig())
-        assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures-4.1.yar"
-        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures-4.1.yar",
+        assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar?yara_version=4.1.0"
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar?yara_version=4.1.0",
                                log_response_text=False)
 
         version_mock.return_value = '10.100'
         mdc = MalwareDetectionClient(InsightsConfig())
-        assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures-10.100.yar"
-        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures-10.100.yar",
+        assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar?yara_version=10.100"
+        get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar?yara_version=10.100",
                                log_response_text=False)
 
         # Bypass the _find_yara method so self.yara_version isn't set
@@ -442,7 +442,7 @@ class TestGetRules:
         get.assert_called_with(replaced_url, log_response_text=False)
         log_mock.debug.assert_called_with("Downloading rules from: %s", replaced_url)
 
-        replaced_url = replaced_url_prefix + "signatures-4.1.yar"
+        replaced_url += '?yara_version=4.1'
         with patch('os.path.exists', return_value=True):
             with patch("insights.client.apps.malware_detection.call", return_value='4.1'):
                 mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))


### PR DESCRIPTION
* Add yara version as a query parameter when requesting signatures.yar

Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
Sends the yara version to the malware detection backend which is responsible to determining which signatures file to send back to the client.  Previously the client requested a specific file to send.  But now the client always asks for the same signatures.yar file but appends a ?yara_version=x.y.z query parameter to the request, which the backend parses and chooses the appropriate signatures file based on that version.