### PR TITLE
Feat: Add spec and parser for cryptsetup luksDump

### DIFF
--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -101,7 +101,7 @@ insights.specs.datasources.lpstat
 
 
 insights.specs.datasources.luks_devices
----------------------------------
+---------------------------------------
 
 .. automodule:: insights.specs.datasources.luks_devices
     :members: LUKS_block_devices, LocalSpecs, LUKS_data_sources

--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -104,7 +104,7 @@ insights.specs.datasources.luks_devices
 ---------------------------------------
 
 .. automodule:: insights.specs.datasources.luks_devices
-    :members: LUKS_block_devices, LocalSpecs, LUKS_data_sources
+    :members: Luks_block_devices, LocalSpecs, Luks_data_sources
     :show-inheritance:
     :undoc-members:
 

--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -99,6 +99,15 @@ insights.specs.datasources.lpstat
     :show-inheritance:
     :undoc-members:
 
+
+insights.specs.datasources.luks_devices
+---------------------------------
+
+.. automodule:: insights.specs.datasources.luks_devices
+    :members: LUKS_block_devices, LocalSpecs, LUKS_data_sources
+    :show-inheritance:
+    :undoc-members:
+
 insights.specs.datasources.malware_detection
 --------------------------------------------
 

--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -104,7 +104,7 @@ insights.specs.datasources.luks_devices
 ---------------------------------------
 
 .. automodule:: insights.specs.datasources.luks_devices
-    :members: Luks_block_devices, LocalSpecs, Luks_data_sources
+    :members: luks_block_devices, luks_data_sources, LocalSpecs
     :show-inheritance:
     :undoc-members:
 

--- a/docs/shared_components_catalog/cryptsetup.rst
+++ b/docs/shared_components_catalog/cryptsetup.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.components.cryptsetup
+   :members:
+   :show-inheritance:

--- a/docs/shared_parsers_catalog/cryptsetup_luksDump.rst
+++ b/docs/shared_parsers_catalog/cryptsetup_luksDump.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.cryptsetup_luksDump
+   :members:
+   :show-inheritance:

--- a/insights/collect.py
+++ b/insights/collect.py
@@ -244,6 +244,13 @@ plugins:
     # needed because some specs aren't given names before they're used in DefaultSpecs
         - name: insights.core.spec_factory
           enabled: true
+
+    # needed by the 'luks_data_sources' spec
+        - name: insights.parsers.blkid.BlockIDInfo
+          enabled: true
+
+        - name: insights.components.cryptsetup
+          enabled: true
 """.strip()
 
 

--- a/insights/components/cryptsetup.py
+++ b/insights/components/cryptsetup.py
@@ -1,0 +1,55 @@
+"""
+HasCryptsetupWithTokens, HasCryptsetupWithoutTokens
+===================================================
+
+The ``HasCryptsetupWithTokens``/``HasCryptsetupWithoutTokens`` component uses
+``InstalledRpms`` parser to determine if cryptsetup package is installed and if
+it has tokens support (since version 2.4.0), if not it raises ``SkipComponent``
+so that the dependent component will not fire. Can be added as a dependency of
+a parser so that the parser only fires if the ``cryptsetup`` dependency and
+token support is met.
+"""
+from insights.core.plugins import component
+from insights.parsers.installed_rpms import InstalledRpms, InstalledRpm
+from insights.core.dr import SkipComponent
+
+
+@component(InstalledRpms)
+class HasCryptsetupWithTokens(object):
+    """The ``HasCryptsetupWithTokens`` component uses ``InstalledRpms`` parser
+    to determine if cryptsetup package is installed and if it has tokens
+    support (since version 2.4.0), if not it raises ``SkipComponent``
+
+    Raises:
+        SkipComponent: When ``cryptsetup`` package is strictly less than 2.4.0,
+        or when cryptsetup package is not installed
+    """
+    def __init__(self, rpms):
+        rpm = rpms.get_max("cryptsetup")
+
+        if rpm is None:
+            raise SkipComponent("cryptsetup package is not installed")
+
+        if rpm < InstalledRpm("cryptsetup-2.4.0-0"):
+            raise SkipComponent("cryptsetup package with token support is not installed")
+
+
+@component(InstalledRpms)
+class HasCryptsetupWithoutTokens(object):
+    """The ``HasCryptsetupWithoutTokens`` component uses ``InstalledRpms``
+    parser to determine if cryptsetup package is installed and if it does not
+    have tokens support (below version 2.4.0), if not it raises
+    ``SkipComponent``
+
+    Raises:
+        SkipComponent: When ``cryptsetup`` package is at least 2.4.0, or when
+        cryptsetup package is not installed
+    """
+    def __init__(self, rpms):
+        rpm = rpms.get_max("cryptsetup")
+
+        if rpm is None:
+            raise SkipComponent("cryptsetup package is not installed")
+
+        if rpm >= InstalledRpm("cryptsetup-2.4.0-0"):
+            raise SkipComponent("cryptsetup package with token support is installed")

--- a/insights/parsers/cryptsetup_luksDump.py
+++ b/insights/parsers/cryptsetup_luksDump.py
@@ -36,19 +36,19 @@ class DocParser(object):
         FirstLevelKVPair = FirstIndent >> Key + Value1
         SecondLevelKVPair = SecondIndent >> WithIndent(Key + Value)
 
-        LUKS2SectionName = Key << Char("\n")
-        LUKS2SectionEntry = (FirstLevelKVPair + Many(SecondLevelKVPair).map(dict)).map(self.convert_type)
-        LUKS2Section = LUKS2SectionName + Many(LUKS2SectionEntry).map(dict) << Opt(Many(Char("\n")))
-        LUKS2Body = Many(LUKS2Section, lower=1)
+        Luks2SectionName = Key << Char("\n")
+        Luks2SectionEntry = (FirstLevelKVPair + Many(SecondLevelKVPair).map(dict)).map(self.convert_type)
+        Luks2Section = Luks2SectionName + Many(Luks2SectionEntry).map(dict) << Opt(Many(Char("\n")))
+        Luks2Body = Many(Luks2Section, lower=1)
 
-        LUKS1Section = ZeroLevelKVPair + Many(SecondLevelKVPair).map(dict) << Opt(Many(Char("\n")))
-        LUKS1Body = Many(LUKS1Section.map(self.convert_status), lower=1)
+        Luks1Section = ZeroLevelKVPair + Many(SecondLevelKVPair).map(dict) << Opt(Many(Char("\n")))
+        Luks1Body = Many(Luks1Section.map(self.convert_status), lower=1)
 
         KVBlock = Many(Key + Value1).map(dict)
-        LUKS_Header = (FirstLine + KVBlock) << Opt(Many(Char("\n")))
+        Luks_Header = (FirstLine + KVBlock) << Opt(Many(Char("\n")))
 
-        # LUKS2Body has to go first, because LUKS1Body consumes also valid LUKS2 bodies
-        self.Top = Lift(self.join_header_and_body) * LUKS_Header * (LUKS2Body | LUKS1Body) << EOF
+        # Luks2Body has to go first, because Luks1Body consumes also valid Luks2 bodies
+        self.Top = Lift(self.join_header_and_body) * Luks_Header * (Luks2Body | Luks1Body) << EOF
 
     def join_header_and_body(self, header, body):
         return dict([header] + body)
@@ -69,7 +69,7 @@ class DocParser(object):
 
 
 @parser(Specs.cryptsetup_luksDump)
-class LUKS_Dump(Parser):
+class Luks_dump(Parser):
     """
     Sample input data is in the format::
 
@@ -121,7 +121,7 @@ class LUKS_Dump(Parser):
 
     Examples:
         >>> type(parsed_result)
-        <class 'insights.parsers.cryptsetup_luksDump.LUKS_Dump'>
+        <class 'insights.parsers.cryptsetup_luksDump.Luks_dump'>
 
         >>> from pprint import pprint
         >>> pprint(parsed_result.dump["header"])
@@ -163,7 +163,7 @@ class LUKS_Dump(Parser):
 
     def __init__(self, context):
         self.parse_dump = DocParser()
-        super(LUKS_Dump, self).__init__(context)
+        super(Luks_dump, self).__init__(context)
 
     def parse_content(self, content):
         if len(content) == 0 or (len(content) == 1 and "not a valid LUKS" in content[0]):

--- a/insights/parsers/cryptsetup_luksDump.py
+++ b/insights/parsers/cryptsetup_luksDump.py
@@ -1,6 +1,6 @@
 """
-Luks_dump - command ``cryptsetup luksDump``
-===========================================
+LuksDump - command ``cryptsetup luksDump``
+==========================================
 This class provides parsing for the output of cryptsetup luksDump
 <device_name>. Outputs from LUKS1 and LUKS2 are supported.
 """
@@ -45,10 +45,10 @@ class DocParser(object):
         Luks1Body = Many(Luks1Section.map(self.convert_status), lower=1)
 
         KVBlock = Many(Key + Value1).map(dict)
-        Luks_Header = (FirstLine + KVBlock) << Opt(Many(Char("\n")))
+        LuksHeader = (FirstLine + KVBlock) << Opt(Many(Char("\n")))
 
         # Luks2Body has to go first, because Luks1Body consumes also valid Luks2 bodies
-        self.Top = Lift(self.join_header_and_body) * Luks_Header * (Luks2Body | Luks1Body) << EOF
+        self.Top = Lift(self.join_header_and_body) * LuksHeader * (Luks2Body | Luks1Body) << EOF
 
     def join_header_and_body(self, header, body):
         return dict([header] + body)
@@ -69,7 +69,7 @@ class DocParser(object):
 
 
 @parser(Specs.cryptsetup_luksDump)
