### PR TITLE
fix: Replace non ascii characters with question marks

### DIFF
--- a/insights/parsr/tests/test_iniparser.py
+++ b/insights/parsr/tests/test_iniparser.py
@@ -1,4 +1,7 @@
+# coding:UTF-8
 from insights.parsr.iniparser import parse_doc
+from insights.parsr.query import last
+from six import PY2
 
 
 DATA = """
@@ -32,6 +35,17 @@ the_force
 
 """.strip()
 
+DATA_UNICODE_TEST = """
+[global]
+secret-name = "vsphere-creds"
+secret-namespace = kube-system
+insecure-flag = 1
+
+[workspace]
+datacenter = 1-测试部
+folder = "/1-测试部/xxxxxxxxx"
+""".strip()
+
 
 def test_iniparser():
     res = parse_doc(DATA, None)
@@ -58,3 +72,17 @@ def test_multiple_values():
 def test_no_value():
     res = parse_doc(DATA, None)
     assert res["novalue"]["the_force"][0].value is None
+
+
+def test_unicode():
+    res = parse_doc(DATA_UNICODE_TEST, None)
+    assert res["global"]["insecure-flag"][last].value == "1"
+    assert res["global"]["secret-name"][last].value == '"vsphere-creds"'
+    assert res["global"]["secret-namespace"][last].value == "kube-system"
+
+    if PY2:
+        assert res["workspace"]["datacenter"][last].value == "1-?????????"
+        assert res["workspace"]["folder"][last].value == '"/1-?????????/xxxxxxxxx"'
+    else:
+        assert res["workspace"]["datacenter"][last].value == "1-???"
+        assert res["workspace"]["folder"][last].value == '"/1-???/xxxxxxxxx"'


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
Iniparser is only setup to parse string.printable characters. This doesn't include non ascii characters from various languages, which causes an exception when they're in a config file. So replace the characters with question marks.

Fixes #3450