### PR TITLE
Fix tests that removing temp archives

### DIFF
--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -11,6 +11,7 @@ PATH = '/usr/share/xml/scap/ref_id.xml'
 
 @patch("insights.client.apps.compliance.ComplianceClient._assert_oscap_rpms_exist")
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None, compressor='gz', obfuscate=False)
+@patch("insights.client.archive.atexit", Mock())
 def test_oscap_scan(config, assert_rpms):
     compliance_client = ComplianceClient(config)
     compliance_client._get_inventory_id = lambda: ''
@@ -27,6 +28,7 @@ def test_oscap_scan(config, assert_rpms):
 
 @patch("insights.client.apps.compliance.ComplianceClient._assert_oscap_rpms_exist")
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None, compressor='gz', obfuscate=True)
+@patch("insights.client.archive.atexit", Mock())
 def test_oscap_scan_with_obfuscation(config, assert_rpms, tmpdir):
     results_file = tmpdir.mkdir('results').join('result.xml')
     results_file.write("""
@@ -85,6 +87,7 @@ def test_oscap_scan_with_obfuscation(config, assert_rpms, tmpdir):
 
 @patch("insights.client.apps.compliance.ComplianceClient._assert_oscap_rpms_exist")
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None, compressor='gz', obfuscate=True, obfuscate_hostname=True)
+@patch("insights.client.archive.atexit", Mock())
 def test_oscap_scan_with_hostname_obfuscation(config, assert_rpms, tmpdir):
     results_file = tmpdir.mkdir('results').join('result.xml')
     results_file.write("""
@@ -155,6 +158,7 @@ def test_oscap_scan_with_hostname_obfuscation(config, assert_rpms, tmpdir):
 
 @patch("insights.client.apps.compliance.ComplianceClient._assert_oscap_rpms_exist")
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None, compressor='gz')
+@patch("insights.client.archive.atexit", Mock())
 def test_oscap_scan_with_results_repaired(config, assert_rpms, tmpdir):
     results_file = tmpdir.mkdir('results').join('result.xml')
     results_file.write("""

--- a/insights/tests/client/test_archive.py
+++ b/insights/tests/client/test_archive.py
@@ -3,7 +3,6 @@ from mock.mock import patch, Mock, call
 from unittest import TestCase
 from pytest import raises
 
-
 test_timestamp = '000000'
 test_hostname = 'testhostname'
 test_archive_name = 'insights-testhostname-000000'

--- a/insights/tests/client/test_client.py
+++ b/insights/tests/client/test_client.py
@@ -343,8 +343,9 @@ def test_upload_412_write_unregistered_file(_, upload_archive, write_unregistere
 
 @patch('insights.client.archive.InsightsArchive.storing_archive')
 @patch('insights.client.archive.tempfile.mkdtemp', Mock())
+@patch('insights.client.archive.os.makedirs', Mock())
+@patch('insights.client.archive.atexit', Mock())
 def test_cleanup_tmp(storing_archive):
-
     config = InsightsConfig(keep_archive=False)
     arch = InsightsArchive(config)
     arch.tmp_dir = "/test"
@@ -362,17 +363,19 @@ def test_cleanup_tmp(storing_archive):
 
 @patch('insights.client.archive.InsightsArchive.storing_archive')
 @patch('insights.client.archive.tempfile.mkdtemp', Mock())
+@patch('insights.client.archive.os.makedirs', Mock())
+@patch('insights.client.archive.atexit', Mock())
 def test_cleanup_tmp_obfuscation(storing_archive):
     config = InsightsConfig(keep_archive=False, obfuscate=True)
     arch = InsightsArchive(config)
-    arch.tmp_dir = "/test"
-    arch.tar_file = "/test/test.tar.gz"
-    arch.keep_archive_dir = "/test-keep-archive"
+    arch.tmp_dir = '/var/tmp/insights-archive-000000'
+    arch.tar_file = '/var/tmp/insights-archive-test.tar.gz'
+    arch.keep_archive_dir = '/var/tmp/test-archive'
     arch.cleanup_tmp()
     assert not os.path.exists(arch.tmp_dir)
     storing_archive.assert_not_called()
 
-    config.keep_archive = True
+    arch.config.keep_archive = True
     arch.cleanup_tmp()
     assert not os.path.exists(arch.tmp_dir)
     storing_archive.assert_called_once()


### PR DESCRIPTION
Signed-off-by: ahitacat <ahitacat@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

Test were passing but it ended throwing these errors:
```
ERROR:insights.client.archive:ERROR: Could not create /var/cache/insights-client
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/home/bfahr/work/insights/insights-core/insights/client/archive.py", line 261, in storing_archive
    os.makedirs(self.keep_archive_dir)
  File "/usr/lib64/python3.8/os.py", line 223, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/var/cache/insights-client'
```
This PR mocked `atexit` call that was causing this error.