### PR TITLE
Deprecate insights.core.scannable & engine_log parser

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -866,6 +866,9 @@ class Scannable(six.with_metaclass(ScanMeta, Parser)):
     strings or False).
 
     """
+    def __init__(self, *args, **kwargs):
+        deprecated(Scannable, "Please use the :class:`insights.core.Parser` instead", "3.2.25")
+        super(Scannable, self).__init__(*args, **kwargs)
 
     @classmethod
     def _scan(cls, result_key, scanner):

--- a/insights/parsers/engine_log.py
+++ b/insights/parsers/engine_log.py
@@ -39,5 +39,5 @@ class EngineLog(LogFileOutput):
     Provide access to ovirt engine logs using the LogFileOutput parser class.
     """
     def __init__(self, *args, **kwargs):
-        deprecated(EngineLog, "Import EngineLog from insights.parsers.ovirt_engine_log instead")
+        deprecated(EngineLog, "Import EngineLog from insights.parsers.ovirt_engine_log instead", "3.2.25")
         super(EngineLog, self).__init__(*args, **kwargs)


### PR DESCRIPTION
### Complete Description of Additions/Changes:

The following will be deprecated after insights-core-3.2.25:
* insights.core.scannable: Better use the `core.Parser` with filter.
* insights.parsers.engine_log: Use insights.parsers.ovirt_engine_log instead.

Signed-off-by: Sachin Patil <psachin@redhat.com>

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?


<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
