### PR TITLE
Remove RPM_OUTPUT_SHADOW_UTILS

### DIFF
--- a/insights/tests/test_soscleaner.py
+++ b/insights/tests/test_soscleaner.py
@@ -17,21 +17,6 @@ from insights.contrib.soscleaner import SOSCleaner
 
 ReportItem = namedtuple("ReportItem", ("name", "relative_path"))
 
-RPM_OUTPUT_SHADOW_UTILS =\
-    "{\"name\":\"shadow-utils\","\
-    "\"epoch\":\"2\","\
-    "\"version\":\"4.1.5.1\","\
-    "\"release\":\"5.el6\","\
-    "\"arch\":\"x86_64\","\
-    "\"installtime\":\"Wed 13 Jan 2021 10:04:18 AM CET\","\
-    "\"buildtime\":\"1455012203\","\
-    "\"vendor\":\"Red Hat, Inc.\","\
-    "\"buildhost\":\"x86-027.build.eng.bos.redhat.com\","\
-    "\"sigpgp\":"\
-    "\"RSA/8, "\
-    "Tue 08 Mar 2016 11:15:08 AM CET, "\
-    "Key ID 199e2f91fd431d51\"}"
-
 
 def _soscleaner():
     soscleaner = SOSCleaner()


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The RPM_OUTPUT_SHADOW_UTILS (introduced in #3331) does not appear anywhere in the SOSCleaner tests or anywhere else. Removing it to declutter the test case.
