### PR TITLE
New location for temp directory

### DIFF
--- a/insights/client/archive.py
+++ b/insights/client/archive.py
@@ -17,6 +17,7 @@ import atexit
 
 from .utilities import determine_hostname, _expand_paths, write_data_to_file
 from .insights_spec import InsightsFile, InsightsCommand
+from .constants import InsightsConstants as constants
 
 logger = logging.getLogger(__name__)
 
@@ -42,11 +43,13 @@ class InsightsArchive(object):
         """
         self.config = config
         self.cleanup_previous_archive()
+        if not os.path.exists(constants.insights_tmp_path):
+            os.mkdir(constants.insights_tmp_path, 0o700)
         # input this to core collector as `tmp_path`
-        self.tmp_dir = tempfile.mkdtemp(dir='/var/tmp/', prefix='insights-archive-')
+        self.tmp_dir = tempfile.mkdtemp(dir=constants.insights_tmp_path, prefix='insights-archive-')
 
         # we don't really need this anymore...
-        self.archive_tmp_dir = tempfile.mkdtemp(dir='/var/tmp/', prefix='insights-archive-')
+        self.archive_tmp_dir = tempfile.mkdtemp(dir=constants.insights_tmp_path, prefix='insights-archive-')
 
         # We should not hint the hostname in the archive if it has to be obfuscated
         if config.obfuscate_hostname:
@@ -250,7 +253,8 @@ class InsightsArchive(object):
         '''
         Used at the start, this will clean the temporary directory of previous killed runs
         '''
-        for file in glob.glob('/var/tmp/insights-archive-*'):
+        archive_glob = os.path.join(constants.insights_tmp_path, 'insights-archive-*')
+        for file in glob.glob(archive_glob):
             os.path.join('', file)
             logger.debug("Deleting previous archive %s", file)
             shutil.rmtree(file, True)

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -78,7 +78,8 @@ class InsightsConstants(object):
     sig_kill_bad = 101
     cached_branch_info = os.path.join(default_conf_dir, '.branch_info')
     pidfile = os.path.join(os.sep, 'var', 'run', 'insights-client.pid')
-    egg_release_file = os.path.join(os.sep, 'var', 'tmp', 'insights-client', 'insights-client-egg-release')
+    insights_tmp_path = os.path.join(os.sep, 'var', 'tmp', 'insights-client')
+    egg_release_file = os.path.join(insights_tmp_path, 'insights-client-egg-release')
     ppidfile = os.path.join(os.sep, 'tmp', 'insights-client.ppid')
     valid_compressors = ("gz", "xz", "bz2", "none")
     # RPM version in which core collection was released


### PR DESCRIPTION
Signed-off-by: ahitacat <ahitacat@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

This PR adds a new temporary directory for use during the collection of the archive. Insights-client was using `var/tmp/` with this modification the new temporary path is `/var/tmp/insights-client`. This change is motivated by:
1) SELinux denials
2) Alignment with the use of others directories