### PR TITLE
Refractor cleanup local files for unregistration processes

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -23,7 +23,6 @@ from .connection import InsightsConnection
 from .archive import InsightsArchive
 from .support import registration_check
 from .constants import InsightsConstants as constants
-from .schedule import get_scheduler
 
 NETWORK = constants.custom_network_log_level
 LOG_FORMAT = ("%(asctime)s %(levelname)8s %(name)s %(message)s")
@@ -200,16 +199,18 @@ def get_registration_status(config, pconn):
     return registration_check(pconn)
 
 
+def __cleanup_local_files():
+    write_unregistered_file()
+    delete_cache_files()
+    write_to_disk(constants.machine_id_file, delete=True)
+    logger.debug('Unregistered and removed machine-id')
+
+
 # -LEGACY-
 def _legacy_handle_unregistration(config, pconn):
     """
         returns (bool): True success, False failure
     """
-    def __cleanup_local_files():
-        write_unregistered_file()
-        get_scheduler(config).remove_scheduling()
-        delete_cache_files()
-        write_to_disk(constants.machine_id_file, delete=True)
 
     check = get_registration_status(config, pconn)
 
@@ -248,10 +249,7 @@ def handle_unregistration(config, pconn):
     unreg = pconn.unregister()
     if unreg or config.force:
         # only set if unreg was successful or --force was set
-        write_unregistered_file()
-        delete_cache_files()
-        write_to_disk(constants.machine_id_file, delete=True)
-        logger.debug('Unregistered and removed machine-id')
+        __cleanup_local_files()
     return unreg
 
 

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -174,6 +174,7 @@ def post_update(client, config):
         # put this first to avoid conflicts with register
         if config.unregister:
             if client.unregister():
+                get_scheduler(config).remove_scheduling()
                 sys.exit(constants.sig_kill_ok)
             else:
                 sys.exit(constants.sig_kill_bad)


### PR DESCRIPTION
Signed-off-by: ahitacat <ahitacat@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Create a private method to clean the local files that set the register status for `insights-client`. This process was done for both unregistration (legacy_upload = True and False). The method was already created, this PR just use this method as well when `legacy_upload` is False.
