### PR TITLE
fix: remove duplicated containers from running_rhel_containers

### DIFF
--- a/insights/specs/datasources/container/__init__.py
+++ b/insights/specs/datasources/container/__init__.py
@@ -14,12 +14,21 @@ def running_rhel_containers(broker):
     """
     Returns a list of tuple of (image, <podman|docker>, container_id) of the running
     containers.
+
+    From RHEL 8, the "docker" command is from the package "podman-docker". In
+    general when using command "docker" to access a container, the following
+    message will be reported on the top::
+
+        Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
+
+    But sometimes, this line won't be outputted as expected, in this case, it's
+    necessary to remove the duplicated containers from the output of "docker".
     """
     def _is_rhel_image(ctx, c_info):
         """Only collect the containers based from RHEL images"""
         try:
             ret = ctx.shell_out("/usr/bin/%s exec %s cat /etc/redhat-release" % c_info, timeout=DEFAULT_SHELL_TIMEOUT)
-            if ret and "red hat enterprise linux" in ret[0].lower():
+            if ret and len(ret) == 1 and "red hat enterprise linux" in ret[0].lower():
                 return True
         except Exception:
             # return False when there is no such file "/etc/redhat-releas"
@@ -27,16 +36,28 @@ def running_rhel_containers(broker):
         return False
 
     cs = []
+    podman_container = set()
     if (PodmanListContainers in broker):
         podman_c = broker[PodmanListContainers]
         for name in podman_c.running_containers:
-            c_info = ('podman', podman_c.containers[name]['CONTAINER ID'][:12])
-            cs.append((podman_c.containers[name]['IMAGE'],) + c_info) if _is_rhel_image(broker[HostContext], c_info) else None
+            container_id = podman_c.containers[name]['CONTAINER ID']
+            podman_container.add(container_id)
+            c_info = ('podman', container_id[:12])
+            if not _is_rhel_image(broker[HostContext], c_info):
+                # skip containers from non-rhel image
+                continue
+            cs.append((podman_c.containers[name]['IMAGE'],) + c_info)
     if (DockerListContainers in broker):
         docker_c = broker[DockerListContainers]
         for name in docker_c.running_containers:
-            c_info = ('docker', docker_c.containers[name]['CONTAINER ID'][:12])
-            cs.append((docker_c.containers[name]['IMAGE'],) + c_info) if _is_rhel_image(broker[HostContext], c_info) else None
+            container_id = docker_c.containers[name]['CONTAINER ID']
+            c_info = ('docker', container_id[:12])
+            if (container_id in podman_container or
+                    not _is_rhel_image(broker[HostContext], c_info)):
+                # skip containers from non-rhel image and
+                # skip duplicated containers managed by "podman"
+                continue
+            cs.append((docker_c.containers[name]['IMAGE'],) + c_info)
     if cs:
         # Return list of tuple:
         # - (image, <podman|docker>, container_id)

--- a/insights/tests/datasources/container/test_running_rhel_containers.py
+++ b/insights/tests/datasources/container/test_running_rhel_containers.py
@@ -7,8 +7,18 @@ from insights.core.dr import SkipComponent
 from insights.core.context import HostContext
 from insights.parsers.podman_list import PodmanListContainers
 from insights.parsers.docker_list import DockerListContainers
