### PR TITLE
Automatically retry malware-detection downloads & uploads

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -373,10 +373,12 @@ class MalwareDetectionClient:
                 # Remove extras slashes (/) in the file name and leading double slashes too (normpath doesn't)
                 item = os.path.normpath(item).replace('//', '/')
                 # Assume the item represents a filesystem item
-                if os.path.exists(item):
-                    self.scan_fsobjects.append(item)
-                else:
+                if not os.path.exists(item):
                     logger.info("Skipping missing filesystem_scan_only item: '%s'", item)
+                elif os.path.islink(item):
+                    logger.info("Skipping symlink filesystem_scan_only item: '%s'.  Please use non-symlink items", item)
+                else:
+                    self.scan_fsobjects.append(item)
 
             if self.scan_fsobjects:
                 logger.info("Scan only the specified filesystem item%s: %s", "s" if len(self.scan_fsobjects) > 1 else "",
@@ -402,12 +404,17 @@ class MalwareDetectionClient:
                 filesystem_scan_exclude = [filesystem_scan_exclude]
             for item in filesystem_scan_exclude:
                 item = os.path.normpath(item).replace('//', '/')
-                if os.path.exists(item):
-                    self.filesystem_scan_exclude_list.append(item)
+                if not os.path.exists(item):
+                    logger.info("Skipping missing filesystem_scan_exclude item: '%s'", item)
+                elif os.path.islink(item):
+                    logger.info("Skipping symlink filesystem_scan_exclude item: '%s'.  Please use non-symlink items", item)
                 else:
-                    logger.debug("Skipping missing filesystem_scan_exclude item: '%s'", item)
-            logger.info("Excluding specified filesystem item%s: %s", "s" if len(self.filesystem_scan_exclude_list) > 1 else "",
-                        self.filesystem_scan_exclude_list)
+                    self.filesystem_scan_exclude_list.append(item)
+            if self.filesystem_scan_exclude_list:
+                logger.info("Excluding specified filesystem item%s: %s", "s" if len(self.filesystem_scan_exclude_list) > 1 else "",
+                            self.filesystem_scan_exclude_list)
+            else:
+                logger.info("Unable to find the items specified for the filesystem_scan_exclude option.  Not excluding any filesystem items")
 
     @staticmethod
     def _parse_processes_scan_option(option_items):
@@ -504,7 +511,7 @@ class MalwareDetectionClient:
                 logger.info("Excluding specified process ID%s: %s", "s" if len(self.processes_scan_exclude_list) > 1 else "",
                             self.processes_scan_exclude_list)
             else:
-                logger.error("Unable to find the items specified for the processes_scan_exclude option.  Skipping ...")
+                logger.error("Unable to find the items specified for the processes_scan_exclude option.  Not excluding any processes.")
 
     def _parse_filesystem_scan_since_option(self):
         """
@@ -655,16 +662,24 @@ class MalwareDetectionClient:
             log_rule_contents = True
 
         logger.debug("Downloading rules from: %s", self.rules_location)
-        try:
-            self.insights_config.cert_verify = True
-            conn = InsightsConnection(self.insights_config)
-            response = conn.get(self.rules_location, log_response_text=log_rule_contents)
-            if response.status_code != 200:
-                logger.error("%s %s: %s", response.status_code, response.reason, response.text)
-                exit(constants.sig_kill_bad)
-        except Exception as e:
-            logger.error("Unable to download rules from %s: %s", self.rules_location, str(e))
-            exit(constants.sig_kill_bad)
+        self.insights_config.cert_verify = True
+        conn = InsightsConnection(self.insights_config)
+
+        for attempt in range(1, self.insights_config.retries + 1):
+            try:
+                response = conn.get(self.rules_location, log_response_text=log_rule_contents)
+                if response.status_code != 200:
+                    raise Exception("%s %s: %s" % (response.status_code, response.reason, response.text))
+                break
+            except Exception as e:
+                if attempt < self.insights_config.retries:
+                    logger.debug("Unable to download rules from %s: %s", self.rules_location, str(e))
+                    retry_delay = attempt ** 2
+                    logger.debug("Trying again in %d seconds ...", retry_delay)
+                    time.sleep(retry_delay)
+                else:
+                    logger.error("Unable to download rules from %s: %s", self.rules_location, str(e))
+                    exit(constants.sig_kill_bad)
 
         self.temp_rules_file = NamedTemporaryFile(prefix='tmp_malware-detection-client_rules.', mode='wb', delete=True)
         self.temp_rules_file.write(response.content)

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -786,6 +786,7 @@ class InsightsConfig(object):
             self.content_type = content_types.get(self.app)
             self.core_collect = True
             self.legacy_upload = False
+            self._set_app_config()
         if self.output_dir:
             # get full path
             self.output_dir = os.path.abspath(self.output_dir)
@@ -825,6 +826,15 @@ class InsightsConfig(object):
             #   Therefore, only force legacy_upload to False when attempting
             #   to change Ansible hostname from the CLI, when not registering.
             self.legacy_upload = False
+
+    def _set_app_config(self):
+        '''
+        Set App specific insights config values that differ from the default values
+        Config values may have been set manually however, so need to take that into consideration
+        '''
+        if self.app == 'malware-detection':
+            if self.retries < 5:
+                self.retries = 5
 
     def _determine_filename_and_extension(self):
         '''

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -54,8 +54,9 @@ GET_RULES_TARGET = "insights.client.apps.malware_detection.MalwareDetectionClien
 BUILD_YARA_COMMAND_TARGET = "insights.client.apps.malware_detection.MalwareDetectionClient._build_yara_command"
 FINDMNT_TARGET = "insights.client.apps.malware_detection.MalwareDetectionClient._parse_exclude_network_filesystem_mountpoints_option"
 
-# Run the test_processes_scan_since test?
+# Run these slowish tests?
 TEST_PROCESSES_SCAN_SINCE = getenv_bool("TEST_PROCESSES_SCAN_SINCE", False)
+TEST_DOWNLOAD_FAILURE_RETRIES = getenv_bool("TEST_DOWNLOAD_FAILURE_RETRIES", False)
 
 # Are we running on RHEL6? (well actually, with python 2.6)
 IS_RHEL6 = sys.version_info < (2, 7)
@@ -290,35 +291,32 @@ class TestGetRules:
         # Test the standard rules_location urls, with basic auth attempting to be used to download the rules
         # Basic auth is used by default, but needs to have a valid username and password for it to work
         # Without a username and password, then cert auth will be used
+        expected_rules_url = "https://console.redhat.com/api/malware-detection/v1/test-rule.yar"
 
         # Test with just a username specified - expect basic auth to be used but fails
         get.return_value = Mock(status_code=401, reason="Unauthorized", text="No can do")
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(username='user'))
-        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar",
-                               log_response_text=True)
-        log_mock.error.assert_called_with("%s %s: %s", 401, "Unauthorized", ANY)
+        get.assert_called_with(expected_rules_url, log_response_text=True)
+        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "401 Unauthorized: No can do")
 
         # Test with just a password specified - expect basic auth to be used but fails
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(password='pass'))
-        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar",
-                               log_response_text=True)
-        log_mock.error.assert_called_with("%s %s: %s", 401, "Unauthorized", ANY)
+        get.assert_called_with(expected_rules_url, log_response_text=True)
+        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "401 Unauthorized: No can do")
 
         # Test with 'incorrect' username and/or password - expect basic auth failure
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(username='user', password='badpass'))
-        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar",
-                               log_response_text=True)
-        log_mock.error.assert_called_with("%s %s: %s", 401, "Unauthorized", ANY)
+        get.assert_called_with(expected_rules_url, log_response_text=True)
+        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "401 Unauthorized: No can do")
 
         # Test with 'correct' username and password - expect basic auth success
         get.return_value = Mock(status_code=200, content=b"Rule Content")
         mdc = MalwareDetectionClient(InsightsConfig(username='user', password='goodpass'))
-        assert mdc.rules_location == "https://console.redhat.com/api/malware-detection/v1/test-rule.yar"
-        get.assert_called_with("https://console.redhat.com/api/malware-detection/v1/test-rule.yar",
-                               log_response_text=True)
+        assert mdc.rules_location == expected_rules_url
+        get.assert_called_with(expected_rules_url, log_response_text=True)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'false'})
     @patch("os.path.exists", return_value=True)  # mock call to os.path.exists in _find_yara
@@ -400,11 +398,13 @@ class TestGetRules:
     def test_download_failures(self, log_mock, yara, conf, cmd, session, proxies, get, findmnt, remove):
         from requests.exceptions import ConnectionError, Timeout
         # Test various problems downloading rules
+        expected_rules_url = os.environ['RULES_LOCATION']
+
         # 404 error - unlikely to occur unless an incorrect rules_location was manually specified
         get.return_value = Mock(status_code=404, reason="Not found", text="Nup")
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig())
-        log_mock.error.assert_called_with("%s %s: %s", 404, "Not found", "Nup")
+        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "404 Not found: Nup")
         assert get.call_count == 1
 
         # Test other errors downloading rules from the backend - these are more likely to occur
@@ -412,17 +412,49 @@ class TestGetRules:
         get.side_effect = [ConnectionError("Couldn't connect"), Timeout("Timeout")]
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(username='user', password='pass'))
-        log_mock.error.assert_called_with("Unable to download rules from %s: %s",
-                                          os.environ['RULES_LOCATION'], "Couldn't connect")
+        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "Couldn't connect")
         assert get.call_count == 2
 
         # Then handling a Timeout error
         # Note, because we aren't downloading from console.redhat.com, there won't be 'cert.*' appended to the URL
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig())
-        log_mock.error.assert_called_with("Unable to download rules from %s: %s",
-                                          os.environ['RULES_LOCATION'], "Timeout")
+        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "Timeout")
         assert get.call_count == 3
+
+    @pytest.mark.skipif(not TEST_DOWNLOAD_FAILURE_RETRIES,
+                        reason='test_download_failure_retries is slow due to the inherent delay in the retry logic. '
+                               'Use TEST_DOWNLOAD_FAILURE_RETRIES=True to enable test')
+    @patch.dict(os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'http://localhost/rules.yar'})
+    @patch(FIND_YARA_TARGET, return_value=YARA)
+    @patch(LOGGER_TARGET)
+    def test_download_failure_retries(self, log_mock, yara, conf, cmd, session, proxies, get, findmnt, remove):
+        from requests.exceptions import ConnectionError
+        # Testing the download failure retry logic
+        expected_rules_url = os.environ['RULES_LOCATION']
+
+        # Status code != 200 will trigger a retry, but only if retries > 1
+        get.return_value = Mock(status_code=404, reason="Not found", text="Nup")
+        with pytest.raises(SystemExit):
+            MalwareDetectionClient(InsightsConfig(retries=1))
+        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "404 Not found: Nup")
+        # Last call to logger.debug will be about downloading rules, not about retrying, which shows retrying wasn't invoked
+        log_mock.debug.assert_called_with('Downloading rules from: %s', expected_rules_url)
+
+        # Set retries > 1 and now retrying happens
+        with pytest.raises(SystemExit):
+            MalwareDetectionClient(InsightsConfig(retries=2))
+        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "404 Not found: Nup")
+        # This time, the last call to logger.debug will be about retrying the download
+        log_mock.debug.assert_called_with("Trying again in %d seconds ...", 1)
+
+        # Other network errors that raise an exception will trigger a retry
+        get.side_effect = ConnectionError("Couldn't connect")
+        with pytest.raises(SystemExit):
+            MalwareDetectionClient(InsightsConfig(retries=3))
+        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "Couldn't connect")
+        # Because we've set retries to 3, the last attempted retry will wait 4 seconds (= 2**2)
+        log_mock.debug.assert_called_with("Trying again in %d seconds ...", 4)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': '//console.redhat.com/rules.yar'})
     @patch(FIND_YARA_TARGET, return_value=YARA)
@@ -914,6 +946,34 @@ class TestMalwareDetectionOptions:
 
     @patch("insights.client.apps.malware_detection.call")
     @patch(LOGGER_TARGET)
+    @patch.dict(os.environ, {'TEST_SCAN': 'false'})
+    def test_filesystem_scan_only_exclude_symlinks(self, log_mock, call_mock, yara, rules, cmd, extract_tmp_files, create_test_files):
+        # Testing using symlinks for filesystem scan_only and scan_exclude items
+        # Symlinks will be skipped, whereas broken symlinks are treated like missing files
+        symlink = os.path.join(TEMP_TEST_DIR, 'scan_me/link_file')
+        broken_symlink = os.path.join(TEMP_TEST_DIR, 'scan_me/broken_link')
+        os.environ['FILESYSTEM_SCAN_ONLY'] = "%s,%s" % (symlink, broken_symlink)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            with pytest.raises(SystemExit):
+                mdc = MalwareDetectionClient(None)
+                assert mdc.scan_fsobjects == []
+        log_mock.info.assert_any_call("Skipping symlink filesystem_scan_only item: '%s'.  Please use non-symlink items", symlink)
+        log_mock.info.assert_any_call("Skipping missing filesystem_scan_only item: '%s'", broken_symlink)
+        log_mock.error.assert_called_with("Nothing to scan with filesystem_scan_only option and scan_processes is disabled")
+
+        scan_only = os.path.join(TEMP_TEST_DIR, 'scan_me')
+        os.environ['FILESYSTEM_SCAN_ONLY'] = scan_only
+        os.environ['FILESYSTEM_SCAN_EXCLUDE'] = "%s,%s" % (symlink, broken_symlink)
+        with patch("insights.client.apps.malware_detection.MALWARE_CONFIG_FILE", TEMP_CONFIG_FILE):
+            mdc = MalwareDetectionClient(None)
+        assert mdc.filesystem_scan_exclude_list == []
+        assert mdc.scan_fsobjects == [scan_only]
+        log_mock.info.assert_any_call("Skipping symlink filesystem_scan_exclude item: '%s'.  Please use non-symlink items", symlink)
+        log_mock.info.assert_any_call("Skipping missing filesystem_scan_exclude item: '%s'", broken_symlink)
+        log_mock.info.assert_any_call("Unable to find the items specified for the filesystem_scan_exclude option.  Not excluding any filesystem items")
+
+    @patch("insights.client.apps.malware_detection.call")
+    @patch(LOGGER_TARGET)
     def test_network_filesystem_mountpoints(self, log_mock, call_mock, yara, rules, cmd, extract_tmp_files, create_test_files):
         # Test the exclude_network_filesystem_mountpoints option by 'creating' various mountpoints to exclude
         os.environ['EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'] = 'true'  # Override the default setting for this test class
@@ -1108,7 +1168,7 @@ class TestMalwareDetectionOptions:
         assert mdc.scan_pids == ['1']
         assert mdc.processes_scan_exclude_list == []
         log_mock.error.assert_any_call("Unable to parse '%s' in to a range of PIDs: %s", '3..ten', ANY)
-        log_mock.error.assert_any_call("Unable to find the items specified for the processes_scan_exclude option.  Skipping ...")
+        log_mock.error.assert_any_call("Unable to find the items specified for the processes_scan_exclude option.  Not excluding any processes.")
 
 
 @pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)


### PR DESCRIPTION
Signed-off-by: Mark Huth <mhuth@redhat.com>

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

This PR sets the number of download/upload retries for malware-detection to 5.  This is especially important for uploads because we don't want to fail after one unsuccessful attempt to upload the results archive.  Doing a malware scan could take a long time, and if we are unable to upload the archive, then insights-client fails and deletes the archive, which would waste all that effort in doing the scan, and be an unhappy user experience.  A better user experience would be to at least retry uploading the archive a number of times before failing.  (An even better user experience would be to keep the archive instead of deleting it  but that's another PR for another day.)