### PR TITLE
Fix: Fix error with umask not being restored when dir exists

### DIFF
--- a/insights/tests/test_fs.py
+++ b/insights/tests/test_fs.py
@@ -45,21 +45,28 @@ def test_exists_ensure_path_exists():
     assert os.path.exists(path)
 
 
-@pytest.fixture(params=['644', '775', '777'])
+@pytest.fixture(params=[('644', '644'), ('775', '755'), ('777', '755')])
 def mode(request):
     yield request.param
 
 
 @pytest.fixture
 def mode_dir(mode):
-    path = os.path.join('/tmp/insights-test-{mode}'.format(mode=mode))
+    path = os.path.join('/tmp/insights-test-{mode}'.format(mode=mode[0]))
     yield path
     fs.remove(path)
 
 
 def test_ensure_path_mode(mode, mode_dir):
-    fs.ensure_path(mode_dir, int(mode, 8))
-    assert oct(os.stat(mode_dir).st_mode)[-3:] == mode
+    fs.ensure_path(mode_dir, int(mode[0], 8))
+    assert oct(os.stat(mode_dir).st_mode)[-3:] == mode[1]
+
+
+def test_ensure_path_mode_default():
+    path = os.path.join('/tmp/insights-test-default')
+    fs.ensure_path(path)
+    assert oct(os.stat(path).st_mode)[-3:] == '755'
+    fs.remove(path)
 
 
 def test_touch_times():

--- a/insights/util/fs.py
+++ b/insights/util/fs.py
@@ -69,7 +69,7 @@ def remove(path, chmod=False):
     subproc.call(cmd)
 
 
-def ensure_path(path, mode=0o777):
+def ensure_path(path, mode=0o755):
     """Ensure that path exists in a multiprocessing safe way.
 
     If the path does not exist, recursively create it and its parent
@@ -94,11 +94,12 @@ def ensure_path(path, mode=0o777):
     """
 
     if path:
+        umask = os.umask(0o022)
         try:
-            umask = os.umask(000)
             os.makedirs(path, mode)
             os.umask(umask)
         except OSError as e:
+            os.umask(umask)
             if e.errno != errno.EEXIST:
                 raise
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Addresses BZs 2088120 and 2104839 where the archive yum updates.xml
  and the locally created archive were being left in world writable
  state.
* Change default umask and mode to more reasonable values as defaults
* Updated tests

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>