### PR TITLE
fix: Add ability to return exceptions during insights collect

### DIFF
--- a/insights/client/core_collector.py
+++ b/insights/client/core_collector.py
@@ -52,7 +52,12 @@ class CoreCollector(DataCollector):
         manifest = collect.default_manifest
         if hasattr(self.config, 'manifest') and self.config.manifest:
             manifest = self.config.manifest
-        collected_data_path = collect.collect(manifest=manifest, tmp_path=self.archive.tmp_dir, rm_conf=core_blacklist, client_timeout=self.config.cmd_timeout)
+        collected_data_path, exceptions = collect.collect(
+            manifest=manifest,
+            tmp_path=self.archive.tmp_dir,
+            rm_conf=core_blacklist,
+            client_timeout=self.config.cmd_timeout
+        )
 
         # update the archive dir with the reported data location from Insights Core
         if not collected_data_path:

--- a/insights/tests/client/data_collector/test_redact.py
+++ b/insights/tests/client/data_collector/test_redact.py
@@ -37,7 +37,7 @@ def test_redact_called_classic(redact):
 @patch('insights.client.core_collector.CoreCollector._write_version_info', Mock())
 @patch('insights.client.core_collector.CoreCollector._write_tags', Mock())
 @patch('insights.client.core_collector.CoreCollector._write_blacklist_report', Mock())
-@patch('insights.client.core_collector.collect.collect', Mock(return_value='/var/tmp/testarchive/insights-test'))
+@patch('insights.client.core_collector.collect.collect', Mock(return_value=('/var/tmp/testarchive/insights-test', {})))
 @patch('insights.client.core_collector.CoreCollector.redact')
 def test_redact_called_core(redact):
     '''

--- a/insights/tests/test_collect.py
+++ b/insights/tests/test_collect.py
@@ -1,0 +1,39 @@
+from mock.mock import Mock
+
+from insights.collect import _parse_broker_exceptions
+from insights.core.dr import Broker
+from insights.core.plugins import ContentException
+
+
+def test_parse_broker_exceptions_no_errors():
+    exc_to_report = set([OSError])
+    broker = Broker()
+    errors = _parse_broker_exceptions(broker, exc_to_report)
+    assert not errors
+
+
+def test_parse_broker_exceptions_oserror():
+    exc_to_report = set([OSError])
+    broker = Broker()
+    component_one = Mock()
+    broker.add_exception(component_one, OSError("OS Error occurred"))
+    component_two = Mock()
+    broker.add_exception(component_two, OSError("OS Error occurred again"))
+    errors = _parse_broker_exceptions(broker, exc_to_report)
+    assert OSError in errors.keys()
+    assert len(errors[OSError]) == 2
+    assert all(type(ex) is OSError for ex, comp in errors[OSError])
+
+
+def test_parse_broker_exceptions_oserror_contentexception():
+    exc_to_report = set([OSError])
+    broker = Broker()
+    component_one = Mock()
+    broker.add_exception(component_one, OSError("OS Error occurred"))
+    component_two = Mock()
+    broker.add_exception(component_two, ContentException("Bad content"))
+    errors = _parse_broker_exceptions(broker, exc_to_report)
+    assert OSError in errors.keys()
+    assert ContentException not in errors.keys()
+    assert len(errors[OSError]) == 1
+    assert all(type(ex) is OSError for ex, comp in errors[OSError])

--- a/insights/tests/test_serde.py
+++ b/insights/tests/test_serde.py
@@ -53,8 +53,10 @@ def deserialize_foo(_type, data, root=None):
 
 
 def test_marshal():
+    broker = dr.Broker()
     foo = Foo()
-    data, errors = marshal(foo)
+    broker[thing] = foo
+    data, errors = marshal(thing, broker)
     assert data
     assert not errors
     d = data["object"]
@@ -63,14 +65,18 @@ def test_marshal():
 
 
 def test_marshal_with_errors():
+    broker = dr.Broker()
     doo = Doo(2)
-    data, errors = marshal(doo)
+    broker[thing] = doo
+    data, errors = marshal(thing, broker)
     assert not data
     assert isinstance(errors, str)
 
     # one raises error, one has result
+    broker = dr.Broker()
     objs = [Doo(4), Doo(6)]
-    data, errors = marshal(objs)
+    broker[thing] = objs
+    data, errors = marshal(thing, broker)
     assert data
     assert errors
     assert len(data) == 1
@@ -80,15 +86,19 @@ def test_marshal_with_errors():
     assert d["b"] == 2
 
     # all raises error, no results
+    broker = dr.Broker()
     objs = [Doo(4), Doo(3)]
-    data, errors = marshal(objs)
+    broker[thing] = objs
+    data, errors = marshal(thing, broker)
     assert not data
     assert errors
     assert len(errors) == 2
 
     # all have resutls, no errors
+    broker = dr.Broker()
     objs = [Doo(8), Doo(6)]
-    data, errors = marshal(objs)
+    broker[thing] = objs
+    data, errors = marshal(thing, broker)
     assert data
     assert not errors
     assert len(data) == 2
@@ -103,8 +113,10 @@ def test_marshal_with_errors_with_pool():
         from concurrent.futures import ThreadPoolExecutor
         with ThreadPoolExecutor(thread_name_prefix="insights-collector-pool", max_workers=5) as pool:
             # one raises error, one has result
+            broker = dr.Broker()
             objs = [Doo(4), Doo(6)]
-            data, errors = marshal(objs, None, pool)
+            broker[thing] = objs
+            data, errors = marshal(thing, broker, pool=pool)
             assert data
             assert errors
             assert len(data) == 1
@@ -114,15 +126,19 @@ def test_marshal_with_errors_with_pool():
             assert d["b"] == 2
 
             # all raises error, no results
+            broker = dr.Broker()
             objs = [Doo(4), Doo(3)]
-            data, errors = marshal(objs, None, pool)
+            broker[thing] = objs
+            data, errors = marshal(thing, broker, pool=pool)
             assert not data
             assert errors
             assert len(errors) == 2
 
             # all have resutls, no errors
+            broker = dr.Broker()
             objs = [Doo(8), Doo(6)]
-            data, errors = marshal(objs, None, pool)
+            broker[thing] = objs
+            data, errors = marshal(thing, broker, pool=pool)
             assert data
             assert not errors
             assert len(data) == 2


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Modified how exceptions are handleled in the `insights.core.serde.marshal` function, so error tracebacks are captured and serialized to a meta-data file in the archive (as before) and also exceptions are added to the broker for later retrieval.

* Added `_parse_broker_exceptions` and modified `collect` function in the `insights.collect` module, so all broker exceptions are analyzed after core collection and exception types that are defined in `EXCEPTIONS_TO_REPORT` set will be included as a dict and returned from the `collect()` function, as a second value in the tuple. This is needed so insights-client can analyze those errors and direct the collection logic flow differently if necessary.
