### PR TITLE
Handle network exceptions when accessing egg URL

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -105,11 +105,14 @@ class InsightsClient(object):
             url = self.connection.base_url + '/platform' + constants.module_router_path
         else:
             url = self.connection.base_url + constants.module_router_path
-        response = self.connection.get(url)
-        if response.status_code == 200:
-            return response.json()["url"]
-        else:
-            logger.warning("Unable to fetch egg url. Defaulting to /release")
+        try:
+            response = self.connection.get(url)
+            if response.status_code == 200:
+                return response.json()["url"]
+            else:
+                raise ConnectionError("%s: %s" % (response.status_code, response.reason))
+        except ConnectionError as e:
+            logger.warning("Unable to fetch egg url %s: %s. Defaulting to /release", url, str(e))
             return '/release'
 
     def fetch(self, force=False):


### PR DESCRIPTION
Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement

This PR is for more gracefully handling network exceptions if there is a problem accessing/downloading the egg URL.  Its to better handle the error shown in https://bugzilla.redhat.com/show_bug.cgi?id=2107323.  It doesn't actually have anything to do with retrying downloads because --retry only applies to uploads.

Logs before PR (unhandled exceptions and tracebacks):
![Screenshot from 2022-11-09 14-41-15](https://user-images.githubusercontent.com/4008744/200740768-5e11d542-f710-4023-98ad-e46d6f82d0f5.png)

Logs after PR (helpful error messages and graceful failure):
![Screenshot from 2022-11-09 14-39-18](https://user-images.githubusercontent.com/4008744/200740835-9a4adf74-b6ff-4e59-8537-42e79c3dee21.png)