-class Luks_dump(Parser):
+class LuksDump(Parser):
     """
     Sample input data is in the format::
 
@@ -121,7 +121,7 @@ class Luks_dump(Parser):
 
     Examples:
         >>> type(parsed_result)
-        <class 'insights.parsers.cryptsetup_luksDump.Luks_dump'>
+        <class 'insights.parsers.cryptsetup_luksDump.LuksDump'>
 
         >>> from pprint import pprint
         >>> pprint(parsed_result.dump["header"])
@@ -163,7 +163,7 @@ class Luks_dump(Parser):
 
     def __init__(self, context):
         self.parse_dump = DocParser()
-        super(Luks_dump, self).__init__(context)
+        super(LuksDump, self).__init__(context)
 
     def parse_content(self, content):
         if len(content) == 0 or (len(content) == 1 and "not a valid LUKS" in content[0]):

--- a/insights/parsers/cryptsetup_luksDump.py
+++ b/insights/parsers/cryptsetup_luksDump.py
@@ -100,6 +100,8 @@ class LUKS_Dump(Parser):
                 Time cost:  7
                 Memory:     1048576
                 Threads:    4
+                Salt:       3d c4 1b 52 fe 1c 90 d8 2a 35 b2 62 34 e9 0a 59 
+                            e9 0e 48 57 b2 dd 45 9e ed 9a 33 1e 07 cd 2a 19 
                 AF stripes: 4000
                 AF hash:    sha256
                 Area offset:32768 [bytes]
@@ -112,38 +114,45 @@ class LUKS_Dump(Parser):
           0: pbkdf2
                 Hash:       sha256
                 Iterations: 129774
+                Salt:       e6 31 d5 74 e0 65 83 82 35 03 29 56 0e 80 36 5c 
+                            4d cd 4d f9 de 69 39 97 d5 b3 ac c4 fd c5 ca 50 
+                Digest:     21 aa b3 dc 9d 46 9b 0f 3a 0f 57 13 80 c6 0b bf 
+                            67 66 9e 73 ed 7d 09 2c 3d b6 fa f4 fe 0c ce 67 
 
     Examples:
-        >>> type(dump)
+        >>> type(parsed_result)
         <class 'insights.parsers.cryptsetup_luksDump.LUKS_Dump'>
 
-        >>> dump.dump["header"]
-        {'Version': '2',
-         'Epoch': '6',
-         'Metadata area': '16384 [bytes]',
+        >>> from pprint import pprint
+        >>> pprint(parsed_result.dump["header"])
+        {'Epoch': '6',
+         'Flags': '(no flags)',
          'Keyslots area': '16744448 [bytes]',
-         'UUID': 'cfbcc942-e06b-4c4a-952f-e9c9b2011c27',
          'Label': '(no label)',
+         'Metadata area': '16384 [bytes]',
          'Subsystem': '(no subsystem)',
-         'Flags': '(no flags)'}
+         'UUID': 'cfbcc942-e06b-4c4a-952f-e9c9b2011c27',
+         'Version': '2'}
 
-        >>> dump.dump["Keyslots"]["0"]
-        {'Key': '512 bits',
-         'Priority': 'normal',
+        >>> pprint(parsed_result.dump["Keyslots"]["0"])
+        {'AF hash': 'sha256',
+         'AF stripes': '4000',
+         'Area length': '258048 [bytes]',
+         'Area offset': '32768 [bytes]',
          'Cipher': 'aes-xts-plain64',
          'Cipher key': '512 bits',
-         'PBKDF': 'argon2id',
-         'Time cost': '7',
-         'Memory': '1048576',
-         'Threads': '4',
-         'AF stripes': '4000',
-         'AF hash': 'sha256',
-         'Area offset': '32768 [bytes]',
-         'Area length': '258048 [bytes]',
          'Digest ID': '0',
+         'Key': '512 bits',
+         'Memory': '1048576',
+         'PBKDF': 'argon2id',
+         'Priority': 'normal',
+         'Salt': '3d c4 1b 52 fe 1c 90 d8 2a 35 b2 62 34 e9 0a 59 e9 0e 48 57 b2 dd 45 '
+                 '9e ed 9a 33 1e 07 cd 2a 19',
+         'Threads': '4',
+         'Time cost': '7',
          'type': 'luks2'}
 
-        >>> dump.dump["Tokens"]["0"]["type"]
+        >>> parsed_result.dump["Tokens"]["0"]["type"]
         'systemd-tpm2'
 
 

--- a/insights/parsers/cryptsetup_luksDump.py
+++ b/insights/parsers/cryptsetup_luksDump.py
@@ -101,7 +101,7 @@ class LUKS_Dump(Parser):
                 Memory:     1048576
                 Threads:    4
                 Salt:       3d c4 1b 52 fe 1c 90 d8 2a 35 b2 62 34 e9 0a 59 
-                            e9 0e 48 57 b2 dd 45 9e ed 9a 33 1e 07 cd 2a 19 
+                            e9 0e 48 57 b2 dd 45 
                 AF stripes: 4000
                 AF hash:    sha256
                 Area offset:32768 [bytes]
@@ -115,9 +115,9 @@ class LUKS_Dump(Parser):
                 Hash:       sha256
                 Iterations: 129774
                 Salt:       e6 31 d5 74 e0 65 83 82 35 03 29 56 0e 80 36 5c 
-                            4d cd 4d f9 de 69 39 97 d5 b3 ac c4 fd c5 ca 50 
+                            4d cd 4d f9 de 69 39 97 
                 Digest:     21 aa b3 dc 9d 46 9b 0f 3a 0f 57 13 80 c6 0b bf 
-                            67 66 9e 73 ed 7d 09 2c 3d b6 fa f4 fe 0c ce 67 
+                            67 66 9e 73 ed 7d 09 2c 
 
     Examples:
         >>> type(parsed_result)
@@ -146,8 +146,7 @@ class LUKS_Dump(Parser):
          'Memory': '1048576',
          'PBKDF': 'argon2id',
          'Priority': 'normal',
-         'Salt': '3d c4 1b 52 fe 1c 90 d8 2a 35 b2 62 34 e9 0a 59 e9 0e 48 57 b2 dd 45 '
-                 '9e ed 9a 33 1e 07 cd 2a 19',
+         'Salt': '3d c4 1b 52 fe 1c 90 d8 2a 35 b2 62 34 e9 0a 59 e9 0e 48 57 b2 dd 45',
          'Threads': '4',
          'Time cost': '7',
          'type': 'luks2'}

--- a/insights/parsers/cryptsetup_luksDump.py
+++ b/insights/parsers/cryptsetup_luksDump.py
@@ -160,7 +160,7 @@ class LUKS_Dump(Parser):
         dump(dict of dicts): A top level dict containing the dictionaries
             representing the header, data segments, keyslots, digests
             and tokens.
-    """ # noqa
+    """  # noqa
 
     def __init__(self, context):
         self.parse_dump = DocParser()

--- a/insights/parsers/cryptsetup_luksDump.py
+++ b/insights/parsers/cryptsetup_luksDump.py
@@ -156,7 +156,8 @@ class LUKS_Dump(Parser):
             representing the header, data segments, keyslots, digests
             and tokens.
 
-    """
+    """ # noqa
+
     def parse_dump(self, text):
         self.dump = None
         header = LUKS_Header(text)
@@ -170,6 +171,6 @@ class LUKS_Dump(Parser):
 
     def parse_content(self, content):
         try:
-            self.dump = self.parse_dump("\n".join(content).replace("\t", " "*8) + "\n")
+            self.dump = self.parse_dump("\n".join(content).replace("\t", " " * 8) + "\n")
         except:
             self.dump = None

--- a/insights/parsers/cryptsetup_luksDump.py
+++ b/insights/parsers/cryptsetup_luksDump.py
@@ -1,0 +1,175 @@
+"""
+LUKS_Dump - command ``cryptsetup luksDump``
+============================================================
+This class provides parsing for the output of cryptsetup luksDump
+<device_name>. Outputs from LUKS1 and LUKS2 are supported.
+"""
+
+from insights import parser, Parser
+from insights.specs import Specs
+import string
+
+from insights.parsr import Literal, AnyChar, Char, Opt, String, WS, HangingString, WithIndent, Many
+
+
+def convert_type(section):
+    section[1]["type"] = section[0][1]
+    return [section[0][0], section[1]]
+
+
+def convert_status(section):
+    section[2]["status"] = section[1]
+    return [section[0], section[2]]
+
+
+value_chars = set(string.printable) - set("\n\r")
+
+FirstLine = Literal("LUKS header information", value="header") << AnyChar.until(Char("\n")) + Opt(Many(Char("\n")))
+FirstIndent = Literal("  ")
+# we need to replace the \t by 8 spaces in the input,
+# otherwise WithIndent does not work properly
+# SecondIndent = Literal("\t")
+SecondIndent = Literal(" " * 8)
+
+Key = String(value_chars - set(":")) << Char(":") % "Key"
+Value = WS >> HangingString(value_chars) % "Value"
+
+MultilineContinuation = Many((Char("\n") + Literal(" " * 15) + SecondIndent) >> String(value_chars))
+Value1 = WS >> String(value_chars) + Opt(MultilineContinuation).map(lambda x: "".join(x)) << Char("\n")
+Value1 = Value1.map(lambda x: ("".join(x)).strip())
+
+ZeroLevelKVPair = Key + Value1
+FirstLevelKVPair = FirstIndent >> Key + Value1
+SecondLevelKVPair = SecondIndent >> WithIndent(Key + Value)
+
+LUKS2SectionName = Key << Char("\n")
+LUKS2SectionEntry = (FirstLevelKVPair + Many(SecondLevelKVPair).map(dict)).map(convert_type)
+LUKS2Section = LUKS2SectionName + Many(LUKS2SectionEntry).map(dict) << Opt(Many(Char("\n")))
+LUKS2Body = Many(LUKS2Section).map(dict)
+
+LUKS1Section = ZeroLevelKVPair + Many(SecondLevelKVPair).map(dict) << Opt(Many(Char("\n")))
+LUKS1Body = Many(LUKS1Section.map(convert_status)).map(dict)
+
+KVBlock = Many(Key + Value1).map(dict)
+LUKS_Header = (FirstLine + KVBlock) << Opt(Many(Char("\n")))
+LUKS_Header = LUKS_Header.map(lambda x: dict([x]))
+
+
+@parser(Specs.cryptsetup_luksDump)
+class LUKS_Dump(Parser):
+    """
+    Sample input data is in the format::
+
+        LUKS header information
+        Version:       	2
+        Epoch:         	6
+        Metadata area: 	16384 [bytes]
+        Keyslots area: 	16744448 [bytes]
+        UUID:          	cfbcc942-e06b-4c4a-952f-e9c9b2011c27
+        Label:         	(no label)
+        Subsystem:     	(no subsystem)
+        Flags:       	(no flags)
+
+        Data segments:
+          0: crypt
+                offset: 16777216 [bytes]
+                length: (whole device)
+                cipher: aes-xts-plain64
+                sector: 4096 [bytes]
+
+        Keyslots:
+          0: luks2
+                Key:        512 bits
+                Priority:   normal
+                Cipher:     aes-xts-plain64
+                Cipher key: 512 bits
+                PBKDF:      argon2id
+                Time cost:  7
+                Memory:     1048576
+                Threads:    4
+                AF stripes: 4000
+                AF hash:    sha256
+                Area offset:32768 [bytes]
+                Area length:258048 [bytes]
+                Digest ID:  0
+        Tokens:
+          0: systemd-tpm2
+                Keyslot:    2
+        Digests:
+          0: pbkdf2
+                Hash:       sha256
+                Iterations: 129774
+
+    Examples:
+        >>> type(ros_input)
+        <class 'insights.parsers.ros_config.RosConfig'>
+        >>> ros_input.rules[0]['allow_disallow']
+        'disallow'
+        >>> ros_input.rules[0]['hostlist']
+        ['.*']
+        >>> ros_input.rules[0]['operationlist']
+        ['all']
+        >>> ros_input.specs[0].get('state')
+        'mandatory on'
+        >>> ros_input.specs[0].get('metrics')['mem.util.used']
+        []
+        >>> ros_input.specs[0].get('metrics')['kernel.all.cpu.user']
+        []
+        >>> ros_input.specs[0].get('logging_interval')
+        'default'
+
+        >>> type(dump)
+        Out[6]: insights.parsers.cryptsetup_luksDump.LUKS_Dump
+
+        >>> dump.dump["header"]
+        {'Version': '2',
+         'Epoch': '6',
+         'Metadata area': '16384 [bytes]',
+         'Keyslots area': '16744448 [bytes]',
+         'UUID': 'cfbcc942-e06b-4c4a-952f-e9c9b2011c27',
+         'Label': '(no label)',
+         'Subsystem': '(no subsystem)',
+         'Flags': '(no flags)'}
+
+        >>> dump.dump["Keyslots"]["0"]
+        {'Key': '512 bits',
+         'Priority': 'normal',
+         'Cipher': 'aes-xts-plain64',
+         'Cipher key': '512 bits',
+         'PBKDF': 'argon2id',
+         'Time cost': '7',
+         'Memory': '1048576',
+         'Threads': '4',
+         'AF stripes': '4000',
+         'AF hash': 'sha256',
+         'Area offset': '32768 [bytes]',
+         'Area length': '258048 [bytes]',
+         'Digest ID': '0',
+         'type': 'luks2'}
+
+        >>> dump.dump["Tokens"]["0"]["type"]
+        'systemd-tpm2'
+
+
+    Attributes:
+        dump(dict of dicts): A top level dict containing the dictionaries
+            representing the header, data segments, keyslots, digests
+            and tokens.
+
+    """
+    def parse_dump(self, text):
+        self.dump = None
+        header = LUKS_Header(text)
+
+        if header["header"]["Version"] == "1":
+            header, body = (LUKS_Header + LUKS1Body)(text)
+            return header | body
+        elif header["header"]["Version"] == "2":
+            header, body = (LUKS_Header + LUKS2Body)(text)
+            return header | body
+
+    def parse_content(self, content):
+        try:
+            self.dump = self.parse_dump("\n".join(content).replace("\t", " "*8) + "\n")
+        except:
+            self.dump = None

--- a/insights/parsers/cryptsetup_luksDump.py
+++ b/insights/parsers/cryptsetup_luksDump.py
@@ -1,6 +1,6 @@
 """
