### PR TITLE
feat: revert and refine the padman list specs and parsers

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -482,6 +482,8 @@ class DefaultSpecs(Specs):
     pluginconf_d = glob_file("/etc/yum/pluginconf.d/*.conf")
     pmlog_summary = command_with_args("/usr/bin/pmlogsummary %s", pmlog_summary_args)
     pmrep_metrics = simple_command("/usr/bin/pmrep -t 1s -T 1s network.interface.out.packets network.interface.collisions swap.pagesout mssql.memory_manager.stolen_server_memory mssql.memory_manager.total_server_memory -o csv")
+    podman_list_containers = simple_command("/usr/bin/podman ps --all --no-trunc")
+    podman_list_images = simple_command("/usr/bin/podman images --all --no-trunc --digests")
     postconf_builtin = simple_command("/usr/sbin/postconf -C builtin")
     postconf = simple_command("/usr/sbin/postconf")
     postgresql_conf = first_file([

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -200,6 +200,8 @@ class InsightsArchiveSpecs(Specs):
     pcs_quorum_status = simple_file("insights_commands/pcs_quorum_status")
     pcs_status = simple_file("insights_commands/pcs_status")
     pmrep_metrics = first_file(["insights_commands/pmrep_-t_1s_-T_1s_network.interface.out.packets_network.interface.collisions_swap.pagesout_mssql.memory_manager.stolen_server_memory_mssql.memory_manager.total_server_memory_-o_csv", "insights_commands/pmrep_-t_1s_-T_1s_network.interface.out.packets_network.interface.collisions_swap.pagesout_-o_csv"])
+    podman_list_containers = simple_file("insights_commands/podman_ps_--all_--no-trunc")
+    podman_list_images = simple_file("insights_commands/podman_images_--all_--no-trunc_--digests")
     postconf_builtin = simple_file("insights_commands/postconf_-C_builtin")
     postconf = simple_file("insights_commands/postconf")
     ps_alxwww = simple_file("insights_commands/ps_alxwww")

--- a/insights/tests/parsers/test_podman_list.py
+++ b/insights/tests/parsers/test_podman_list.py
@@ -74,11 +74,6 @@ def test_podman_list_images_no_data():
     assert 'No data.' in str(ex)
 
 
-def test_podman_undefined_key_field():
-    with pytest.raises(NotImplementedError):
-        assert podman_list.PodmanList(context_wrap(PODMAN_LIST_CONTAINERS))
-
-
 def test_podman_documentation():
     failed_count, tests = doctest.testmod(
         podman_list,


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

- Revert the `podman list` specs
- Change the `PodmanList` parsers to base on the `DockerList` parsers, since the output of the `podman` commands is the same as the `docker` commands
- This is the preparation for the support of `Container Specs`
