### PR TITLE
fix: fix errors in ethtool

### DIFF
--- a/insights/parsers/ethtool.py
+++ b/insights/parsers/ethtool.py
@@ -52,6 +52,7 @@ if sys.version_info.major == 3:
     # Python 3
     unicode = str
 
+
 def extract_iface_name_from_path(path, name):
     """
     Extract the 'real' interface name from the path name.  Basically this

--- a/insights/parsers/ethtool.py
+++ b/insights/parsers/ethtool.py
@@ -48,7 +48,7 @@ from ..parsers import ParseException
 from .. import parser, LegacyItemAccess, CommandParser
 from insights.specs import Specs
 
-if sys.version_info.major == 3:
+if sys.version_info[0] == 3:
     # Python 3
     unicode = str
 

--- a/insights/parsers/ethtool.py
+++ b/insights/parsers/ethtool.py
@@ -42,11 +42,15 @@ TimeStamp - command ``/sbin/ethtool -T {interface}``
 
 import os
 import re
+import sys
 from collections import namedtuple
 from ..parsers import ParseException
 from .. import parser, LegacyItemAccess, CommandParser
 from insights.specs import Specs
 
+if sys.version_info.major == 3:
+    # Python 3
+    unicode = str
 
 def extract_iface_name_from_path(path, name):
     """
@@ -501,7 +505,7 @@ class CoalescingInfo(CommandParser):
         for line in content[2:]:
             if line.strip():
                 (key, value) = [s.strip() for s in line.split(":", 1)]
-                if value.isnumeric():
+                if unicode(value).isnumeric():
                     value = int(value)
                     self.data[key] = value
                     setattr(self, key.replace("-", "_"), value)
@@ -601,7 +605,7 @@ class Ring(CommandParser):
             elif ':' in line:
                 # key: value, store in section data for now
                 key, value = (s.strip() for s in line.split(":", 1))
-                if value.isnumeric():
+                if unicode(value).isnumeric():
                     section_data[key.replace(" ", "_").lower()] = int(value)
 
         # Handle last found section, if any

--- a/insights/parsers/ethtool.py
+++ b/insights/parsers/ethtool.py
@@ -501,7 +501,7 @@ class CoalescingInfo(CommandParser):
         for line in content[2:]:
             if line.strip():
                 (key, value) = [s.strip() for s in line.split(":", 1)]
-                if 'n/a' not in value:
+                if value.isnumeric():
                     value = int(value)
                     self.data[key] = value
                     setattr(self, key.replace("-", "_"), value)
@@ -601,7 +601,7 @@ class Ring(CommandParser):
             elif ':' in line:
                 # key: value, store in section data for now
                 key, value = (s.strip() for s in line.split(":", 1))
-                if 'n/a' not in value:
+                if value.isnumeric():
                     section_data[key.replace(" ", "_").lower()] = int(value)
 
         # Handle last found section, if any

--- a/insights/parsers/ethtool.py
+++ b/insights/parsers/ethtool.py
@@ -501,9 +501,10 @@ class CoalescingInfo(CommandParser):
         for line in content[2:]:
             if line.strip():
                 (key, value) = [s.strip() for s in line.split(":", 1)]
-                value = int(value)
-                self.data[key] = value
-                setattr(self, key.replace("-", "_"), value)
+                if 'n/a' not in value:
+                    value = int(value)
+                    self.data[key] = value
+                    setattr(self, key.replace("-", "_"), value)
 
 
 @parser(Specs.ethtool_g)
@@ -600,7 +601,8 @@ class Ring(CommandParser):
             elif ':' in line:
                 # key: value, store in section data for now
                 key, value = (s.strip() for s in line.split(":", 1))
-                section_data[key.replace(" ", "_").lower()] = int(value)
+                if 'n/a' not in value:
+                    section_data[key.replace(" ", "_").lower()] = int(value)
 
         # Handle last found section, if any
         set_section(section, section_data)
