### PR TITLE
refactor: remove duplicated specs from get_dependency_specs

### DIFF
--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -398,9 +398,11 @@ def get_dependency_specs(component):
         req = list()
         for cmp in get_delegate(comp).requires:
             if get_name(cmp).startswith("insights.specs."):
-                req.append(get_simple_name(cmp))
+                cmpn = get_simple_name(cmp)
+                req.append(cmpn) if cmpn not in req else None
             else:
-                req.extend(get_requires(cmp) + get_at_least_one(cmp))
+                union = get_requires(cmp) + get_at_least_one(cmp)
+                req.extend([ss for ss in union if ss not in req])
         return req
 
     def get_at_least_one(comp):
@@ -412,10 +414,10 @@ def get_dependency_specs(component):
                 ssalo = get_at_least_one(cmp)
                 if ssreq and ssalo:
                     # they are mixed and in the same `requires` level
-                    salo.append([ss for ss in ssreq + ssalo])
+                    salo.append([ss for ss in ssreq + ssalo if ss not in salo])
                 else:
                     # no mixed, just add them one by one
-                    salo.extend(ssreq or ssalo)
+                    salo.extend([ss for ss in ssreq or ssalo if ss not in salo])
             alo.append(tuple(salo))
         return alo
 

--- a/insights/tests/test_get_dependency_specs.py
+++ b/insights/tests/test_get_dependency_specs.py
@@ -31,79 +31,80 @@ from insights.core.dr import get_dependency_specs
 
 
 @condition(InstalledRpms, [Up2Date, PsAuxcww], optional=[Messages])
-def condition_1(*args):
+def condition_01(*args):
     return True
 
 
 @condition(VirtWhat, Tags, RedHatRelease, optional=[Date, Uptime])
-def condition_2(*args):
+def condition_02(*args):
     return True
 
 
 @condition(LsVarLog, [LsBoot, LsEtc])
-def condition_3(*args):
+def condition_03(*args):
     return True
 
 
 @condition(LsVarWwwPerms, [LsDev, LsDisk], optional=[LsVarRun])
-def condition_4(*args):
+def condition_04(*args):
     return True
 
 
 @condition([LsPci, LsPciVmmkn])
-def condition_5(*args):
+def condition_05(*args):
     return True
 
 
 @condition([LvmConf, LvmConfig])
-def condition_6(*args):
+def condition_06(*args):
     return True
 
 
 @condition(Mount, [LsTmp, LsVarTmp], optional=[LsUsrBin])
-def condition_7(*args):
+def condition_07(*args):
     return True
 
 
-@rule(Lsof, condition_1, condition_2,
-      [LsCPU, condition_3], [condition_4, LsSCSI], [condition_5, condition_6],
-      optional=[LSBlock, condition_7])
-def report(*args):
+@rule(Lsof, condition_01, condition_02,
+      [LsCPU, condition_03], [condition_04, LsSCSI],
+      [condition_05, condition_06],
+      optional=[LSBlock, condition_07])
+def report_01(*args):
     return make_fail("HIT")
 
 
 @condition(LsVarLog, [LsBoot, LsEtc])
-def ABC(*args):
+def condition_11(*args):
     return True
 
 
-@condition([LsPci, ABC])
-def DEF(*args):
+@condition([LsPci, condition_11])
+def condition_12(*args):
     return True
 
 
 @condition(LsPci, LsBoot, LsDisk)
-def XYZ(*args):
+def report_11(*args):
     return True
 
 
-@condition(PsAuxcww, LsVarLog, [Uname, RedhatRelease], [LsPci, ABC])
-def OPQ(*args):
+@condition(PsAuxcww, LsVarLog, [Uname, RedhatRelease], [LsPci, condition_11])
+def condition_21(*args):
     return True
 
 
-@condition(RedHatRelease, LsVarLog, DEF, OPQ)
-def RST(*args):
+@condition(RedHatRelease, LsVarLog, condition_12, condition_21)
+def report_21(*args):
     return True
 
 
 def test_get_dependency_specs_1_level_requires_only():
-    specs = get_dependency_specs(XYZ)
+    specs = get_dependency_specs(report_11)
     assert sorted(specs) == ['ls_boot', 'ls_disk', 'lspci']
 
 
 def test_get_dependency_specs_2_level():
-    specs = get_dependency_specs(DEF)
+    specs = get_dependency_specs(condition_12)
     # [
     #     ('lspci', [('ls_etc', 'ls_boot'), 'ls_var_log'])
     # ]
@@ -123,7 +124,7 @@ def test_get_dependency_specs_2_level():
 
 
 def test_get_dependency_specs_complex():
-    specs = get_dependency_specs(report)
+    specs = get_dependency_specs(report_01)
     # [
     #     'installed_rpms',
     #     'tags',
@@ -144,7 +145,7 @@ def test_get_dependency_specs_complex():
 
 
 def test_get_dependency_specs_duplicate():
-    specs = get_dependency_specs(RST)
+    specs = get_dependency_specs(report_21)
     # [
     #     ('uname', 'redhat_release'),
     #     'ps_auxcww',

--- a/insights/tests/test_get_dependency_specs.py
+++ b/insights/tests/test_get_dependency_specs.py
@@ -1,6 +1,8 @@
 from insights import condition, rule, make_fail
 from insights.parsers.installed_rpms import InstalledRpms
 from insights.parsers.up2date import Up2Date
+from insights.parsers.uname import Uname
+from insights.parsers.redhat_release import RedhatRelease
 from insights.parsers.messages import Messages
 from insights.parsers.ps import PsAuxcww
 from insights.parsers.virt_what import VirtWhat
@@ -85,6 +87,16 @@ def XYZ(*args):
     return True
 
 
+@condition(PsAuxcww, LsVarLog, [Uname, RedhatRelease], [LsPci, ABC])
+def OPQ(*args):
+    return True
+
+
+@condition(RedHatRelease, LsVarLog, DEF, OPQ)
+def RST(*args):
+    return True
+
+
 def test_get_dependency_specs_1_level_requires_only():
     specs = get_dependency_specs(XYZ)
     assert sorted(specs) == ['ls_boot', 'ls_disk', 'lspci']
@@ -129,3 +141,21 @@ def test_get_dependency_specs_complex():
     # order due to python versions.  Here we just check the number of the
     # `at_least_one` specs
     assert len([alo for alo in specs if isinstance(alo, tuple)]) == 5
+
+
+def test_get_dependency_specs_duplicate():
+    specs = get_dependency_specs(RST)
+    # [
+    #     ('uname', 'redhat_release'),
+    #     'ps_auxcww',
+    #     'ls_var_log',
+    #     ('ls_pci', ['ls_var_log', ('ls_boot', 'ls_etc')])
+    # ]
+    # There is only one such item in the result
+    assert ('uname', 'redhat_release') in specs
+    specs.remove(('uname', 'redhat_release'))
+    assert ('uname', 'redhat_release') not in specs
+
+    assert 'ls_var_log' in specs
+    specs.remove('ls_var_log')
+    assert 'ls_var_log' not in specs


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
This Patch removed the duplicated items from the list returned by get_dependency_specs