### PR TITLE
fix: bz-2126966: use SIGTERM for rpm instead of SIGKILL

### DIFF
--- a/insights/specs/datasources/system_user_dirs.py
+++ b/insights/specs/datasources/system_user_dirs.py
@@ -4,6 +4,7 @@ Custom datasource for CVE-2021-35937, CVE-2021-35938, and CVE-2021-35939.
 
 import grp
 import pwd
+import signal
 
 from insights.core.context import HostContext
 from insights.core.dr import SkipComponent
@@ -17,7 +18,8 @@ class LocalSpecs(Specs):
     Local spec used only by the system_user_dirs datasource
     """
     rpm_args = simple_command(
-        'rpm -qa --qf="[%{=NAME}; %{FILEMODES:perms}; %{FILEUSERNAME}; %{FILEGROUPNAME}\n]"'
+        'rpm -qa --qf="[%{=NAME}; %{FILEMODES:perms}; %{FILEUSERNAME}; %{FILEGROUPNAME}\n]"',
+        signum=signal.SIGTERM
     )
 
 

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -541,7 +541,7 @@ class DefaultSpecs(Specs):
     rhsm_releasever = simple_file('/var/lib/rhsm/cache/releasever.json')
     rndc_status = simple_command("/usr/sbin/rndc status")
     ros_config = simple_file("/var/lib/pcp/config/pmlogger/config.ros")
-    rpm_ostree_status = simple_command("/usr/bin/rpm-ostree status --json")
+    rpm_ostree_status = simple_command("/usr/bin/rpm-ostree status --json", signum=signal.SIGTERM)
     rpm_V_packages = simple_command("/bin/rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony", keep_rc=True, signum=signal.SIGTERM)
     rsyslog_conf = glob_file(["/etc/rsyslog.conf", "/etc/rsyslog.d/*.conf"])
     samba = simple_file("/etc/samba/smb.conf")


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Fix bz-2126966, the "rpm/yum/dnf" related command should use "SIGTERM" instead of the default "SIGKILL".
- also modified the "rpm_ostree_status"