### PR TITLE
Avoid test to write in disk if machine-id is not found

### DIFF
--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -123,6 +123,7 @@ class TestDefaultValues:
     @patch(GET_RULES_TARGET, return_value=TEST_RULE_FILE)
     @patch(FIND_YARA_TARGET, return_value=YARA)
     @patch(LOGGER_TARGET)
+    @patch('insights.client.utilities.write_to_disk', Mock())
     def test_running_default_options(self, log_mock, yara, rules, cmd, create_test_files):
         # Try running malware-detection with the default options
         # With the default options, test_scan is true, so some of the option values will be changed for that and


### PR DESCRIPTION
Signed-off-by: ahitacat <ahitacat@redhat.com>

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Malware test was trying to create a `machine-id` file if there isn't one in the system.
I have mocked the method that tries to create the machine-id as a solution.
