### PR TITLE
fix: remove the inner functions of the _make_rpm_formatter

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -52,19 +52,13 @@ def _make_rpm_formatter(fmt=None):
             '"buildhost":"%{BUILDHOST}"',
             '"sigpgp":"%{SIGPGP:pgpsig}"'
         ]
-
-    def inner(idx=None):
-        if idx:
-            return "\{" + ",".join(fmt[:idx]) + "\}\n"
-        else:
-            return "\{" + ",".join(fmt) + "\}\n"
-    return inner
-
-
-format_rpm = _make_rpm_formatter()
+    return "\{" + ",".join(fmt) + "\}\n"
 
 
 class DefaultSpecs(Specs):
+    # Required functions
+    rpm_format = _make_rpm_formatter()
+
     # Dep specs that aren't in the registry
     block_devices_by_uuid = listdir("/dev/disk/by-uuid/", context=HostContext)
     etc_and_sub_dirs = sorted(["/etc", "/etc/pki/tls/private", "/etc/pki/tls/certs",
@@ -268,7 +262,7 @@ class DefaultSpecs(Specs):
     init_process_cgroup = simple_file("/proc/1/cgroup")
     initctl_lst = simple_command("/sbin/initctl --system list")
     insights_client_conf = simple_file('/etc/insights-client/insights-client.conf')
-    installed_rpms = simple_command("/bin/rpm -qa --qf '%s'" % format_rpm(), context=HostContext, signum=signal.SIGTERM)
+    installed_rpms = simple_command("/bin/rpm -qa --qf '%s'" % rpm_format, context=HostContext, signum=signal.SIGTERM)
     interrupts = simple_file("/proc/interrupts")
     ip6tables = simple_command("/sbin/ip6tables-save")
     ip_addr = simple_command("/sbin/ip addr")
@@ -676,6 +670,6 @@ class DefaultSpecs(Specs):
     zipl_conf = simple_file("/etc/zipl.conf")
 
     # Container collection specs
-    container_installed_rpms = container_execute(running_rhel_containers, "rpm -qa --qf '%s'" % format_rpm(), context=HostContext, signum=signal.SIGTERM)
+    container_installed_rpms = container_execute(running_rhel_containers, "rpm -qa --qf '%s'" % rpm_format, context=HostContext, signum=signal.SIGTERM)
     container_nginx_conf = container_collect(container_nginx_conf_ds)
     container_redhat_release = container_collect(running_rhel_containers, "/etc/redhat-release")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -264,7 +264,7 @@ class DefaultSpecs(Specs):
     init_process_cgroup = simple_file("/proc/1/cgroup")
     initctl_lst = simple_command("/sbin/initctl --system list")
     insights_client_conf = simple_file('/etc/insights-client/insights-client.conf')
-    installed_rpms = simple_command("/bin/rpm -qa --qf '%s'" % rpm_format, context=HostContext, signum=signal.SIGTERM)
+    installed_rpms = simple_command("/bin/rpm -qa --qf '%s'" % _rpm_format, context=HostContext, signum=signal.SIGTERM)
     interrupts = simple_file("/proc/interrupts")
     ip6tables = simple_command("/sbin/ip6tables-save")
     ip_addr = simple_command("/sbin/ip addr")
@@ -311,7 +311,7 @@ class DefaultSpecs(Specs):
     ls_dev = simple_command("/bin/ls -lanR /dev")
     ls_disk = simple_command("/bin/ls -lanR /dev/disk")
     ls_edac_mc = simple_command("/bin/ls -lan /sys/devices/system/edac/mc")
-    ls_etc = simple_command("/bin/ls -lan {0}".format(' '.join(etc_and_sub_dirs)), keep_rc=True)
+    ls_etc = simple_command("/bin/ls -lan {0}".format(' '.join(_etc_and_sub_dirs)), keep_rc=True)
     ls_etc_ssh = simple_command("/bin/ls -lanL /etc/ssh")
     ls_ipa_idoverride_memberof = simple_command("/bin/ls -lan /usr/share/ipa/ui/js/plugins/idoverride-memberof")
     ls_krb5_sssd = simple_command("/bin/ls -lan /var/lib/sss/pubconf/krb5.include.d")
@@ -672,6 +672,6 @@ class DefaultSpecs(Specs):
     zipl_conf = simple_file("/etc/zipl.conf")
 
     # Container collection specs
-    container_installed_rpms = container_execute(running_rhel_containers, "rpm -qa --qf '%s'" % rpm_format, context=HostContext, signum=signal.SIGTERM)
+    container_installed_rpms = container_execute(running_rhel_containers, "rpm -qa --qf '%s'" % _rpm_format, context=HostContext, signum=signal.SIGTERM)
     container_nginx_conf = container_collect(container_nginx_conf_ds)
     container_redhat_release = container_collect(running_rhel_containers, "/etc/redhat-release")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -56,9 +56,6 @@ def _make_rpm_formatter(fmt=None):
 
 
 class DefaultSpecs(Specs):
-    # Variables that need to be pre-loaded
-    rpm_format = _make_rpm_formatter()
-
     # Dep specs that aren't in the registry
     block_devices_by_uuid = listdir("/dev/disk/by-uuid/", context=HostContext)
     etc_and_sub_dirs = sorted(["/etc", "/etc/pki/tls/private", "/etc/pki/tls/certs",
@@ -67,6 +64,7 @@ class DefaultSpecs(Specs):
     httpd_pid = simple_command("/usr/bin/pgrep -o httpd")
     openshift_router_pid = simple_command("/usr/bin/pgrep -n openshift-route")
     ovs_vsctl_list_br = simple_command("/usr/bin/ovs-vsctl list-br")
+    rpm_format = _make_rpm_formatter()
 
     # Regular collection specs
     abrt_ccpp_conf = simple_file("/etc/abrt/plugins/CCpp.conf")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -55,16 +55,20 @@ def _make_rpm_formatter(fmt=None):
     return "\{" + ",".join(fmt) + "\}\n"
 
 
+_etc_and_sub_dirs = sorted(["/etc", "/etc/pki/tls/private", "/etc/pki/tls/certs",
+                           "/etc/pki/ovirt-vmconsole", "/etc/nova/migration", "/etc/sysconfig",
+                           "/etc/cloud/cloud.cfg.d", "/etc/rc.d/init.d"])
+""" List of directories for spec `ls_etc` """
+_rpm_format = _make_rpm_formatter()
+""" Query format for specs `installed_rpms` and `container_installed_rpms` """
+
+
 class DefaultSpecs(Specs):
     # Dep specs that aren't in the registry
     block_devices_by_uuid = listdir("/dev/disk/by-uuid/", context=HostContext)
-    etc_and_sub_dirs = sorted(["/etc", "/etc/pki/tls/private", "/etc/pki/tls/certs",
-                               "/etc/pki/ovirt-vmconsole", "/etc/nova/migration", "/etc/sysconfig",
-                               "/etc/cloud/cloud.cfg.d", "/etc/rc.d/init.d"])
     httpd_pid = simple_command("/usr/bin/pgrep -o httpd")
     openshift_router_pid = simple_command("/usr/bin/pgrep -n openshift-route")
     ovs_vsctl_list_br = simple_command("/usr/bin/ovs-vsctl list-br")
-    rpm_format = _make_rpm_formatter()
 
     # Regular collection specs
     abrt_ccpp_conf = simple_file("/etc/abrt/plugins/CCpp.conf")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -56,7 +56,7 @@ def _make_rpm_formatter(fmt=None):
 
 
 class DefaultSpecs(Specs):
-    # Required functions
+    # Variables that need to be pre-loaded
     rpm_format = _make_rpm_formatter()
 
     # Dep specs that aren't in the registry


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Remove the inner function as commented [here](https://github.com/RedHatInsights/insights-core/pull/3572/files#r1008107573) by Ryan.