-LUKS_Dump - command ``cryptsetup luksDump``
-============================================================
+Luks_dump - command ``cryptsetup luksDump``
+===========================================
 This class provides parsing for the output of cryptsetup luksDump
 <device_name>. Outputs from LUKS1 and LUKS2 are supported.
 """

--- a/insights/parsers/cryptsetup_luksDump.py
+++ b/insights/parsers/cryptsetup_luksDump.py
@@ -5,54 +5,67 @@ This class provides parsing for the output of cryptsetup luksDump
 <device_name>. Outputs from LUKS1 and LUKS2 are supported.
 """
 
-from insights import parser, Parser
+from insights import parser, Parser, SkipComponent
+from insights.parsers import ParseException
+from insights.parsr import (Literal, AnyChar, Char, Opt, String, WS,
+                            HangingString, WithIndent, Many, EOF, Lift)
 from insights.specs import Specs
+
 import string
 
-from insights.parsr import Literal, AnyChar, Char, Opt, String, WS, HangingString, WithIndent, Many
 
+class DocParser(object):
+    def __init__(self):
+        value_chars = set(string.printable) - set("\n\r")
 
-def convert_type(section):
-    section[1]["type"] = section[0][1]
-    return [section[0][0], section[1]]
+        FirstLine = Literal("LUKS header information", value="header") << AnyChar.until(Char("\n")) + Opt(Many(Char("\n")))
+        FirstIndent = Literal("  ")
+        # we need to replace the \t by 8 spaces in the input,
+        # otherwise WithIndent does not work properly
+        # SecondIndent = Literal("\t")
+        SecondIndent = Literal(" " * 8)
 
+        Key = String(value_chars - set(":")) << Char(":") % "Key"
+        Value = WS >> HangingString(value_chars) % "Value"
 
-def convert_status(section):
-    section[2]["status"] = section[1]
-    return [section[0], section[2]]
+        MultilineContinuation = Many((Char("\n") + Literal(" " * 15) + SecondIndent) >> String(value_chars))
+        Value1 = WS >> String(value_chars) + Opt(MultilineContinuation).map(lambda x: "".join(x)) << Char("\n")
+        Value1 = Value1.map(lambda x: ("".join(x)).strip())
 
+        ZeroLevelKVPair = Key + Value1
+        FirstLevelKVPair = FirstIndent >> Key + Value1
+        SecondLevelKVPair = SecondIndent >> WithIndent(Key + Value)
 
-value_chars = set(string.printable) - set("\n\r")
+        LUKS2SectionName = Key << Char("\n")
+        LUKS2SectionEntry = (FirstLevelKVPair + Many(SecondLevelKVPair).map(dict)).map(self.convert_type)
+        LUKS2Section = LUKS2SectionName + Many(LUKS2SectionEntry).map(dict) << Opt(Many(Char("\n")))
+        LUKS2Body = Many(LUKS2Section, lower=1)
 
-FirstLine = Literal("LUKS header information", value="header") << AnyChar.until(Char("\n")) + Opt(Many(Char("\n")))
-FirstIndent = Literal("  ")
-# we need to replace the \t by 8 spaces in the input,
-# otherwise WithIndent does not work properly
-# SecondIndent = Literal("\t")
-SecondIndent = Literal(" " * 8)
+        LUKS1Section = ZeroLevelKVPair + Many(SecondLevelKVPair).map(dict) << Opt(Many(Char("\n")))
+        LUKS1Body = Many(LUKS1Section.map(self.convert_status), lower=1)
 
-Key = String(value_chars - set(":")) << Char(":") % "Key"
-Value = WS >> HangingString(value_chars) % "Value"
+        KVBlock = Many(Key + Value1).map(dict)
+        LUKS_Header = (FirstLine + KVBlock) << Opt(Many(Char("\n")))
 
-MultilineContinuation = Many((Char("\n") + Literal(" " * 15) + SecondIndent) >> String(value_chars))
-Value1 = WS >> String(value_chars) + Opt(MultilineContinuation).map(lambda x: "".join(x)) << Char("\n")
-Value1 = Value1.map(lambda x: ("".join(x)).strip())
+        # LUKS2Body has to go first, because LUKS1Body consumes also valid LUKS2 bodies
+        self.Top = Lift(self.join_header_and_body) * LUKS_Header * (LUKS2Body | LUKS1Body) << EOF
 
-ZeroLevelKVPair = Key + Value1
-FirstLevelKVPair = FirstIndent >> Key + Value1
-SecondLevelKVPair = SecondIndent >> WithIndent(Key + Value)
+    def join_header_and_body(self, header, body):
+        return dict([header] + body)
 
-LUKS2SectionName = Key << Char("\n")
-LUKS2SectionEntry = (FirstLevelKVPair + Many(SecondLevelKVPair).map(dict)).map(convert_type)
-LUKS2Section = LUKS2SectionName + Many(LUKS2SectionEntry).map(dict) << Opt(Many(Char("\n")))
-LUKS2Body = Many(LUKS2Section).map(dict)
+    def convert_type(self, section):
+        section[1]["type"] = section[0][1]
+        return [section[0][0], section[1]]
 
-LUKS1Section = ZeroLevelKVPair + Many(SecondLevelKVPair).map(dict) << Opt(Many(Char("\n")))
-LUKS1Body = Many(LUKS1Section.map(convert_status)).map(dict)
+    def convert_status(self, section):
+        section[2]["status"] = section[1]
+        return [section[0], section[2]]
 
-KVBlock = Many(Key + Value1).map(dict)
-LUKS_Header = (FirstLine + KVBlock) << Opt(Many(Char("\n")))
-LUKS_Header = LUKS_Header.map(lambda x: dict([x]))
+    def __call__(self, content):
+        try:
+            return self.Top(content)
+        except Exception:
+            raise ParseException("There was an exception when parsing one of the outputs of cryptsetup luksDump commands.")
 
 
 @parser(Specs.cryptsetup_luksDump)
@@ -101,25 +114,8 @@ class LUKS_Dump(Parser):
                 Iterations: 129774
 
     Examples:
-        >>> type(ros_input)
-        <class 'insights.parsers.ros_config.RosConfig'>
-        >>> ros_input.rules[0]['allow_disallow']
-        'disallow'
-        >>> ros_input.rules[0]['hostlist']
-        ['.*']
-        >>> ros_input.rules[0]['operationlist']
-        ['all']
-        >>> ros_input.specs[0].get('state')
-        'mandatory on'
-        >>> ros_input.specs[0].get('metrics')['mem.util.used']
-        []
-        >>> ros_input.specs[0].get('metrics')['kernel.all.cpu.user']
-        []
-        >>> ros_input.specs[0].get('logging_interval')
-        'default'
-
         >>> type(dump)
