### PR TITLE
Rename downloaded temp malware rules file

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -603,7 +603,7 @@ class MalwareDetectionClient:
         # malware-detection client exits.
         # However it can happen that the rules file isn't removed for some reason, so remove any existing
         # rules files before beginning a new scan, otherwise they may show up as matches in the scan results.
-        old_rules_files = glob('/tmp/tmp_malware-detection-client_rules.*')
+        old_rules_files = glob('/tmp/.tmpsigs*')
         for old_rules_file in old_rules_files:
             logger.debug("Removing old rules file %s", old_rules_file)
             os.remove(old_rules_file)
@@ -680,7 +680,7 @@ class MalwareDetectionClient:
                     logger.error("Unable to download rules from %s: %s", self.rules_location, str(e))
                     exit(constants.sig_kill_bad)
 
-        self.temp_rules_file = NamedTemporaryFile(prefix='tmp_malware-detection-client_rules.', mode='wb', delete=True)
+        self.temp_rules_file = NamedTemporaryFile(prefix='.tmpsigs', mode='wb', delete=True)
         self.temp_rules_file.write(response.content)
         self.temp_rules_file.flush()
         return self.temp_rules_file.name

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -31,7 +31,7 @@ RANDOM_STRING = ''.join(random.choice(string.ascii_lowercase) for _ in range(5))
 TEMP_TEST_DIR = "/tmp/malware-detection_test_dir_%s" % RANDOM_STRING
 
 YARA = '/bin/yara'  # Fake yara executable
-RULES_FILE = os.path.join(TEMP_TEST_DIR, 'rules.yar')
+RULES_FILE = os.path.join(TEMP_TEST_DIR, '.tmpsigs.yar')
 TEST_RULE_FILE = os.path.join(TEMP_TEST_DIR, 'test-rule.yar')
 TEST_RULE_SCRIPT = os.path.join(TEMP_TEST_DIR, 'test-rule_process_match.sh')
 CONFIG = yaml.safe_load(DEFAULT_MALWARE_CONFIG)  # Config 'returned' from _load_config


### PR DESCRIPTION
Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

This is a rather weak attempt at hiding the downloaded malware rules file, but its slightly less obvious than what's currently being used.  This is a temporary fix until I can get something better happening, eg having the rules file in memory and written to disk as needed.