### PR TITLE
FIX: Update canonical_facts to load needed components

### DIFF
--- a/insights/util/canonical_facts.py
+++ b/insights/util/canonical_facts.py
@@ -135,7 +135,7 @@ def canonical_facts(
 
 
 def get_canonical_facts(path=None):
-    load_components("insights.specs.default")
+    load_components("insights.specs.default", "insights.specs.insights_archive")
 
     set_enabled(canonical_facts, True)
     set_enabled(SubscriptionManagerID, True)
@@ -148,8 +148,5 @@ def get_canonical_facts(path=None):
 
 if __name__ == "__main__":
     import json
-
-    # Load both default and archive to support host and archive collection
-    load_components("insights.specs.default", "insights.specs.insights_archive")
 
     print(json.dumps(get_canonical_facts()))


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* get_canonical_facts needs to work for legacy archives that do not include meta_data
* related to PR #3444 

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>