### PR TITLE
fix: let container_execute to support rpm_format of installed_rpms

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -1005,10 +1005,10 @@ class container_execute(foreach_execute):
         for e in source:
             try:
                 # e       = (image, <podman|docker>, container_id, <...>)
-                image, e = e[0], e[1:]
-                # e       = (<podman|docker>, container_id, <...>)
+                image, engine, cid = e[0], e[1], e[2]
                 # the_cmd = <podman|docker> exec container_id cmd
-                the_cmd = ("/usr/bin/%s exec %s " + self.cmd) % e
+                cmd = self.cmd % e[3:] if len(e) > 3 else self.cmd
+                the_cmd = "/usr/bin/%s exec %s %s" % (engine, cid, cmd)
                 ccp = ContainerCommandProvider(the_cmd, ctx, image=image, args=e,
                         split=self.split, keep_rc=self.keep_rc, ds=self,
                         timeout=self.timeout, inherit_env=self.inherit_env, signum=self.signum)
@@ -1057,13 +1057,11 @@ class container_collect(foreach_execute):
         for e in source:
             try:
                 # e        = (image, <podman|docker>, container_id, <path>)
-                image, e = e[0], e[1:]
-                # e        = (<podman|docker>, container_id, <path>)
+                image, engine, cid = e[0], e[1], e[2]
                 # self.cmd = path or None
-                # elems    = (<podman|docker>, container_id, path)
-                elems = e if self.cmd is None else e + (self.cmd,)
-                # the_cmd = <podman|docker> exec container_id cat path
-                the_cmd = "/usr/bin/%s exec %s cat %s" % elems
+                # the_cmd  = <podman|docker> exec container_id cat path
+                path = e[3:] if (len(e) > 3 and self.cmd is None) else self.cmd
+                the_cmd = "/usr/bin/%s exec %s cat %s" % (engine, cid, path)
                 cfp = ContainerFileProvider(the_cmd, ctx, image=image, args=None,
                         split=self.split, keep_rc=self.keep_rc, ds=self,
                         timeout=self.timeout, inherit_env=self.inherit_env, signum=self.signum)

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -1060,7 +1060,7 @@ class container_collect(foreach_execute):
                 image, engine, cid = e[0], e[1], e[2]
                 # self.cmd = path or None
                 # the_cmd  = <podman|docker> exec container_id cat path
