### PR TITLE
fix: support InstanceType in saphostctrl

### DIFF
--- a/insights/combiners/sap.py
+++ b/insights/combiners/sap.py
@@ -4,8 +4,8 @@ Sap
 This combiner combines the result of
 insights.parsers.saphostctrl.SAPHostCtrlInstances` and
 `:class:`insights.parsers.lssap.Lssap` to get the available SAP instances.
-Prefer the ``SAPHostCtrlInstances`` to ``Lssap``.
 
+Prefer the ``SAPHostCtrlInstances`` to ``Lssap``.
 """
 
 from collections import namedtuple
@@ -17,18 +17,18 @@ from insights.parsers.saphostctrl import SAPHostCtrlInstances
 
 
 SAPInstances = namedtuple("SAPInstances",
-        field_names=["name", "hostname", "sid", "type", "number", "fqdn", "version"])
+        field_names=["name", "hostname", "sid", "type", "full_type", "number", "fqdn", "version"])
 """namedtuple: Type for storing the SAP instance."""
 
-FUNC_TYPES = ('SMDA',)
-"""
-SMDA   :    Solution Manager Diagnostics Agents
-"""
+FUNC_TYPES = {
+    'SMDA': 'Solution Manager Diagnostic Agent',
+    'SMA': 'Solution Manager Diagnostic Agent',  # BZ-1969572
+}
 NETW_TYPES = ('D', 'ASCS', 'DVEBMGS', 'J', 'SCS', 'ERS', 'W', 'G', 'JC')
 """
 D      :    NetWeaver (ABAP Dialog Instance)
 ASCS   :    NetWeaver (ABAP Central Services)
