### PR TITLE
Fix: Restore the spec cni_podman_bridge_conf

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -127,6 +127,7 @@ class DefaultSpecs(Specs):
     cloud_init_log = simple_file("/var/log/cloud-init.log")
     cluster_conf = simple_file("/etc/cluster/cluster.conf")
     cmdline = simple_file("/proc/cmdline")
+    cni_podman_bridge_conf = simple_file("/etc/cni/net.d/87-podman-bridge.conflist")
     corosync = simple_file("/etc/sysconfig/corosync")
     corosync_cmapctl = foreach_execute(corosync_ds.corosync_cmapctl_cmds, "%s")
     corosync_conf = simple_file("/etc/corosync/corosync.conf")


### PR DESCRIPTION
Signed-off-by: shlao <shlao@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

The rule `podman_cni_bridge.py` needs the spec `cni_podman_bridge_conf`
