### PR TITLE
feat: New datasource "sys_fs_cgroup_uniq_memory_swappiness" and its parser

### DIFF
--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -212,7 +212,7 @@ insights.specs.datasources.ssl_certificate
     :undoc-members:
 
 insights.specs.datasources.sys_fs_cgroup_memory
-------------------------------------------------------------
+-----------------------------------------------
 
 .. automodule:: insights.specs.datasources.sys_fs_cgroup_memory
     :members: sys_fs_cgroup_uniq_memory_swappiness

--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -211,6 +211,14 @@ insights.specs.datasources.ssl_certificate
     :show-inheritance:
     :undoc-members:
 
+insights.specs.datasources.sys_fs_cgroup_memory
+------------------------------------------------------------
+
+.. automodule:: insights.specs.datasources.sys_fs_cgroup_memory
+    :members: sys_fs_cgroup_uniq_memory_swappiness
+    :show-inheritance:
+    :undoc-members:
+
 insights.specs.datasources.sys_fs_cgroup_memory_tasks_number
 ------------------------------------------------------------
 

--- a/docs/shared_parsers_catalog/sys_fs_cgroup_memory.rst
+++ b/docs/shared_parsers_catalog/sys_fs_cgroup_memory.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.sys_fs_cgroup_memory
+   :members:
+   :show-inheritance:

--- a/insights/parsers/sys_fs_cgroup_memory.py
+++ b/insights/parsers/sys_fs_cgroup_memory.py
@@ -1,8 +1,11 @@
 """
-SysFsCgroupMemory - Datasource ``sys_fs_cgroup_memory``
-=======================================================
+Memory controller information of cgroup - ``/sys/fs/cgroup/memeory``
+====================================================================
 
-This module provides processing for the ``sys_fs_cgroup_memory`` datasources.
+Parser included in this module is:
+
+SysFsCgroupUniqMemorySwappiness - Datasource ``sys_fs_cgroup_uniq_memory_swappiness``
+-------------------------------------------------------------------------------------
 """
 from collections import namedtuple
 
@@ -27,19 +30,22 @@ class SysFsCgroupUniqMemorySwappiness(Parser):
     Examples:
         >>> type(sys_fs_cgroup_uniq_memory_swappiness)
         <class 'insights.parsers.sys_fs_cgroup_memory_swappiness.SysFsCgroupUniqMemorySwappiness'>
-        >>> sys_fs_cgroup_uniq_memory_swappiness.data[0]
+        >>> sys_fs_cgroup_uniq_memory_swappiness.stats[0]
         MemorySwappiness(count=1, value=10)
-        >>> sys_fs_cgroup_uniq_memory_swappiness.data[0].count
+        >>> sys_fs_cgroup_uniq_memory_swappiness.stats[0].count
         1
-        >>> sys_fs_cgroup_uniq_memory_swappiness.data[1].value
+        >>> sys_fs_cgroup_uniq_memory_swappiness.stats[1].value
         60