@@ -756,6 +758,7 @@ class TimeStamp(CommandParser):
         >>> eno1.data['Hardware Receive Filter Modes']['all']
         'HWTSTAMP_FILTER_ALL'
     """
+
     @property
     def ifname(self):
         """(str): the interface name"""
@@ -767,6 +770,7 @@ class TimeStamp(CommandParser):
 
         group = None
         for line in content[1:]:
+            line = line.strip()
             if ":" in line:
                 key, val = [i.strip() for i in line.split(':', 1)]
                 group = {}
@@ -775,7 +779,7 @@ class TimeStamp(CommandParser):
                 key, val = [i.strip() for i in line.split(None, 1)]
                 group[key] = val.strip('()')
             elif line:
-                raise ParseException('bad line: {0}'.format(line))
+                group[line] = None
 
 
 @parser(Specs.ethtool)
@@ -853,6 +857,7 @@ class Ethtool(CommandParser):
         >>> ethinfo.supported_ports  # This is converted to a list of strings
         ['TP', 'MII']
     """
+
     @property
     def ifname(self):
         """str: Return the name of network interface in content."""

--- a/insights/tests/parsers/test_ethtool.py
+++ b/insights/tests/parsers/test_ethtool.py
@@ -690,7 +690,6 @@ def test_ethtool_timestamp():
 def test_ethtool_timestamp_no_cap_value():
     timestamp = ethtool.TimeStamp(context_wrap(ETHTOOL_T_NO_CAP_VALUE, path="sbin/ethtool_-T_ens192"))
     assert timestamp.ifname == 'ens192'
-    print(timestamp.data)
     assert timestamp.data['Capabilities']['software-receive'] is None
     assert timestamp.data['Hardware Transmit Timestamp Modes'] == 'none'
 

--- a/insights/tests/parsers/test_ethtool.py
+++ b/insights/tests/parsers/test_ethtool.py
@@ -67,7 +67,15 @@ RX negotiated:  off
 TX negotiated:  off
 """.strip()
 
-
+ETHTOOL_T_NO_CAP_VALUE = """
+Time stamping parameters for ens192:
+Capabilities:
+	software-receive
+	software-system-clock
+PTP Hardware Clock: none
+Hardware Transmit Timestamp Modes: none
+Hardware Receive Filter Modes: none
+"""
 def test_ethtool_a():
     context = context_wrap(SUCCESS_ETHTOOL_A, path=SUCCESS_ETHTOOL_A_PATH)
     result = ethtool.Pause(context)
@@ -657,6 +665,15 @@ Hardware Receive Filter Modes:
     all                   (HWTSTAMP_FILTER_ALL)
 '''
 
+ETHTOOL_T_NO_CAP_VALUE = """
+Time stamping parameters for ens192:
+Capabilities:
+	software-receive
+	software-system-clock
+PTP Hardware Clock: none
+Hardware Transmit Timestamp Modes: none
+Hardware Receive Filter Modes: none
+"""
 
 def test_ethtool_timestamp():
     timestamp = ethtool.TimeStamp(context_wrap(TEST_ETHTOOL_TIMESTAMP, path="sbin/ethtool_-T_eno1"))
@@ -666,10 +683,13 @@ def test_ethtool_timestamp():
     assert timestamp.data['PTP Hardware Clock'] == '0'
     assert timestamp.data['Hardware Transmit Timestamp Modes']['off'] == 'HWTSTAMP_TX_OFF'
     assert timestamp.data['Hardware Receive Filter Modes']['all'] == 'HWTSTAMP_FILTER_ALL'
-    with pytest.raises(ParseException) as pe:
-        ethtool.TimeStamp(context_wrap(TEST_ETHTOOL_TIMESTAMP_AB, path="sbin/ethtool_-T_eno1"))
-        assert 'bad line:' in str(pe)
 
+def test_ethtool_timestamp_no_cap_value():
+    timestamp = ethtool.TimeStamp(context_wrap(ETHTOOL_T_NO_CAP_VALUE, path="sbin/ethtool_-T_ens192"))
+    assert timestamp.ifname == 'ens192'
+    print(timestamp.data)
+    assert timestamp.data['Capabilities']['software-receive'] == None
+    assert timestamp.data['Hardware Transmit Timestamp Modes'] == 'none'
 
 TEST_EXTRACT_FROM_PATH_1 = """
     ethtool_-a_eth0

--- a/insights/tests/parsers/test_ethtool.py
+++ b/insights/tests/parsers/test_ethtool.py
@@ -151,7 +151,7 @@ tx-usecs-irq: 0
 tx-frame-low: 25
 
 tx-usecs-high: 0
