### PR TITLE
Delete old malware rules files from /var/tmp as well

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -603,7 +603,9 @@ class MalwareDetectionClient:
         # malware-detection client exits.
         # However it can happen that the rules file isn't removed for some reason, so remove any existing
         # rules files before beginning a new scan, otherwise they may show up as matches in the scan results.
-        old_rules_files = glob('/tmp/.tmpmdsigs*') + glob('/tmp/tmp_malware-detection-client_rules.*')
+        old_rules_files = sum([glob(os.path.join(path, rules))
+                               for path in ('/tmp', '/var/tmp')
+                               for rules in ('.tmpmdsigs*', 'tmp_malware-detection-client_rules.*')], [])
         for old_rules_file in old_rules_files:
             logger.debug("Removing old rules file %s", old_rules_file)
             os.remove(old_rules_file)


### PR DESCRIPTION
Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

Some customers have /var/tmp instead of /tmp and unfortunately the logic for deleting old malware rules files fails in that case. This PR adds /var/tmp as a location to try deleting old rules files from.  Why do we want to delete old malware rules files ... because they cause false positives in matching systems.