-from insights.tests.parsers.test_podman_list import PODMAN_LIST_CONTAINERS
-from insights.tests.parsers.test_docker_list import DOCKER_LIST_CONTAINERS
+
+PODMAN_LIST_CONTAINERS_2_UP = """
+CONTAINER ID                                                       IMAGE         COMMAND                                            CREATED             STATUS                      PORTS                  NAMES               SIZE
+03e2861336a76e29155836113ff6560cb70780c32f95062642993b2b3d0fc216   rhel7_httpd   "/usr/sbin/httpd -DFOREGROUND"                     45 seconds ago      Up 37 seconds               0.0.0.0:8080->80/tcp   angry_saha          796 B (virtual 669.2 MB)
+05516ea08b565e37e2a4bca3333af40a240c368131b77276da8dec629b7fe102   bd8638c869ea  "/bin/sh -c 'yum install -y vsftpd-2.2.2-6.el6'"   18 hours ago        Up 18 hours ago                                    tender_rosalind     4.751 MB (virtual 200.4 MB)
+""".strip()
+
+DOCKER_LIST_CONTAINERS_1_UP = """
+CONTAINER ID                                                       IMAGE         COMMAND                                            CREATED             STATUS                      PORTS                  NAMES               SIZE
+d3e2861336a76e29155836113ff6560cb70780c32f95062642993b2b3d0fc216   rhel7_httpd   "/usr/sbin/httpd -DFOREGROUND"                     45 seconds ago      Up 37 seconds               0.0.0.0:8080->80/tcp   angry_saha          796 B (virtual 669.2 MB)
+d5516ea08b565e37e2a4bca3333af40a240c368131b77276da8dec629b7fe102   bd8638c869ea  "/bin/sh -c 'yum install -y vsftpd-2.2.2-6.el6'"   18 hours ago        Exited (137) 18 hours ago                          tender_rosalind     4.751 MB (virtual 200.4 MB)
+""".strip()
 
 FEDORA = """
 Fedora release 23 (Twenty Three)
@@ -28,10 +38,10 @@ def fake_shell_out(cmd, split=True, timeout=None, keep_rc=False, env=None, signu
     raise Exception()
 
 
-@patch("insights.core.context.HostContext.shell_out", side_effect=fake_shell_out)
-def test_get_running_rhel_containers(fso):
-    p_ctn = PodmanListContainers(context_wrap(PODMAN_LIST_CONTAINERS))
-    d_ctn = DockerListContainers(context_wrap(DOCKER_LIST_CONTAINERS))
+@patch("insights.core.context.HostContext.shell_out", return_value=[REDHAT_RELEASE7, ])
+def test_get_running_rhel_containers_both_ok(fso):
+    p_ctn = PodmanListContainers(context_wrap(PODMAN_LIST_CONTAINERS_2_UP))
+    d_ctn = DockerListContainers(context_wrap(DOCKER_LIST_CONTAINERS_1_UP))
     assert p_ctn is not None
     assert d_ctn is not None
 
@@ -41,15 +51,56 @@ def test_get_running_rhel_containers(fso):
         HostContext: HostContext()}
 
     ret = running_rhel_containers(broker)
-    assert len(ret) == 1
+    assert len(ret) == 3
     assert ('rhel7_httpd', 'podman', '03e2861336a7') in ret
-    assert ('rhel7_httpd', 'docker', '03e2861336a7') not in ret
+    assert ('bd8638c869ea', 'podman', '05516ea08b56') in ret
+    assert ('rhel7_httpd', 'docker', 'd3e2861336a7') in ret
+    # the stopped container is not collected
+
+
+@patch("insights.core.context.HostContext.shell_out", side_effect=fake_shell_out)
+def test_get_running_rhel_containers_podman_only(fso):
+    p_ctn = PodmanListContainers(context_wrap(PODMAN_LIST_CONTAINERS_2_UP))
+    d_ctn = DockerListContainers(context_wrap(DOCKER_LIST_CONTAINERS_1_UP))
+    assert p_ctn is not None
+    assert d_ctn is not None
+
+    broker = {
+        PodmanListContainers: p_ctn,
+        DockerListContainers: d_ctn,
+        HostContext: HostContext()}
+
+    ret = running_rhel_containers(broker)
+    assert len(ret) == 2
+    assert ('rhel7_httpd', 'podman', '03e2861336a7') in ret
+    assert ('bd8638c869ea', 'podman', '05516ea08b56') in ret
+    # docker container is from Fedora image, not collected
+
+
+@patch("insights.core.context.HostContext.shell_out", return_value=[REDHAT_RELEASE7, ])
+def test_get_running_rhel_containers_skip_dup(fso):
+    p_ctn = PodmanListContainers(context_wrap(PODMAN_LIST_CONTAINERS_2_UP))
+    # use the 'podman list' result as input for docker
+    d_ctn = DockerListContainers(context_wrap(PODMAN_LIST_CONTAINERS_2_UP))
+    assert p_ctn is not None
+    assert d_ctn is not None
+
+    broker = {
+        PodmanListContainers: p_ctn,
+        DockerListContainers: d_ctn,
+        HostContext: HostContext()}
+
+    ret = running_rhel_containers(broker)
+    assert len(ret) == 2
+    assert ('rhel7_httpd', 'podman', '03e2861336a7') in ret
+    assert ('bd8638c869ea', 'podman', '05516ea08b56') in ret
+    # duplicated container is removed from docker, not collected
 
 
 @patch("insights.core.context.HostContext.shell_out", return_value=[FEDORA, ])
 def test_get_running_rhel_containers_empty(fso):
-    p_ctn = PodmanListContainers(context_wrap(PODMAN_LIST_CONTAINERS))
-    d_ctn = DockerListContainers(context_wrap(DOCKER_LIST_CONTAINERS))
+    p_ctn = PodmanListContainers(context_wrap(PODMAN_LIST_CONTAINERS_2_UP))
+    d_ctn = DockerListContainers(context_wrap(DOCKER_LIST_CONTAINERS_1_UP))
     assert p_ctn is not None
     assert d_ctn is not None
 


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

From RHEL 8, the "docker" command is from the package "podman-docker". In
general when using command "docker" to access a container, the following
message will be reported on the top::
        `Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.`
But sometimes, this line won't be outputted as expected, in this case, it's
necessary to remove the duplicated containers from the output of "docker".

This PR enhances the `runing_rhel_containers` and remove such duplicates.
