### PR TITLE
fix: enhance redhat_release combiner to exclude non-RHEL linux

### DIFF
--- a/insights/combiners/redhat_release.py
+++ b/insights/combiners/redhat_release.py
@@ -4,8 +4,8 @@ Red Hat Release
 
 Combiner for Red Hat Release information. It uses the results of
 the ``Uname`` parser and the ``RedhatRelease`` parser to determine the release
-major and minor version.  ``Uname`` is the preferred source of data.
-The Red Hat Release is in obtained from the system in the form major.minor.
+major and minor version. Use ``OsRelease`` to judge the system is RHEL or Non-RHEL.
+``Uname`` is the preferred source of data. The Red Hat Release is in obtained from the system in the form major.minor.
 For example, for a Red Hat Enterprise Linux 7.2 system, the release would be
 major = 7, minor = 2 and rhel = '7.2'.
 
@@ -13,11 +13,11 @@ major = 7, minor = 2 and rhel = '7.2'.
 
 from collections import namedtuple
 from insights.core.plugins import combiner
+from insights.parsers.os_release import OsRelease
 from insights.parsers.redhat_release import RedhatRelease as rht_release
 from insights.parsers.uname import Uname
 from insights.core.serde import serializer, deserializer
 from insights.parsers import SkipComponent
-
 
 Release = namedtuple("Release", field_names=["major", "minor"])
 """namedtuple: Type for storing the release information."""
@@ -33,11 +33,11 @@ def deserialize(_type, obj, root=None):
     return Release(**obj)
 
 
-@combiner([Uname, rht_release])
+@combiner([Uname, rht_release, OsRelease])
 class RedHatRelease(object):
     """
     Combiner class to check uname and redhat-release for RHEL major/minor
-    version.
+    version. OsRelease is to check the system is RHEL or Non-RHEL.
     Prefer uname to redhat-release.
 
     Attributes:
@@ -67,9 +67,13 @@ class RedHatRelease(object):
         >>> rh_rel.rhel8 is None
         True
     """
-    def __init__(self, uname, rh_rel):
+
+    def __init__(self, uname, rh_rel, os_rel):
         self.major = self.minor = self.rhel = None
-        if uname and uname.redhat_release.major != -1:
+        if os_rel and (os_rel.data['ID'] != "rhel" or 'Red Hat' not in os_rel.data['NAME']):
+            # this is not rhel linux according /etc/os-release
+            raise SkipComponent("Unable to determine release: {0} ".format(os_rel.data['NAME']))
+        elif uname and uname.redhat_release.major != -1:
             self.major = uname.redhat_release.major
             self.minor = uname.redhat_release.minor
             self.rhel = '{0}.{1}'.format(self.major, self.minor)
@@ -90,13 +94,13 @@ class RedHatRelease(object):
 @serializer(RedHatRelease)
 def serialize_RedHatRelease(obj, root=None):
     return {
-            "major": obj.major,
-            "minor": obj.minor,
-            "rhel": obj.rhel,
-            "rhel6": obj.rhel6,
-            "rhel7": obj.rhel7,
-            "rhel8": obj.rhel8,
-            "rhel9": obj.rhel9,
+        "major": obj.major,
+        "minor": obj.minor,
+        "rhel": obj.rhel,
+        "rhel6": obj.rhel6,
+        "rhel7": obj.rhel7,
+        "rhel8": obj.rhel8,
+        "rhel9": obj.rhel9,
     }
 
 

--- a/insights/tests/combiners/test_redhat_release.py
+++ b/insights/tests/combiners/test_redhat_release.py
@@ -1,4 +1,5 @@
 from insights.parsers.uname import Uname
+from insights.parsers.os_release import OsRelease
 from insights.parsers.redhat_release import RedhatRelease
 from insights.combiners.redhat_release import RedHatRelease
 from insights.combiners import redhat_release as rr