-        Out[6]: insights.parsers.cryptsetup_luksDump.LUKS_Dump
+        <class 'insights.parsers.cryptsetup_luksDump.LUKS_Dump'>
 
         >>> dump.dump["header"]
         {'Version': '2',
@@ -155,22 +151,13 @@ class LUKS_Dump(Parser):
         dump(dict of dicts): A top level dict containing the dictionaries
             representing the header, data segments, keyslots, digests
             and tokens.
-
     """ # noqa
 
-    def parse_dump(self, text):
-        self.dump = None
-        header = LUKS_Header(text)
-
-        if header["header"]["Version"] == "1":
-            header, body = (LUKS_Header + LUKS1Body)(text)
-            return header | body
-        elif header["header"]["Version"] == "2":
-            header, body = (LUKS_Header + LUKS2Body)(text)
-            return header | body
+    def __init__(self, context):
+        self.parse_dump = DocParser()
+        super(LUKS_Dump, self).__init__(context)
 
     def parse_content(self, content):
-        try:
-            self.dump = self.parse_dump("\n".join(content).replace("\t", " " * 8) + "\n")
-        except:
-            self.dump = None
+        if len(content) == 0 or (len(content) == 1 and "not a valid LUKS" in content[0]):
+            raise SkipComponent
+        self.dump = self.parse_dump("\n".join(content).replace("\t", " " * 8) + "\n")

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -102,6 +102,7 @@ class Specs(SpecSet):
     crypto_policies_state_current = RegistryPoint()
     crypto_policies_opensshserver = RegistryPoint()
     crypto_policies_bind = RegistryPoint()
+    cryptsetup_luksDump = RegistryPoint(multi_output=True)
     crt = RegistryPoint()
     cups_ppd = RegistryPoint(multi_output=True)
     current_clocksource = RegistryPoint()

--- a/insights/specs/datasources/luks_devices.py
+++ b/insights/specs/datasources/luks_devices.py
@@ -11,7 +11,7 @@ import re
 
 
 @datasource(BlockIDInfo, HostContext)
-def Luks_block_devices(broker):
+def luks_block_devices(broker):
     """
     This datasource provides a list of LUKS encrypted device.
 
@@ -36,14 +36,14 @@ def Luks_block_devices(broker):
     raise SkipComponent
 
 
-@datasource(Luks_block_devices)
+@datasource(luks_block_devices)
 class LocalSpecs(Specs):
     """ Local specs used only by LUKS_data_sources datasource. """
-    cryptsetup_luksDump_commands = foreach_execute(Luks_block_devices, "cryptsetup luksDump --disable-external-tokens %s")
+    cryptsetup_luks_dump_commands = foreach_execute(luks_block_devices, "cryptsetup luksDump --disable-external-tokens %s")
 
 
-@datasource(HostContext, LocalSpecs.cryptsetup_luksDump_commands)
-def Luks_data_sources(broker):
+@datasource(HostContext, LocalSpecs.cryptsetup_luks_dump_commands)
+def luks_data_sources(broker):
     """
     This datasource provides the output of 'cryptsetup luksDump' command for
     every LUKS encrypted device on the system. The digest and salt fields are
@@ -58,7 +58,7 @@ def Luks_data_sources(broker):
     """
     datasources = []
 
-    for command in broker[LocalSpecs.cryptsetup_luksDump_commands]:
+    for command in broker[LocalSpecs.cryptsetup_luks_dump_commands]:
         regex = re.compile(r'[\t ]*(MK digest:|MK salt:|Salt:|Digest:)(\s*([a-z0-9][a-z0-9] ){16}\n)*(\s*([a-z0-9][a-z0-9] )+\n)?', flags=re.IGNORECASE)
         filtered_content = regex.sub("", "\n".join(command.content) + "\n")
 

--- a/insights/specs/datasources/luks_devices.py
+++ b/insights/specs/datasources/luks_devices.py
@@ -1,0 +1,32 @@
+"""
+Custom datasource for gathering a list of encrypted LUKS block devices.
+"""
+from insights.core.context import HostContext
+from insights.core.dr import SkipComponent
+from insights.core.plugins import datasource
+from insights.parsers.blkid import BlockIDInfo
+
+
+@datasource(BlockIDInfo, HostContext)
+def LUKS_block_devices(broker):
+    """
+    This datasource provides a list of LUKS encrypted device.
+
+    Sample data returned::
+
+        ['/dev/sda', '/dev/nvme0n1p3']
+
+    Returns:
+        list: List of the LUKS encrypted block devices.
+
+    Raises:
+        SkipComponent: When there is not any LUKS encrypted block device.
+    """
+
+    block_id = broker[BlockIDInfo]
+    if block_id:
+        devices = block_id.filter_by_type("crypto_LUKS")
+        if devices:
+            return sorted(map(lambda x: x["NAME"], devices))
+
+    raise SkipComponent

--- a/insights/specs/datasources/luks_devices.py
+++ b/insights/specs/datasources/luks_devices.py
@@ -11,7 +11,7 @@ import re
 
 
 @datasource(BlockIDInfo, HostContext)
-def LUKS_block_devices(broker):
+def Luks_block_devices(broker):
     """
     This datasource provides a list of LUKS encrypted device.
 
@@ -36,14 +36,14 @@ def LUKS_block_devices(broker):
     raise SkipComponent
 
 
-@datasource(LUKS_block_devices)
+@datasource(Luks_block_devices)
 class LocalSpecs(Specs):
     """ Local specs used only by LUKS_data_sources datasource. """
-    cryptsetup_luksDump_commands = foreach_execute(LUKS_block_devices, "cryptsetup luksDump --disable-external-tokens %s")
+    cryptsetup_luksDump_commands = foreach_execute(Luks_block_devices, "cryptsetup luksDump --disable-external-tokens %s")
 
 
 @datasource(HostContext, LocalSpecs.cryptsetup_luksDump_commands)
-def LUKS_data_sources(broker):
+def Luks_data_sources(broker):
     """
     This datasource provides the output of 'cryptsetup luksDump' command for
     every LUKS encrypted device on the system. The digest and salt fields are

--- a/insights/specs/datasources/luks_devices.py
+++ b/insights/specs/datasources/luks_devices.py
@@ -59,9 +59,6 @@ def Luks_data_sources(broker):
     datasources = []
 
     for command in broker[LocalSpecs.cryptsetup_luksDump_commands]:
-        print(command.content)
-        print(type(command.content))
-
         regex = re.compile(r'[\t ]*(MK digest:|MK salt:|Salt:|Digest:)(\s*([a-z0-9][a-z0-9] ){16}\n)*(\s*([a-z0-9][a-z0-9] )+\n)?', flags=re.IGNORECASE)
         filtered_content = regex.sub("", "\n".join(command.content) + "\n")
 

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -145,7 +145,7 @@ class DefaultSpecs(Specs):
     crypto_policies_state_current = simple_file("/etc/crypto-policies/state/current")
     crypto_policies_opensshserver = simple_file("/etc/crypto-policies/back-ends/opensshserver.config")
     crypto_policies_bind = simple_file("/etc/crypto-policies/back-ends/bind.config")
-    cryptsetup_luksDump = luks_devices.Luks_data_sources
+    cryptsetup_luksDump = luks_devices.luks_data_sources
     cups_ppd = glob_file("etc/cups/ppd/*")
     current_clocksource = simple_file("/sys/devices/system/clocksource/clocksource0/current_clocksource")
     date = simple_command("/bin/date")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -145,7 +145,7 @@ class DefaultSpecs(Specs):
     crypto_policies_state_current = simple_file("/etc/crypto-policies/state/current")
     crypto_policies_opensshserver = simple_file("/etc/crypto-policies/back-ends/opensshserver.config")
     crypto_policies_bind = simple_file("/etc/crypto-policies/back-ends/bind.config")
-    cryptsetup_luksDump = foreach_execute(luks_devices.LUKS_block_devices, "bash -c '/usr/sbin/cryptsetup --disable-external-tokens luksDump %s | sed -z \"s/[\\t ]*\\(MK digest:\\|MK salt:\\|Salt:\\|Digest:\\)\\(\\s*\\([a-z0-9][a-z0-9] \\)\\{16\\}\\n\\)*\\(\\s*\\([a-z0-9][a-z0-9] \\)\\+\\n\\)\\?//g\"'")
+    cryptsetup_luksDump = luks_devices.LUKS_data_sources
     cups_ppd = glob_file("etc/cups/ppd/*")
     current_clocksource = simple_file("/sys/devices/system/clocksource/clocksource0/current_clocksource")
     date = simple_command("/bin/date")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -26,7 +26,7 @@ from insights.specs.datasources import (
     aws, awx_manage, cloud_init, candlepin_broker, corosync as corosync_ds,
     dir_list, ethernet, httpd, ipcs, kernel_module_list, lpstat, md5chk,
     package_provides, ps as ps_datasource, sap, satellite_missed_queues,
-    ssl_certificate, sys_fs_cgroup_memory_tasks_number, system_user_dirs, user_group, yum_updates)
+    ssl_certificate, sys_fs_cgroup_memory_tasks_number, system_user_dirs, user_group, yum_updates, luks_devices)
 from insights.specs.datasources.sap import sap_hana_sid, sap_hana_sid_SID_nr
 from insights.specs.datasources.pcp import pcp_enabled, pmlog_summary_args
 
@@ -145,6 +145,7 @@ class DefaultSpecs(Specs):
     crypto_policies_state_current = simple_file("/etc/crypto-policies/state/current")
     crypto_policies_opensshserver = simple_file("/etc/crypto-policies/back-ends/opensshserver.config")
     crypto_policies_bind = simple_file("/etc/crypto-policies/back-ends/bind.config")
+    cryptsetup_luksDump = foreach_execute(luks_devices.LUKS_block_devices, "bash -c '/usr/sbin/cryptsetup --disable-external-tokens luksDump %s | sed -z \"s/[\\t ]*\\(MK digest:\\|MK salt:\\|Salt:\\|Digest:\\)\\(\\s*\\([a-z0-9][a-z0-9] \\)\\{16\\}\\n\\)*\\(\\s*\\([a-z0-9][a-z0-9] \\)\\+\\n\\)\\?//g\"'")
     cups_ppd = glob_file("etc/cups/ppd/*")
     current_clocksource = simple_file("/sys/devices/system/clocksource/clocksource0/current_clocksource")
     date = simple_command("/bin/date")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -145,7 +145,7 @@ class DefaultSpecs(Specs):
     crypto_policies_state_current = simple_file("/etc/crypto-policies/state/current")
     crypto_policies_opensshserver = simple_file("/etc/crypto-policies/back-ends/opensshserver.config")
     crypto_policies_bind = simple_file("/etc/crypto-policies/back-ends/bind.config")
