### PR TITLE
feat: new spec and parser for 'azure_instance_id'

### DIFF
--- a/docs/shared_parsers_catalog/azure_instance.rst
+++ b/docs/shared_parsers_catalog/azure_instance.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.azure_instance
+   :members:
+   :show-inheritance:

--- a/insights/parsers/azure_instance.py
+++ b/insights/parsers/azure_instance.py
@@ -1,0 +1,159 @@
+"""
+AzureInstance
+=============
+
+The following Azure Instance related parsers are placed in this module:
+
+AzureInstanceID - 'vmId' of Azure Instance
+------------------------------------------
+
+AzureInstanceType - 'vmSize' of Azure Instance
+----------------------------------------------
+
+AzureInstancePlan - 'plan' of Azure Instance
+--------------------------------------------
+"""
+import json
+from insights.parsers import SkipException, ParseException
+from insights import parser, CommandParser
+from insights.specs import Specs
+
+
+def validate_content(content):
+    if not content or 'curl: ' in content[0]:
+        raise SkipException()
+
+
+@parser(Specs.azure_instance_id)
+class AzureInstanceID(CommandParser):
+    """
+    Class for parsing the Azure Instance type returned by command
+    ``curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/vmId?api-version=2021-12-13&format=text``,
+
+
+    Typical output of this command is::
+
+        f904ece8-c6c1-4b5c-881f-309b50f25e50
+
+    Raises:
+        SkipException: When content is empty or no parse-able content.
+
+    Attributes:
+        id (str): The instance ID of the VM instance in Azure.
+
+    Examples:
+        >>> azure_id.id
+        'f904ece8-c6c1-4b5c-881f-309b50f25e50'
+    """
+
+    def parse_content(self, content):
+        validate_content(content)
+
+        self.id = content[0].strip()
+
+    def __repr__(self):
+        return "<instance_id: {i}>".format(i=self.id)
+
+
+@parser(Specs.azure_instance_type)
+class AzureInstanceType(CommandParser):
+    """
+    Class for parsing the Azure Instance type returned by command
+    ``curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-12-13&format=text``,
+
+
+    Typical output of this command is::
+
+        Standard_L64s_v2
+
+    Raises:
+        SkipException: When content is empty or no parse-able content.
+        ParseException: When type cannot be recognized.
+
+    Attributes:
+        type (str): The type of VM instance in Azure, e.g: Standard
+        size (str): The size of VM instance in Azure, e.g: L64s, NC12s
+        version (str): The version of VM instance in Azure, e.g: v2, v3, `None` for non-version
+        raw (str): The fully type string returned by the ``curl`` command
+
+    Examples:
+        >>> azure_type.type
+        'Standard'
+        >>> azure_type.size
+        'L64s'
+        >>> azure_type.version
+        'v2'
+        >>> azure_type.raw
+        'Standard_L64s_v2'
+    """
+    def parse_content(self, content):
+        validate_content(content)
+
+        self.raw = self.type = self.size = self.version = None
+        # Ignore any curl stats that may be present in data
+        for l in content:
+            l_strip = l.strip()
+            if ' ' not in l_strip and '_' in l_strip:
+                self.raw = l_strip
+                type_sp = l_strip.split('_')
+                self.type, self.size = type_sp[0], type_sp[1]
+                if len(type_sp) >= 3:
+                    self.version = type_sp[2]
+
+        if not self.type:
+            raise ParseException('Unrecognized type: "{0}"', content[0])
+
+    def __repr__(self):
+        return "<azure_type: {t}, size: {s}, version: {v},  raw: {r}>".format(
+                t=self.type, s=self.size, v=self.version, r=self.raw)
+
+
+@parser(Specs.azure_instance_plan)
+class AzureInstancePlan(CommandParser):
+    """
+    Class for parsing the Azure Instance Plan returned by command
+    ``curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/plan?api-version=2021-12-13&format=json``,
+
+
+    Typical Output of this command is::
+
+        {
+            "name": "planName",
+            "product": "planProduct",
+            "publisher": "planPublisher"
+        },
+
+    Raises:
+        SkipException: When content is empty or no parse-able content.
+
+    Attributes:
+        name (str): The name of the plan for the VM Instance in Azure, e.g: rhel7
+        product (str): The product of the plan for the VM Instance in Azure, e.g: RHEL
+        publisher (str): The publisher of the plan for the VM Instance in Azure, e.g: Red hat
+        raw (str): The full JSON of the plan returned by the ``curl`` command
+
+    Examples:
+        >>> azure_plan.name == 'planName'
+        True
+        >>> azure_plan.product == 'planProduct'
+        True
+        >>> azure_plan.publisher == 'planPublisher'
+        True
+    """
+    def parse_content(self, content):
+        validate_content(content)
+
+        try:
+            plan = json.loads(content[0])
+        except:
+            raise ParseException("Unable to parse JSON")
+
+        self.raw = content[0]
+        self.name = plan["name"] if plan["name"] != "" else None
+        self.product = plan["product"] if plan["product"] != "" else None
+        self.publisher = plan["publisher"] if plan["publisher"] != "" else None
+
+    def __repr__(self):
+        return "<azure_plan_name: {n}, product: {pr}, publisher: {pu}, raw: {r}".format(
+            n=self.name, pr=self.product, pu=self.publisher, r=self.raw
+        )

