### PR TITLE
fix: Convert aws_token to string since sometimes it's unicode

### DIFF
--- a/insights/specs/datasources/aws.py
+++ b/insights/specs/datasources/aws.py
@@ -36,7 +36,7 @@ def aws_imdsv2_token(broker):
     try:
         token = broker[LocalSpecs.aws_imdsv2_token].content[0].strip()
         if token:
-            return token
+            return str(token)
     except Exception as e:
         raise SkipComponent("Unexpected exception:{e}".format(e=str(e)))
     raise SkipComponent


### PR DESCRIPTION
When I test the playbooks, I found the spec "aws_instance_id_doc" can not be collected on RHEL 7.5:
```
2022-12-23 08:42:34,794     INFO insights.core.dr Trying insights.specs.default.DefaultSpecs.aws_instance_id_doc
2022-12-23 08:42:34,794    DEBUG insights.core.plugins The provider can only be a single string or a tuple of strings, but got 'AQAAAPTeS4-aK9v5iEb27uBubd5HjzogWpB_-0K1_sgGoVverKIrkg=='.
```
After debugging it, I found the return type of `aws_imdsv2_token` is unicode.

Signed-off-by: Huanhuan Li <huali@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?
