### PR TITLE
DRAFT fix: The run command loading default plugins

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -364,6 +364,8 @@ def run(component=None, root=None, print_summary=False,
             for c in dr.DELEGATES:
                 if c.__module__.startswith(plugins):
                     component.append(c)
+    else:
+        load_default_plugins()
 
     if component:
         if not isinstance(component, (list, set)):


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
I moved the load_default_plugins in the run function to be up under the if print summary, but I didn't think about run being executed without print summary. So this adds it back if not print summary.