### PR TITLE
fix: make SAPHostCtrlInstances compatible with old archives

### DIFF
--- a/insights/parsers/saphostctrl.py
+++ b/insights/parsers/saphostctrl.py
@@ -108,8 +108,12 @@ class SAPHostCtrlInstances(CommandParser, list):
             inst[fields[0]] = fields[2]
 
             if fields[0] == 'InstanceName':
+                short_type = fields[2].strip('0123456789')
+                # Back forward compatible: a short InstanceType was from the InstanceName
+                if 'InstanceType' not in inst:
+                    inst.update(dict(InstanceType=short_type))
                 self.instances.append(fields[2])
-                _types.add(fields[2].strip('0123456789'))
+                _types.add(short_type)
             _sids.add(fields[2]) if fields[0] == 'SID' else None
 
         if len(self) < 1:

--- a/insights/tests/parsers/test_saphostctrl.py
+++ b/insights/tests/parsers/test_saphostctrl.py
@@ -181,7 +181,7 @@ def test_saphostctrl():
 
 def test_saphostctrl_old():
     sap = SAPHostCtrlInstances(context_wrap(SAPHOSTCTRL_HOSTINSTANCES_DOCS_OLD))
-    assert sorted(sap.types) == sorted(['HANA Test', 'HDB'])
+    assert sap.types == ['HDB']  # short types only
     assert sap[0]['InstanceType'] == 'HANA Test'
     assert sap[1]['InstanceType'] == 'HDB'
 

--- a/insights/tests/parsers/test_saphostctrl.py
+++ b/insights/tests/parsers/test_saphostctrl.py
@@ -25,6 +25,28 @@ SAPHOSTCTRL_HOSTINSTANCES_DOCS = '''
  SapVersionInfo , String , 749, patch 211, changelist 1754007
 '''
 
+SAPHOSTCTRL_HOSTINSTANCES_DOCS_OLD = '''
+*********************************************************
+ CreationClassName , String , SAPInstance
+ SID , String , D89
+ SystemNumber , String , 88
+ InstanceName , String , HDB88
+ InstanceType , String , HANA Test
+ Hostname , String , lu0417
+ FullQualifiedHostname , String , lu0417.example.com
+ IPAddress , String , 10.0.0.88
+ SapVersionInfo , String , 749, patch 211, changelist 1754007
+*********************************************************
+ CreationClassName , String , SAPInstance
+ SID , String , D90
+ SystemNumber , String , 90
+ InstanceName , String , HDB90
+ Hostname , String , lu0418
+ FullQualifiedHostname , String , lu0418.example.com
+ IPAddress , String , 10.0.0.90
+ SapVersionInfo , String , 749, patch 211, changelist 1754007
+'''
+
 SAPHOSTCTRL_HOSTINSTANCES_GOOD = '''
 *********************************************************
  SID , String , D89
@@ -155,6 +177,13 @@ def test_saphostctrl():
     assert sorted(sap.types) == sorted([
         'HDB', 'ERS', 'ASCS', 'DVEBMGS', 'SCS', 'D', 'SMDA'
     ])
+
+
+def test_saphostctrl_old():
+    sap = SAPHostCtrlInstances(context_wrap(SAPHOSTCTRL_HOSTINSTANCES_DOCS_OLD))
+    assert sorted(sap.types) == sorted(['HANA Test', 'HDB'])
+    assert sap[0]['InstanceType'] == 'HANA Test'
+    assert sap[1]['InstanceType'] == 'HDB'
 
 
 def test_saphostctrl_bad():

--- a/insights/tests/parsers/test_saphostctrl.py
+++ b/insights/tests/parsers/test_saphostctrl.py
@@ -30,8 +30,8 @@ SAPHOSTCTRL_HOSTINSTANCES_DOCS_OLD = '''
  CreationClassName , String , SAPInstance
  SID , String , D89
  SystemNumber , String , 88
- InstanceName , String , HDB88
  InstanceType , String , HANA Test
+ InstanceName , String , HDB88
  Hostname , String , lu0417
  FullQualifiedHostname , String , lu0417.example.com
  IPAddress , String , 10.0.0.88


### PR DESCRIPTION
- fix: #3530
- Generate the InstanceType as per the InstanceName, since it is not collected by the old archives.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
- Since the old archives didn't collect the InstanceType lines, when applying the new logic of #3512 against the old archives an exception will be thrown and the `Sap` combiner gets fail.
- This PR fixes this and makes the parse compatible with the old archives.