-DVEBMGS:    NetWeaver (Primary Application server
+DVEBMGS:    NetWeaver (Primary Application server)
 J      :    NetWeaver (Java App Server Instance)
 SCS    :    NetWeaver (Java Central Services)
 ERS    :    NetWeaver (Enqueue Replication Server)
@@ -90,7 +90,7 @@ class Sap(dict):
         if insts:
             self._types = insts.types
             self.all_instances = insts.instances
-            for inst in insts.data:
+            for inst in insts:
                 k = inst['InstanceName']
                 if (hn == inst['Hostname'].split('.')[0] or
                         fqdn == inst['FullQualifiedHostname'] or
@@ -99,6 +99,7 @@ class Sap(dict):
                 data[k] = SAPInstances(k,
                                        inst['Hostname'],
                                        inst['SID'],
+                                       inst['InstanceName'].strip('1234567890'),
                                        inst['InstanceType'],
                                        inst['SystemNumber'],
                                        inst['FullQualifiedHostname'],
@@ -114,6 +115,7 @@ class Sap(dict):
                                        inst['SAPLOCALHOST'],
                                        inst['SID'],
                                        t,
+                                       t,  # Use short
                                        inst['Nr'],
                                        None,
                                        inst['Version'])
@@ -122,8 +124,11 @@ class Sap(dict):
 
         self.update(data)
 
-        for i in self.all_instances:
-            (self.function_instances if i.startswith(FUNC_TYPES) else self.business_instances).append(i)
+        for i in self.values():
+            if i.type in FUNC_TYPES or i.full_type in FUNC_TYPES.values():
+                self.function_instances.append(i.name)
+            else:
+                self.business_instances.append(i.name)
 
     def version(self, instance):
         """str: Returns the version of the ``instance``."""
@@ -134,7 +139,11 @@ class Sap(dict):
         return self[instance].sid if instance in self else None
 
     def type(self, instance):
-        """str: Returns the type code of the ``instance``."""
+        """str: Returns the short type code of the ``instance``."""
+        return self[instance].type if instance in self else None
+
+    def full_type(self, instance):
+        """str: Returns the full type code of the ``instance``."""
         return self[instance].type if instance in self else None
 
     def hostname(self, instance):

--- a/insights/combiners/sap.py
+++ b/insights/combiners/sap.py
@@ -144,7 +144,7 @@ class Sap(dict):
 
     def full_type(self, instance):
         """str: Returns the full type code of the ``instance``."""
-        return self[instance].type if instance in self else None
+        return self[instance].full_type if instance in self else None
 
     def hostname(self, instance):
         """str: Returns the hostname of the ``instance``."""

--- a/insights/combiners/sap.py
+++ b/insights/combiners/sap.py
@@ -20,10 +20,10 @@ SAPInstances = namedtuple("SAPInstances",
         field_names=["name", "hostname", "sid", "type", "full_type", "number", "fqdn", "version"])
 """namedtuple: Type for storing the SAP instance."""
 
-FUNC_TYPES = {
-    'SMDA': 'Solution Manager Diagnostic Agent',
-    'SMA': 'Solution Manager Diagnostic Agent',  # BZ-1969572
-}
+FUNC_FULL_TYPES = [
+    'Solution Manager Diagnostic Agent',
+    'Diagnostic Agent'
+]
 NETW_TYPES = ('D', 'ASCS', 'DVEBMGS', 'J', 'SCS', 'ERS', 'W', 'G', 'JC')
 """
 D      :    NetWeaver (ABAP Dialog Instance)
@@ -125,10 +125,9 @@ class Sap(dict):
         self.update(data)
 
         for i in self.values():
-            if i.type in FUNC_TYPES or i.full_type in FUNC_TYPES.values():
-                self.function_instances.append(i.name)
-            else:
-                self.business_instances.append(i.name)
+            (self.function_instances
+                if i.full_type in FUNC_FULL_TYPES else
+                    self.business_instances).append(i.name)
 
     def version(self, instance):
         """str: Returns the version of the ``instance``."""

--- a/insights/parsers/saphostctrl.py
+++ b/insights/parsers/saphostctrl.py
@@ -15,10 +15,10 @@ from insights.specs import Specs
 
 SAP_INST_FILTERS = [
         '******',
-        'CreationClassName',
         'SID',
         'SystemNumber',
         'InstanceName',
+        'InstanceType',
         'Hostname',
         'SapVersionInfo',
         'FullQualifiedHostname'
@@ -27,7 +27,7 @@ add_filter(Specs.saphostctl_getcimobject_sapinstance, SAP_INST_FILTERS)
 
 
 @parser(Specs.saphostctl_getcimobject_sapinstance)
-class SAPHostCtrlInstances(CommandParser):
+class SAPHostCtrlInstances(CommandParser, list):
     """
     This class provides processing for the output of the
     ``/usr/sap/hostctrl/exe/saphostctrl -function GetCIMObject -enuminstances SAPInstance``
@@ -36,19 +36,19 @@ class SAPHostCtrlInstances(CommandParser):
     Sample output of the command::
 
         *********************************************************
-         CreationClassName , String , SAPInstance
          SID , String , D89
          SystemNumber , String , 88
          InstanceName , String , HDB88
+         InstanceType , String , HANA Test
          Hostname , String , hdb88
          FullQualifiedHostname , String , hdb88.example.com
          IPAddress , String , 10.0.0.88
          SapVersionInfo , String , 749, patch 211, changelist 1754007
         *********************************************************
-         CreationClassName , String , SAPInstance
          SID , String , D90
          SystemNumber , String , 90
          InstanceName , String , HDB90
+         InstanceType , String , HANA Test
          Hostname , String , hdb90
          FullQualifiedHostname , String , hdb90.example.com
          IPAddress , String , 10.0.0.90
@@ -57,86 +57,70 @@ class SAPHostCtrlInstances(CommandParser):
     Examples:
         >>> type(sap_inst)
         <class 'insights.parsers.saphostctrl.SAPHostCtrlInstances'>
-        >>> sap_inst.data[-1]['CreationClassName']
-        'SAPInstance'
-        >>> sap_inst.data[-1]['SID']
+        >>> sap_inst[1]['SID']
         'D90'
-        >>> sap_inst.data[-1]['SapVersionInfo']  # Note: captured as one string
+        >>> sap_inst[0]['SapVersionInfo']
         '749, patch 211, changelist 1754007'
-        >>> sap_inst.data[0]['InstanceType']  # Inferred code from InstanceName
-        'HDB'
+        >>> sap_inst[1]['InstanceType']
+        'HANA Test'
+        >>> sap_inst.types
+        ['HDB']
+        >>> sorted(sap_inst.sids)
+        ['D89', 'D90']
 
     Attributes:
-        data (list): List of dicts where keys are the lead name of each line and
-            values are the string value.
-        instances (list): The list of instances found in the cluster output.
         sids (list): The list of SID found in the cluster output.
-        types (list): The list of instance types found in the cluster output.
+        types (list): The list of short instance types.  The short instance
+            type is set as the characthers of the `InstanceName` before the
+            `SystemNumber`.
+
     Raises:
         SkipException: When input is empty.
         ParseException: When input cannot be parsed.
     """
     REQUIRED_DIRECTIVES = (
-        'CreationClassName',
         'SID',
         'SystemNumber',
         'InstanceName',
+        'InstanceType',
         'Hostname',
         'SapVersionInfo',
         'FullQualifiedHostname'
     )
 
     def parse_content(self, content):
-        if not content:
-            raise SkipException("Empty content")
-        if len(content) == 1:
-            raise ParseException("Incorrect content: '{0}'".format(content))
-
-        self.data = []
         self.instances = []
-        _current_instance = {}
         _sids = set()
         _types = set()
 
-        def _update_instance(inst):
-            for _dir in self.REQUIRED_DIRECTIVES:
-                if _dir not in inst:
-                    raise ParseException('Missing: "{0}"'.format(_dir))
-
-            if not inst['InstanceName'].endswith(inst['SystemNumber']):
-                raise ParseException(
-                    'InstanceName: "{0}" missing match with SystemNumber: "{1}"'.format(inst['InstanceName'], inst['SystemNumber']))
-            # InstanceType = The chars in InstanceName before the SystemNumber
-            # subtract len(sysnumber) characters from instance name
-            inst['InstanceType'] = inst['InstanceName'][0:-len(inst['SystemNumber'])]
-
-        _current_instance = {}
+        inst = {}
         for line in (l.strip() for l in content):
             if line.startswith('******'):
-                # Skip separator lines but save and reset current instance
-                if _current_instance:
-                    _update_instance(_current_instance)
-                    self.instances.append(_current_instance['InstanceName'])
-                    self.data.append(_current_instance)
-                    _types.add(_current_instance['InstanceType'])
-                    _sids.add(_current_instance['SID'])
-                _current_instance = {}
+                inst = {}
+                self.append(inst)
                 continue
+
             fields = [i.strip() for i in line.split(',', 2)]
             if len(fields) < 3:
                 raise ParseException("Incorrect line: '{0}'".format(line))
-            # TODO: if we see something other than 'String' in the second
-            # field, we could maybe change its type, say to an integer?
-            _current_instance[fields[0]] = fields[2]
-        # the last instance
-        if _current_instance:
-            _update_instance(_current_instance)
-            self.instances.append(_current_instance['InstanceName'])
-            self.data.append(_current_instance)
-            _types.add(_current_instance['InstanceType'])
-            _sids.add(_current_instance['SID'])
+
+            inst[fields[0]] = fields[2]
+
+            if fields[0] == 'InstanceName':
+                self.instances.append(fields[2])
+                _types.add(fields[2].strip('0123456789'))
+            _sids.add(inst['SID']) if fields[0] == 'SID' else None
+
+        if len(self) < 1:
+            raise SkipException("Nothing need to parser")
+
         self.sids = list(_sids)
         self.types = list(_types)
 
-    def __len__(self):
-        return len(self.data)
+    @property
+    def data(self):
+        """
+        (list): List of dicts where keys are the lead name of each line and
+            values are the string value.
+        """
+        return list(self)

--- a/insights/parsers/saphostctrl.py
+++ b/insights/parsers/saphostctrl.py
@@ -109,10 +109,10 @@ class SAPHostCtrlInstances(CommandParser, list):
             if fields[0] == 'InstanceName':
                 self.instances.append(fields[2])
                 _types.add(fields[2].strip('0123456789'))
-            _sids.add(inst['SID']) if fields[0] == 'SID' else None
+            _sids.add(fields[2]) if fields[0] == 'SID' else None
 
         if len(self) < 1:
-            raise SkipException("Nothing need to parser")
+            raise SkipException("Nothing need to parse")
 
         self.sids = list(_sids)
         self.types = list(_types)
@@ -123,4 +123,4 @@ class SAPHostCtrlInstances(CommandParser, list):
         (list): List of dicts where keys are the lead name of each line and
             values are the string value.
         """
-        return list(self)
+        return self

--- a/insights/parsers/saphostctrl.py
+++ b/insights/parsers/saphostctrl.py
@@ -69,9 +69,10 @@ class SAPHostCtrlInstances(CommandParser, list):
         ['D89', 'D90']
 
     Attributes:
+        instances (list): The list of instances found in the cluster output.
         sids (list): The list of SID found in the cluster output.
         types (list): The list of short instance types.  The short instance
-            type is set as the characthers of the `InstanceName` before the
+            type is set as the characters of the `InstanceName` before the
             `SystemNumber`.
 
     Raises:

--- a/insights/tests/combiners/test_sap.py
+++ b/insights/tests/combiners/test_sap.py
@@ -1,3 +1,6 @@
+import pytest
+import doctest
+
 from insights.parsers.hostname import Hostname as HnF
 from insights import SkipComponent
 from insights.parsers.lssap import Lssap
@@ -6,8 +9,7 @@ from insights.combiners import sap
 from insights.combiners.sap import Sap
 from insights.combiners.hostname import Hostname
 from insights.tests import context_wrap
-import pytest
-import doctest
+from insights.tests.parsers.test_saphostctrl import SAPHOSTCTRL_HOSTINSTANCES_DOCS, SAPHOSTCTRL_HOSTINSTANCES_GOOD
 
 Lssap_nw_TEST = """
  - lssap version 1.0 -
@@ -61,167 +63,44 @@ Lssap_doc_TEST = """
 HOSTNAME = 'lu0417.example.com'
 HOSTNAME1 = 'li-ld-1810.example.com'
 
-SAPHOSTCTRL_HOSTINSTANCES = '''
-*********************************************************
- CreationClassName , String , SAPInstance
- SID , String , D89
- SystemNumber , String , 88
- InstanceName , String , HDB88
- Hostname , String , lu0417
- FullQualifiedHostname , String , lu0417.example.com
- IPAddress , String , 10.0.0.88
- SapVersionInfo , String , 749, patch 211, changelist 1754007
-*********************************************************
- CreationClassName , String , SAPInstance
- SID , String , D90
- SystemNumber , String , 90
- InstanceName , String , HDB90
- Hostname , String , lu0418
- FullQualifiedHostname , String , lu0418.example.com
- IPAddress , String , 10.0.0.90
- SapVersionInfo , String , 749, patch 211, changelist 1754007
-'''
-
-SAPHOSTCTRL_HOSTINSTANCES_GOOD = '''
-*********************************************************
- CreationClassName , String , SAPInstance
- SID , String , D89
- SystemNumber , String , 88
- InstanceName , String , HDB88
- Hostname , String , li-ld-1810
- FullQualifiedHostname , String , li-ld-1810.example.com
- IPAddress , String , 10.0.0.1
- SapVersionInfo , String , 749, patch 211, changelist 1754007
-*********************************************************
- CreationClassName , String , SAPInstance
- SID , String , D90
- SystemNumber , String , 90
- InstanceName , String , HDB90
- Hostname , String , li-ld-1810
- FullQualifiedHostname , String , li-ld-1810.example.com
- IPAddress , String , 10.0.0.1
- SapVersionInfo , String , 749, patch 211, changelist 1754007
-*********************************************************
- CreationClassName , String , SAPInstance
- SID , String , D79
- SystemNumber , String , 08
- InstanceName , String , ERS08
- Hostname , String , d79ers
- FullQualifiedHostname , String , d79ers.example.com
- IPAddress , String , 10.0.0.15
- SapVersionInfo , String , 749, patch 301, changelist 1779613
-*********************************************************
- CreationClassName , String , SAPInstance
- SID , String , D79
- SystemNumber , String , 07
- InstanceName , String , ASCS07
- Hostname , String , d79ascs
- FullQualifiedHostname , String , d79ascs.example.com
- IPAddress , String , 10.0.0.14
- SapVersionInfo , String , 749, patch 301, changelist 1779613
-*********************************************************
- CreationClassName , String , SAPInstance
- SID , String , D79
- SystemNumber , String , 09
- InstanceName , String , DVEBMGS09
- Hostname , String , d79pas
- FullQualifiedHostname , String , d79pas.example.com
- IPAddress , String , 10.0.0.16
- SapVersionInfo , String , 749, patch 301, changelist 1779613
-*********************************************************
- CreationClassName , String , SAPInstance
- SID , String , D80
- SystemNumber , String , 10
- InstanceName , String , SCS10
- Hostname , String , d80scs
- FullQualifiedHostname , String , d80scs.example.com
- IPAddress , String , 10.0.0.17
- SapVersionInfo , String , 749, patch 301, changelist 1779613
-*********************************************************
- CreationClassName , String , SAPInstance
- SID , String , D62
- SystemNumber , String , 62
- InstanceName , String , HDB62
- Hostname , String , d62dbsrv
- FullQualifiedHostname , String , li-ld-1810.example.com
- IPAddress , String , 10.0.1.12
- SapVersionInfo , String , 749, patch 211, changelist 1754007
-*********************************************************
- CreationClassName , String , SAPInstance
- SID , String , D52
- SystemNumber , String , 52
- InstanceName , String , ASCS52
- Hostname , String , d52ascs
- FullQualifiedHostname , String , d52ascs.example.com
- IPAddress , String , 10.0.0.20
- SapVersionInfo , String , 749, patch 401, changelist 1806777
-*********************************************************
- CreationClassName , String , SAPInstance
- SID , String , D52
- SystemNumber , String , 54
- InstanceName , String , D54
- Hostname , String , d52pas
- FullQualifiedHostname , String , d52pas.example.com
- IPAddress , String , 10.0.0.22
- SapVersionInfo , String , 749, patch 401, changelist 1806777
-*********************************************************
- CreationClassName , String , SAPInstance
- SID , String , SMA
- SystemNumber , String , 91
- InstanceName , String , SMDA91
- Hostname , String , li-ld-1810
- FullQualifiedHostname , String , li-ld-1810.example.com
- IPAddress , String , 10.0.0.1
- SapVersionInfo , String , 749, patch 200, changelist 1746260
-*********************************************************
- CreationClassName , String , SAPInstance
- SID , String , B15
- SystemNumber , String , 00
- InstanceName , String , HDB00
- Hostname , String , sapb15hdba1
- FullQualifiedHostname , String , li-ld-1810.example.com
- SapVersionInfo , String , 749, patch 418, changelist 1816226
-*********************************************************
-'''
-
 SAPHOSTCTRL_HOSTINSTANCES_R_CASE = '''
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , R4D
  SystemNumber , String , 12
  InstanceName , String , DVEBMGS12
+ InstanceType , String , Primary Application Server
  Hostname , String , r4d00
  FullQualifiedHostname , String , r4d00.example.corp
  SapVersionInfo , String , 753, patch 501, changelist 1967207
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , R4D
  SystemNumber , String , 10
  InstanceName , String , ASCS10
+ InstanceType , String , ABAP Central Services
  Hostname , String , r4d01
  FullQualifiedHostname , String , r4d01.example.corp
  SapVersionInfo , String , 753, patch 501, changelist 1967207
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , WDX
  SystemNumber , String , 20
  InstanceName , String , W20
+ InstanceType , String , WebDispatcher
  Hostname , String , r4d02
  FullQualifiedHostname , String , host_97.example.corp
  SapVersionInfo , String , 773, patch 121, changelist 1917131
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , SMD
  SystemNumber , String , 98
  InstanceName , String , SMDA98
+ InstanceType , String , Solution Manager Diagnostic Agent
  Hostname , String , r4d01
  FullQualifiedHostname , String , host_97.example.corp
  SapVersionInfo , String , 745, patch 400, changelist 1734487
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , SMD
  SystemNumber , String , 97
  InstanceName , String , SMDA97
+ InstanceType , String , Solution Manager Diagnostic Agent
  Hostname , String , r4d00
  FullQualifiedHostname , String , host_97.example.corp
  SapVersionInfo , String , 745, patch 400, changelist 1734487
@@ -245,7 +124,7 @@ def test_lssap_netweaver():
 
 def test_saphostcrtl_hana():
     lssap = Lssap(context_wrap(Lssap_nw_TEST))
-    inst = SAPHostCtrlInstances(context_wrap(SAPHOSTCTRL_HOSTINSTANCES))
+    inst = SAPHostCtrlInstances(context_wrap(SAPHOSTCTRL_HOSTINSTANCES_DOCS))
     hn = Hostname(HnF(context_wrap(HOSTNAME)), None, None, None)
     sap = Sap(hn, inst, lssap)
     assert 'D50' not in sap

--- a/insights/tests/combiners/test_sap.py
+++ b/insights/tests/combiners/test_sap.py
@@ -161,6 +161,7 @@ def test_saphostcrtl_hana_2():
     assert sap.version('HDB90') == '749, patch 211, changelist 1754007'
     assert sap.hostname('HDB62') == 'd62dbsrv'
     assert sap.type('SCS10') == 'SCS'
+    assert sap.full_type('SCS10') == 'Java Central Services'
     assert sap.is_netweaver is True
     assert sap.is_hana is True
     assert sap.is_ascs is True

--- a/insights/tests/datasources/test_sap.py
+++ b/insights/tests/datasources/test_sap.py
@@ -16,46 +16,46 @@ from insights.specs.datasources.sap import (
 
 SAPHOSTCTRL_HOSTINSTANCES = '''
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , RH1
  SystemNumber , String , 01
  InstanceName , String , ASCS01
+ InstanceType , String , ABAP Central Services
  Hostname , String , vm37-39
  FullQualifiedHostname , String , vm37-39.pek2.com
  IPAddress , String , 10.72.37.39
  SapVersionInfo , String , 745, patch 100, changelist 1652052
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , RH1
  SystemNumber , String , 00
  InstanceName , String , D00
+ InstanceType , String , ABAP Dialog Instance
  Hostname , String , vm37-39
  FullQualifiedHostname , String , vm37-39.pek2.com
  IPAddress , String , 10.72.37.39
  SapVersionInfo , String , 745, patch 100, changelist 1652052
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , SR1
  SystemNumber , String , 02
  InstanceName , String , HDB02
+ InstanceType , String , HANA
  Hostname , String , vm37-39
  FullQualifiedHostname , String , vm37-39.pek2.com
  IPAddress , String , 10.72.37.39
  SapVersionInfo , String , 749, patch 418, changelist 1816226
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , RH2
  SystemNumber , String , 04
  InstanceName , String , ASCS04
+ InstanceType , String , ABAP Central Services
  Hostname , String , vm37-39
  FullQualifiedHostname , String , vm37-39.pek2.com
  IPAddress , String , 10.72.37.39
  SapVersionInfo , String , 745, patch 100, changelist 1652052
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , RH2
  SystemNumber , String , 03
  InstanceName , String , D03
+ InstanceType , String , ABAP Dialog Instance
  Hostname , String , vm37-39
  FullQualifiedHostname , String , vm37-39.pek2.com
  IPAddress , String , 10.72.37.39

--- a/insights/tests/parsers/test_saphostctrl.py
+++ b/insights/tests/parsers/test_saphostctrl.py
@@ -144,6 +144,7 @@ def test_saphostctrl_docs():
 def test_saphostctrl():
     sap = SAPHostCtrlInstances(context_wrap(SAPHOSTCTRL_HOSTINSTANCES_GOOD))
     assert len(sap) == 11
+    assert sap.data[-3]['SapVersionInfo'] == '749, patch 401, changelist 1806777'
     assert sap[-3]['SapVersionInfo'] == '749, patch 401, changelist 1806777'
     assert sorted(sap.instances) == sorted([
         'HDB88', 'HDB90', 'ERS08', 'ASCS07', 'DVEBMGS09', 'SCS10', 'HDB62',

--- a/insights/tests/parsers/test_saphostctrl.py
+++ b/insights/tests/parsers/test_saphostctrl.py
@@ -6,129 +6,130 @@ import pytest
 
 SAPHOSTCTRL_HOSTINSTANCES_DOCS = '''
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , D89
  SystemNumber , String , 88
  InstanceName , String , HDB88
- Hostname , String , hdb88
- FullQualifiedHostname , String , hdb88.example.com
+ InstanceType , String , HANA Test
+ Hostname , String , lu0417
+ FullQualifiedHostname , String , lu0417.example.com
  IPAddress , String , 10.0.0.88
  SapVersionInfo , String , 749, patch 211, changelist 1754007
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , D90
  SystemNumber , String , 90
  InstanceName , String , HDB90
- Hostname , String , hdb90
- FullQualifiedHostname , String , hdb90.example.com
+ InstanceType , String , HANA Test
+ Hostname , String , lu0418
+ FullQualifiedHostname , String , lu0418.example.com
  IPAddress , String , 10.0.0.90
  SapVersionInfo , String , 749, patch 211, changelist 1754007
-*********************************************************
 '''
 
 SAPHOSTCTRL_HOSTINSTANCES_GOOD = '''
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , D89
  SystemNumber , String , 88
  InstanceName , String , HDB88
+ InstanceType , String , HANA
  Hostname , String , li-ld-1810
  FullQualifiedHostname , String , li-ld-1810.example.com
  IPAddress , String , 10.0.0.1
  SapVersionInfo , String , 749, patch 211, changelist 1754007
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , D90
  SystemNumber , String , 90
  InstanceName , String , HDB90
+ InstanceType , String , HANA
  Hostname , String , li-ld-1810
  FullQualifiedHostname , String , li-ld-1810.example.com
  IPAddress , String , 10.0.0.1
  SapVersionInfo , String , 749, patch 211, changelist 1754007
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , D79
  SystemNumber , String , 08
  InstanceName , String , ERS08
+ InstanceType , String , Enqueue Replication Server
  Hostname , String , d79ers
  FullQualifiedHostname , String , d79ers.example.com
  IPAddress , String , 10.0.0.15
  SapVersionInfo , String , 749, patch 301, changelist 1779613
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , D79
  SystemNumber , String , 07
  InstanceName , String , ASCS07
+ InstanceType , String , ABAP Central Services
  Hostname , String , d79ascs
  FullQualifiedHostname , String , d79ascs.example.com
  IPAddress , String , 10.0.0.14
  SapVersionInfo , String , 749, patch 301, changelist 1779613
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , D79
  SystemNumber , String , 09
  InstanceName , String , DVEBMGS09
+ InstanceType , String , Primary Application Server
  Hostname , String , d79pas
  FullQualifiedHostname , String , d79pas.example.com
  IPAddress , String , 10.0.0.16
  SapVersionInfo , String , 749, patch 301, changelist 1779613
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , D80
  SystemNumber , String , 10
  InstanceName , String , SCS10
+ InstanceType , String , Java Central Services
  Hostname , String , d80scs
  FullQualifiedHostname , String , d80scs.example.com
  IPAddress , String , 10.0.0.17
  SapVersionInfo , String , 749, patch 301, changelist 1779613
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , D62
  SystemNumber , String , 62
  InstanceName , String , HDB62
+ InstanceType , String , HANA
  Hostname , String , d62dbsrv
  FullQualifiedHostname , String , li-ld-1810.example.com
  IPAddress , String , 10.0.1.12
  SapVersionInfo , String , 749, patch 211, changelist 1754007
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , D52
  SystemNumber , String , 52
  InstanceName , String , ASCS52
+ InstanceType , String , ABAP Central Services
  Hostname , String , d52ascs
  FullQualifiedHostname , String , d52ascs.example.com
  IPAddress , String , 10.0.0.20
  SapVersionInfo , String , 749, patch 401, changelist 1806777
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , D52
  SystemNumber , String , 54
  InstanceName , String , D54
+ InstanceType , String , ABAP Dialog Instance
  Hostname , String , d52pas
  FullQualifiedHostname , String , d52pas.example.com
  IPAddress , String , 10.0.0.22
  SapVersionInfo , String , 749, patch 401, changelist 1806777
 *********************************************************
- CreationClassName , String , SAPInstance
  SID , String , SMA
  SystemNumber , String , 91
  InstanceName , String , SMDA91
+ InstanceType , String , Solution Manager Diagnostic Agent
  Hostname , String , li-ld-1810
  FullQualifiedHostname , String , li-ld-1810.example.com
  IPAddress , String , 10.0.0.1
  SapVersionInfo , String , 749, patch 200, changelist 1746260
+*********************************************************
+ SID , String , B15
+ SystemNumber , String , 00
+ InstanceName , String , HDB00
+ InstanceType , String , HANA
+ Hostname , String , sapb15hdba1
+ FullQualifiedHostname , String , li-ld-1810.example.com
+ SapVersionInfo , String , 749, patch 418, changelist 1816226
 '''
 
 SAPHOSTCTRL_HOSTINSTANCES_BAD = '''
- CreationClassName , String
  SID , String , D89
  SystemNumber , String , 88
-'''
-
-SAPHOSTCTRL_HOSTINSTANCES_BAD1 = '''
- CreationClassName , String , SAPInstance
- SID , String , D89
- SystemNumber , String , 88
+ InstanceName , String
 '''
 
 
@@ -142,11 +143,11 @@ def test_saphostctrl_docs():
 
 def test_saphostctrl():
     sap = SAPHostCtrlInstances(context_wrap(SAPHOSTCTRL_HOSTINSTANCES_GOOD))
-    assert len(sap) == 10
-    assert sap.data[-2]['SapVersionInfo'] == '749, patch 401, changelist 1806777'
+    assert len(sap) == 11
+    assert sap[-3]['SapVersionInfo'] == '749, patch 401, changelist 1806777'
     assert sorted(sap.instances) == sorted([
         'HDB88', 'HDB90', 'ERS08', 'ASCS07', 'DVEBMGS09', 'SCS10', 'HDB62',
-        'ASCS52', 'D54', 'SMDA91'
+        'HDB00', 'ASCS52', 'D54', 'SMDA91'
     ])
     for sid in ['D89', 'D90', 'D79', 'D80', 'D62', 'D52', 'SMA']:
         assert sid in sap.sids
@@ -156,14 +157,8 @@ def test_saphostctrl():
 
 
 def test_saphostctrl_bad():
-    with pytest.raises(ParseException) as pe:
-        SAPHostCtrlInstances(context_wrap(SAPHOSTCTRL_HOSTINSTANCES_BAD))
-    assert "Incorrect line: 'CreationClassName , String'" in str(pe)
-
-    with pytest.raises(SkipException) as pe:
+    with pytest.raises(SkipException):
         SAPHostCtrlInstances(context_wrap(''))
-    assert "Empty content" in str(pe)
 
-    with pytest.raises(ParseException) as pe:
-        SAPHostCtrlInstances(context_wrap(SAPHOSTCTRL_HOSTINSTANCES_BAD1))
-    assert "Missing:" in str(pe)
+    with pytest.raises(ParseException):
+        SAPHostCtrlInstances(context_wrap(SAPHOSTCTRL_HOSTINSTANCES_BAD))


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?  -> BZ-1969572
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

From BZ-1969572, the "InstanceType" should be used as the identifier for SAP `function_instance`
- Added the InstanceType to the fixed filter of saphostctrl
- Remove the unused "CreationClassName" from the fixed filter
- Add a full_type function to get the full InstanceType
- check "Solution Manager Diagnostic Agent" for function_instance
- Convert the Parser SAPHostCtrlInstances to a list