### PR TITLE
fix: LuksDump not parsing multiple data segments

### DIFF
--- a/insights/parsers/cryptsetup_luksDump.py
+++ b/insights/parsers/cryptsetup_luksDump.py
@@ -34,7 +34,7 @@ class DocParser(object):
 
         ZeroLevelKVPair = Key + Value1
         FirstLevelKVPair = FirstIndent >> Key + Value1
-        SecondLevelKVPair = SecondIndent >> WithIndent(Key + Value)
+        SecondLevelKVPair = SecondIndent >> WithIndent(Key + Value) << Opt(Many(Char("\n")))
 
         Luks2SectionName = Key << Char("\n")
         Luks2SectionEntry = (FirstLevelKVPair + Many(SecondLevelKVPair).map(dict)).map(self.convert_type)

--- a/insights/tests/parsers/test_cryptsetup_luksDump.py
+++ b/insights/tests/parsers/test_cryptsetup_luksDump.py
@@ -65,6 +65,20 @@ Data segments:
 	cipher: aes-xts-plain64
 	sector: 4096 [bytes]
 
+  1: crypt
+	offset: 16777216 [bytes]
+	length: (whole device)
+	cipher: aes-xts-plain64
+	sector: 4096 [bytes]
+	flags : backup-previous
+
+  2: crypt
+	offset: 16777216 [bytes]
+	length: (whole device)
+	cipher: aes-xts-plain64
+	sector: 4096 [bytes]
+	flags : backup-final
+
 Keyslots:
   0: luks2
 	Key:        512 bits
@@ -146,7 +160,7 @@ def test_cryptsetup_luks_dump_luks2():
     assert luks2_parsed.dump["header"]["Version"] == "2"
     assert len(luks2_parsed.dump["Keyslots"].keys()) == 3
     assert luks2_parsed.dump["Keyslots"]["0"]["type"] == "luks2"
-    assert len(luks2_parsed.dump["Data segments"].keys()) == 1
+    assert len(luks2_parsed.dump["Data segments"].keys()) == 3
     assert len(luks2_parsed.dump["Tokens"].keys()) == 1
     assert len(luks2_parsed.dump["Digests"].keys()) == 1
 


### PR DESCRIPTION
Signed-off-by: daniel.zatovic <daniel.zatovic@gmail.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

Every second-level section in the `cryptsetup luksDump` output is immediately followed (without a newline) by another second-level section. E.g. the "Digests" section

```
Digests:
  0: pbkdf2
	Hash:       sha256
	Iterations: 119373
  1: pbkdf2
	Hash:       sha256
	Iterations: 1000
```

However, when there are multiple data segments, there _is_ a newline:

```
Data segments:
  0: crypt
	offset: 16777216 [bytes]
	length: (whole device)
	cipher: aes-xts-plain64
	sector: 4096 [bytes]

  1: crypt
	offset: 16777216 [bytes]
	length: (whole device)
	cipher: aes-xts-plain64
	sector: 4096 [bytes]
	flags : backup-previous
```

Most of the time, there is a single data segment. However, during re-encryption, there might appear multiple segments. The parser didn't assume this.