### PR TITLE
fix: Restrict Sphinx's version since it breaks docs build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ develop = set([
 
 docs = set([
     'docutils',
-    'Sphinx',
+    'Sphinx<=5.0.2',
     'nbsphinx',
     'sphinx_rtd_theme',
     'ipython',


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
The release of v5.1.0 breaks docs build for a lot of projects apparently according to the issue on their project. So restrict the version to v5.0.2 and below.