+
+    Attributes:
+        stats (int): a list of ``MemorySwappiness`` objects
     """
 
     MemorySwappiness = namedtuple('MemorySwappiness', ['value', 'count'])
     """namedtuple: Structure to hold a line of ``sys_fs_cgroup_uniq_memory_swappiness`` datasource."""
 
     def parse_content(self, content):
-        self.data = []
+        self.stats = []
         for line in content:
             parts = line.split()
-            self.data.append(self.MemorySwappiness(int(parts[0]), int(parts[1])))
+            self.stats.append(self.MemorySwappiness(int(parts[0]), int(parts[1])))

--- a/insights/parsers/sys_fs_cgroup_memory.py
+++ b/insights/parsers/sys_fs_cgroup_memory.py
@@ -1,0 +1,45 @@
+"""
+SysFsCgroupMemory - Datasource ``sys_fs_cgroup_memory``
+=======================================================
+
+This module provides processing for the ``sys_fs_cgroup_memory`` datasources.
+"""
+from collections import namedtuple
+
+from insights.core import Parser
+from insights.core.plugins import parser
+from insights.specs import Specs
+
+
+@parser(Specs.sys_fs_cgroup_uniq_memory_swappiness)
+class SysFsCgroupUniqMemorySwappiness(Parser):
+    """
+    Class to parse the datasource ``sys_fs_cgroup_uniq_memory_swappiness`` output.
+
+    Sample output of datasource looks like::
+        10   1
+        60   66
+
+    The two columns that are output are:
+    1. value - the value of memory.swappiness
+    2. count - how many memory.swappiness files have the same setting
+
+    Examples:
+        >>> type(sys_fs_cgroup_uniq_memory_swappiness)
+        <class 'insights.parsers.sys_fs_cgroup_memory_swappiness.SysFsCgroupUniqMemorySwappiness'>
+        >>> sys_fs_cgroup_uniq_memory_swappiness.data[0]
+        MemorySwappiness(count=1, value=10)
+        >>> sys_fs_cgroup_uniq_memory_swappiness.data[0].count
+        1
+        >>> sys_fs_cgroup_uniq_memory_swappiness.data[1].value
+        60
+    """
+
+    MemorySwappiness = namedtuple('MemorySwappiness', ['value', 'count'])
+    """namedtuple: Structure to hold a line of ``sys_fs_cgroup_uniq_memory_swappiness`` datasource."""
+
+    def parse_content(self, content):
+        self.data = []
+        for line in content:
+            parts = line.split()
+            self.data.append(self.MemorySwappiness(int(parts[0]), int(parts[1])))

--- a/insights/parsers/sys_fs_cgroup_memory.py
+++ b/insights/parsers/sys_fs_cgroup_memory.py
@@ -38,7 +38,7 @@ class SysFsCgroupUniqMemorySwappiness(Parser):
         60
 
     Attributes:
-        stats (int): a list of ``MemorySwappiness`` objects
+        stats (list): a list of ``MemorySwappiness`` objects
     """
 
     MemorySwappiness = namedtuple('MemorySwappiness', ['value', 'count'])

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -673,6 +673,7 @@ class Specs(SpecSet):
     swift_object_expirer_conf = RegistryPoint()
     swift_proxy_server_conf = RegistryPoint()
     sys_fs_cgroup_memory_tasks_number = RegistryPoint()
+    sys_fs_cgroup_uniq_memory_swappiness = RegistryPoint()
     sys_kernel_sched_features = RegistryPoint()
     sys_vmbus_class_id = RegistryPoint(multi_output=True)
     sys_vmbus_device_id = RegistryPoint(multi_output=True)

--- a/insights/specs/datasources/sys_fs_cgroup_memory.py
+++ b/insights/specs/datasources/sys_fs_cgroup_memory.py
@@ -20,7 +20,7 @@ def sys_fs_cgroup_uniq_memory_swappiness(broker):
         60   66
 
     Returns:
-        str: Returns a multiline string in the format as ``value  count``.
+        str: Returns a multiline string in the format as ``value   count``.
 
     Raises:
         SkipComponent: When any exception occurs.

