### PR TITLE
Ensure full path when using timeout command

### DIFF
--- a/insights/client/insights_spec.py
+++ b/insights/client/insights_spec.py
@@ -8,7 +8,7 @@ import time
 import sys
 from subprocess import Popen, PIPE, STDOUT
 from tempfile import NamedTemporaryFile
-from insights.util import mangle
+from insights.util import mangle, which
 
 from .constants import InsightsConstants as constants
 from .utilities import determine_hostname
@@ -61,13 +61,15 @@ class InsightsCommand(InsightsSpec):
         else:
             signal = 'KILL'
 
-        timeout_command = 'timeout -s %s %s %s' % (
-            signal, self.config.cmd_timeout, self.command)
-
         # ensure consistent locale for collected command output
         cmd_env = {'LC_ALL': 'C',
                    'PATH': '/sbin:/bin:/usr/sbin:/usr/bin',
                    'PYTHONPATH': os.getenv('PYTHONPATH')}
+
+        timeout = which('timeout', env=cmd_env)
+        timeout_command = '%s -s %s %s %s' % (
+            timeout, signal, self.config.cmd_timeout, self.command)
+
         args = shlex.split(timeout_command)
 
         # never execute this stuff


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* util/subproc was already using which to get the full path for timeout, but the command spec was not.  This change uses the which util to ensure the full path is obtained for the timeout command
* Fix #1130

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>