@@ -26,11 +27,36 @@ REDHAT_RELEASE_8_CONTAINER_2 = """
 Red Hat Enterprise Linux Server release 8.6 (Ootpa)
 """.strip()
 
+RHEL_OS_RELEASE = """
+NAME="Red Hat Enterprise Linux"
+VERSION="8.5 (Ootpa)"
+ID="rhel"
+ID_LIKE="fedora"
+VERSION_ID="8.5"
+PRETTY_NAME="Red Hat Enterprise Linux 8.5 (Ootpa)"
+"""
+
+ORACLE_LINUX_OS_RELEASE = """
+NAME="Oracle Linux Server"
+VERSION="8.3"
+ID="ol"
+ID_LIKE="fedora"
+VARIANT="Server"
+VARIANT_ID="server"
+VERSION_ID="8.3"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="Oracle Linux Server 8.3"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:linux:8:3:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+"""
+
 
 def test_RedHatRelease_uname():
     un = Uname(context_wrap(UNAME))
     expected = (7, 2)
-    result = RedHatRelease(un, None)
+    result = RedHatRelease(un, None, None)
     assert result.major == expected[0]
     assert result.minor == expected[1]
     assert result.rhel == result.rhel7 == '7.2'
@@ -40,7 +66,7 @@ def test_RedHatRelease_uname():
 def test_RedHatRelease_redhat_release():
     rel = RedhatRelease(context_wrap(REDHAT_RELEASE))
     expected = (7, 2)
-    result = RedHatRelease(None, rel)
+    result = RedHatRelease(None, rel, None)
     assert result.major == expected[0]
     assert result.minor == expected[1]
     assert result.rhel == result.rhel7 == '7.2'
@@ -48,11 +74,30 @@ def test_RedHatRelease_redhat_release():
     assert result.rhel9 is None
 
 
+def test_RedHatRelease_redhat_release_with_os_release():
+    rel = RedhatRelease(context_wrap(REDHAT_RELEASE))
+    os_rel = OsRelease(context_wrap(RHEL_OS_RELEASE))
+    expected = (7, 2)
+    result = RedHatRelease(None, rel, os_rel)
+    assert result.major == expected[0]
+    assert result.minor == expected[1]
+    assert result.rhel == result.rhel7 == '7.2'
+    assert result.rhel8 is None
+    assert result.rhel9 is None
+
+
+def test_RedHatRelease_redhat_release_with_oracle_os_release():
+    rel = RedhatRelease(context_wrap(REDHAT_RELEASE))
+    os_rel = OsRelease(context_wrap(ORACLE_LINUX_OS_RELEASE))
+    with pytest.raises(SkipComponent):
+        RedHatRelease(None, rel, os_rel)
+
+
 def test_RedHatRelease_both():
     un = Uname(context_wrap(UNAME))
     rel = RedhatRelease(context_wrap(REDHAT_RELEASE))
     expected = (7, 2)
-    result = RedHatRelease(un, rel)
+    result = RedHatRelease(un, rel, None)
     assert result.major == expected[0]
     assert result.minor == expected[1]
     assert result.rhel == result.rhel7 == '7.2'
@@ -65,15 +110,15 @@ def test_raise():
     un = Uname(context_wrap(BAD_UNAME))
 
     with pytest.raises(SkipComponent):
-        RedHatRelease(un, None)
+        RedHatRelease(un, None, None)
 
     with pytest.raises(SkipComponent):
-        RedHatRelease(None, None)
+        RedHatRelease(None, None, None)
 
 
 def test_doc_examples():
     env = {
-            'rh_rel': RedHatRelease(Uname(context_wrap(UNAME)), None),
-          }
+        'rh_rel': RedHatRelease(Uname(context_wrap(UNAME)), None, None),
+    }
     failed, total = doctest.testmod(rr, globs=env)
     assert failed == 0

--- a/insights/tests/components/test_rhel_version.py
+++ b/insights/tests/components/test_rhel_version.py
@@ -33,14 +33,14 @@ Red Hat Enterprise Linux release 9.0 (Plow)
 # RHEL6 Tests
 def test_is_rhel6():
     rr = RedhatRelease(context_wrap(REDHAT_RELEASE1))