-                path = e[3:] if (len(e) > 3 and self.cmd is None) else self.cmd
+                path = e[3] if (len(e) > 3 and self.cmd is None) else self.cmd
                 the_cmd = "/usr/bin/%s exec %s cat %s" % (engine, cid, path)
                 cfp = ContainerFileProvider(the_cmd, ctx, image=image, args=None,
                         split=self.split, keep_rc=self.keep_rc, ds=self,

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -1004,10 +1004,11 @@ class container_execute(foreach_execute):
             source = [source]
         for e in source:
             try:
-                # e       = (image, <podman|docker>, container_id, <...>)
-                image, engine, cid = e[0], e[1], e[2]
+                # e       = (image, <podman|docker>, container_id, <args>)
+                image, engine, cid, args = e[0], e[1], e[2], e[3:]
+                # handle command with args
+                cmd = self.cmd % args if args else self.cmd
                 # the_cmd = <podman|docker> exec container_id cmd
-                cmd = self.cmd % e[3:] if len(e) > 3 else self.cmd
                 the_cmd = "/usr/bin/%s exec %s %s" % (engine, cid, cmd)
                 ccp = ContainerCommandProvider(the_cmd, ctx, image=image, args=e,
                         split=self.split, keep_rc=self.keep_rc, ds=self,
@@ -1056,12 +1057,17 @@ class container_collect(foreach_execute):
             source = [source]
         for e in source:
             try:
-                # e        = (image, <podman|docker>, container_id, <path>)
-                image, engine, cid = e[0], e[1], e[2]
-                # self.cmd = path or None
-                # the_cmd  = <podman|docker> exec container_id cat path
-                path = e[3] if (len(e) > 3 and self.cmd is None) else self.cmd
-                the_cmd = "/usr/bin/%s exec %s cat %s" % (engine, cid, path)
+                # e       = (image, <podman|docker>, container_id, <path>)
+                image, e = e[0], e[1:]
+                if self.cmd is None or self.cmd == '%s':
+                    # path is provided by `provider`
+                    e, path = e[:-1], e[-1]
+                else:
+                    # path is provided by self.cmd
+                    e, path = e, self.cmd
+                # e       = (<podman|docker>, container_id)
+                # the_cmd = <podman|docker> exec container_id cat path
+                the_cmd = ("/usr/bin/%s exec %s cat " % e) + path
                 cfp = ContainerFileProvider(the_cmd, ctx, image=image, args=None,
                         split=self.split, keep_rc=self.keep_rc, ds=self,
                         timeout=self.timeout, inherit_env=self.inherit_env, signum=self.signum)

--- a/insights/util/autology/datasources.py
+++ b/insights/util/autology/datasources.py
@@ -21,6 +21,8 @@ GLOB_FILE_TYPE = 'glob_file'
 """ str: Literal constant for a simple_file Spec object """
 FOREACH_EXECUTE_TYPE = 'foreach_execute'
 """ str: Literal constant for a foreach_execute Spec object """
+CONTAINER_EXECUTE_TYPE = 'container_execute'
+""" str: Literal constant for a container_execute Spec object """
 LISTDIR_TYPE = 'listdir'
 """ str: Literal constant for a listdir Spec object """
 LIST_TYPE = 'list'
@@ -35,6 +37,8 @@ FIRST_FILE_TYPE = 'first_file'
 """ str: Literal constant for a first_file Spec object """
 FOREACH_COLLECT_TYPE = 'foreach_collect'
 """ str: Literal constant for a foreach_collect Spec object """
+CONTAINER_COLLECT_TYPE = 'container_collect'
+""" str: Literal constant for a container_collect Spec object """
 FIRST_OF_TYPE = 'first_of'
 """ str: Literal constant for a first_of Spec object """
 COMMAND_WITH_ARGS_TYPE = 'command_with_args'
@@ -67,6 +71,11 @@ def is_foreach_execute(m_obj):
     return isinstance(m_obj, insights.core.spec_factory.foreach_execute)
 
 
+def is_container_execute(m_obj):
+    """ bool: True if broker object is a is_container_execute object """
+    return isinstance(m_obj, insights.core.spec_factory.container_execute)
+
+
 def is_first_file(m_obj):
     """ bool: True if broker object is a first_file object """
     return isinstance(m_obj, insights.core.spec_factory.first_file)
@@ -80,6 +89,11 @@ def is_first_of(m_obj):
 def is_foreach_collect(m_obj):
     """ bool: True if broker object is a is_foreach_collect object """
     return isinstance(m_obj, insights.core.spec_factory.foreach_collect)
+
+
+def is_container_collect(m_obj):
+    """ bool: True if broker object is a is_container_collect object """
+    return isinstance(m_obj, insights.core.spec_factory.container_collect)
 
 
 def is_listdir(m_obj):
@@ -212,6 +226,22 @@ class Spec(dict):
 
             m_spec['repr'] = 'foreach_execute("{cmd}", provider={provider})'
 
+        elif is_container_execute(m_type):
+            m_spec['cmd'] = next((v for k, v in m_members if k == "cmd"), None)
+            m_spec['type_name'] = CONTAINER_EXECUTE_TYPE
+            provider = next((v for k, v in m_members if k == "provider"), None)
+            if provider:
+                m_spec['provider'] = cls.from_object(provider)
+
+            else:
+                m_spec['provider'] = Spec(
+                    name=ANONYMOUS_SPEC_NAME,
+                    type=None,
+                    type_name=NONE_TYPE,
+                    repr='NONE PROVIDER')
+
+            m_spec['repr'] = 'container_execute("{cmd}", provider={provider})'
+
         elif is_first_of(m_type):
             m_spec['type_name'] = FIRST_OF_TYPE
             deps = next((v for k, v in m_members if k == "deps"), None)
@@ -234,6 +264,15 @@ class Spec(dict):
             if provider:
                 m_spec['provider'] = cls.from_object(provider)
             m_spec['repr'] = 'foreach_collect("{path}", provider={provider})'
+
+        elif is_container_collect(m_type):
+            m_spec['type_name'] = CONTAINER_COLLECT_TYPE
+            # container_collect is based on foreach_execute, it used obj.cmd as the path
+            m_spec['path'] = next((v for k, v in m_members if k == 'cmd'), None)
+            provider = next((v for k, v in m_members if k == "provider"), None)
+            if provider:
+                m_spec['provider'] = cls.from_object(provider)
+            m_spec['repr'] = 'container_collect("{path}", provider={provider})'
 
         elif is_head(m_type):
             m_spec['type_name'] = HEAD_TYPE


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

- fix the following issue:
 The `rpm_format` of `installed_rpms` includes `%` characters, which caused the `collect_execute` cannot collect it from the container correctly.
 https://github.com/RedHatInsights/insights-core/blob/1880a9c21b6c54c018fd0237b20ae6aeffd60d29/insights/core/spec_factory.py#L1011
 This patch fixes this issue with:
 ```the_cmd = "/usr/bin/%s exec %s %s" % (engine, cid, cmd)```
- and update the insights/util/autology/datasources.py correspondingly
