### PR TITLE
fix: the parser "LvmConfig" raises exception

### DIFF
--- a/insights/parsers/lvm.py
+++ b/insights/parsers/lvm.py
@@ -699,7 +699,8 @@ def _lvm_render(o):
     if isinstance(o, dict):
         parts = ['"%s": %s' % (k, _lvm_render(v)) for k, v in o.items()]
         return "{%s}" % ",".join(parts)
-    if isinstance(o, str) and o.isdigit():
+    # for umask=077, it can not be parsed by json directly, transfer it to string first
+    if isinstance(o, str) and o.isdigit() and o.startswith('0') and len(o) > 1:
         return '"%s"' % o
     return "%s" % o
 

--- a/insights/parsers/lvm.py
+++ b/insights/parsers/lvm.py
@@ -699,6 +699,8 @@ def _lvm_render(o):
     if isinstance(o, dict):
         parts = ['"%s": %s' % (k, _lvm_render(v)) for k, v in o.items()]
         return "{%s}" % ",".join(parts)
+    if isinstance(o, str) and o.isdigit():
+        return '"%s"' % o
     return "%s" % o
 
 

--- a/insights/parsers/lvm.py
+++ b/insights/parsers/lvm.py
@@ -36,7 +36,6 @@ LvmSystemDevices - file ``/etc/lvm/devices/system.devices``
 from __future__ import print_function
 
 import json
-from collections import defaultdict
 
 from insights.parsers import ParseException, optlist_to_dict, SkipException
 from insights.specs import Specs
@@ -698,7 +697,7 @@ class LvmConf(LegacyItemAccess, Parser):
 @parser(Specs.lvmconfig)
 class LvmConfig(CommandParser):
     def parse_content(self, content):
-        self.data = defaultdict(dict)
+        self.data = dict()
         key = None
         for line in content:
             line = line.rstrip()
@@ -717,8 +716,8 @@ class LvmConfig(CommandParser):
                     try:
                         v = json.loads(v)
                     except Exception:
-                        raise SkipException("Failed to parse line %s." % line)
-                self.data[key][k] = v
+                        raise ParseException("Failed to parse line %s." % line)
+                self.data.setdefault(key, {}).update({k: v})
             else:
                 pass  # inferring this a stderr, so skipping
 

--- a/insights/parsers/lvm.py
+++ b/insights/parsers/lvm.py
@@ -695,20 +695,10 @@ class LvmConf(LegacyItemAccess, Parser):
         self.data = lvm_conf_dict
 
 
-def _lvm_render(o):
-    if isinstance(o, dict):
-        parts = ['"%s": %s' % (k, _lvm_render(v)) for k, v in o.items()]
-        return "{%s}" % ",".join(parts)
-    # for umask=077, it can not be parsed by json directly, transfer it to string first
-    if isinstance(o, str) and o.isdigit() and o.startswith('0') and len(o) > 1:
-        return '"%s"' % o
-    return "%s" % o
-
-
 @parser(Specs.lvmconfig)
 class LvmConfig(CommandParser):
     def parse_content(self, content):
-        dd = defaultdict(dict)
+        self.data = defaultdict(dict)
         key = None
         for line in content:
             line = line.rstrip()
@@ -721,10 +711,16 @@ class LvmConfig(CommandParser):
                 key = None
             elif line[0] == "\t":
                 k, v = line.strip().split("=", 1)
-                dd[key][k] = v
+                # umask=077 will raise exception, and also no need to
+                # transfer it, just keep it as string
+                if k != 'umask':
+                    try:
+                        v = json.loads(v)
+                    except Exception:
+                        raise SkipException("Failed to parse line %s." % line)
+                self.data[key][k] = v
             else:
                 pass  # inferring this a stderr, so skipping
-        self.data = json.loads(_lvm_render(dict(dd)))
 
 
 @parser(Specs.lvm_system_devices)

--- a/insights/tests/parsers/lvm_test_data.py
+++ b/insights/tests/parsers/lvm_test_data.py
@@ -223,3 +223,15 @@ local {
 	system_id=""
 	host_id=0
 }""".strip()
+
+LVMCONFIG2 = """
+global {
+	umask=077
+	test=0
+	units="r"
+	si_unit_consistency=1
+	suffix=1
+	activation=1
+	fallback_to_lvm1=0
+}
+""".strip()

--- a/insights/tests/parsers/lvm_test_data.py
+++ b/insights/tests/parsers/lvm_test_data.py
@@ -235,3 +235,15 @@ global {
 	fallback_to_lvm1=0
 }
 """.strip()
+
+LVMCONFIG3 = """
+global {
+	test=077
+	test=0
+	units="r"
+	si_unit_consistency=1
+	suffix=1
+	activation=1
+	fallback_to_lvm1=0
+}
+""".strip()

--- a/insights/tests/parsers/test_lvm.py
+++ b/insights/tests/parsers/test_lvm.py
@@ -2,10 +2,10 @@ from __future__ import print_function
 import pytest
 import doctest
 
-from insights.parsers import SkipException
+from insights.parsers import ParseException, SkipException
 from insights.parsers import lvm
 from insights.tests import context_wrap
-from .lvm_test_data import LVMCONFIG, LVMCONFIG2
+from .lvm_test_data import LVMCONFIG, LVMCONFIG2, LVMCONFIG3
 
 WARNINGS_CONTENT = """
 WARNING
@@ -192,6 +192,11 @@ def test_lvmconfig():
 def test_lvmconfig_2():
     p = lvm.LvmConfig(context_wrap(LVMCONFIG2))
     assert p.data['global']['umask'] == '077'
+
+
+def test_lvmconfig_exception():
+    with pytest.raises(ParseException):
+        lvm.LvmConfig(context_wrap(LVMCONFIG3))
 
 
 def test_vgsheading_warnings():

--- a/insights/tests/parsers/test_lvm.py
+++ b/insights/tests/parsers/test_lvm.py
@@ -5,7 +5,7 @@ import doctest
 from insights.parsers import SkipException
 from insights.parsers import lvm
 from insights.tests import context_wrap
-from .lvm_test_data import LVMCONFIG
+from .lvm_test_data import LVMCONFIG, LVMCONFIG2
 
 WARNINGS_CONTENT = """
 WARNING
@@ -187,6 +187,11 @@ def test_lvmconfig():
     p = lvm.LvmConfig(context_wrap(LVMCONFIG))
     assert p.data["dmeventd"]["raid_library"] == "libdevmapper-event-lvm2raid.so"
     assert p.data["global"]["thin_check_options"] == ["-q", "--clear-needs-check-flag"]
+
+
+def test_lvmconfig_2():
+    p = lvm.LvmConfig(context_wrap(LVMCONFIG2))
+    assert p.data['global']['umask'] == '077'
 
 
 def test_vgsheading_warnings():


### PR DESCRIPTION
It fails to parse the content when there is "umask=077" in the configuration.

Signed-off-by: Huanhuan Li <huali@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
fixes: https://github.com/RedHatInsights/insights-core/issues/3475