-    rel = RR(None, rr)
+    rel = RR(None, rr, None)
     result = IsRhel6(rel)
     assert isinstance(result, IsRhel6)
 
 
 def test_not_rhel6():
     rr = RedhatRelease(context_wrap(REDHAT_RELEASE2))
-    rel = RR(None, rr)
+    rel = RR(None, rr, None)
     with pytest.raises(SkipComponent) as e:
         IsRhel6(rel)
     assert "Not RHEL6" in str(e)
@@ -49,14 +49,14 @@ def test_not_rhel6():
 # RHEL7 Server Tests
 def test_is_rhel7s():
     rr = RedhatRelease(context_wrap(REDHAT_RELEASE2))
-    rel = RR(None, rr)
+    rel = RR(None, rr, None)
     result = IsRhel7(rel)
     assert isinstance(result, IsRhel7)
 
 
 def test_not_rhel7s():
     rr = RedhatRelease(context_wrap(REDHAT_RELEASE1))
-    rel = RR(None, rr)
+    rel = RR(None, rr, None)
     with pytest.raises(SkipComponent) as e:
         IsRhel7(rel)
     assert "Not RHEL7" in str(e)
@@ -66,21 +66,21 @@ def test_not_rhel7s():
 def test_uname_is_rhel7():
     uname = Uname(context_wrap(UNAME))
     rr = RedhatRelease(context_wrap(REDHAT_RELEASE3))
-    rel = RR(uname, rr)
+    rel = RR(uname, rr, None)
     result = IsRhel7(rel)
     assert isinstance(result, IsRhel7)
 
 
 def test_is_rhel7():
     rr = RedhatRelease(context_wrap(REDHAT_RELEASE3))
-    rel = RR(None, rr)
+    rel = RR(None, rr, None)
     result = IsRhel7(rel)
     assert isinstance(result, IsRhel7)
 
 
 def test_not_rhel7():
     rr = RedhatRelease(context_wrap(REDHAT_RELEASE1))
-    rel = RR(None, rr)
+    rel = RR(None, rr, None)
     with pytest.raises(SkipComponent) as e:
         IsRhel7(rel)
     assert "Not RHEL7" in str(e)
@@ -89,14 +89,14 @@ def test_not_rhel7():
 # RHEL8 Tests
 def test_is_rhel8():
     rr = RedhatRelease(context_wrap(REDHAT_RELEASE4))
-    rel = RR(None, rr)
+    rel = RR(None, rr, None)
     result = IsRhel8(rel)
     assert isinstance(result, IsRhel8)
 
 
 def test_not_rhel8():
     rr = RedhatRelease(context_wrap(REDHAT_RELEASE2))
-    rel = RR(None, rr)
+    rel = RR(None, rr, None)
     with pytest.raises(SkipComponent) as e:
         IsRhel8(rel)
     assert "Not RHEL8" in str(e)
@@ -105,14 +105,14 @@ def test_not_rhel8():
 # RHEL9 Tests
 def test_is_rhel9():
     rr = RedhatRelease(context_wrap(REDHAT_RELEASE5))
-    rel = RR(None, rr)
+    rel = RR(None, rr, None)
     result = IsRhel9(rel)
     assert isinstance(result, IsRhel9)
 
 
 def test_not_rhel9():
     rr = RedhatRelease(context_wrap(REDHAT_RELEASE2))
-    rel = RR(None, rr)
+    rel = RR(None, rr, None)
     with pytest.raises(SkipComponent) as e:
         IsRhel9(rel)
     assert "Not RHEL9" in str(e)


### PR DESCRIPTION
Signed-off-by: Chen lizhong <lichen@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

To fix the issue https://github.com/RedHatInsights/insights-core/issues/3637
Use the /etc/os-release to check it is RHEL or not.
