### PR TITLE
Don't look for yara installed in /usr/local/bin

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -273,7 +273,7 @@ class MalwareDetectionClient:
         # Try to find yara in only these usual locations.
         # /bin/yara and /usr/bin/yara will exist if yara is installed via rpm
         # /usr/local/bin/yara will (likely) exist if the user has compiled and installed yara manually
-        for yara in ['/bin/yara', '/usr/bin/yara', '/usr/local/bin/yara']:
+        for yara in ['/bin/yara', '/usr/bin/yara']:
             if os.path.exists(yara) and yara_version_ok(yara):
                 logger.debug("Using yara binary: %s", yara)
                 return yara

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -181,11 +181,11 @@ class TestFindYara:
         assert mdc.yara_version == '4.1'
         cmd.assert_called()
 
-        # 'Find' yara in /usr/local/bin/yara (fails to 'find' /bin/yara and /usr/bin/yara)
-        with patch('os.path.exists', side_effect=[False, False, True]):
+        # 'Find' yara in /usr/bin/yara (fails to 'find' /bin/yara)
+        with patch('os.path.exists', side_effect=[False, True]):
             with patch("insights.client.apps.malware_detection.call", return_value='4.1'):
                 mdc = MalwareDetectionClient(None)
-        assert mdc.yara_binary == '/usr/local/bin/yara'
+        assert mdc.yara_binary == '/usr/bin/yara'
         assert mdc.yara_version == '4.1'
         cmd.assert_called()
 


### PR DESCRIPTION
Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

Removes /usr/local/bin from the list of paths used to search for the yara binary.  When installing from the yara rpm the binary should only be found in /usr/bin or /bin