### PR TITLE
Feat register no machine-id

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from os.path import isfile
 import sys
 import json
 import logging
@@ -126,10 +127,17 @@ def _legacy_handle_registration(config, pconn):
         write_to_disk(constants.machine_id_file, delete=True)
         logger.debug('Re-register set, forcing registration.')
 
-    logger.debug('Machine-id: %s', generate_machine_id(new=config.reregister))
+    machine_id_present = isfile(constants.machine_id_file)
 
     # check registration with API
     check = get_registration_status(config, pconn)
+
+    if machine_id_present and check['status'] is False:
+        logger.info("Machine-id found, insights-client can not be registered."
+                    " Please, unregister insights-client first: `insights-client --unregister`")
+        return False
+
+    logger.debug('Machine-id: %s', generate_machine_id(new=config.reregister))
 
     for m in check['messages']:
         logger.debug(m)

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import functools
+from os.path import isfile
 import json
 import logging
 import os
@@ -135,9 +136,7 @@ def update(client, config):
 
 @phase
 def post_update(client, config):
-    # create a machine id first thing. we'll need it for all uploads
-    logger.debug('Machine ID: %s', client.get_machine_id())
-    logger.debug("CONFIG: %s", config)
+
     print_egg_versions()
 
     if config.list_specs:
@@ -179,12 +178,14 @@ def post_update(client, config):
             else:
                 sys.exit(constants.sig_kill_bad)
 
-        if config.offline:
-            logger.debug('Running client in offline mode. Bypassing registration.')
-            return
-
-        if config.no_upload:
-            logger.debug("Running client without uploading. Bypassing registration.")
+        if config.offline or config.no_upload:
+            # create a machine id first thing. we'll need it for all uploads
+            logger.debug('Machine ID: %s', client.get_machine_id())
+            logger.debug("CONFIG: %s", config)
+            if config.offline:
+                logger.debug('Running client in offline mode. Bypassing registration.')
+            else:
+                logger.debug("Running client without uploading. Bypassing registration.")
             return
 
         if config.display_name and not config.register:
@@ -212,23 +213,25 @@ def post_update(client, config):
         return
     # -------delete everything above this line-------
 
-    if config.offline:
-        logger.debug('Running client in offline mode. Bypassing registration.')
-        return
-
-    if config.no_upload:
-        logger.debug("Running client without uploading. Bypassing registration.")
-        return
-
-    # --payload short circuits registration check
-    if config.payload:
-        logger.debug('Uploading a specified archive. Bypassing registration.')
+    if config.offline or config.no_upload or config.payload:
+        # create a machine id first thing. we'll need it for all uploads
+        logger.debug('Machine ID: %s', client.get_machine_id())
+        logger.debug("CONFIG: %s", config)
+        if config.offline:
+            logger.debug('Running client in offline mode. Bypassing registration.')
+        elif config.no_upload:
+            logger.debug("Running client without uploading. Bypassing registration.")
+        else:
+            logger.debug('Uploading a specified archive. Bypassing registration.')
         return
 
     # check registration status before anything else
-    reg_check = client.get_registration_status()
-    if reg_check is None:
-        sys.exit(constants.sig_kill_bad)
+    if isfile(constants.machine_id_file):
+        reg_check = client.get_registration_status()
+        if reg_check is None:
+            sys.exit(constants.sig_kill_bad)
+    else:
+        reg_check = False
 
     # --status
     if config.status:
@@ -266,6 +269,11 @@ def post_update(client, config):
     if config.register:
         # don't actually need to make a call to register() since
         #   system creation and upload are a single event on the platform
+        if reg_check is False and isfile(constants.machine_id_file):
+            # Do not register if a machine_id file is found
+            logger.info("Machine-id found, insights-client can not be registered."
+                        " Please, unregister insights-client first: `insights-client --unregister`")
+            sys.exit(constants.sig_kill_bad)
         if reg_check:
             logger.info('This host has already been registered.')
         if not config.disable_schedule:
