### PR TITLE
Update the marker for MustGatherContext

### DIFF
--- a/insights/core/context.py
+++ b/insights/core/context.py
@@ -274,7 +274,7 @@ class InsightsOperatorContext(ExecutionContext):
 @fs_root
 class MustGatherContext(ExecutionContext):
     """Recognizes must-gather archives"""
-    marker = "namespaces"
+    marker = "cluster-scoped-resources"
 
 
 class OpenStackContext(ExecutionContext):


### PR DESCRIPTION
The current marker 'namespaces' matches RHCOS SOSReport archives. RHCOS SOS-Report archives are always identified as MustGatherContext instead of SosArchiveContext, thus no rule hits result when running rules against RHCOS SOS-Report. The commit changes the marker of MustGatherContext to 'cluster-scoped-resources' to avoid matching RHCOS SOSReport.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
