### PR TITLE
Do not union the mount points

### DIFF
--- a/insights/combiners/mounts.py
+++ b/insights/combiners/mounts.py
@@ -43,13 +43,13 @@ class Mounts(object):
 
     def __init__(self, binmount, procmounts, mountinfo):
         self._mounts = {}
-        all_mount_points = set()
+        all_mount_points = []
         if binmount:
-            all_mount_points = set(binmount.mounts.keys())
+            all_mount_points = binmount.mounts.keys()
         elif procmounts:
-            all_mount_points = set(procmounts.mounts.keys())
+            all_mount_points = procmounts.mounts.keys()
         elif mountinfo:
-            all_mount_points = set(mountinfo.mounts.keys())
+            all_mount_points = mountinfo.mounts.keys()
 
         for mount_point in all_mount_points:
             this_binmount = binmount.get_dir(mount_point) if binmount else None

--- a/insights/combiners/mounts.py
+++ b/insights/combiners/mounts.py
@@ -48,7 +48,7 @@ class Mounts(object):
             all_mount_points = set(binmount.mounts.keys())
         elif procmounts:
             all_mount_points = set(procmounts.mounts.keys())
-        else:
+        elif mountinfo:
             all_mount_points = set(mountinfo.mounts.keys())
 
         for mount_point in all_mount_points:

--- a/insights/combiners/mounts.py
+++ b/insights/combiners/mounts.py
@@ -13,7 +13,7 @@ Examples:
     >>> type(mounts)
     <class 'insights.combiners.mounts.Mounts'>
     >>> len(mounts)
-    19
+    15
     >>> '/boot' in mounts
     True
     >>> mounts['/boot'].mount_source

--- a/insights/combiners/mounts.py
+++ b/insights/combiners/mounts.py
@@ -43,11 +43,14 @@ class Mounts(object):
 
     def __init__(self, binmount, procmounts, mountinfo):
         self._mounts = {}
+        all_mount_points = set()
+        if binmount:
+            all_mount_points = set(binmount.mounts.keys())
+        elif procmounts:
+            all_mount_points = set(procmounts.mounts.keys())
+        else:
+            all_mount_points = set(mountinfo.mounts.keys())
 
-        all_mount_points = set().union(
-                    binmount.mounts.keys() if binmount else [],
-                    procmounts.mounts.keys() if procmounts else [],
-                    mountinfo.mounts.keys() if mountinfo else [])
         for mount_point in all_mount_points:
             this_binmount = binmount.get_dir(mount_point) if binmount else None
             this_procmounts = procmounts.get_dir(mount_point) if procmounts else None
@@ -70,7 +73,7 @@ class Mounts(object):
 
             # create MountEntry
             source_mount = this_mountinfo if this_mountinfo else (
-                            this_procmounts if this_procmounts else this_binmount)
+                this_procmounts if this_procmounts else this_binmount)
             basicinfo = {}
             basicinfo['mount_point'] = mount_point
             basicinfo['mount_source'] = source_mount.get('mount_source') or source_mount.get('filesystem')
@@ -81,7 +84,7 @@ class Mounts(object):
 
             self._mounts[mount_point] = entry_info
             self.rows = sorted(self._mounts.values(), key=lambda r:
-                        (r.mount_addtlinfo.get('mount_id', '-1'), r.mount_point))
+            (r.mount_addtlinfo.get('mount_id', '-1'), r.mount_point))
 
     @property
     def mount_points(self):

--- a/insights/tests/combiners/test_mounts.py
+++ b/insights/tests/combiners/test_mounts.py
@@ -75,7 +75,7 @@ def test_combiner_mounts_all():
     procmounts = ProcMounts(context_wrap(PROCMOUNTS_DATA))
     mountinfo = MountInfo(context_wrap(MOUNTINFO_DATA))
     mounts = Mounts(mount, procmounts, mountinfo)
-    assert len(mounts) == 19
+    assert len(mounts) == 15
 
     assert '/' in mounts
     root_entry = mounts['/']
@@ -96,8 +96,8 @@ def test_combiner_mounts_all():
     assert mounts.search(mount_source="/dev/mapper/vgsys-root")[0]['mount_point'] == '/'
 
     assert mounts.rows[0] == mounts['/proc']
-    assert len([row for row in mounts]) == 19
-    assert len(mounts.mount_points) == 19
+    assert len([row for row in mounts]) == 15
+    assert len(mounts.mount_points) == 15
     assert mounts.get_dir('/var/somedir') == mounts['/var']
     assert mounts.get_dir('not/absolute/path') is None
 
@@ -106,7 +106,7 @@ def test_combiner_wo_mountinfo():
     mount = Mount(context_wrap(MOUNT_DATA))
     procmounts = ProcMounts(context_wrap(PROCMOUNTS_DATA))
     mounts = Mounts(mount, procmounts, None)
-    assert len(mounts) == 19
+    assert len(mounts) == 15
 
     assert '/' in mounts
     root_entry = mounts['/']
@@ -151,7 +151,7 @@ def test_combiner_wo_procmount():
     mount = Mount(context_wrap(MOUNT_DATA))
     mountinfo = MountInfo(context_wrap(MOUNTINFO_DATA))
     mounts = Mounts(mount, None, mountinfo)
-    assert len(mounts) == 19
+    assert len(mounts) == 15
 
     assert '/' in mounts
     root_entry = mounts['/']


### PR DESCRIPTION
  For IBM GPFS, there is internal mount concept. If a file system is only internally mounted, it does not show up in mount or df output.
  Reference: https://www.ibm.com/support/pages/gpfs-internal-and-external-mount-states

Signed-off-by: Chen lizhong <lichen@redhat.com>

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