-    cryptsetup_luksDump = luks_devices.LUKS_data_sources
+    cryptsetup_luksDump = luks_devices.Luks_data_sources
     cups_ppd = glob_file("etc/cups/ppd/*")
     current_clocksource = simple_file("/sys/devices/system/clocksource/clocksource0/current_clocksource")
     date = simple_command("/bin/date")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -38,7 +38,6 @@ class InsightsArchiveSpecs(Specs):
         "insights_commands/find_.etc.origin.node_.etc.origin.master_.etc.pki_.etc.ipa_-type_f_-exec_.usr.bin.openssl_x509_-noout_-enddate_-in_-exec_echo_FileName",
         "insights_commands/find_.etc.origin.node_.etc.origin.master_.etc.pki_-type_f_-exec_.usr.bin.openssl_x509_-noout_-enddate_-in_-exec_echo_FileName"
     ])
-    cryptsetup_luksDump = glob_file("insights_commands/bash_-c_.usr.sbin.cryptsetup_--disable-external-tokens_luksDump*")
     chkconfig = simple_file("insights_commands/chkconfig_--list")
     chronyc_sources = simple_file("insights_commands/chronyc_sources")
     corosync_cmapctl = glob_file("insights_commands/corosync-cmapctl*")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -38,6 +38,7 @@ class InsightsArchiveSpecs(Specs):
         "insights_commands/find_.etc.origin.node_.etc.origin.master_.etc.pki_.etc.ipa_-type_f_-exec_.usr.bin.openssl_x509_-noout_-enddate_-in_-exec_echo_FileName",
         "insights_commands/find_.etc.origin.node_.etc.origin.master_.etc.pki_-type_f_-exec_.usr.bin.openssl_x509_-noout_-enddate_-in_-exec_echo_FileName"
     ])
+    cryptsetup_luksDump = glob_file("insights_commands/bash_-c_.usr.sbin.cryptsetup_--disable-external-tokens_luksDump*")
     chkconfig = simple_file("insights_commands/chkconfig_--list")
     chronyc_sources = simple_file("insights_commands/chronyc_sources")
     corosync_cmapctl = glob_file("insights_commands/corosync-cmapctl*")

--- a/insights/tests/components/test_cryptsetup.py
+++ b/insights/tests/components/test_cryptsetup.py
@@ -1,0 +1,36 @@
+import pytest
+
+from insights import SkipComponent
+from insights.components.cryptsetup import HasCryptsetupWithTokens, HasCryptsetupWithoutTokens
+from insights.parsers.installed_rpms import InstalledRpms
+from insights.tests import context_wrap
+
+RPMS_TOKENS_SUPPORT = "cryptsetup-2.4.3-2.fc36.x86_64"
+RPMS_NO_TOKENS_SUPPORT = "cryptsetup-2.0.3-6.el7.x86_64"
+RPMS_CRYPTSETUP_NOT_INSTALLED = "cryptsetup-libs-2.0.3-6.el7.x86_64"
+
+
+def test_has_cryptsetup_with_tokens():
+    rpms = InstalledRpms(context_wrap(RPMS_TOKENS_SUPPORT))
+    HasCryptsetupWithTokens(rpms)
+
+    rpms = InstalledRpms(context_wrap(RPMS_NO_TOKENS_SUPPORT))
+    with pytest.raises(SkipComponent):
+        HasCryptsetupWithTokens(rpms)
+
+    rpms = InstalledRpms(context_wrap(RPMS_CRYPTSETUP_NOT_INSTALLED))
+    with pytest.raises(SkipComponent):
+        HasCryptsetupWithTokens(rpms)
+
+
+def test_has_cryptsetup_without_tokens():
+    rpms = InstalledRpms(context_wrap(RPMS_NO_TOKENS_SUPPORT))
+    HasCryptsetupWithoutTokens(rpms)
+
+    rpms = InstalledRpms(context_wrap(RPMS_TOKENS_SUPPORT))
+    with pytest.raises(SkipComponent):
+        HasCryptsetupWithoutTokens(rpms)
+
+    rpms = InstalledRpms(context_wrap(RPMS_CRYPTSETUP_NOT_INSTALLED))
+    with pytest.raises(SkipComponent):
+        HasCryptsetupWithoutTokens(rpms)

--- a/insights/tests/datasources/test_luks_devices.py
+++ b/insights/tests/datasources/test_luks_devices.py
@@ -1,7 +1,7 @@
 from mock.mock import Mock
 
 from insights.parsers.blkid import BlockIDInfo
-from insights.specs.datasources.luks_devices import LocalSpecs, LUKS_data_sources, LUKS_block_devices
+from insights.specs.datasources.luks_devices import LocalSpecs, Luks_data_sources, Luks_block_devices
 from insights.tests import context_wrap
 
 
@@ -144,7 +144,7 @@ def test_luks_devices_listing():
     blkid = BlockIDInfo(context_wrap(BLKID_INFO))
     broker = {BlockIDInfo: blkid}
 
-    luks_devices = LUKS_block_devices(broker)
+    luks_devices = Luks_block_devices(broker)
     assert set(luks_devices) == set(["/dev/loop0", "/dev/nvme0n1p3"])
 
 
@@ -153,7 +153,7 @@ def test_luks1_filtering():
     command.content = LUKS1_DUMP.splitlines()
     command.cmd = "cryptsetup luksDump /dev/sda"
     broker = {LocalSpecs.cryptsetup_luksDump_commands: [command]}
-    result = LUKS_data_sources(broker)
+    result = Luks_data_sources(broker)
 
     assert len(result) == 1
 
@@ -170,7 +170,7 @@ def test_luks2_filtering():
     command.content = LUKS2_DUMP.splitlines()
     command.cmd = "cryptsetup luksDump /dev/sda"
     broker = {LocalSpecs.cryptsetup_luksDump_commands: [command]}
-    result = LUKS_data_sources(broker)
+    result = Luks_data_sources(broker)
 
     assert len(result) == 1
 

--- a/insights/tests/datasources/test_luks_devices.py
+++ b/insights/tests/datasources/test_luks_devices.py
@@ -1,0 +1,184 @@
+from mock.mock import Mock
+
+from insights.parsers.blkid import BlockIDInfo
+from insights.specs.datasources.luks_devices import LocalSpecs, LUKS_data_sources, LUKS_block_devices
+from insights.tests import context_wrap
+
+
+LUKS1_DUMP = """LUKS header information for luks1
+
+Version:       	1
+Cipher name:   	aes
+Cipher mode:   	xts-plain64
+Hash spec:     	sha256
+Payload offset:	4096
+MK bits:       	512
+MK digest:     	ca fe ba be df 8c c4 b4 b8 0a cc dd 98 b5 d8 64 3a 95 3e 9e 
+MK salt:       	ca fe ba be 04 3b 77 d8 ff 08 1e 0a 41 68 45 a5 
+               	ca fe ba be 7b 3f a9 69 9c 9b 51 24 58 47 8d a2 
+               	ca fe ba be 7b 3f a9 69 9c 9b 51 24 58 47 8d a2 
+               	ca fe ba be 7b 3f a9 69 9c 9b 51 24 58 47 8d a2 
+               	ca fe ba be 7b 3f a9 69 9c 9b 51 24 58 47 8d a2 
+               	ca fe ba be 7b 3f a9 69 9c de ad be ef 
+MK iterations: 	106562
+UUID:          	263902da-5f0c-43a9-82eb-cc6f14d90448
+
+Key Slot 0: ENABLED
+	Iterations:         	2099250
+	Salt:               	de ad be ef 
+	Salt:               	ca fe ba be a1 f3 ae cb 4a 3f f0 2d de ad be ef 
+	                      	de ad be ef 
+	Key material offset:	8
+	AF stripes:            	4000
+Key Slot 1: ENABLED
+	Iterations:         	1987820
+	Salt:               	ca fe ba be f2 b7 7d f3 29 c2 c8 80 de ad be ef 
+	                      	ca fe ba be 9f a1 87 07 c6 4f aa cd de ad be ef 
+	                      	ca fe ba be 9f a1 87 07 c6 4f aa de ad be ef 
+	Key material offset:	512
+	AF stripes:            	4000
+Key Slot 2: ENABLED
+	Iterations:         	2052006
+	Salt:               	ca fe ba be 47 94 e7 40 22 c1 bb 4a de ad be ef 
+	                      	ca fe ba be 52 e8 8d 70 b2 1e 9d 47 de ad be ef 
+	Key material offset:	1016
+	AF stripes:            	4000
+Key Slot 3: DISABLED
+Key Slot 4: DISABLED
+Key Slot 5: DISABLED
+Key Slot 6: DISABLED
+Key Slot 7: DISABLED
+""" # noqa
+
+LUKS2_DUMP = """LUKS header information
+Version:       	2
+Epoch:         	6
+Metadata area: 	16384 [bytes]
+Keyslots area: 	16744448 [bytes]
+UUID:          	cfbcc942-e06b-4c4a-952f-e9c9b2011c27
+Label:         	(no label)
+Subsystem:     	(no subsystem)
+Flags:       	(no flags)
+
+Data segments:
+  0: crypt
+	offset: 16777216 [bytes]
+	length: (whole device)
+	cipher: aes-xts-plain64
+	sector: 4096 [bytes]
+
+Keyslots:
+  0: luks2
+	Key:        512 bits
+	Priority:   normal
+	Cipher:     aes-xts-plain64
+	Cipher key: 512 bits
+	PBKDF:      argon2id
+	Time cost:  7
+	Memory:     1048576
+	Threads:    4
+	Salt:       ca fe ba be fe 1c 90 d8 2a 35 b2 b2 de ad be ef 
+	            ca fe ba be b2 dd 45 9e ed 9a 33 b2 de ad be ef 
+                    de ad be ef 
+	AF stripes: 4000
+	AF hash:    sha256
+	Area offset:32768 [bytes]
+	Area length:258048 [bytes]
+	Digest ID:  0
+  1: luks2
+	Key:        512 bits
+	Priority:   normal
+	Cipher:     aes-xts-plain64
+	Cipher key: 512 bits
+	PBKDF:      argon2id
+	Time cost:  7
+	Memory:     1048576
+	Threads:    4
+	Salt:       ca fe ba be c1 94 15 86 2a e9 26 f8 de ad be ef 
+	            ca fe ba be 05 2d 80 c9 56 e8 4d 6f de ad be ef 
+	AF stripes: 4000
+	AF hash:    sha256
+	Area offset:290816 [bytes]
+	Area length:258048 [bytes]
+	Digest ID:  0
+  2: luks2
+	Key:        512 bits
+	Priority:   normal
+	Cipher:     aes-xts-plain64
+	Cipher key: 512 bits
+	PBKDF:      pbkdf2
+	Hash:       sha512
+	Iterations: 1000
+	Salt:       ca fe ba be d7 8f a6 de a0 cb a4 d1 de ad be ef 
+	            ca fe ba be fb 53 43 06 e8 83 90 93 de ad be ef 
+	AF stripes: 4000
+	AF hash:    sha512
+	Area offset:548864 [bytes]
+	Area length:258048 [bytes]
+	Digest ID:  0
+Tokens:
+  0: systemd-tpm2
+	Keyslot:    2
+Digests:
+  0: pbkdf2
+	Hash:       sha256
+	Iterations: 129774
+	Salt:       ca fe ba be e0 65 83 82 35 03 29 56 de ad be ef 
+	            ca fe ba be de 69 39 97 d5 b3 ac c4 de ad be ef 
+                    de ad be ef 
+	Digest:     ca fe ba be 9d 46 9b 0f 3a 0f 57 13 de ad be ef 
+	            ca fe ba be ed 7d 09 2c 3d b6 fa f4 de ad be ef 
+""" # noqa
+
+BLKID_INFO = """
+/dev/nvme0n1p3: UUID="3676157d-f2f5-465c-a4c3-3c2a52c8d3f4" TYPE="crypto_LUKS" PARTUUID="d403bcbd-0eea-4bff-95b9-2237740f5c8b"
+/dev/nvme0n1p1: UUID="1950-8713" BLOCK_SIZE="512" TYPE="vfat" PARTLABEL="EFI System Partition" PARTUUID="004d0ca3-373f-4d44-a085-c19c47da8b5e"
+/dev/nvme0n1p2: LABEL="BOOTFS" UUID="UVTk76-UWOc-vk7s-galL-dxIP-4UXO-0jG4MH" BLOCK_SIZE="4096" TYPE="ext4" PARTUUID="f8508c37-eeb1-4598-b084-5364d489031f"
+/dev/loop0: UUID="11124c1d-990b-4277-9f74-c5a34eb2cd04" TYPE="crypto_LUKS"
+/dev/mapper/luks-d32e910a-c65a-4bc7-8cb8-8b0a4ec50dce: UUID="c7c45f2d-1d1b-4cf0-9d51-e2b0046682f8" TYPE="LVM2_member"
+/dev/zram0: LABEL="zram0" UUID="c7116820-f2de-4aee-8ea6-0b23c6491598" TYPE="swap"
+"""
+
+
+def test_luks_devices_listing():
+    blkid = BlockIDInfo(context_wrap(BLKID_INFO))
+    broker = {BlockIDInfo: blkid}
+
+    luks_devices = LUKS_block_devices(broker)
+    assert set(luks_devices) == set(["/dev/loop0", "/dev/nvme0n1p3"])
+
+
+def test_luks1_filtering():
+    command = Mock()
+    command.content = LUKS1_DUMP.splitlines()
+    command.cmd = "cryptsetup luksDump /dev/sda"
+    broker = {LocalSpecs.cryptsetup_luksDump_commands: [command]}
+    result = LUKS_data_sources(broker)
+
+    assert len(result) == 1
+
+    text_result = "\n".join(result[0].content)
+    assert "MK digest:" not in text_result
+    assert "MK salt:" not in text_result
+    assert "MK iterations:" in text_result
+    assert "ca fe ba be" not in text_result
+    assert "de ad be ef" not in text_result
+
+
+def test_luks2_filtering():
+    command = Mock()
+    command.content = LUKS2_DUMP.splitlines()
+    command.cmd = "cryptsetup luksDump /dev/sda"
+    broker = {LocalSpecs.cryptsetup_luksDump_commands: [command]}
+    result = LUKS_data_sources(broker)
+
+    assert len(result) == 1
+
+    text_result = "\n".join(result[0].content)
+    assert "Salt:" not in text_result
+    assert "Digest:" not in text_result
+    assert "ca fe ba be" not in text_result
+    assert "de ad be ef" not in text_result
+
+    assert "AF stripes:" in text_result
+    assert "Digest ID:" in text_result

