### PR TITLE
Handle exception when updating rules

### DIFF
--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -127,7 +127,12 @@ def pre_update(client, config):
 
 @phase
 def update(client, config):
-    client.update()
+    try:
+        client.update()
+    except Exception as e:
+        logger.error("Failed to update rules. Error: %s", str(e))
+        sys.exit(constants.sig_kill_bad)
+
     if config.payload:
         logger.debug('Uploading a payload. Bypassing rules update.')
         return

--- a/insights/tests/client/phase/test_update.py
+++ b/insights/tests/client/phase/test_update.py
@@ -80,3 +80,17 @@ def test_exit_ok(insights_config, insights_client):
     with raises(SystemExit) as exc_info:
         update()
     assert exc_info.value.code == 0
+
+
+@patch("insights.client.phase.v1.InsightsClient")
+@patch("insights.client.phase.v1.InsightsConfig")
+@patch("insights.client.phase.v1.logger")
+def test_exit_error(logger, insights_config, insights_client):
+    from requests.exceptions import ConnectionError
+
+    insights_client.return_value.update.side_effect = ConnectionError("Connection error")
+    with raises(SystemExit) as exc_info:
+        update()
+
+    assert exc_info.value.code == 101
+    logger.error.assert_called_with("Failed to update rules. Error: %s", 'Connection error')


### PR DESCRIPTION
Signed-off-by: ahitacat <ahitacat@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Insights-client was printing to the terminal the traceback of an connection error.
~~~
# insights-client --register
Fatal error
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/urllib3/connectionpool.py", line 699, in urlopen
    httplib_response = self._make_request(
  File "/usr/lib/python3.9/site-packages/urllib3/connectionpool.py", line 382, in _make_request
    self._validate_conn(conn)
  File "/usr/lib/python3.9/site-packages/urllib3/connectionpool.py", line 1010, in _validate_conn
    conn.connect()
  File "/usr/lib/python3.9/site-packages/urllib3/connection.py", line 411, in connect
    self.sock = ssl_wrap_socket(
  File "/usr/lib/python3.9/site-packages/urllib3/util/ssl_.py", line 449, in ssl_wrap_socket
    ssl_sock = _ssl_wrap_socket_impl(
  File "/usr/lib/python3.9/site-packages/urllib3/util/ssl_.py", line 493, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
  File "/usr/lib64/python3.9/ssl.py", line 500, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/lib64/python3.9/ssl.py", line 1040, in _create
    self.do_handshake()
  File "/usr/lib64/python3.9/ssl.py", line 1309, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)

During handling of the above exception, another exception occurred:
~~~
This solution catches the exception during the `update()` phase and exits insights-client with an error a user-friendly print.
~~~
Failed to update rules. Error: HTTPSConnectionPool(host='cert-api.access.redhat.com', port=443): Max retries exceeded with url: /r/insights/platform/module-update-router/v1/channel?module=insights-core (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f8e1cfde860>: Failed to establish a new connection: [Errno 113] No route to host',))
~~~

Resolves: rhbz#2094243