--- a/insights/parsers/azure_instance_plan.py
+++ b/insights/parsers/azure_instance_plan.py
@@ -14,11 +14,16 @@ import json
 from insights.parsers import SkipException, ParseException
 from insights import parser, CommandParser
 from insights.specs import Specs
+from insights.util import deprecated
 
 
 @parser(Specs.azure_instance_plan)
 class AzureInstancePlan(CommandParser):
     """
+    .. warning::
+        This parser is deprecated, please use
+        :py:class:`insights.parsers.azure_instance.AzureInstancePlan` instead.
+
     Class for parsing the Azure Instance Plan returned by command
     ``curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/plan?api-version=2018-10-01&format=json``,
 
@@ -48,6 +53,9 @@ class AzureInstancePlan(CommandParser):
         >>> azure_plan.publisher == 'planPublisher'
         True
     """
+    def __init__(self, *args, **kwargs):
+        deprecated(AzureInstancePlan, "Import AzureInstancePlan from insights.parsers.azure_instance instead", "3.2.25")
+        super(AzureInstancePlan, self).__init__(*args, **kwargs)
 
     def parse_content(self, content):
         if not content or 'curl: ' in content[0]:

--- a/insights/parsers/azure_instance_type.py
+++ b/insights/parsers/azure_instance_type.py
@@ -13,11 +13,16 @@ For more details, See: https://docs.microsoft.com/en-us/azure/virtual-machines/l
 from insights.parsers import SkipException, ParseException
 from insights import parser, CommandParser
 from insights.specs import Specs
+from insights.util import deprecated
 
 
 @parser(Specs.azure_instance_type)
 class AzureInstanceType(CommandParser):
     """
+    .. warning::
+        This parser is deprecated, please use
+        :py:class:`insights.parsers.azure_instance.AzureInstanceType` instead.
+
     Class for parsing the Azure Instance type returned by command
     ``curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2018-10-01&format=text``,
 
@@ -46,6 +51,9 @@ class AzureInstanceType(CommandParser):
         >>> azure_inst.raw
         'Standard_L64s_v2'
     """
+    def __init__(self, *args, **kwargs):
+        deprecated(AzureInstanceType, "Import AzureInstanceType from insights.parsers.azure_instance instead", "3.2.25")
+        super(AzureInstanceType, self).__init__(*args, **kwargs)
 
     def parse_content(self, content):
         if not content or 'curl: ' in content[0]:

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -21,6 +21,7 @@ class Specs(SpecSet):
     awx_manage_check_license = RegistryPoint()
     awx_manage_check_license_data = RegistryPoint(filterable=True)
     awx_manage_print_settings = RegistryPoint()