--- a/insights/tests/datasources/test_luks_devices.py
+++ b/insights/tests/datasources/test_luks_devices.py
@@ -48,7 +48,7 @@ Key Slot 4: DISABLED
 Key Slot 5: DISABLED
 Key Slot 6: DISABLED
 Key Slot 7: DISABLED
-""" # noqa
+"""  # noqa
 
 LUKS2_DUMP = """LUKS header information
 Version:       	2
@@ -128,7 +128,7 @@ Digests:
                     de ad be ef 
 	Digest:     ca fe ba be 9d 46 9b 0f 3a 0f 57 13 de ad be ef 
 	            ca fe ba be ed 7d 09 2c 3d b6 fa f4 de ad be ef 
-""" # noqa
+"""  # noqa
 
 BLKID_INFO = """
 /dev/nvme0n1p3: UUID="3676157d-f2f5-465c-a4c3-3c2a52c8d3f4" TYPE="crypto_LUKS" PARTUUID="d403bcbd-0eea-4bff-95b9-2237740f5c8b"

--- a/insights/tests/datasources/test_luks_devices.py
+++ b/insights/tests/datasources/test_luks_devices.py
@@ -1,7 +1,7 @@
 from mock.mock import Mock
 
 from insights.parsers.blkid import BlockIDInfo
-from insights.specs.datasources.luks_devices import LocalSpecs, Luks_data_sources, Luks_block_devices
+from insights.specs.datasources.luks_devices import LocalSpecs, luks_data_sources, luks_block_devices
 from insights.tests import context_wrap
 
 
@@ -144,7 +144,7 @@ def test_luks_devices_listing():
     blkid = BlockIDInfo(context_wrap(BLKID_INFO))
     broker = {BlockIDInfo: blkid}
 
-    luks_devices = Luks_block_devices(broker)
+    luks_devices = luks_block_devices(broker)
     assert set(luks_devices) == set(["/dev/loop0", "/dev/nvme0n1p3"])
 
 
@@ -152,8 +152,8 @@ def test_luks1_filtering():
     command = Mock()
     command.content = LUKS1_DUMP.splitlines()
     command.cmd = "cryptsetup luksDump /dev/sda"
-    broker = {LocalSpecs.cryptsetup_luksDump_commands: [command]}
-    result = Luks_data_sources(broker)
+    broker = {LocalSpecs.cryptsetup_luks_dump_commands: [command]}
+    result = luks_data_sources(broker)
 
     assert len(result) == 1
 
@@ -169,8 +169,8 @@ def test_luks2_filtering():
     command = Mock()
     command.content = LUKS2_DUMP.splitlines()
     command.cmd = "cryptsetup luksDump /dev/sda"
-    broker = {LocalSpecs.cryptsetup_luksDump_commands: [command]}
-    result = Luks_data_sources(broker)
+    broker = {LocalSpecs.cryptsetup_luks_dump_commands: [command]}
+    result = luks_data_sources(broker)
 
     assert len(result) == 1
 

--- a/insights/tests/parsers/test_cryptsetup_luksDump.py
+++ b/insights/tests/parsers/test_cryptsetup_luksDump.py
@@ -129,41 +129,41 @@ Digests:
 LUKS_BAD_DUMP = "Device /dev/nvme0n1p1 is not a valid LUKS device."
 
 
-def test_cryptsetup_luksDump_Luks1():
-    Luks1Parsed = cryptsetup_luksDump.Luks_dump(context_wrap(LUKS1_DUMP))
-    print(Luks1Parsed.dump)
-    assert Luks1Parsed.dump is not None
-    assert set(Luks1Parsed.dump.keys()) == set(["header"] + ["Key Slot " + str(x) for x in range(8)])
-    assert Luks1Parsed.dump["header"]["Version"] == "1"
-    assert Luks1Parsed.dump["Key Slot 0"]["status"] == "ENABLED"
-    assert Luks1Parsed.dump["Key Slot 7"]["status"] == "DISABLED"
+def test_cryptsetup_luks_dump_luks1():
+    luks1_parsed = cryptsetup_luksDump.LuksDump(context_wrap(LUKS1_DUMP))
+    print(luks1_parsed.dump)
+    assert luks1_parsed.dump is not None
+    assert set(luks1_parsed.dump.keys()) == set(["header"] + ["Key Slot " + str(x) for x in range(8)])
+    assert luks1_parsed.dump["header"]["Version"] == "1"
+    assert luks1_parsed.dump["Key Slot 0"]["status"] == "ENABLED"
+    assert luks1_parsed.dump["Key Slot 7"]["status"] == "DISABLED"
 
 
-def test_cryptsetup_luksDump_Luks2():
-    Luks2_parsed = cryptsetup_luksDump.Luks_dump(context_wrap(LUKS2_DUMP))
-    assert Luks2_parsed.dump is not None
-    assert set(Luks2_parsed.dump.keys()) == set(["header", "Data segments", "Keyslots", "Tokens", "Digests"])
-    assert Luks2_parsed.dump["header"]["Version"] == "2"
-    assert len(Luks2_parsed.dump["Keyslots"].keys()) == 3
-    assert Luks2_parsed.dump["Keyslots"]["0"]["type"] == "luks2"
-    assert len(Luks2_parsed.dump["Data segments"].keys()) == 1
-    assert len(Luks2_parsed.dump["Tokens"].keys()) == 1
-    assert len(Luks2_parsed.dump["Digests"].keys()) == 1
+def test_cryptsetup_luks_dump_luks2():
+    luks2_parsed = cryptsetup_luksDump.LuksDump(context_wrap(LUKS2_DUMP))
+    assert luks2_parsed.dump is not None
+    assert set(luks2_parsed.dump.keys()) == set(["header", "Data segments", "Keyslots", "Tokens", "Digests"])
+    assert luks2_parsed.dump["header"]["Version"] == "2"
+    assert len(luks2_parsed.dump["Keyslots"].keys()) == 3
+    assert luks2_parsed.dump["Keyslots"]["0"]["type"] == "luks2"
+    assert len(luks2_parsed.dump["Data segments"].keys()) == 1
+    assert len(luks2_parsed.dump["Tokens"].keys()) == 1
+    assert len(luks2_parsed.dump["Digests"].keys()) == 1
 