--- a/insights/specs/datasources/sys_fs_cgroup_memory.py
+++ b/insights/specs/datasources/sys_fs_cgroup_memory.py
@@ -1,0 +1,44 @@
+"""
+Custom datasources for the files under /sys/fs/cgroup/memory
+"""
+import os
+
+from insights.core.context import HostContext
+from insights.core.dr import SkipComponent
+from insights.core.plugins import datasource
+from insights.core.spec_factory import DatasourceProvider
+
+
+@datasource(HostContext)
+def sys_fs_cgroup_uniq_memory_swappiness(broker):
+    """
+    This datasource reads all the memory.swappiness files under /sys/fs/cgroup/memory directory
+    one by one and returns the uniq memory swappiness setting of the all control groups.
+
+    The output of this datasource looks like:
+        10   1
+        60   66
+
+    Returns:
+        str: Returns a multiline string in the format as ``value  count``.
+
+    Raises:
+        SkipComponent: When any exception occurs.
+    """
+    file_name = "memory.swappiness"
+    data = {}
+
+    for root, _, files in os.walk("/sys/fs/cgroup/memory"):
+        if file_name in files:
+            file_path = os.path.join(root, file_name)
+            with open(file_path, 'r') as setting:
+                key = setting.read().strip()
+                data[key] = data.get(key, 0) + 1
+
+    if not data:
+        raise SkipComponent()
+
+    data_list = []
+    for value, count in data.items():
+        data_list.append("{0}   {1}".format(value, count))
+        return DatasourceProvider(content="\n".join(data_list), relative_path='insights_commands/sys_fs_cgroup_uniq_memory_swappiness')

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -27,7 +27,8 @@ from insights.specs.datasources import (
     aws, awx_manage, cloud_init, candlepin_broker, corosync as corosync_ds,
     dir_list, ethernet, httpd, ipcs, kernel, kernel_module_list, lpstat, md5chk,
     package_provides, ps as ps_datasource, sap, satellite_missed_queues,
-    semanage, ssl_certificate, sys_fs_cgroup_memory, sys_fs_cgroup_memory_tasks_number, rpm_pkgs, user_group, yum_updates, luks_devices)
+    semanage, ssl_certificate, sys_fs_cgroup_memory, sys_fs_cgroup_memory_tasks_number,
+    rpm_pkgs, user_group, yum_updates, luks_devices)
 from insights.specs.datasources.sap import sap_hana_sid, sap_hana_sid_SID_nr
 from insights.specs.datasources.pcp import pcp_enabled, pmlog_summary_args
 from insights.specs.datasources.container import running_rhel_containers, containers_inspect

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -27,7 +27,7 @@ from insights.specs.datasources import (
     aws, awx_manage, cloud_init, candlepin_broker, corosync as corosync_ds,
     dir_list, ethernet, httpd, ipcs, kernel, kernel_module_list, lpstat, md5chk,
     package_provides, ps as ps_datasource, sap, satellite_missed_queues,
-    semanage, ssl_certificate, sys_fs_cgroup_memory_tasks_number, rpm_pkgs, user_group, yum_updates, luks_devices)
+    semanage, ssl_certificate, sys_fs_cgroup_memory, sys_fs_cgroup_memory_tasks_number, rpm_pkgs, user_group, yum_updates, luks_devices)
 from insights.specs.datasources.sap import sap_hana_sid, sap_hana_sid_SID_nr
 from insights.specs.datasources.pcp import pcp_enabled, pmlog_summary_args
 from insights.specs.datasources.container import running_rhel_containers, containers_inspect
@@ -606,6 +606,7 @@ class DefaultSpecs(Specs):
     swift_object_expirer_conf = first_file(["/var/lib/config-data/puppet-generated/swift/etc/swift/object-expirer.conf", "/etc/swift/object-expirer.conf"])
     swift_proxy_server_conf = first_file(["/var/lib/config-data/puppet-generated/swift/etc/swift/proxy-server.conf", "/etc/swift/proxy-server.conf"])
     sys_fs_cgroup_memory_tasks_number = sys_fs_cgroup_memory_tasks_number.sys_fs_cgroup_memory_tasks_number_data_datasource
+    sys_fs_cgroup_uniq_memory_swappiness = sys_fs_cgroup_memory.sys_fs_cgroup_uniq_memory_swappiness
     sys_vmbus_class_id = glob_file('/sys/bus/vmbus/devices/*/class_id')
     sys_vmbus_device_id = glob_file('/sys/bus/vmbus/devices/*/device_id')
     sysconfig_grub = simple_file("/etc/default/grub")  # This is the file where the "/etc/sysconfig/grub" point to

