### PR TITLE
[WIP] Allow --retries to work with network exceptions

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -314,6 +314,7 @@ def _legacy_upload(config, pconn, tar_file, content_type, collection_duration=No
     logger.info('Uploading Insights data.')
     api_response = None
     for tries in range(config.retries):
+        logger.debug("Upload attempt %d of %d ...", tries + 1, config.retries)
         upload = pconn.upload_archive(tar_file, '', collection_duration)
 
         if upload.status_code in (200, 201):
@@ -363,6 +364,7 @@ def upload(config, pconn, tar_file, content_type, collection_duration=None):
         return _legacy_upload(config, pconn, tar_file, content_type, collection_duration)
     logger.info('Uploading Insights data.')
     for tries in range(config.retries):
+        logger.debug("Upload attempt %d of %d ...", tries + 1, config.retries)
         upload = pconn.upload_archive(tar_file, content_type, collection_duration)
 
         if upload.status_code in (200, 202):

--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -837,8 +837,10 @@ class InsightsConfig(object):
         Config values may have been set manually however, so need to take that into consideration
         '''
         if self.app == 'malware-detection':
-            if self.retries < 5:
-                self.retries = 5
+            # Add extra retries for malware, mainly because it could take a long time to run
+            # and the results archive shouldn't be discarded after a single failed upload attempt
+            if self.retries < 3:
+                self.retries = 3
 
     def _determine_filename_and_extension(self):
         '''

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -188,7 +188,23 @@ class InsightsConnection(object):
             HTTP response object
         '''
         logger.log(NETWORK, "%s %s", method, url)
-        res = self.session.request(url=url, method=method, timeout=self.config.http_timeout, **kwargs)
+        try:
+            res = self.session.request(url=url, method=method, timeout=self.config.http_timeout, **kwargs)
+        except Exception as e:
+            # The _http_request method is often used without exception handing higher up the call stack
+            # Instead of handing exceptions, callers just check the status_code to determine if an error has occurred
+            # So rather than re-raising any exceptions, create a mock Response object with a generic error code/reason
+            # 'Bad Gateway' seems most appropriate if a network connection failure raises an exception
+            # Headers are added to the mock Response object to satisfy various logging statements up the stack
+            from mock.mock import Mock
+            status_code = 502
+            reason = 'Bad Gateway'
+            if 'timeout' in str(e).lower():
+                status_code = 504
+                reason = 'Gateway Timeout'
+            res = Mock(status_code=status_code, reason=reason, text="%s: %s" % (reason, str(e)),
+                       headers={}, request=Mock(headers={}))
+
         logger.log(NETWORK, "HTTP Status: %d %s", res.status_code, res.reason)
         if log_response_text or res.status_code != 200:
             logger.log(NETWORK, "HTTP Response Text: %s", res.text)

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -245,6 +245,8 @@ class TestFindYara:
 @patch.object(InsightsConnection, '_init_session', return_value=Mock())
 @patch.object(MalwareDetectionClient, '_build_yara_command')
 @patch.object(MalwareDetectionClient, '_load_config', return_value=CONFIG)
+# NOTE: Downloading the malware rules file happens within the malware client code so it's possible to test it here
+# However uploading the results archive is done outside the malware client code so it's not possible to test here
 class TestGetRules:
     """ Testing the _get_rules method """
 


### PR DESCRIPTION
Signed-off-by: Mark Huth <mhuth@redhat.com>

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
This is an idea to fix https://bugzilla.redhat.com/show_bug.cgi?id=2117686

The insights-core connection.py code doesn't really handle network exceptions.  Callers of the connection._http_request code just expect to see status_codes containing errors rather than handling any network exceptions.  This PR catches network exceptions in the _http_request method and converts it into a requests.Response object with an error status code that can be handled further up the call stack by functions that just look at the status_code.  However, rather than creating a *real* response object, I create a Mock Response object, because we didn't really get a response, but the functions up the call stack only really handle responses, not exceptions.  And so it is with the --retries logic, it only really works with responses and status_codes.  

With this in mind, rather than rewriting all this network stack stuff to raise/handle exceptions and potentially break existing functionality, I just create a fake response object for the network exception and give it a generic 502 Bad Gateway response code.  

Cop out? ... indeed.  Ugly? ... perhaps.  Simple(r)? ... yep.  Seems to work? ... seems to ...