### PR TITLE
fix(parsers): add support for missing logs

### DIFF
--- a/insights/parsers/greenboot_status.py
+++ b/insights/parsers/greenboot_status.py
@@ -11,7 +11,8 @@ from insights.specs import Specs
 _green = "Boot Status is GREEN"
 _red = "Boot Status is RED"
 _fallback = "FALLBACK BOOT DETECTED"
-add_filter(Specs.greenboot_status, [_green, _red, _fallback])
+_nologs = "WARNING: No greenboot logs were found!"
+add_filter(Specs.greenboot_status, [_green, _red, _fallback, _nologs])
 
 
 @parser(Specs.greenboot_status)
@@ -33,3 +34,4 @@ class GreenbootStatus(LogFileOutput):
 GreenbootStatus.token_scan("green", _green)
 GreenbootStatus.token_scan("red", _red)
 GreenbootStatus.token_scan("fallback", _fallback)
+GreenbootStatus.token_scan("nologs", _nologs)

--- a/insights/tests/parsers/test_greenboot_status.py
+++ b/insights/tests/parsers/test_greenboot_status.py
@@ -61,6 +61,10 @@ Feb 22 22:50:26 example greenboot-status[905]: FALLBACK BOOT DETECTED! Default r
 Feb 22 22:50:26 example systemd[1]: Started greenboot MotD Generator.
 """
 
+NOLOGS = """
+WARNING: No greenboot logs were found!
+"""
+
 
 def test_greenboot_status_green():
     green = context_wrap(GREEN)
@@ -81,3 +85,11 @@ def test_greenboot_status_fallback():
     p = GreenbootStatus(fb)
     assert p.green
     assert p.fallback
+
+
+def test_greenboot_status_nolog():
+    fb = context_wrap(NOLOGS)
+    p = GreenbootStatus(fb)
+    assert p.nologs
+    assert not p.green
+    assert not p.red


### PR DESCRIPTION

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

We discovered that the [greenboot-status parser](https://github.com/RedHatInsights/insights-core/blob/6cea5730e2dcb45d71702867b9bac35f94e99a2/insights/parsers/greenboot_status.py) does not check for the case where `greenboot-status` outputs "WARNING: No greenboot logs were found!". In this case, the archive contained no greenboot-status command output. The absence of this output [caused puptoo](https://github.com/RedHatInsights/insights-puptoo/blob/c221d6454b55c30f7ebe17cc517fe9d7f28c78f4/src/puptoo/process/profile.py#L213) to not set the profile["host_type"] field to "edge". When host_type was not set to "edge", the hosts were not showing up in Edge inventory.
