### PR TITLE
unpin ipython==8.6.0 for branch 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ docs = set([
     'Sphinx',
     'nbsphinx',
     'sphinx_rtd_theme',
-    'ipython==8.6.0',
+    'ipython<8.7.0',
     'MarkupSafe==2.0.1',
     'colorama',
     'Pygments',


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The `3.0` branch is [designed to run with Python 3.6](https://github.com/RedHatInsights/insights-core/blob/master/docs/quickstart_insights_core.rst#L28). The pinned version of [ipython is not compatible with Python 3.6](https://libraries.io/pypi/ipython/8.6.0). The pinning makes running `pip install -e ".[develop]"` impossible. As a result, setting up a fresh development environment is impossible without removing the pin. I'm not sure whether https://github.com/RedHatInsights/insights-core/pull/3615 was meant to be backported to `3.0`.