@@ -289,6 +297,10 @@ def post_update(client, config):
             sys.exit(constants.sig_kill_ok)
         else:
             sys.exit(constants.sig_kill_bad)
+
+    # create a machine id first thing. we'll need it for all uploads
+    logger.debug('Machine ID: %s', client.get_machine_id())
+    logger.debug("CONFIG: %s", config)
 
 
 @phase

--- a/insights/tests/client/phase/test_LEGACY_post_update.py
+++ b/insights/tests/client/phase/test_LEGACY_post_update.py
@@ -1,7 +1,6 @@
 # -*- coding: UTF-8 -*-
-
 from insights.client.phase.v1 import post_update
-from mock.mock import patch
+from mock.mock import patch, MagicMock
 from pytest import raises
 
 
@@ -46,12 +45,12 @@ def test_post_update_legacy_upload_on(insights_config, insights_client):
     Registration is processed in legacy_upload=True
     """
     insights_config.return_value.load_all.return_value.legacy_upload = True
+    insights_client.return_value.register.return_value = False
     try:
         post_update()
     except SystemExit:
         pass
     insights_client.return_value.register.assert_called_once()
-    insights_client.return_value.get_machine_id.assert_called_once()
 
 
 @patch("insights.client.phase.v1.InsightsClient")
@@ -79,3 +78,19 @@ def test_post_update_no_upload(insights_config, insights_client):
         pass
     insights_client.return_value.register.assert_not_called()
     insights_client.return_value.get_machine_id.assert_called_once()
+
+
+@patch("insights.client.phase.v1.InsightsClient")
+@patch_insights_config
+def test_post_update_register_machineid(insights_config, insights_client):
+    """
+    Client run with --register.
+        If machine-id found, exit with 0 exit code (don't kill parent)
+        Also enable scheduling.
+    """
+    insights_config.return_value.load_all.return_value.register = True
+    insights_client.return_value.get_registration_status = MagicMock(return_value=False)
+    insights_client.return_value.register = MagicMock(return_value=False)
+    with raises(SystemExit) as exc_info:
+        post_update()
+    assert exc_info.value.code == 101

--- a/insights/tests/client/phase/test_post_update.py
+++ b/insights/tests/client/phase/test_post_update.py
@@ -1,5 +1,8 @@
 # -*- coding: UTF-8 -*-
 
+from contextlib import contextmanager
+import os
+from shutil import rmtree
 from insights.client.phase.v1 import post_update
 from mock.mock import patch, MagicMock
 from pytest import raises
@@ -29,9 +32,10 @@ def patch_insights_config(old_function):
 # DRY this at some point... for the love of god
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[True])
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_no_options_registered(insights_config, insights_client):
+def test_post_update_no_options_registered(insights_config, insights_client, _isfile):
     """
     Client run with no options.
         If registered, exit with 0 exit code (don't kill parent)
@@ -46,9 +50,10 @@ def test_post_update_no_options_registered(insights_config, insights_client):
     insights_client.return_value.set_display_name.assert_not_called()
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[False])
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_no_options_unregistered(insights_config, insights_client):
+def test_post_update_no_options_unregistered(insights_config, insights_client, _isfile):
     """
     Client run with no options.
         If unregistered, exit with 101 exit code (kill parent)
@@ -57,15 +62,14 @@ def test_post_update_no_options_unregistered(insights_config, insights_client):
     with raises(SystemExit) as exc_info:
         post_update()
     assert exc_info.value.code == 101
-    insights_client.return_value.get_machine_id.assert_called_once()
-    insights_client.return_value.get_registration_status.assert_called_once()
     insights_client.return_value.clear_local_registration.assert_not_called()
     insights_client.return_value.set_display_name.assert_not_called()
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[True])
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_no_options_err_reg_check(insights_config, insights_client):
+def test_post_update_no_options_err_reg_check(insights_config, insights_client, _isfile):
     """
     Client run with no options.
         If registration check fails, exit with 101 exit code
@@ -74,15 +78,15 @@ def test_post_update_no_options_err_reg_check(insights_config, insights_client):
     with raises(SystemExit) as exc_info:
         post_update()
     assert exc_info.value.code == 101
-    insights_client.return_value.get_machine_id.assert_called_once()
     insights_client.return_value.get_registration_status.assert_called_once()
     insights_client.return_value.clear_local_registration.assert_not_called()
     insights_client.return_value.set_display_name.assert_not_called()
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[True])
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_check_status_registered(insights_config, insights_client):
+def test_post_update_check_status_registered(insights_config, insights_client, _isfile):
     """
     Just check status.
         If registered, exit with 100 exit code (kill parent)
@@ -92,15 +96,15 @@ def test_post_update_check_status_registered(insights_config, insights_client):
     with raises(SystemExit) as exc_info:
         post_update()
     assert exc_info.value.code == 100
-    insights_client.return_value.get_machine_id.assert_called_once()
     insights_client.return_value.get_registration_status.assert_called_once()
     insights_client.return_value.clear_local_registration.assert_not_called()
     insights_client.return_value.set_display_name.assert_not_called()
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[False])
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_check_status_unregistered(insights_config, insights_client):
+def test_post_update_check_status_unregistered(insights_config, insights_client, _isfile):
     """
     Just check status.
         If unregistered, exit with 100 exit code (kill parent)