-tx-frame-high: 0
+tx-frame-high: n/a
 
 """.strip()
 
@@ -177,7 +177,7 @@ def test_get_ethtool_c():
     context.path = TEST_ETHTOOL_C_PATH
     result = ethtool.CoalescingInfo(context)
     assert keys_in(["adaptive-rx", "adaptive-tx", "pkt-rate-high",
-                    "tx-usecs-irq", "tx-frame-low", "tx-usecs-high", "tx-frame-high"], result.data)
+                    "tx-usecs-irq", "tx-frame-low", "tx-usecs-high"], result.data)
     assert result.ifname == "eth2"
     assert not result.adaptive_rx
     assert not result.adaptive_tx
@@ -185,7 +185,7 @@ def test_get_ethtool_c():
     assert result.tx_usecs_irq == 0
     assert result.tx_frame_low == 25
     assert result.tx_usecs_high == 0
-    assert result.tx_frame_high == 0
+    assert 'tx_frame_high' not in result.data
 
 
 def test_get_ethtool_c_cannot_get():

--- a/insights/tests/parsers/test_ethtool.py
+++ b/insights/tests/parsers/test_ethtool.py
@@ -7,7 +7,6 @@ from insights.util import keys_in
 
 import doctest
 
-
 TEST_ETHTOOL_A_DOCS = '''
 Pause parameters for eth0:
 Autonegotiate:  on
@@ -70,12 +69,14 @@ TX negotiated:  off
 ETHTOOL_T_NO_CAP_VALUE = """
 Time stamping parameters for ens192:
 Capabilities:
-	software-receive
-	software-system-clock
+    software-receive
+    software-system-clock
 PTP Hardware Clock: none
 Hardware Transmit Timestamp Modes: none
 Hardware Receive Filter Modes: none
 """
+
+
 def test_ethtool_a():
     context = context_wrap(SUCCESS_ETHTOOL_A, path=SUCCESS_ETHTOOL_A_PATH)
     result = ethtool.Pause(context)
@@ -668,12 +669,13 @@ Hardware Receive Filter Modes:
 ETHTOOL_T_NO_CAP_VALUE = """
 Time stamping parameters for ens192:
 Capabilities:
-	software-receive
-	software-system-clock
+    software-receive
+    software-system-clock
 PTP Hardware Clock: none
 Hardware Transmit Timestamp Modes: none
 Hardware Receive Filter Modes: none
 """
+
 
 def test_ethtool_timestamp():
     timestamp = ethtool.TimeStamp(context_wrap(TEST_ETHTOOL_TIMESTAMP, path="sbin/ethtool_-T_eno1"))
@@ -684,12 +686,14 @@ def test_ethtool_timestamp():
     assert timestamp.data['Hardware Transmit Timestamp Modes']['off'] == 'HWTSTAMP_TX_OFF'
     assert timestamp.data['Hardware Receive Filter Modes']['all'] == 'HWTSTAMP_FILTER_ALL'
 
+
 def test_ethtool_timestamp_no_cap_value():
     timestamp = ethtool.TimeStamp(context_wrap(ETHTOOL_T_NO_CAP_VALUE, path="sbin/ethtool_-T_ens192"))
     assert timestamp.ifname == 'ens192'
     print(timestamp.data)
-    assert timestamp.data['Capabilities']['software-receive'] == None
+    assert timestamp.data['Capabilities']['software-receive'] is None
     assert timestamp.data['Hardware Transmit Timestamp Modes'] == 'none'
+
 
 TEST_EXTRACT_FROM_PATH_1 = """
     ethtool_-a_eth0


### PR DESCRIPTION
Signed-off-by: Chen lizhong <lichen@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Fix errors:
insights.parsers.ethtool.CoalescingInfo ValueError("invalid literal for int() with base 10: 'n/a'")
insights.parsers.ethtool.TimeStamp ParseException('bad line: \tsoftware-receive')
insights.parsers.ethtool.TimeStamp ParseException('bad line: \thardware-transmit')
insights.parsers.ethtool.Ring ValueError("invalid literal for int() with base 10: 'n/a'"
