### PR TITLE
Added no_proxy autoconfiguration from rhsm conf and tests

### DIFF
--- a/insights/client/auto_config.py
+++ b/insights/client/auto_config.py
@@ -55,7 +55,7 @@ def verify_connectivity(config):
         return False
 
 
-def set_auto_configuration(config, hostname, ca_cert, proxy, is_satellite, is_stage):
+def set_auto_configuration(config, hostname, ca_cert, proxy, is_satellite, is_stage, rhsm_no_proxy=None):
     """
     Set config based on discovered data
     """
@@ -63,6 +63,7 @@ def set_auto_configuration(config, hostname, ca_cert, proxy, is_satellite, is_st
     logger.debug("Attempting to auto configure hostname: %s", hostname)
     logger.debug("Attempting to auto configure CA cert: %s", ca_cert)
     logger.debug("Attempting to auto configure proxy: %s", proxy)
+    logger.debug("Attempting to auto configure no_proxy: %s", rhsm_no_proxy)
     saved_base_url = config.base_url
     if ca_cert is not None:
         saved_cert_verify = config.cert_verify
@@ -70,6 +71,8 @@ def set_auto_configuration(config, hostname, ca_cert, proxy, is_satellite, is_st
     if proxy is not None:
         saved_proxy = config.proxy
         config.proxy = proxy
+    if rhsm_no_proxy and rhsm_no_proxy != '':
+        config.no_proxy = rhsm_no_proxy
     if is_satellite:
         # satellite
         config.base_url = hostname + '/r/insights'
@@ -128,6 +131,9 @@ def _try_satellite6_configuration(config):
         rhsm_proxy_port = rhsm_config.get('server', 'proxy_port').strip()
         rhsm_proxy_user = rhsm_config.get('server', 'proxy_user').strip()
         rhsm_proxy_pass = rhsm_config.get('server', 'proxy_password').strip()
+        rhsm_no_proxy = rhsm_config.get('server', 'no_proxy').strip()
+        if rhsm_no_proxy.lower() == 'none' or rhsm_no_proxy == '':
+            rhsm_no_proxy = None
 
         proxy = None
 
@@ -170,7 +176,7 @@ def _try_satellite6_configuration(config):
             is_satellite = True
 
         logger.debug("Trying to set auto_configuration")
-        set_auto_configuration(config, rhsm_hostname, rhsm_ca, proxy, is_satellite, is_stage)
+        set_auto_configuration(config, rhsm_hostname, rhsm_ca, proxy, is_satellite, is_stage, rhsm_no_proxy=rhsm_no_proxy)
         return True
     except Exception as e:
         logger.debug(e)

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -243,6 +243,10 @@ DEFAULT_OPTS = {
         # non-CLI
         'default': False,  # legacy
     },
+    'no_proxy': {
+        # non-CLI
+        'default': None
+    },
     'no_upload': {
         'default': False,
         'opt': ['--no-upload'],

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -274,27 +274,27 @@ def test_get_profiles_matching_os(config, os_release_info_mock):
 
 
 @patch("insights.client.apps.compliance.os_release_info", return_value=(None, '6.5'))
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_os_release(config, os_release_info_mock):
     compliance_client = ComplianceClient(config)
     assert compliance_client.os_release() == '6.5'
 
 
 @patch("insights.client.apps.compliance.os_release_info", return_value=(None, '6.5'))
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/tests')
 def test_os_minor_version(config, os_release_info_mock):
     compliance_client = ComplianceClient(config)
     assert compliance_client.os_minor_version() == '5'
 
 
 @patch("insights.client.apps.compliance.os_release_info", return_value=(None, '6.5'))
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_os_major_version(config, os_release_info_mock):
     compliance_client = ComplianceClient(config)
     assert compliance_client.os_major_version() == '6'
 
 
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_profile_files(config):
     compliance_client = ComplianceClient(config)
     compliance_client.os_release = lambda: '7'
@@ -302,14 +302,14 @@ def test_profile_files(config):
 
 
 @patch("insights.client.apps.compliance.call", return_value=(0, PATH))
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_find_scap_policy(config, call):
     compliance_client = ComplianceClient(config)
     compliance_client.profile_files = lambda: ['/something']
     assert compliance_client.find_scap_policy('ref_id') == PATH
 
 
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_find_scap_policy_with_one_datastream_file(config, tmpdir):
     compliance_client = ComplianceClient(config)
     dir1 = tmpdir.mkdir('scap')
@@ -323,7 +323,7 @@ def test_find_scap_policy_with_one_datastream_file(config, tmpdir):
         assert compliance_client.find_scap_policy('content_profile_anssi_bp28_high') == file
 
 
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_find_scap_policy_with_two_datastream_file(config, tmpdir):
     compliance_client = ComplianceClient(config)
     dir1 = tmpdir.mkdir('scap')
@@ -343,7 +343,7 @@ def test_find_scap_policy_with_two_datastream_file(config, tmpdir):
 
 
 @patch("insights.client.apps.compliance.call", return_value=(1, 'bad things happened'.encode('utf-8')))
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_find_scap_policy_not_found(config, call):
     compliance_client = ComplianceClient(config)
     compliance_client.profile_files = lambda: ['/something']
@@ -351,7 +351,7 @@ def test_find_scap_policy_not_found(config, call):
 
 
 @patch("insights.client.apps.compliance.call", return_value=(0, ''.encode('utf-8')))
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_run_scan(config, call):
     compliance_client = ComplianceClient(config)
     output_path = '/tmp/oscap_results-ref_id.xml'
@@ -365,7 +365,7 @@ def test_run_scan(config, call):
 
 
 @patch("insights.client.apps.compliance.call", return_value=(1, 'bad things happened'.encode('utf-8')))
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_run_scan_fail(config, call):
     compliance_client = ComplianceClient(config)
     output_path = '/tmp/oscap_results-ref_id.xml'
@@ -380,7 +380,7 @@ def test_run_scan_fail(config, call):
 
 
 @patch("insights.client.apps.compliance.call", return_value=(0, ''.encode('utf-8')))
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_run_scan_missing_profile(config, call):
     compliance_client = ComplianceClient(config)
     output_path = '/tmp/oscap_results-ref_id.xml'
@@ -390,20 +390,20 @@ def test_run_scan_missing_profile(config, call):
     call.assert_not_called()
 
 
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_tailored_file_is_not_downloaded_if_not_needed(config):
     compliance_client = ComplianceClient(config)
     assert compliance_client.download_tailoring_file({'attributes': {'tailored': False}}) is None
 
 
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_tailored_file_is_not_downloaded_if_tailored_is_missing(config):
     compliance_client = ComplianceClient(config)
     assert compliance_client.download_tailoring_file({'id': 'foo', 'attributes': {'ref_id': 'aaaaa'}}) is None
 
 
 @patch("insights.client.apps.compliance.open", new_callable=mock_open)
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_tailored_file_is_downloaded_from_initial_profile_if_os_minor_version_is_missing(config, call):
     compliance_client = ComplianceClient(config)
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
@@ -412,7 +412,7 @@ def test_tailored_file_is_downloaded_from_initial_profile_if_os_minor_version_is
 
 
 @patch("insights.client.apps.compliance.os_release_info", return_value=(None, '6.5'))
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_tailored_file_is_not_downloaded_if_os_minor_version_mismatches(config, os_release_info_mock):
     compliance_client = ComplianceClient(config)
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
@@ -422,7 +422,7 @@ def test_tailored_file_is_not_downloaded_if_os_minor_version_mismatches(config, 
 
 @patch("insights.client.apps.compliance.os_release_info", return_value=(None, '6.5'))
 @patch("insights.client.apps.compliance.open", new_callable=mock_open)
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_tailored_file_is_downloaded_if_needed(config, call, os_release_info_mock):
     compliance_client = ComplianceClient(config)
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=200, json=Mock(return_value={'data': [{'attributes': 'data'}]})))
@@ -430,21 +430,21 @@ def test_tailored_file_is_downloaded_if_needed(config, call, os_release_info_moc
     assert compliance_client.download_tailoring_file({'id': 'foo', 'attributes': {'tailored': False, 'ref_id': 'aaaaa', 'os_minor_version': '5'}}) is None
 
 
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_build_oscap_command_does_not_append_tailoring_path(config):
     compliance_client = ComplianceClient(config)
     expected_command = 'oscap xccdf eval --profile aaaaa --results output_path xml_sample'
     assert expected_command == compliance_client.build_oscap_command('aaaaa', 'xml_sample', 'output_path', None)
 
 
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test_build_oscap_command_append_tailoring_path(config):
     compliance_client = ComplianceClient(config)
     expected_command = 'oscap xccdf eval --profile aaaaa --tailoring-file tailoring_path --results output_path xml_sample'
     assert expected_command == compliance_client.build_oscap_command('aaaaa', 'xml_sample', 'output_path', 'tailoring_path')
 
 
-@patch("insights.client.config.InsightsConfig")
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test__get_inventory_id(config):
     compliance_client = ComplianceClient(config)
     compliance_client.conn._fetch_system_by_machine_id = lambda: []

--- a/insights/tests/client/auto_config/test_autoconfig_urls.py
+++ b/insights/tests/client/auto_config/test_autoconfig_urls.py
@@ -10,10 +10,10 @@ def test_rhsm_legacy_url(set_auto_configuration, initConfig):
     '''
     Ensure the correct host URL is selected for auto_config on a legacy RHSM upload
     '''
-    initConfig().get.side_effect = ['subscription.rhsm.redhat.com', '443', '', '', '', '', '']
+    initConfig().get.side_effect = ['subscription.rhsm.redhat.com', '443', '', '', '', '', '', '']
     config = Mock(base_url=None, upload_url=None, legacy_upload=True)
     _try_satellite6_configuration(config)
-    set_auto_configuration.assert_called_with(config, 'cert-api.access.redhat.com', None, None, False, False)
+    set_auto_configuration.assert_called_with(config, 'cert-api.access.redhat.com', None, None, False, False, rhsm_no_proxy=None)
 
 
 @patch("insights.client.auto_config.rhsmCertificate", Mock())
@@ -24,11 +24,11 @@ def test_rhsm_platform_url(set_auto_configuration, initConfig):
     '''
     Ensure the correct host URL is selected for auto_config on a platform RHSM upload
     '''
-    initConfig().get.side_effect = ['subscription.rhsm.redhat.com', '443', '', '', '', '', '']
+    initConfig().get.side_effect = ['subscription.rhsm.redhat.com', '443', '', '', '', '', '', '']
     config = Mock(base_url=None, upload_url=None, legacy_upload=False)
     _try_satellite6_configuration(config)
     # set_auto_configuration.assert_called_with(config, 'console.redhat.com', None, None, False)
-    set_auto_configuration.assert_called_with(config, 'cert-api.access.redhat.com', None, None, False, False)
+    set_auto_configuration.assert_called_with(config, 'cert-api.access.redhat.com', None, None, False, False, rhsm_no_proxy=None)
 
 
 @patch("insights.client.auto_config.rhsmCertificate", Mock())
@@ -43,12 +43,12 @@ def test_rhsm_stage_legacy_url(set_auto_configuration, initConfig):
     so the result is the same as platform upload.
 
     '''
-    initConfig().get.side_effect = ['subscription.rhsm.stage.redhat.com', '443', '', '', '', '', '']
+    initConfig().get.side_effect = ['subscription.rhsm.stage.redhat.com', '443', '', '', '', '', '', '']
     config = Mock(base_url=None, upload_url=None, legacy_upload=True)
     _try_satellite6_configuration(config)
     # config.legacy_upload is modified in the function
     config.legacy_upload = False
-    set_auto_configuration.assert_called_with(config, 'cert.cloud.stage.redhat.com', None, None, False, True)
+    set_auto_configuration.assert_called_with(config, 'cert.cloud.stage.redhat.com', None, None, False, True, rhsm_no_proxy=None)
 
 
 @patch("insights.client.auto_config.rhsmCertificate", Mock())
@@ -59,10 +59,10 @@ def test_rhsm_stage_platform_url(set_auto_configuration, initConfig):
     '''
     Ensure the correct host URL is selected for auto_config on a platform staging RHSM upload
     '''
-    initConfig().get.side_effect = ['subscription.rhsm.stage.redhat.com', '443', '', '', '', '', '']
+    initConfig().get.side_effect = ['subscription.rhsm.stage.redhat.com', '443', '', '', '', '', '', '']
     config = Mock(base_url=None, upload_url=None, legacy_upload=False)
     _try_satellite6_configuration(config)
-    set_auto_configuration.assert_called_with(config, 'cert.cloud.stage.redhat.com', None, None, False, True)
+    set_auto_configuration.assert_called_with(config, 'cert.cloud.stage.redhat.com', None, None, False, True, rhsm_no_proxy=None)
 
 
 @patch("insights.client.auto_config.rhsmCertificate", Mock())
@@ -73,10 +73,10 @@ def test_sat_legacy_url(set_auto_configuration, initConfig):
     '''
     Ensure the correct host URL is selected for auto_config on a legacy Sat upload
     '''
-    initConfig().get.side_effect = ['test.satellite.com', '443', '', '', '', '', 'test_cert']
+    initConfig().get.side_effect = ['test.satellite.com', '443', '', '', '', '', '', 'test_cert']
     config = Mock(base_url=None, upload_url=None, legacy_upload=True)
     _try_satellite6_configuration(config)
-    set_auto_configuration.assert_called_with(config, 'test.satellite.com:443/redhat_access', 'test_cert', None, True, False)
+    set_auto_configuration.assert_called_with(config, 'test.satellite.com:443/redhat_access', 'test_cert', None, True, False, rhsm_no_proxy=None)
 
 
 @patch("insights.client.auto_config.rhsmCertificate", Mock())
@@ -87,10 +87,10 @@ def test_sat_platform_url(set_auto_configuration, initConfig):
     '''
     Ensure the correct host URL is selected for auto_config on a platform Sat upload
     '''
-    initConfig().get.side_effect = ['test.satellite.com', '443', '', '', '', '', 'test_cert']
+    initConfig().get.side_effect = ['test.satellite.com', '443', '', '', '', '', '', 'test_cert']
     config = Mock(base_url=None, upload_url=None, legacy_upload=False)
     _try_satellite6_configuration(config)
-    set_auto_configuration.assert_called_with(config, 'test.satellite.com:443/redhat_access', 'test_cert', None, True, False)
+    set_auto_configuration.assert_called_with(config, 'test.satellite.com:443/redhat_access', 'test_cert', None, True, False, rhsm_no_proxy=None)
 
 
 @patch("insights.client.auto_config.verify_connectivity", Mock())

--- a/insights/tests/client/connection/test_init_session.py
+++ b/insights/tests/client/connection/test_init_session.py
@@ -1,5 +1,6 @@
 from insights.client.connection import InsightsConnection
 from mock.mock import Mock, patch
+from os import environ as os_environ
 
 
 @patch("insights.client.connection.requests.Session")
@@ -29,3 +30,101 @@ def test_proxy_request(init, session):
         "https://cert-api.access.redhat.com/r/insights",
         timeout=config.http_timeout
     )
+
+
+def test_get_proxy_env():
+    """
+    Test geting proxy configuration through environment, with and without no_proxy setting.
+    """
+    config = Mock()
+    config.no_proxy = None
+    config.proxy = None
+    config.base_url = "redhat.com"
+
+    connection = InsightsConnection(config)
+
+    with patch.dict(os_environ, {"HTTPS_PROXY": "env.proxy.example.com"}, clear=True):
+        connection.get_proxies()
+    assert connection.proxies == {'https': 'env.proxy.example.com'}
+
+
+def test_get_proxy_rhsm():
+    """
+    Test getting proxy configuration through rhsm (auto-config), with and without no_proxy setting.
+    """
+    config = Mock()
+    config.no_proxy = None
+    config.base_url = "redhat.com"
+    config.proxy = "rhsm.proxy.example.com"
+
+    connection = InsightsConnection(config)
+
+    connection.get_proxies()
+    assert connection.proxies == {"https": config.proxy}
+
+
+def test_get_no_proxy_env():
+    """
+    Test geting proxy configuration through environment with no_proxy modification.
+    """
+
+    config = Mock()
+    config.no_proxy = None
+    config.proxy = None
+    config.base_url = "redhat.com"
+
+    connection = InsightsConnection(config)
+
+    with patch.dict(os_environ, {"HTTPS_PROXY": "env.proxy.example.com", "NO_PROXY": "*"}, clear=True):
+        connection.get_proxies()
+    assert connection.proxies is None
+
+    with patch.dict(os_environ, {"HTTPS_PROXY": "env.proxy.example.com", "NO_PROXY": "redhat.com"}, clear=True):
+        connection.get_proxies()
+    assert connection.proxies is None
+
+    with patch.dict(os_environ, {"HTTPS_PROXY": "env.proxy.example.com", "NO_PROXY": "url.com"}, clear=True):
+        connection.get_proxies()
+    assert connection.proxies == {'https': 'env.proxy.example.com'}
+
+
+def test_get_no_proxy_rhsm():
+    """
+    Test geting proxy configuration through rhsm (auto-config) with no_proxy modification.
+    """
+    config = Mock()
+    config.proxy = "rhsm.proxy.example.com"
+    config.base_url = "redhat.com"
+    config.no_proxy = ""
+
+    connection = InsightsConnection(config)
+
+    config.no_proxy = "*"
+    connection.get_proxies()
+    assert connection.proxies is None
+
+    config.no_proxy = "redhat.com"
+    connection.get_proxies()
+    assert connection.proxies is None
+
+    config.no_proxy = "url.com"
+    connection.get_proxies()
+    assert connection.proxies == {"https": config.proxy}
+
+
+@patch("insights.client.connection.logger.debug")
+def test_get_rhsm_and_env(logger):
+    """
+    no_proxy from environment doesn't change the proxy configuration from auto-config
+    """
+    config = Mock()
+    config.proxy = "rhsm.proxy.example.com"
+    config.no_proxy = None
+    config.base_url = "redhat.com"
+
+    connection = InsightsConnection(config)
+
+    with patch.dict(os_environ, {"NO_PROXY": "redhat.com"}, clear=True):
+        connection.get_proxies()
+    assert connection.proxies == {"https": config.proxy}
+    assert logger.called_with("You have environment variable NO_PROXY set as well as 'proxy' set in your configuration file. NO_PROXY environment variable will be ignored.")


### PR DESCRIPTION
Signed-off-by: ahitacat <ahitacat@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Insights-client wasn't honoring the no_proxy configuration of `/etc/rhsm/rhsm.conf` file.

This PR adds the no_proxy value to the auto-configuration module, to retrieve the value of the rhsm configuration file. It provides some tests related to this.

This fix is related to: [rhbz#2065233]((https://bugzilla.redhat.com/show_bug.cgi?id=2065233)