### PR TITLE
Removed assert of virt-who

### DIFF
--- a/insights/tests/client/collection_rules/test_map_components.py
+++ b/insights/tests/client/collection_rules/test_map_components.py
@@ -222,7 +222,6 @@ def test_log_long_key(logger_warning):
     map_rm_conf_to_components(rm_conf, uploader_json)
     logger_warning.assert_any_call("- /usr/bin/find /etc/origin/node                   => certificates_enddate\n  /etc/origin/master /etc/pki /etc/ipa\n  /etc/tower/tower.cert -type f -exec\n  /usr/bin/openssl x509 -noout -enddate -in '{}'\n  \\; -exec echo 'FileName= {}' \\;")
     logger_warning.assert_any_call("- /usr/bin/md5sum /etc/pki/product/69.pem          => md5chk_files")
-    logger_warning.assert_any_call("- /etc/sysconfig/virt-who                          => sysconfig_virt_who")
     logger_warning.assert_any_call("- krb5_conf_d                                      => krb5")
 
 


### PR DESCRIPTION
Signed-off-by: ahitacat <ahitacat@redhat.com>

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
virt-who command were removed in egg v3.0.298, this was causing to not be asserted in the tests.
