### PR TITLE
fix: add deprecated warning message in insights.combiners.mounts

### DIFF
--- a/insights/combiners/mounts.py
+++ b/insights/combiners/mounts.py
@@ -29,6 +29,7 @@ from insights.core.plugins import combiner
 from insights.parsers import keyword_search
 from insights.parsers.mount import Mount, ProcMounts, MountInfo
 from insights.parsers.mount import MountEntry, MountAddtlInfo
+from insights.util import deprecated
 
 
 @combiner([Mount, ProcMounts, MountInfo])
@@ -42,6 +43,7 @@ class Mounts(object):
     """
 
     def __init__(self, binmount, procmounts, mountinfo):
+        deprecated(Mounts, "Use the parsers in insights.mount module instead", "3.1.0")
         self._mounts = {}
 
         all_mount_points = set().union(

--- a/insights/combiners/mounts.py
+++ b/insights/combiners/mounts.py
@@ -35,12 +35,12 @@ from insights.util import deprecated
 @combiner([Mount, ProcMounts, MountInfo])
 class Mounts(object):
     """
-    ``Mounts`` combiner consolidates data from the parsers in
-    ``insights.parsers.mounts`` module.
-
-    Note:
+    .. warning::
         This class is deprecated now and will be removed in version 3.2.0.
         Use insights.parsers.mount directly.
+
+    ``Mounts`` combiner consolidates data from the parsers in
+    ``insights.parsers.mounts`` module.
 
     Attributes:
         rows (list): list of :class:`MountEntry` objects for each mount entry

--- a/insights/combiners/mounts.py
+++ b/insights/combiners/mounts.py
@@ -43,7 +43,7 @@ class Mounts(object):
     """
 
     def __init__(self, binmount, procmounts, mountinfo):
-        deprecated(Mounts, "Use the parsers in insights.mount module instead", "3.1.0")
+        deprecated(Mounts, "Use the parsers in insights.mount module instead", "3.1.25")
         self._mounts = {}
 
         all_mount_points = set().union(

--- a/insights/combiners/mounts.py
+++ b/insights/combiners/mounts.py
@@ -38,12 +38,16 @@ class Mounts(object):
     ``Mounts`` combiner consolidates data from the parsers in
     ``insights.parsers.mounts`` module.
 
+    Note:
+        This class is deprecated now and will be removed in version 3.2.0.
+        Use insights.parsers.mount directly.
+
     Attributes:
         rows (list): list of :class:`MountEntry` objects for each mount entry
     """
 
     def __init__(self, binmount, procmounts, mountinfo):
-        deprecated(Mounts, "Use the parsers in insights.mount module instead", "3.1.25")
+        deprecated(Mounts, "Use the parsers in insights.parsers.mount module instead", "3.1.25")
         self._mounts = {}
 
         all_mount_points = set().union(


### PR DESCRIPTION
Signed-off-by: Chen lizhong <lichen@redhat.com>

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Before remove the combiner.mounts, give deprecate warning by this MR.
https://github.com/RedHatInsights/insights-core/pull/3606
