### PR TITLE
fix: Restore the spec ovs_appctl_fdb_show_bridge

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -484,6 +484,8 @@ class DefaultSpecs(Specs):
     ose_node_config = simple_file("/etc/origin/node/node-config.yaml")
     ovirt_engine_server_log = simple_file("/var/log/ovirt-engine/server.log")
     ovirt_engine_ui_log = simple_file("/var/log/ovirt-engine/ui.log")
+    ovs_vsctl_list_br = simple_command("/usr/bin/ovs-vsctl list-br")
+    ovs_appctl_fdb_show_bridge = foreach_execute(ovs_vsctl_list_br, "/usr/bin/ovs-appctl fdb/show %s")
     ovs_vsctl_list_bridge = simple_command("/usr/bin/ovs-vsctl list bridge")
     ovs_vsctl_show = simple_command("/usr/bin/ovs-vsctl show")
     package_provides_command = package_provides.cmd_and_pkg

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -196,6 +196,7 @@ class InsightsArchiveSpecs(Specs):
     od_cpu_dma_latency = simple_file("insights_commands/od_-An_-t_d_.dev.cpu_dma_latency")
     open_vm_tools_stat_raw_text_session = simple_file("insights_commands/vmware-toolbox-cmd_stat_raw_text_session")
     openvswitch_other_config = simple_file("insights_commands/ovs-vsctl_-t_5_get_Open_vSwitch_._other_config")
+    ovs_appctl_fdb_show_bridge = glob_file("insights_commands/ovs-appctl_fdb.show_*")
     ovs_vsctl_list_bridge = simple_file("insights_commands/ovs-vsctl_list_bridge")
     ovs_vsctl_show = simple_file("insights_commands/ovs-vsctl_show")
     package_provides_command = glob_file("insights_commands/echo_*java*")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -196,7 +196,6 @@ class InsightsArchiveSpecs(Specs):
     od_cpu_dma_latency = simple_file("insights_commands/od_-An_-t_d_.dev.cpu_dma_latency")
     open_vm_tools_stat_raw_text_session = simple_file("insights_commands/vmware-toolbox-cmd_stat_raw_text_session")
     openvswitch_other_config = simple_file("insights_commands/ovs-vsctl_-t_5_get_Open_vSwitch_._other_config")
-    ovs_appctl_fdb_show_bridge = glob_file("insights_commands/ovs-appctl_fdb.show_*")
     ovs_vsctl_list_bridge = simple_file("insights_commands/ovs-vsctl_list_bridge")
     ovs_vsctl_show = simple_file("insights_commands/ovs-vsctl_show")
     package_provides_command = glob_file("insights_commands/echo_*java*")


### PR DESCRIPTION
### Description:

Restore the spec which was removed in https://github.com/RedHatInsights/insights-core/commit/eb70e566a327b12445dbba4b6ca05b90772effa0

Signed-off-by: Sachin Patil <psachin@redhat.com>

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
