### PR TITLE
Feat: add secure spec to default.py

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -606,6 +606,7 @@ class DefaultSpecs(Specs):
     sctp_eps = simple_file('/proc/net/sctp/eps')
     sctp_snmp = simple_file('/proc/net/sctp/snmp')
     sealert = simple_command('/usr/bin/sealert -l "*"')
+    secure = simple_file("/var/log/secure")
     selinux_config = simple_file("/etc/selinux/config")
     sestatus = simple_command("/usr/sbin/sestatus -b")
     setup_named_chroot = simple_file("/usr/libexec/setup-named-chroot.sh")

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -267,7 +267,6 @@ class SosSpecs(Specs):
     sap_host_profile = simple_file("/usr/sap/hostctrl/exe/host_profile")
     sched_rt_runtime_us = simple_file("/proc/sys/kernel/sched_rt_runtime_us")
     scsi_mod_use_blk_mq = simple_file("/sys/module/scsi_mod/parameters/use_blk_mq")
-    secure = simple_file("/var/log/secure")
     sestatus = simple_file("sos_commands/selinux/sestatus_-b")
     sssd_logs = glob_file("var/log/sssd/*.log")
     samba_logs = glob_file("var/log/samba/log.*")


### PR DESCRIPTION
Signed-off-by: Xinting Li <xintli@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
secure parser is only used for sos_archive currently, but insights rule also use this parser. Add this spec in default.py.
