### PR TITLE
chore: remove the unused 'ethernet_interfaces' spec

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -157,7 +157,6 @@ class Specs(SpecSet):
     etc_udev_40_redhat_rules = RegistryPoint(filterable=True)
     etc_udev_oracle_asm_rules = RegistryPoint(multi_output=True, filterable=True)
     etcd_conf = RegistryPoint(filterable=True)
-    ethernet_interfaces = RegistryPoint()
     ethtool = RegistryPoint(multi_output=True)
     ethtool_S = RegistryPoint(multi_output=True)
     ethtool_T = RegistryPoint(multi_output=True)

--- a/insights/specs/datasources/ethernet.py
+++ b/insights/specs/datasources/ethernet.py
@@ -10,7 +10,7 @@ from insights.specs import Specs
 
 
 class LocalSpecs(Specs):
-    """ Local specs used only by ethernet_interfaces datasource. """
+    """ Local specs used only by ethernet.interfaces datasource. """
     ip_link = simple_command("/sbin/ip -o link")
 
 
@@ -30,7 +30,7 @@ def interfaces(broker):
     Note:
         This datasource may be executed using the following command:
 
-        ``insights cat --no-header ethernet_interfaces``
+        ``insights cat --no-header ethernet.interfaces``
 
     Sample data returned::
 

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -184,7 +184,6 @@ class DefaultSpecs(Specs):
                                        "/usr/lib/udev/rules.d/40-redhat.rules", "/usr/local/lib/udev/rules.d/40-redhat.rules"])
     etc_udev_oracle_asm_rules = glob_file(r"/etc/udev/rules.d/*asm*.rules")
     etcd_conf = simple_file("/etc/etcd/etcd.conf")
-    ethernet_interfaces = listdir("/sys/class/net", context=HostContext)
     ethtool = foreach_execute(ethernet.interfaces, "/sbin/ethtool %s")
     ethtool_S = foreach_execute(ethernet.interfaces, "/sbin/ethtool -S %s")
     ethtool_T = foreach_execute(ethernet.interfaces, "/sbin/ethtool -T %s")

--- a/insights/tests/datasources/test_ethernet.py
+++ b/insights/tests/datasources/test_ethernet.py
@@ -6,7 +6,6 @@ from insights.parsers.nmcli import NmcliConnShow
 from mock.mock import Mock
 from insights.tests import context_wrap
 
-RELATIVE_PATH = "insights_commands/ethernet_interfaces"
 
 IP_LINK = """
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000\\    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

This spec is not used by any existing specs/datasources, parsers, or rules. Let's just remove it.