### PR TITLE
Fix Tests should not create files in protected directories

### DIFF
--- a/insights/tests/client/test_archive.py
+++ b/insights/tests/client/test_archive.py
@@ -201,9 +201,9 @@ class TestInsightsArchive(TestCase):
         create_archive_dir.assert_called_once()
 
     @patch('insights.client.archive.shutil.copyfile')
-    @patch('insights.client.archive.os.path.join', side_effect=['/var/tmp/test-archive/insights-archive-test.tar.gz'])
     @patch('insights.client.archive.os.path.isdir', Mock())
-    def test_keep_archive(self, os_, copyfile, _, __):
+    @patch('insights.client.archive.os.path.exists', return_value=True)
+    def test_keep_archive(self, path_exists, copyfile, _, __):
         archive = InsightsArchive(Mock())
         archive.tar_file = '/var/tmp/insights-archive-test.tar.gz'
         archive.keep_archive_dir = '/var/tmp/test-archive'
@@ -215,7 +215,8 @@ class TestInsightsArchive(TestCase):
     @patch('insights.client.archive.os.path.isdir', Mock())
     @patch('insights.client.archive.os.path.basename', Mock())
     @patch('insights.client.archive.logger')
-    def test_keep_archive_err_during_copy(self, logger, copyfile, _, __):
+    @patch('insights.client.archive.os.path.exists', return_value=True)
+    def test_keep_archive_err_during_copy(self, path_exists, logger, copyfile, _, __):
         archive = InsightsArchive(Mock())
         archive.archive_stored = '/var/tmp/test-archive/test-store-archive'
         archive.keep_archive_dir = '/var/tmp/test-archive'

--- a/insights/tests/client/test_client.py
+++ b/insights/tests/client/test_client.py
@@ -342,10 +342,14 @@ def test_upload_412_write_unregistered_file(_, upload_archive, write_unregistere
 
 
 @patch('insights.client.archive.InsightsArchive.storing_archive')
+@patch('insights.client.archive.tempfile.mkdtemp', Mock())
 def test_cleanup_tmp(storing_archive):
+
     config = InsightsConfig(keep_archive=False)
     arch = InsightsArchive(config)
-    arch.tar_file = os.path.join(arch.tmp_dir, 'test.tar.gz')
+    arch.tmp_dir = "/test"
+    arch.tar_file = "/test/test.tar.gz"
+    arch.keep_archive_dir = "/test-keep-archive"
     arch.cleanup_tmp()
     assert not os.path.exists(arch.tmp_dir)
     storing_archive.assert_not_called()
@@ -357,10 +361,13 @@ def test_cleanup_tmp(storing_archive):
 
 
 @patch('insights.client.archive.InsightsArchive.storing_archive')
+@patch('insights.client.archive.tempfile.mkdtemp', Mock())
 def test_cleanup_tmp_obfuscation(storing_archive):
     config = InsightsConfig(keep_archive=False, obfuscate=True)
     arch = InsightsArchive(config)
-    arch.tar_file = os.path.join(arch.tmp_dir, 'test.tar.gz')
+    arch.tmp_dir = "/test"
+    arch.tar_file = "/test/test.tar.gz"
+    arch.keep_archive_dir = "/test-keep-archive"
     arch.cleanup_tmp()
     assert not os.path.exists(arch.tmp_dir)
     storing_archive.assert_not_called()


### PR DESCRIPTION
Resolves: issue#3439

Signed-off-by: ahitacat <ahitacat@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
[PR](https://github.com/RedHatInsights/insights-core/pull/3396) added some test that created files under the directory `/var/cache/insights-client/ ` which is protected. 

This PR mocked the creation of files in that protected directory.
