### PR TITLE
fix: Issue with dr.get_spec_name returning wrong value

### DIFF
--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -429,6 +429,10 @@ def get_spec_name(c):
     Query the actual registry point spec name, by looping through the
     dependent components and if ".Specs" is in the name and return it.
     """
+    name = get_name(c)
+    if ".Specs" in name:
+        return name
+
     for cmp in get_dependents(c):
         name = get_name(cmp)
         if ".Specs" in name:


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
When called from the dehydration looking for errors it didn't check if the component passed in was already a registry point spec. So I added a check to catch specs passed in as the component and to return the name of the component instead of looping through the deps.