### PR TITLE
chore: Remove authselect_current from core collection

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -69,7 +69,6 @@ class DefaultSpecs(Specs):
     abrt_status_bare = simple_command("/usr/bin/abrt status --bare=True")
     alternatives_display_python = simple_command("/usr/sbin/alternatives --display python")
     amq_broker = glob_file("/var/opt/amq-broker/*/etc/broker.xml")
-    authselect_current = simple_command("/usr/bin/authselect current")
     dse_ldif = glob_file("/etc/dirsrv/*/dse.ldif")
     auditctl_rules = simple_command("/sbin/auditctl -l")
     auditctl_status = simple_command("/sbin/auditctl -s")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -16,7 +16,6 @@ class InsightsArchiveSpecs(Specs):
     ansible_host = simple_file("ansible_host")
     auditctl_rules = simple_file("insights_commands/auditctl_-l")
     auditctl_status = simple_file("insights_commands/auditctl_-s")
-    authselect_current = simple_file("insights_commands/authselect_current")
     aws_instance_id_doc = simple_file("insights_commands/python_-m_insights.tools.cat_--no-header_aws_instance_id_doc")
     aws_instance_id_pkcs7 = simple_file("insights_commands/python_-m_insights.tools.cat_--no-header_aws_instance_id_pkcs7")
     awx_manage_check_license = simple_file("insights_commands/awx-manage_check_license")


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
The analytics task based on this spec was Done, Remove it from the insights collection (both core collection and uploader.json)