### PR TITLE
Fix issue calling collect from cli

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 import argparse
 import logging
 import os
+import sys
 import tempfile
 import yaml
 
@@ -416,6 +417,12 @@ def collect(manifest=default_manifest, tmp_path=None, compress=False, rm_conf=No
 
 
 def main():
+    # Remove command line args so that they are not parsed by any called modules
+    # The main fxn is only invoked as a cli, if calling from another cli then
+    # use the collect function instead
+    collect_args = [arg for arg in sys.argv[1:]] if len(sys.argv) > 1 else []
+    sys.argv = [sys.argv[0], ] if sys.argv else sys.argv
+
     p = argparse.ArgumentParser()
     p.add_argument("-m", "--manifest", help="Manifest yaml.")
     p.add_argument("-o", "--out_path", help="Path to write output data.")
@@ -423,7 +430,7 @@ def main():
     p.add_argument("-v", "--verbose", help="Verbose output.", action="store_true")
     p.add_argument("-d", "--debug", help="Debug output.", action="store_true")
     p.add_argument("-c", "--compress", help="Compress", action="store_true")
-    args = p.parse_args()
+    args = p.parse_args(args=collect_args)
 
     level = logging.WARNING
     if args.verbose:


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* When collect is called from the cli, the malware datasource calls client configuration which parses the collect args and fails.
* This PR removes the args after parsing to avoid the failure.
* Fix #3505

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>