### PR TITLE
Keep the code to delete previously-named malware rules file

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -603,7 +603,7 @@ class MalwareDetectionClient:
         # malware-detection client exits.
         # However it can happen that the rules file isn't removed for some reason, so remove any existing
         # rules files before beginning a new scan, otherwise they may show up as matches in the scan results.
-        old_rules_files = glob('/tmp/.tmpsigs*')
+        old_rules_files = glob('/tmp/.tmpmdsigs*') + glob('/tmp/tmp_malware-detection-client_rules.*')
         for old_rules_file in old_rules_files:
             logger.debug("Removing old rules file %s", old_rules_file)
             os.remove(old_rules_file)
@@ -680,7 +680,7 @@ class MalwareDetectionClient:
                     logger.error("Unable to download rules from %s: %s", self.rules_location, str(e))
                     exit(constants.sig_kill_bad)
 
-        self.temp_rules_file = NamedTemporaryFile(prefix='.tmpsigs', mode='wb', delete=True)
+        self.temp_rules_file = NamedTemporaryFile(prefix='.tmpmdsigs', mode='wb', delete=True)
         self.temp_rules_file.write(response.content)
         self.temp_rules_file.flush()
         return self.temp_rules_file.name
@@ -798,8 +798,8 @@ class MalwareDetectionClient:
             dir_scan_end = time.time()
             logger.info("Scan time for %s: %d seconds", toplevel_dir, (dir_scan_end - dir_scan_start))
             if dir_scan_end - dir_scan_start >= self.scan_timeout - 2:
-                logger.warning("Scan of %s timed-out and may not have been fully scanned.  "
-                               "Consider increasing the scan_timeout value of %d in %s",
+                logger.warning("Scan of %s timed-out after %d seconds and may not have been fully scanned.  "
+                               "Consider increasing the scan_timeout value in %s",
                                toplevel_dir, self.scan_timeout, MALWARE_CONFIG_FILE)
 
         fs_scan_end = time.time()
@@ -865,8 +865,8 @@ class MalwareDetectionClient:
             pid_scan_end = time.time()
             logger.info("Scan time for process %s: %d seconds", scan_pid, (pid_scan_end - pid_scan_start))
             if pid_scan_end - pid_scan_start >= self.scan_timeout - 2:
-                logger.warning("Scan of process %s timed out and may not have been fully scanned.  "
-                               "Consider increasing the scan_timeout value of %d in %s",
+                logger.warning("Scan of process %s timed-out after %d seconds and may not have been fully scanned.  "
+                               "Consider increasing the scan_timeout value in %s",
                                scan_pid, self.scan_timeout, MALWARE_CONFIG_FILE)
 
         pids_scan_end = time.time()

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -31,7 +31,7 @@ RANDOM_STRING = ''.join(random.choice(string.ascii_lowercase) for _ in range(5))
 TEMP_TEST_DIR = "/tmp/malware-detection_test_dir_%s" % RANDOM_STRING
 
 YARA = '/bin/yara'  # Fake yara executable
-RULES_FILE = os.path.join(TEMP_TEST_DIR, '.tmpsigs.yar')
+RULES_FILE = os.path.join(TEMP_TEST_DIR, '.tmpmdsigs.yar')
 TEST_RULE_FILE = os.path.join(TEMP_TEST_DIR, 'test-rule.yar')
 TEST_RULE_SCRIPT = os.path.join(TEMP_TEST_DIR, 'test-rule_process_match.sh')
 CONFIG = yaml.safe_load(DEFAULT_MALWARE_CONFIG)  # Config 'returned' from _load_config


### PR DESCRIPTION
- just in case the previously-named rules file isn't deleted for some reason

Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

Just some small changes to some recent malware-detection commits I made.  Main one was making sure the old downloaded rules file is still deleted.  I've renamed the file, but its possible (although rare) that the old file could be maintained on the customer's system and isn't deleted as we've changed the file name now that we are deleting.  This commit makes sure the old file name is still deleted as well.