### PR TITLE
fix: py26 CI not found 'Python.h'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         sudo add-apt-repository 'ppa:deadsnakes/ppa'
         sudo apt-get update
-        sudo apt-get install python2.6
+        sudo apt-get install python2.6  python2.6-dev
         sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.6 1
         sudo update-alternatives --set python /usr/bin/python2.6
     - name: get depenencies


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
- fix: #3641 