--- a/insights/tests/datasources/test_sys_fs_cgroup_memory.py
+++ b/insights/tests/datasources/test_sys_fs_cgroup_memory.py
@@ -1,0 +1,53 @@
+import pytest
+from mock.mock import patch, mock_open
+from insights.core.dr import SkipComponent
+from insights.core.spec_factory import DatasourceProvider
+from insights.specs.datasources.sys_fs_cgroup_memory import sys_fs_cgroup_uniq_memory_swappiness
+
+RELATIVE_PATH = 'insights_commands/sys_fs_cgroup_uniq_memory_swappiness'
+EXPECTED_RESULT = "60  3"
+
+
+@patch('insights.specs.datasources.sys_fs_cgroup_memory.open', new_callable=mock_open, read_data='60')
+@patch('insights.specs.datasources.sys_fs_cgroup_memory.os.walk')
+def test_sys_fs_cgroup_uniq_memory_swappiness(mock_walk, mock_ds_open):
+    mock_walk.return_value = [
+        ("/sys/fs/cgroup/memory", (), ("memory.swappiness", "test",)),
+        ("/sys/fs/cgroup/memory/test_1", (), ("memory.swappiness", "test",)),
+        ("/sys/fs/cgroup/memory/test_2", (), ("memory.swappiness", "test",)),
+    ]
+
+    broker = {}
+    result = sys_fs_cgroup_uniq_memory_swappiness(broker)
+    assert result is not None
+    assert isinstance(result, DatasourceProvider)
+    expected = DatasourceProvider(content=EXPECTED_RESULT, relative_path=RELATIVE_PATH)
+    assert len(result.content) == len(expected.content) == 1
+    assert result.content[0].split() == expected.content[0].split()
+    assert result.relative_path == expected.relative_path
+
+
+@patch('insights.specs.datasources.sys_fs_cgroup_memory.open', new_callable=mock_open, read_data='60')
+@patch('insights.specs.datasources.sys_fs_cgroup_memory.os.walk')
+def test_sys_fs_cgroup_uniq_memory_swappiness_without_swappiness_file(mock_walk, mock_ds_open):
+    mock_walk.return_value = [
+        ("/sys/fs/cgroup/memory", (), ("cpu", "test",)),
+        ("/sys/fs/cgroup/memory/test_1", (), ("cpu", "test",)),
+        ("/sys/fs/cgroup/memory/test_2", (), ("cpu", "test",)),
+    ]
+
+    broker = {}
+    with pytest.raises(SkipComponent) as e:
+        sys_fs_cgroup_uniq_memory_swappiness(broker)
+    assert 'SkipComponent' in str(e)
+
+
+@patch('insights.specs.datasources.sys_fs_cgroup_memory.open', new_callable=mock_open, read_data='60')
+@patch('insights.specs.datasources.sys_fs_cgroup_memory.os.walk')
+def test_sys_fs_cgroup_uniq_memory_swappiness_without_memory_dir(mock_walk, mock_ds_open):
+    mock_walk.return_value = []
+
+    broker = {}
+    with pytest.raises(SkipComponent) as e:
+        sys_fs_cgroup_uniq_memory_swappiness(broker)
+    assert 'SkipComponent' in str(e)

--- a/insights/tests/parsers/test_sys_fs_cgroup_memory.py
+++ b/insights/tests/parsers/test_sys_fs_cgroup_memory.py
@@ -10,8 +10,8 @@ UNIQ_MEMORY_SWAPPINESS = """
 def test_sys_fs_cgroup_uniq_memory_swappiness():
     items = SysFsCgroupUniqMemorySwappiness(context_wrap(UNIQ_MEMORY_SWAPPINESS))
     assert items is not None
-    assert len(items.data) == 2
-    assert items.data[0] == SysFsCgroupUniqMemorySwappiness.MemorySwappiness(
+    assert len(items.stats) == 2
+    assert items.stats[0] == SysFsCgroupUniqMemorySwappiness.MemorySwappiness(
         count=1,
         value=10)
-    assert items.data[1].value == 60
+    assert items.stats[1].value == 60

--- a/insights/tests/parsers/test_sys_fs_cgroup_memory.py
+++ b/insights/tests/parsers/test_sys_fs_cgroup_memory.py
@@ -1,0 +1,17 @@
+from insights.parsers.sys_fs_cgroup_memory import SysFsCgroupUniqMemorySwappiness
+from insights.tests import context_wrap
+
+UNIQ_MEMORY_SWAPPINESS = """
+10  1
+60  66
+"""
+
+
+def test_sys_fs_cgroup_uniq_memory_swappiness():
+    items = SysFsCgroupUniqMemorySwappiness(context_wrap(UNIQ_MEMORY_SWAPPINESS))
+    assert items is not None
+    assert len(items.data) == 2
+    assert items.data[0] == SysFsCgroupUniqMemorySwappiness.MemorySwappiness(
+        count=1,
+        value=10)
+    assert items.data[1].value == 60


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
This PR is used to check the memory.swappiness setting under `/sys/fs/cgroup/memory` dir, check the CEECBA-6282 to see the detailed information.