### PR TITLE
feat(client): add --manifest argument

### DIFF
--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -127,6 +127,14 @@ DEFAULT_OPTS = {
         'group': 'actions',
         'dest': 'app'
     },
+    'manifest': {
+        'default': None,
+        'opt': ['--manifest'],
+        'help': 'Collect using the provided manifest',
+        'action': 'store',
+        'group': 'actions',
+        'dest': 'manifest'
+    },
     'compliance': {
         'default': False,
         'opt': ['--compliance'],
@@ -468,6 +476,7 @@ class InsightsConfig(object):
     '''
     Insights client configuration
     '''
+
     def __init__(self, *args, **kwargs):
         # this is only used to print configuration errors upon initial load
         self._print_errors = False

--- a/insights/client/core_collector.py
+++ b/insights/client/core_collector.py
@@ -51,7 +51,11 @@ class CoreCollector(DataCollector):
 
         manifest = collect.default_manifest
         if hasattr(self.config, 'manifest') and self.config.manifest:
-            manifest = self.config.manifest
+            if self.config.app is None:
+                with open(self.config.manifest, 'r') as f:
+                    manifest = f.read()
+            else:
+                manifest = self.config.manifest
         collected_data_path, exceptions = collect.collect(
             manifest=manifest,
             tmp_path=self.archive.tmp_dir,


### PR DESCRIPTION
Add a top-level --manifest argument. This argument expects a path to an
insights collection manifest file. If the argument is not None, the
manifest is used instead of the default manifest to collect data.

Fixes: https://issues.redhat.com/browse/ESSNTL-3540

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