+    azure_instance_id = RegistryPoint()
     azure_instance_plan = RegistryPoint()
     azure_instance_type = RegistryPoint()
     bdi_read_ahead_kb = RegistryPoint(multi_output=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -85,8 +85,9 @@ class DefaultSpecs(Specs):
     awx_manage_check_license = simple_command("/usr/bin/awx-manage check_license")
     awx_manage_check_license_data = awx_manage.awx_manage_check_license_data_datasource
     awx_manage_print_settings = simple_command("/usr/bin/awx-manage print_settings INSIGHTS_TRACKING_STATE SYSTEM_UUID INSTALL_UUID TOWER_URL_BASE AWX_CLEANUP_PATHS AWX_PROOT_BASE_PATH LOG_AGGREGATOR_ENABLED LOG_AGGREGATOR_LEVEL --format json")
-    azure_instance_plan = simple_command("/usr/bin/curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/plan?api-version=2018-10-01&format=json --connect-timeout 5", deps=[IsAzure])
-    azure_instance_type = simple_command("/usr/bin/curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2018-10-01&format=text --connect-timeout 5", deps=[IsAzure])
+    azure_instance_id = simple_command("/usr/bin/curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/vmId?api-version=2021-12-13&format=text --connect-timeout 5", deps=[IsAzure])
+    azure_instance_plan = simple_command("/usr/bin/curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/plan?api-version=2021-12-13&format=json --connect-timeout 5", deps=[IsAzure])
+    azure_instance_type = simple_command("/usr/bin/curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-12-13&format=text --connect-timeout 5", deps=[IsAzure])
     bdi_read_ahead_kb = glob_file("/sys/class/bdi/*/read_ahead_kb")
     bios_uuid = simple_command("/usr/sbin/dmidecode -s system-uuid")
     blkid = simple_command("/sbin/blkid -c /dev/null")

--- a/insights/tests/parsers/test_azure_instance.py
+++ b/insights/tests/parsers/test_azure_instance.py
@@ -73,6 +73,7 @@ def test_azure_instance_id_ab_empty():
 def test_azure_instance_id():
     azure = AzureInstanceID(context_wrap(AZURE_ID))
     assert azure.id == "f904ece8-c6c1-4b5c-881f-309b50f25e50"
+    assert repr(azure) == "<instance_id: {0}>".format(azure.id)
 
 
 # Test AzureInstanceType
@@ -105,6 +106,8 @@ def test_azure_instance_type():
     assert azure.size == "L32s"
     assert azure.version is None
     assert azure.raw == "Standard_L32s"
+    assert repr(azure) == "<azure_type: {t}, size: {s}, version: {v},  raw: {r}>".format(
+                t=azure.type, s=azure.size, v=azure.version, r=azure.raw)
 
     azure = AzureInstanceType(context_wrap(AZURE_TYPE_2))
     assert azure.type == "Standard"
@@ -146,6 +149,8 @@ def test_azure_instance_plan():
     assert azure.product == "rhel"
     assert azure.publisher == "Red Hat"
     assert azure.raw == '{"name": "rhel7", "product": "rhel", "publisher": "Red Hat"}'
+    assert repr(azure) == "<azure_plan_name: {n}, product: {pr}, publisher: {pu}, raw: {r}".format(
+            n=azure.name, pr=azure.product, pu=azure.publisher, r=azure.raw)
 
     azure = AzureInstancePlan(context_wrap(AZURE_PLAN_2))
     assert azure.name is None

--- a/insights/tests/parsers/test_azure_instance.py
+++ b/insights/tests/parsers/test_azure_instance.py
@@ -1,0 +1,170 @@
+import pytest
+import doctest
+from insights.parsers import azure_instance
+from insights.parsers.azure_instance import (AzureInstanceID,
+                                             AzureInstanceType,
+                                             AzureInstancePlan)
+from insights.tests import context_wrap
+from insights.parsers import SkipException, ParseException
+from insights.core.plugins import ContentException
+
+# For AzureInstanceID
+AZURE_ID = "f904ece8-c6c1-4b5c-881f-309b50f25e50"
+
+# For AzureInstanceType
+AZURE_TYPE_1 = "Standard_L32s"
+AZURE_TYPE_2 = "Standard_NV48s_v3"
+AZURE_TYPE_3 = """
+ % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                  Dload  Upload   Total   Spent    Left  Speed
+   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+ 100  1126  100  1126    0     0  1374k      0 --:--:-- --:--:-- --:--:-- 1099k
+Standard_NV48s_v3
+"""
+AZURE_TYPE_DOC = "Standard_L64s_v2"
+AZURE_TYPE_AB_1 = """
+curl: (7) Failed to connect to 169.254.169.254 port 80: Connection timed out
+""".strip()
+AZURE_TYPE_AB_2 = """
+curl: (7) couldn't connect to host
+""".strip()
+AZURE_TYPE_AB_3 = """
+curl: (28) connect() timed out!
+""".strip()
+AZURE_TYPE_AB_4 = """
+.micro
+""".strip()
+AZURE_TYPE_AB_5 = """
+No module named insights.tools
+""".strip()
+
+# For AzureInstancePlan
+AZURE_PLAN_1 = '{"name": "rhel7", "product": "rhel", "publisher": "Red Hat"}'
+AZURE_PLAN_2 = '{"name": "", "product": "", "publisher": "Red Hat"}'
+AZURE_PLAN_3 = '{"name": "", "product": "", "publisher": ""}'
+
+AZURE_PLAN_4 = """
+ % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                  Dload  Upload   Total   Spent    Left  Speed
+   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+ 100  1126  100  1126    0     0  1374k      0 --:--:-- --:--:-- --:--:-- 1099k
+{"name": "rhel7", "product": "rhel", "publisher": "Red Hat"}
+"""
+
+AZURE_PLAN_DOC = '{"name": "planName", "product": "planProduct", "publisher": "planPublisher"}'
+
+AZURE_PLAN_AB_1 = """
+curl: (7) Failed to connect to 169.254.169.254 port 80: Connection timed out
+""".strip()
+AZURE_PLAN_AB_2 = """
+curl: (7) couldn't connect to host
+""".strip()
+AZURE_PLAN_AB_3 = """
+curl: (28) connect() timed out!
+""".strip()
+
+
+# Test AzureInstanceID
+def test_azure_instance_id_ab_empty():
+    with pytest.raises(SkipException):
+        AzureInstanceID(context_wrap(''))
+
+
+def test_azure_instance_id():
+    azure = AzureInstanceID(context_wrap(AZURE_ID))
+    assert azure.id == "f904ece8-c6c1-4b5c-881f-309b50f25e50"
+
+
+# Test AzureInstanceType
+def test_azure_instance_type_ab_other():
+    with pytest.raises(SkipException):
+        AzureInstanceType(context_wrap(AZURE_TYPE_AB_1))
+
+    with pytest.raises(SkipException):
+        AzureInstanceType(context_wrap(AZURE_TYPE_AB_2))
+
+    with pytest.raises(SkipException):
+        AzureInstanceType(context_wrap(AZURE_TYPE_AB_3))
+
+    with pytest.raises(ParseException) as pe:
+        AzureInstanceType(context_wrap(AZURE_TYPE_AB_4))
+        assert 'Unrecognized type' in str(pe)
+
+    with pytest.raises(ContentException) as pe:
+        AzureInstanceType(context_wrap(AZURE_TYPE_AB_5))
+
+
+def test_azure_instance_type_ab_empty():
+    with pytest.raises(SkipException):
+        AzureInstanceType(context_wrap(''))
+
+
+def test_azure_instance_type():
+    azure = AzureInstanceType(context_wrap(AZURE_TYPE_1))
+    assert azure.type == "Standard"
+    assert azure.size == "L32s"
+    assert azure.version is None
+    assert azure.raw == "Standard_L32s"
+
+    azure = AzureInstanceType(context_wrap(AZURE_TYPE_2))
+    assert azure.type == "Standard"
+    assert azure.size == "NV48s"
+    assert azure.version == "v3"
+    assert azure.raw == "Standard_NV48s_v3"
+    assert "NV48s" in str(azure)
+
+
+def test_azure_instance_type_stats():
+    azure = AzureInstanceType(context_wrap(AZURE_TYPE_3))
+    assert azure.type == "Standard"
+    assert azure.size == "NV48s"
+    assert azure.version == "v3"
+    assert azure.raw == "Standard_NV48s_v3"
+
+
+# Test AzureInstancePlan
+def test_azure_instance_plan_ab_other():
+    with pytest.raises(SkipException):
+        AzureInstancePlan(context_wrap(AZURE_PLAN_AB_1))
+
+    with pytest.raises(SkipException):
+        AzureInstancePlan(context_wrap(AZURE_PLAN_AB_2))
+
+    with pytest.raises(SkipException):
+        AzureInstancePlan(context_wrap(AZURE_PLAN_AB_3))
+
+    with pytest.raises(SkipException):
+        AzureInstancePlan(context_wrap(''))
+
+    with pytest.raises(ParseException):
+        AzureInstancePlan(context_wrap(AZURE_PLAN_4))
+
+
+def test_azure_instance_plan():
+    azure = AzureInstancePlan(context_wrap(AZURE_PLAN_1))
+    assert azure.name == "rhel7"
+    assert azure.product == "rhel"
+    assert azure.publisher == "Red Hat"
+    assert azure.raw == '{"name": "rhel7", "product": "rhel", "publisher": "Red Hat"}'
+
+    azure = AzureInstancePlan(context_wrap(AZURE_PLAN_2))
+    assert azure.name is None
+    assert azure.product is None
+    assert azure.publisher == "Red Hat"
+    assert azure.raw == '{"name": "", "product": "", "publisher": "Red Hat"}'
+
+    azure = AzureInstancePlan(context_wrap(AZURE_PLAN_3))
+    assert azure.name is None
+    assert azure.product is None
+    assert azure.publisher is None
+    assert azure.raw == '{"name": "", "product": "", "publisher": ""}'
+
+
+def test_doc_examples():
+    env = {
+        'azure_id': AzureInstanceID(context_wrap(AZURE_ID)),
+        'azure_plan': AzureInstancePlan(context_wrap(AZURE_PLAN_DOC)),
+        'azure_type': AzureInstanceType(context_wrap(AZURE_TYPE_DOC)),
+    }
+    failed, total = doctest.testmod(azure_instance, globs=env)
+    assert failed == 0


### PR DESCRIPTION
- And move the AzureInstancePlan and AzureInstancePlan to azure_instance.py
- More the original parsers as deprecated
- change to use the latest supported API version '2021-12-13' provided by Azure

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?