@@ -110,20 +114,18 @@ def test_post_update_check_status_unregistered(insights_config, insights_client)
     with raises(SystemExit) as exc_info:
         post_update()
     assert exc_info.value.code == 100
-    insights_client.return_value.get_machine_id.assert_called_once()
-    insights_client.return_value.get_registration_status.assert_called_once()
     insights_client.return_value.clear_local_registration.assert_not_called()
     insights_client.return_value.set_display_name.assert_not_called()
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[True])
 @patch("insights.client.phase.v1.get_scheduler")
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_register_registered(insights_config, insights_client, get_scheduler):
+def test_post_update_register_registered(insights_config, insights_client, get_scheduler, _isfile):
     """
     Client run with --register.
-        If registered, exit with 0 exit code (don't kill parent)
-        Also enable scheduling.
+        If registered, exit with 0 exit code
     """
     insights_config.return_value.load_all.return_value.register = True
     insights_client.return_value.get_registration_status = MagicMock(return_value=True)
@@ -137,6 +139,59 @@ def test_post_update_register_registered(insights_config, insights_client, get_s
     get_scheduler.return_value.schedule.assert_called_once()
 
 
+TEMP_TEST_REG_DIR = "/tmp/insights-client-registration"
+
+
+@contextmanager
+def _mock_no_register_files_machineid_present():
+    # mock a directory with the fresh install files
+    if not os.path.exists(TEMP_TEST_REG_DIR):
+        os.mkdir(TEMP_TEST_REG_DIR)
+    try:
+        machine_id_path = os.path.join(TEMP_TEST_REG_DIR, "machine-id")
+        with open(machine_id_path, "w") as machine_id_file:
+            machine_id_file.write("id")
+        yield
+    finally:
+        rmtree(TEMP_TEST_REG_DIR)
+
+
+@patch('insights.client.utilities.constants.machine_id_file',
+       TEMP_TEST_REG_DIR + '/machine-id')
+@patch("insights.client.phase.v1.get_scheduler")
+@patch("insights.client.phase.v1.InsightsClient")
+@patch_insights_config
+def test_post_update_register_machineid(insights_config, insights_client, get_scheduler):
+    """
+    Client run with --register.
+        If machine-id found, exit with 0 exit code (don't kill parent)
+        Also enable scheduling.
+    """
+    insights_config.return_value.load_all.return_value.register = True
+    insights_client.return_value.get_registration_status = MagicMock(return_value=False)
+    with _mock_no_register_files_machineid_present():
+        with raises(SystemExit) as exc_info:
+            post_update()
+    assert exc_info.value.code == 101
+    insights_client.return_value.get_registration_status.assert_called_once()
+    insights_client.return_value.clear_local_registration.assert_not_called()
+    insights_client.return_value.set_display_name.assert_not_called()
+    get_scheduler.return_value.schedule.assert_not_called()
+
+
+@contextmanager
+def _mock_no_machineid_present():
+    # mock a directory with the fresh install files
+    if not os.path.exists(TEMP_TEST_REG_DIR):
+        os.mkdir(TEMP_TEST_REG_DIR)
+    try:
+        yield
+    finally:
+        rmtree(TEMP_TEST_REG_DIR)
+
+
+@patch('insights.client.utilities.constants.machine_id_file',
+       TEMP_TEST_REG_DIR + '/machine-id')
 @patch("insights.client.phase.v1.get_scheduler")
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
@@ -148,20 +203,22 @@ def test_post_update_register_unregistered(insights_config, insights_client, get
     """
     insights_config.return_value.load_all.return_value.register = True
     insights_client.return_value.get_registration_status = MagicMock(return_value=False)
-    with raises(SystemExit) as exc_info:
-        post_update()
+    with _mock_no_machineid_present():
+        with raises(SystemExit) as exc_info:
+            post_update()
     assert exc_info.value.code == 0
     insights_client.return_value.get_machine_id.assert_called_once()
-    insights_client.return_value.get_registration_status.assert_called_once()
+    insights_client.return_value.get_registration_status.assert_not_called()
     insights_client.return_value.clear_local_registration.assert_not_called()
     insights_client.return_value.set_display_name.assert_not_called()
     get_scheduler.return_value.schedule.assert_called_once()
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[True])
 @patch("insights.client.phase.v1.get_scheduler")
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_unregister_registered(insights_config, insights_client, get_scheduler):
+def test_post_update_unregister_registered(insights_config, insights_client, get_scheduler, _isfile):
     """
     Client run with --unregister.
         If registered, exit with 100 exit code
@@ -172,17 +229,17 @@ def test_post_update_unregister_registered(insights_config, insights_client, get
     with raises(SystemExit) as exc_info:
         post_update()
     assert exc_info.value.code == 100
-    insights_client.return_value.get_machine_id.assert_called_once()
     insights_client.return_value.get_registration_status.assert_called_once()
     insights_client.return_value.clear_local_registration.assert_not_called()
     insights_client.return_value.set_display_name.assert_not_called()
     get_scheduler.return_value.remove_scheduling.assert_called_once()
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[False])
 @patch("insights.client.phase.v1.get_scheduler")
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_unregister_unregistered(insights_config, insights_client, get_scheduler):
+def test_post_update_unregister_unregistered(insights_config, insights_client, get_scheduler, _isfile):
     """
     Client run with --unregister.
         If unregistered, exit with 101 exit code
@@ -192,17 +249,16 @@ def test_post_update_unregister_unregistered(insights_config, insights_client, g
     with raises(SystemExit) as exc_info:
         post_update()
     assert exc_info.value.code == 101
-    insights_client.return_value.get_machine_id.assert_called_once()
-    insights_client.return_value.get_registration_status.assert_called_once()
     insights_client.return_value.clear_local_registration.assert_not_called()
     insights_client.return_value.set_display_name.assert_not_called()
     get_scheduler.return_value.remove_scheduling.assert_not_called()
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[True, False])
 @patch("insights.client.phase.v1.get_scheduler")
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_force_register_registered(insights_config, insights_client, get_scheduler):
+def test_post_update_force_register_registered(insights_config, insights_client, get_scheduler, _isfile):
     """
     Client run with --force-reregister.
         If registered, exit with 0 exit code (don't kill parent)
@@ -221,10 +277,11 @@ def test_post_update_force_register_registered(insights_config, insights_client,
     get_scheduler.return_value.schedule.assert_called_once()
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[False, False])
 @patch("insights.client.phase.v1.get_scheduler")
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_force_register_unregistered(insights_config, insights_client, get_scheduler):
+def test_post_update_force_register_unregistered(insights_config, insights_client, get_scheduler, _isfile):
     """
     Client run with --force-reregister.
         If registered, exit with 0 exit code (don't kill parent)
@@ -237,16 +294,16 @@ def test_post_update_force_register_unregistered(insights_config, insights_clien
         post_update()
     assert exc_info.value.code == 0
     insights_client.return_value.get_machine_id.assert_called_once()
-    insights_client.return_value.get_registration_status.assert_called_once()
     insights_client.return_value.clear_local_registration.assert_called_once()
     insights_client.return_value.set_display_name.assert_not_called()
     get_scheduler.return_value.schedule.assert_called_once()  # ASK
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[False])
 @patch("insights.client.phase.v1.get_scheduler")
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_set_display_name_cli_no_register_unreg(insights_config, insights_client, get_scheduler):
+def test_post_update_set_display_name_cli_no_register_unreg(insights_config, insights_client, get_scheduler, _isfile):
     """
     Client is unregistered, and run with --display-name but not --register
         Should exit with code 101 after registration check
@@ -257,16 +314,15 @@ def test_post_update_set_display_name_cli_no_register_unreg(insights_config, ins
     with raises(SystemExit) as exc_info:
         post_update()
     assert exc_info.value.code == 101
-    insights_client.return_value.get_machine_id.assert_called_once()
-    insights_client.return_value.get_registration_status.assert_called_once()
     insights_client.return_value.set_display_name.assert_not_called()
     get_scheduler.return_value.schedule.assert_not_called()
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[True])
 @patch("insights.client.phase.v1.get_scheduler")
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_set_display_name_cli_no_register_reg(insights_config, insights_client, get_scheduler):
+def test_post_update_set_display_name_cli_no_register_reg(insights_config, insights_client, get_scheduler, _isfile):
     """
     Client is registered, and run with --display-name but not --register
         Should exit with code 100 after setting display name
@@ -277,16 +333,16 @@ def test_post_update_set_display_name_cli_no_register_reg(insights_config, insig
     with raises(SystemExit) as exc_info:
         post_update()
     assert exc_info.value.code == 100
-    insights_client.return_value.get_machine_id.assert_called_once()
     insights_client.return_value.get_registration_status.assert_called_once()
     insights_client.return_value.set_display_name.assert_called_once()
     get_scheduler.return_value.schedule.assert_not_called()
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[False, False])
 @patch("insights.client.phase.v1.get_scheduler")
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
-def test_post_update_set_display_name_cli_register(insights_config, insights_client, get_scheduler):
+def test_post_update_set_display_name_cli_register(insights_config, insights_client, get_scheduler, _isfile):
     """
     Client is and run with --display-name and --register
         Should set schedule and exit with code 0
@@ -299,7 +355,6 @@ def test_post_update_set_display_name_cli_register(insights_config, insights_cli
         post_update()
     assert exc_info.value.code == 0
     insights_client.return_value.get_machine_id.assert_called_once()
-    insights_client.return_value.get_registration_status.assert_called_once()
     insights_client.return_value.clear_local_registration.assert_called_once()
     insights_client.return_value.set_display_name.assert_not_called()
     get_scheduler.return_value.schedule.assert_called_once()
@@ -339,10 +394,11 @@ def test_post_update_no_upload(insights_config, insights_client):
     insights_client.return_value.set_display_name.assert_not_called()
 
 
+@patch("insights.client.phase.v1.isfile", side_effect=[True])
 @patch("insights.client.phase.v1.InsightsClient")
 @patch_insights_config
 # @patch("insights.client.phase.v1.InsightsClient")
-def test_exit_ok(insights_config, insights_client):
+def test_exit_ok(insights_config, insights_client, _isfile):
     """
     Support collection replaces the normal client run.
     """


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

If insights-client is not register and there is a machine-id file in the system the registration process should fail. 
It prints a new message asking to unregister the system again.

This resolves: rhbz#2071093