-    assert Luks2_parsed.dump["Tokens"]["0"]["type"] == "systemd-tpm2"
-    assert Luks2_parsed.dump["Keyslots"]["0"]["type"] == "luks2"
+    assert luks2_parsed.dump["Tokens"]["0"]["type"] == "systemd-tpm2"
+    assert luks2_parsed.dump["Keyslots"]["0"]["type"] == "luks2"
 
 
-def test_cryptsetup_luksDump_bad():
+def test_cryptsetup_luks_dump_bad():
     with pytest.raises(SkipComponent):
-        cryptsetup_luksDump.Luks_dump(context_wrap(LUKS_BAD_DUMP)).dump
+        cryptsetup_luksDump.LuksDump(context_wrap(LUKS_BAD_DUMP)).dump
     with pytest.raises(SkipComponent):
-        cryptsetup_luksDump.Luks_dump(context_wrap("")).dump
+        cryptsetup_luksDump.LuksDump(context_wrap("")).dump
 
 
 def test_doc_examples():
     env = {
-            'parsed_result': cryptsetup_luksDump.Luks_dump(context_wrap(LUKS2_DUMP)),
+            'parsed_result': cryptsetup_luksDump.LuksDump(context_wrap(LUKS2_DUMP)),
           }
     failed, total = doctest.testmod(cryptsetup_luksDump, globs=env)
     assert failed == 0

--- a/insights/tests/parsers/test_cryptsetup_luksDump.py
+++ b/insights/tests/parsers/test_cryptsetup_luksDump.py
@@ -1,0 +1,150 @@
+from insights.parsers import cryptsetup_luksDump
+from insights.tests import context_wrap
+
+
+LUKS1_dump = """LUKS header information for luks1
+
+Version:       	1
+Cipher name:   	aes
+Cipher mode:   	xts-plain64
+Hash spec:     	sha256
+Payload offset:	4096
+MK bits:       	512
+MK digest:     	db b8 55 5e df 8c c4 b4 b8 0a cc dd 98 b5 d8 64 3a 95 3e 9e 
+MK salt:       	1b 16 42 cb 04 3b 77 d8 ff 08 1e 0a 41 68 45 a5 
+               	c3 2e 76 04 7b 3f a9 69 9c 9b 51 24 58 47 8d a2 
+               	ca fe ba be 7b 3f a9 69 9c 9b 51 24 58 
+MK iterations: 	106562
+UUID:          	263902da-5f0c-43a9-82eb-cc6f14d90448
+
+Key Slot 0: ENABLED
+	Iterations:         	2099250
+	Salt:               	3d 99 94 f5 a1 f3 ae cb 4a 3f f0 2d 29 46 22 6b 
+	                      	3d 99 94 f5 a1 f3 ae cb 4a 3f f0 2d 29 46 22 6b 
+	                      	4d 25 
+	Key material offset:	8
+	AF stripes:            	4000
+Key Slot 1: ENABLED
+	Iterations:         	1987820
+	Salt:               	27 3c 70 b5 f2 b7 7d f3 29 c2 c8 80 6b ff de cd 
+	                      	aa 58 b3 85 9f a1 87 07 c6 4f aa cd 59 28 97 ea 
+	                      	aa 58 b3 85 9f a1 87 07 c6 4f aa cd 59 28 97 
+	Key material offset:	512
+	AF stripes:            	4000
+Key Slot 2: ENABLED
+	Iterations:         	2052006
+	Salt:               	33 28 f2 0c 47 94 e7 40 22 c1 bb 4a 06 aa f0 5c 
+	                      	38 cc e4 a8 52 e8 8d 70 b2 1e 9d 47 70 a9 f1 2d 
+	Key material offset:	1016
+	AF stripes:            	4000
+Key Slot 3: DISABLED
+Key Slot 4: DISABLED
+Key Slot 5: DISABLED
+Key Slot 6: DISABLED
+Key Slot 7: DISABLED
+"""
+
+LUKS2_dump = """LUKS header information
+Version:       	2
+Epoch:         	6
+Metadata area: 	16384 [bytes]
+Keyslots area: 	16744448 [bytes]
+UUID:          	cfbcc942-e06b-4c4a-952f-e9c9b2011c27
+Label:         	(no label)
+Subsystem:     	(no subsystem)
+Flags:       	(no flags)
+
+Data segments:
+  0: crypt
+	offset: 16777216 [bytes]
+	length: (whole device)
+	cipher: aes-xts-plain64
+	sector: 4096 [bytes]
+
+Keyslots:
+  0: luks2
+	Key:        512 bits
+	Priority:   normal
+	Cipher:     aes-xts-plain64
+	Cipher key: 512 bits
+	PBKDF:      argon2id
+	Time cost:  7
+	Memory:     1048576
+	Threads:    4
+	Salt:       3d c4 1b 52 fe 1c 90 d8 2a 35 b2 62 34 e9 0a 59 
+	            e9 0e 48 57 b2 dd 45 9e ed 9a 33 1e 07 cd 2a 19 
+	AF stripes: 4000
+	AF hash:    sha256
+	Area offset:32768 [bytes]
+	Area length:258048 [bytes]
+	Digest ID:  0
+  1: luks2
+	Key:        512 bits
+	Priority:   normal
+	Cipher:     aes-xts-plain64
+	Cipher key: 512 bits
+	PBKDF:      argon2id
+	Time cost:  7
+	Memory:     1048576
+	Threads:    4
+	Salt:       bb b4 33 41 c1 94 15 86 2a e9 26 f8 d8 16 83 b1 
+	            d0 00 f9 25 05 2d 80 c9 56 e8 4d 6f 75 a2 d5 bf 
+	AF stripes: 4000
+	AF hash:    sha256
+	Area offset:290816 [bytes]
+	Area length:258048 [bytes]
+	Digest ID:  0
+  2: luks2
+	Key:        512 bits
+	Priority:   normal
+	Cipher:     aes-xts-plain64
+	Cipher key: 512 bits
+	PBKDF:      pbkdf2
+	Hash:       sha512
+	Iterations: 1000
+	Salt:       a8 53 27 a8 d7 8f a6 de a0 cb a4 d1 d4 2c 60 19 
+	            f0 32 a2 b0 fb 53 43 06 e8 83 90 93 65 ea 7d 8c 
+	AF stripes: 4000
+	AF hash:    sha512
+	Area offset:548864 [bytes]
+	Area length:258048 [bytes]
+	Digest ID:  0
+Tokens:
+  0: systemd-tpm2
+	Keyslot:    2
+Digests:
+  0: pbkdf2
+	Hash:       sha256
+	Iterations: 129774
+	Salt:       e6 31 d5 74 e0 65 83 82 35 03 29 56 0e 80 36 5c 
+	            4d cd 4d f9 de 69 39 97 d5 b3 ac c4 fd c5 ca 50 
+	Digest:     21 aa b3 dc 9d 46 9b 0f 3a 0f 57 13 80 c6 0b bf 
+	            67 66 9e 73 ed 7d 09 2c 3d b6 fa f4 fe 0c ce 67 
+"""
+
+LUKS_bad_dump = "Device /dev/nvme0n1p1 is not a valid LUKS device."
+
+
+def test_cryptsetup_luksDump_LUKS1():
+    LUKS1_parsed = cryptsetup_luksDump.LUKS_Dump(context_wrap(LUKS1_dump)).dump
+    assert LUKS1_parsed is not None
+    assert set(LUKS1_parsed.keys()) == set(["header"] + ["Key Slot " + str(x) for x in range(8)])
+    assert LUKS1_parsed["header"]["Version"] == "1"
+    assert LUKS1_parsed["Key Slot 0"]["status"] == "ENABLED"
+    assert LUKS1_parsed["Key Slot 7"]["status"] == "DISABLED"
+
+def test_cryptsetup_luksDump_LUKS2():
+    LUKS2_parsed = cryptsetup_luksDump.LUKS_Dump(context_wrap(LUKS2_dump)).dump
+    assert LUKS2_parsed is not None
+    assert set(LUKS2_parsed.keys()) == set(["header", "Data segments", "Keyslots", "Tokens", "Digests"])
+    assert LUKS2_parsed["header"]["Version"] == "2"
+    assert len(LUKS2_parsed["Keyslots"].keys()) == 3
+    assert len(LUKS2_parsed["Data segments"].keys()) == 1
+    assert len(LUKS2_parsed["Tokens"].keys()) == 1
+    assert len(LUKS2_parsed["Digests"].keys()) == 1
+
+    assert LUKS2_parsed["Tokens"]["0"]["type"] == "systemd-tpm2"
+    assert LUKS2_parsed["Keyslots"]["0"]["type"] == "luks2"
+
+def test_cryptsetup_luksDump_bad():
+    assert cryptsetup_luksDump.LUKS_Dump(context_wrap(LUKS_bad_dump)).dump is None

--- a/insights/tests/parsers/test_cryptsetup_luksDump.py
+++ b/insights/tests/parsers/test_cryptsetup_luksDump.py
@@ -46,7 +46,7 @@ Key Slot 4: DISABLED
 Key Slot 5: DISABLED
 Key Slot 6: DISABLED
 Key Slot 7: DISABLED
-""" # noqa
+"""  # noqa
 
 LUKS2_dump = """LUKS header information
 Version:       	2
@@ -123,8 +123,8 @@ Digests:
 	Salt:       e6 31 d5 74 e0 65 83 82 35 03 29 56 0e 80 36 5c 
 	            4d cd 4d f9 de 69 39 97 d5 b3 ac c4 fd c5 ca 50 
 	Digest:     21 aa b3 dc 9d 46 9b 0f 3a 0f 57 13 80 c6 0b bf 
-	            67 66 9e 73 ed 7d 09 2c 3d b6 fa f4 fe 0c ce 67 
-""" # noqa
+	            67 66 9e 73 ed 7d 09 
+"""  # noqa
 
 LUKS_bad_dump = "Device /dev/nvme0n1p1 is not a valid LUKS device."
 

--- a/insights/tests/parsers/test_cryptsetup_luksDump.py
+++ b/insights/tests/parsers/test_cryptsetup_luksDump.py
@@ -1,3 +1,4 @@
+import doctest
 import pytest
 
 from insights.parsers import cryptsetup_luksDump
@@ -158,3 +159,11 @@ def test_cryptsetup_luksDump_bad():
         cryptsetup_luksDump.LUKS_Dump(context_wrap(LUKS_bad_dump)).dump
     with pytest.raises(SkipComponent):
         cryptsetup_luksDump.LUKS_Dump(context_wrap("")).dump
+
+
+def test_doc_examples():
+    env = {
+            'parsed_result': cryptsetup_luksDump.LUKS_Dump(context_wrap(LUKS2_dump)),
+          }
+    failed, total = doctest.testmod(cryptsetup_luksDump, globs=env)
+    assert failed == 0

--- a/insights/tests/parsers/test_cryptsetup_luksDump.py
+++ b/insights/tests/parsers/test_cryptsetup_luksDump.py
@@ -42,7 +42,7 @@ Key Slot 4: DISABLED
 Key Slot 5: DISABLED
 Key Slot 6: DISABLED
 Key Slot 7: DISABLED
-"""
+""" # noqa
 
 LUKS2_dump = """LUKS header information
 Version:       	2
