### PR TITLE
Fix: test error of nmcli command in the datasource ethernet

### DIFF
--- a/insights/tests/datasources/test_ethernet.py
+++ b/insights/tests/datasources/test_ethernet.py
@@ -39,7 +39,9 @@ NAME      UUID                                  TYPE      DEVICE
 team0     bf000427-d9f1-432f-819d-257edb86c6fb  team      --
 """
 
-NMCLI_C_SHOW_EMPTY = ""
+NMCLI_C_SHOW_EMPTY = """
+NAME      UUID                                  TYPE      DEVICE
+"""
 
 EXPECTED = ['enp1s0', 'enp8s0', 'enp1s0.2']
 


### PR DESCRIPTION
Signed-off-by: Xinting Li <xintli@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

- Fixed an incorrect test case newly added to the `ethernet` datasource.
