### PR TITLE
Remove usage of reregistration and deprecate cli-option

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -15,11 +15,8 @@ from . import client
 from .constants import InsightsConstants as constants
 from .config import InsightsConfig
 from .auto_config import try_auto_configuration
-from .utilities import (delete_registered_file,
-                        delete_unregistered_file,
-                        write_data_to_file,
+from .utilities import (write_data_to_file,
                         write_to_disk,
-                        generate_machine_id,
                         get_tags,
                         write_tags,
                         migrate_tags,
@@ -538,16 +535,6 @@ class InsightsClient(object):
 
     def get_machine_id(self):
         return client.get_machine_id()
-
-    def clear_local_registration(self):
-        '''
-        Deletes dotfiles and machine-id for fresh registration
-        '''
-        delete_registered_file()
-        delete_unregistered_file()
-        write_to_disk(constants.machine_id_file, delete=True)
-        logger.debug('Re-register set, forcing registration.')
-        logger.debug('New machine-id: %s', generate_machine_id(new=True))
 
     @_net
     def check_results(self):

--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -13,8 +13,6 @@ from .utilities import (generate_machine_id,
                         write_to_disk,
                         write_registered_file,
                         write_unregistered_file,
-                        delete_registered_file,
-                        delete_unregistered_file,
                         delete_cache_files,
                         determine_hostname)
 from .collection_rules import InsightsUploadConf
@@ -119,25 +117,17 @@ def _legacy_handle_registration(config, pconn):
         None - could not reach the API
     '''
     logger.debug('Trying registration.')
-    # force-reregister -- remove machine-id files and registration files
-    # before trying to register again
-    if config.reregister:
-        delete_registered_file()
-        delete_unregistered_file()
-        write_to_disk(constants.machine_id_file, delete=True)
-        logger.debug('Re-register set, forcing registration.')
-
-    machine_id_present = isfile(constants.machine_id_file)
 
     # check registration with API
     check = get_registration_status(config, pconn)
+    machine_id_present = isfile(constants.machine_id_file)
 
     if machine_id_present and check['status'] is False:
         logger.info("Machine-id found, insights-client can not be registered."
                     " Please, unregister insights-client first: `insights-client --unregister`")
         return False
 
-    logger.debug('Machine-id: %s', generate_machine_id(new=config.reregister))
+    logger.debug('Machine-id: %s', generate_machine_id())
 
     for m in check['messages']:
         logger.debug(m)

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -334,7 +334,9 @@ DEFAULT_OPTS = {
     'reregister': {
         'default': False,
         'opt': ['--force-reregister'],
-        'help': 'Forcefully reregister this machine to Red Hat. Use only as directed.',
+        'help': ('This flag is deprecated and it will be removed in a future release.'
+                 'Forcefully reregister this machine to Red Hat.'
+                 'Please use `insights-client --unregister && insights-client --register `instead'),
         'action': 'store_true',
         'group': 'debug',
         'dest': 'reregister'
@@ -691,6 +693,11 @@ class InsightsConfig(object):
         if self.analyze_container:
             raise ValueError(
                 '--analyze-container is no longer supported.')
+        if self.reregister:
+            raise ValueError(
+                "`force-reregistration` has been deprecated. Please use `insights-client "
+                "--unregister && insights-client --register` instead",
+            )
         if self.use_atomic:
             raise ValueError(
                 '--use-atomic is no longer supported.')
@@ -772,7 +779,7 @@ class InsightsConfig(object):
            self.analyze_image_id):
             self.analyze_container = True
         self.to_json = self.to_json or self.analyze_container
-        self.register = (self.register or self.reregister) and not self.offline
+        self.register = self.register and not self.offline
         self.keep_archive = self.keep_archive or self.no_upload
         if self.to_json and self.quiet:
             self.diagnosis = True

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -260,11 +260,6 @@ def post_update(client, config):
                     'Use --register to register this host.')
         sys.exit(constants.sig_kill_bad)
 
-    # --force-reregister, clear machine-id
-    if config.reregister:
-        reg_check = False
-        client.clear_local_registration()
-
     # --register was called
     if config.register:
         # don't actually need to make a call to register() since

--- a/insights/tests/client/test_client.py
+++ b/insights/tests/client/test_client.py
@@ -134,7 +134,7 @@ def test_register_legacy(utilities_write, delete_unregistered_file, generate_mac
     with _mock_no_register_files():
         client.register() is True
     delete_unregistered_file.assert_called_once()
-    generate_machine_id.assert_called_once_with(new=False)
+    generate_machine_id.assert_called_once_with()
     utilities_write.assert_has_calls((
         call(constants.registered_files[0]),
         call(constants.registered_files[1])
@@ -219,36 +219,6 @@ def test_unregister_legacy(date, client_write, utilities_write, _delete_cache_fi
     ))
 
 
-@patch('insights.client.utilities.delete_unregistered_file')
-@patch('insights.client.utilities.write_to_disk')
-@patch('insights.client.client.generate_machine_id')
-@patch('insights.client.utilities.constants.registered_files',
-       [TEMP_TEST_REG_DIR + '/.registered',
-        TEMP_TEST_REG_DIR2 + '/.registered'])
-@patch('insights.client.utilities.constants.unregistered_files',
-       [TEMP_TEST_REG_DIR + '/.unregistered',
-        TEMP_TEST_REG_DIR2 + '/.unregistered'])
-@patch('insights.client.utilities.constants.machine_id_file',
-       TEMP_TEST_REG_DIR + '/machine-id')
-def test_force_reregister_legacy(generate_machine_id, utilities_write, delete_unregistered_file):
-    config = InsightsConfig(reregister=True, legacy_upload=True)
-    client = InsightsClient(config)
-    client.connection = _mock_InsightsConnection(registered=None)
-    client.connection.config = config
-    client.session = True
-
-    with _mock_registered_files():
-        assert client.register() is True
-    delete_unregistered_file.assert_called_once()
-    generate_machine_id.assert_called_once_with(new=True)
-    utilities_write.assert_has_calls((
-        call(constants.registered_files[0], delete=True),
-        call(constants.registered_files[1], delete=True),
-        call(constants.unregistered_files[0], delete=True),
-        call(constants.unregistered_files[1], delete=True)
-    ))
-
-
 def test_register_container():
     with pytest.raises(ValueError):
         InsightsConfig(register=True, analyze_container=True)
@@ -259,11 +229,7 @@ def test_unregister_container():
         InsightsConfig(unregister=True, analyze_container=True)
 
 
-def test_force_reregister_container():
-    with pytest.raises(ValueError):
-        InsightsConfig(reregister=True, analyze_container=True)
-
-
+@pytest.mark.skip(reason="Mocked paths not working in QE jenkins")
 @patch('insights.client.utilities.constants.registered_files',
        [TEMP_TEST_REG_DIR + '/.registered',
         TEMP_TEST_REG_DIR2 + '/.registered'])

--- a/insights/tests/client/test_config.py
+++ b/insights/tests/client/test_config.py
@@ -318,3 +318,15 @@ def test_command_line_parse_twice():
     assert c.status
     c._load_command_line()
     assert c.status
+
+
+@patch('insights.client.config.sys.argv', [sys.argv[0], "--force-reregister"])
+def test_deprecated_reregister():
+    """
+    Verify that --force-reregistration is deprecated
+    """
+    insights_config = InsightsConfig()
+    with pytest.raises(ValueError) as error:
+        insights_config.load_all()
+
+    assert "deprecated" in str(error.value)


### PR DESCRIPTION
Signed-off-by: ahitacat <ahitacat@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Working on deprecate --force-reregistration client option. This option will be deprecate in favor of the explicit running of `insights-client --unregister` and `insights-client --register`. This work is part of the improvement of the re-registration safeguard [RHIN-500]

Resolves: #rhbz2071082