@@ -120,7 +120,7 @@ Digests:
 	            4d cd 4d f9 de 69 39 97 d5 b3 ac c4 fd c5 ca 50 
 	Digest:     21 aa b3 dc 9d 46 9b 0f 3a 0f 57 13 80 c6 0b bf 
 	            67 66 9e 73 ed 7d 09 2c 3d b6 fa f4 fe 0c ce 67 
-"""
+""" # noqa
 
 LUKS_bad_dump = "Device /dev/nvme0n1p1 is not a valid LUKS device."
 
@@ -132,6 +132,7 @@ def test_cryptsetup_luksDump_LUKS1():
     assert LUKS1_parsed["header"]["Version"] == "1"
     assert LUKS1_parsed["Key Slot 0"]["status"] == "ENABLED"
     assert LUKS1_parsed["Key Slot 7"]["status"] == "DISABLED"
+
 
 def test_cryptsetup_luksDump_LUKS2():
     LUKS2_parsed = cryptsetup_luksDump.LUKS_Dump(context_wrap(LUKS2_dump)).dump
@@ -145,6 +146,7 @@ def test_cryptsetup_luksDump_LUKS2():
 
     assert LUKS2_parsed["Tokens"]["0"]["type"] == "systemd-tpm2"
     assert LUKS2_parsed["Keyslots"]["0"]["type"] == "luks2"
+
 
 def test_cryptsetup_luksDump_bad():
     assert cryptsetup_luksDump.LUKS_Dump(context_wrap(LUKS_bad_dump)).dump is None

--- a/insights/tests/parsers/test_cryptsetup_luksDump.py
+++ b/insights/tests/parsers/test_cryptsetup_luksDump.py
@@ -76,7 +76,7 @@ Keyslots:
 	Memory:     1048576
 	Threads:    4
 	Salt:       3d c4 1b 52 fe 1c 90 d8 2a 35 b2 62 34 e9 0a 59 
-	            e9 0e 48 57 b2 dd 45 9e ed 9a 33 1e 07 cd 2a 19 
+	            e9 0e 48 57 b2 dd 45 
 	AF stripes: 4000
 	AF hash:    sha256
 	Area offset:32768 [bytes]
@@ -92,7 +92,7 @@ Keyslots:
 	Memory:     1048576
 	Threads:    4
 	Salt:       bb b4 33 41 c1 94 15 86 2a e9 26 f8 d8 16 83 b1 
-	            d0 00 f9 25 05 2d 80 c9 56 e8 4d 6f 75 a2 d5 bf 
+	            d0 00 f9 25 05 2d 80 
 	AF stripes: 4000
 	AF hash:    sha256
 	Area offset:290816 [bytes]
@@ -107,7 +107,7 @@ Keyslots:
 	Hash:       sha512
 	Iterations: 1000
 	Salt:       a8 53 27 a8 d7 8f a6 de a0 cb a4 d1 d4 2c 60 19 
-	            f0 32 a2 b0 fb 53 43 06 e8 83 90 93 65 ea 7d 8c 
+	            f0 32 a2 b0 fb 53 43 
 	AF stripes: 4000
 	AF hash:    sha512
 	Area offset:548864 [bytes]
@@ -121,7 +121,7 @@ Digests:
 	Hash:       sha256
 	Iterations: 129774
 	Salt:       e6 31 d5 74 e0 65 83 82 35 03 29 56 0e 80 36 5c 
-	            4d cd 4d f9 de 69 39 97 d5 b3 ac c4 fd c5 ca 50 
+	            4d cd 4d f9 de 69 39 
 	Digest:     21 aa b3 dc 9d 46 9b 0f 3a 0f 57 13 80 c6 0b bf 
 	            67 66 9e 73 ed 7d 09 
 """  # noqa

--- a/insights/tests/parsers/test_cryptsetup_luksDump.py
+++ b/insights/tests/parsers/test_cryptsetup_luksDump.py
@@ -6,7 +6,7 @@ from insights.tests import context_wrap
 from insights import SkipComponent
 
 
-LUKS1_dump = """LUKS header information for luks1
+LUKS1_DUMP = """LUKS header information for luks1
 
 Version:       	1
 Cipher name:   	aes
@@ -48,7 +48,7 @@ Key Slot 6: DISABLED
 Key Slot 7: DISABLED
 """  # noqa
 
-LUKS2_dump = """LUKS header information
+LUKS2_DUMP = """LUKS header information
 Version:       	2
 Epoch:         	6
 Metadata area: 	16384 [bytes]
@@ -126,44 +126,44 @@ Digests:
 	            67 66 9e 73 ed 7d 09 
 """  # noqa
 
-LUKS_bad_dump = "Device /dev/nvme0n1p1 is not a valid LUKS device."
+LUKS_BAD_DUMP = "Device /dev/nvme0n1p1 is not a valid LUKS device."
 
 
-def test_cryptsetup_luksDump_LUKS1():
-    LUKS1_parsed = cryptsetup_luksDump.LUKS_Dump(context_wrap(LUKS1_dump))
-    print(LUKS1_parsed.dump)
-    assert LUKS1_parsed.dump is not None
-    assert set(LUKS1_parsed.dump.keys()) == set(["header"] + ["Key Slot " + str(x) for x in range(8)])
-    assert LUKS1_parsed.dump["header"]["Version"] == "1"
-    assert LUKS1_parsed.dump["Key Slot 0"]["status"] == "ENABLED"
-    assert LUKS1_parsed.dump["Key Slot 7"]["status"] == "DISABLED"
+def test_cryptsetup_luksDump_Luks1():
+    Luks1Parsed = cryptsetup_luksDump.Luks_dump(context_wrap(LUKS1_DUMP))
+    print(Luks1Parsed.dump)
+    assert Luks1Parsed.dump is not None
+    assert set(Luks1Parsed.dump.keys()) == set(["header"] + ["Key Slot " + str(x) for x in range(8)])
+    assert Luks1Parsed.dump["header"]["Version"] == "1"
+    assert Luks1Parsed.dump["Key Slot 0"]["status"] == "ENABLED"
+    assert Luks1Parsed.dump["Key Slot 7"]["status"] == "DISABLED"
 
 
-def test_cryptsetup_luksDump_LUKS2():
-    LUKS2_parsed = cryptsetup_luksDump.LUKS_Dump(context_wrap(LUKS2_dump))
-    assert LUKS2_parsed.dump is not None
-    assert set(LUKS2_parsed.dump.keys()) == set(["header", "Data segments", "Keyslots", "Tokens", "Digests"])
-    assert LUKS2_parsed.dump["header"]["Version"] == "2"
-    assert len(LUKS2_parsed.dump["Keyslots"].keys()) == 3
-    assert LUKS2_parsed.dump["Keyslots"]["0"]["type"] == "luks2"
-    assert len(LUKS2_parsed.dump["Data segments"].keys()) == 1
-    assert len(LUKS2_parsed.dump["Tokens"].keys()) == 1
-    assert len(LUKS2_parsed.dump["Digests"].keys()) == 1
+def test_cryptsetup_luksDump_Luks2():
+    Luks2_parsed = cryptsetup_luksDump.Luks_dump(context_wrap(LUKS2_DUMP))
+    assert Luks2_parsed.dump is not None
+    assert set(Luks2_parsed.dump.keys()) == set(["header", "Data segments", "Keyslots", "Tokens", "Digests"])
+    assert Luks2_parsed.dump["header"]["Version"] == "2"
+    assert len(Luks2_parsed.dump["Keyslots"].keys()) == 3
+    assert Luks2_parsed.dump["Keyslots"]["0"]["type"] == "luks2"
+    assert len(Luks2_parsed.dump["Data segments"].keys()) == 1
+    assert len(Luks2_parsed.dump["Tokens"].keys()) == 1
+    assert len(Luks2_parsed.dump["Digests"].keys()) == 1
 
-    assert LUKS2_parsed.dump["Tokens"]["0"]["type"] == "systemd-tpm2"
-    assert LUKS2_parsed.dump["Keyslots"]["0"]["type"] == "luks2"
+    assert Luks2_parsed.dump["Tokens"]["0"]["type"] == "systemd-tpm2"
+    assert Luks2_parsed.dump["Keyslots"]["0"]["type"] == "luks2"
 
 
 def test_cryptsetup_luksDump_bad():
     with pytest.raises(SkipComponent):
-        cryptsetup_luksDump.LUKS_Dump(context_wrap(LUKS_bad_dump)).dump
+        cryptsetup_luksDump.Luks_dump(context_wrap(LUKS_BAD_DUMP)).dump
     with pytest.raises(SkipComponent):
-        cryptsetup_luksDump.LUKS_Dump(context_wrap("")).dump
+        cryptsetup_luksDump.Luks_dump(context_wrap("")).dump
 
 
 def test_doc_examples():
     env = {
-            'parsed_result': cryptsetup_luksDump.LUKS_Dump(context_wrap(LUKS2_dump)),
+            'parsed_result': cryptsetup_luksDump.Luks_dump(context_wrap(LUKS2_DUMP)),
           }
     failed, total = doctest.testmod(cryptsetup_luksDump, globs=env)
     assert failed == 0


### PR DESCRIPTION
Signed-off-by: daniel.zatovic <daniel.zatovic@gmail.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
- Added `cryptsetup_luksDump` spec which collects the output of `cryptsetup luksDump` spec with salt and digest fields filtered out (although luksDump public is designed to contain only public information, salt and digest can potentially be sensitive)
- Added `LUKS_Dump` parser, which parses the output using `parsr` library (it works for both - LUKS1 and LUKS2 output formats)