### PR TITLE
fix: allow legacy upload to stage

### DIFF
--- a/insights/client/auto_config.py
+++ b/insights/client/auto_config.py
@@ -164,8 +164,6 @@ def _try_satellite6_configuration(config):
         elif _is_staging_rhsm(rhsm_hostname):
             logger.debug('Connected to staging RHSM, using cert.cloud.stage.redhat.com')
             rhsm_hostname = 'cert.cloud.stage.redhat.com'
-            # never use legacy upload for staging
-            config.legacy_upload = False
             config.cert_verify = True
             is_stage = True
             rhsm_ca = None


### PR DESCRIPTION
Allow the value of legacy_upload, as set in the config file, to remain
regardless of whether or not the client is connecting to the stage
environment.

Related: ESSNTL-3782