### PR TITLE
Display message when malware scan_timeout aborts scan

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -797,6 +797,10 @@ class MalwareDetectionClient:
 
             dir_scan_end = time.time()
             logger.info("Scan time for %s: %d seconds", toplevel_dir, (dir_scan_end - dir_scan_start))
+            if dir_scan_end - dir_scan_start >= self.scan_timeout - 2:
+                logger.warning("Scan of %s timed-out and may not have been fully scanned.  "
+                               "Consider increasing the scan_timeout value of %d in %s",
+                               toplevel_dir, self.scan_timeout, MALWARE_CONFIG_FILE)
 
         fs_scan_end = time.time()
         logger.info("Filesystem scan time: %s", time.strftime("%H:%M:%S", time.gmtime(fs_scan_end - fs_scan_start)))
@@ -860,6 +864,10 @@ class MalwareDetectionClient:
 
             pid_scan_end = time.time()
             logger.info("Scan time for process %s: %d seconds", scan_pid, (pid_scan_end - pid_scan_start))
+            if pid_scan_end - pid_scan_start >= self.scan_timeout - 2:
+                logger.warning("Scan of process %s timed out and may not have been fully scanned.  "
+                               "Consider increasing the scan_timeout value of %d in %s",
+                               scan_pid, self.scan_timeout, MALWARE_CONFIG_FILE)
 
         pids_scan_end = time.time()
         logger.info("Processes scan time: %s", time.strftime("%H:%M:%S", time.gmtime(pids_scan_end - pids_scan_start)))


### PR DESCRIPTION
Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

Notify the user if the malware scan_timeout is encountered so they know that the filesystem or process may not have been fully scanned.