### PR TITLE
Create timeout signal for hostcontext only

### DIFF
--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -34,6 +34,7 @@ from pprint import pformat
 from six import StringIO
 
 from insights.core import dr
+from insights.core.context import HostContext
 from insights.util.subproc import CalledProcessError
 from insights import settings
 
@@ -99,8 +100,9 @@ class datasource(PluginType):
         # Grab the timeout from the decorator, or use the default of 120.
         self.timeout = getattr(self, "timeout", 120)
 
-        signal.signal(signal.SIGALRM, self._handle_timeout)
-        signal.alarm(self.timeout)
+        if HostContext in broker:
+            signal.signal(signal.SIGALRM, self._handle_timeout)
+            signal.alarm(self.timeout)
         try:
             return self.component(broker)
         except ContentException as ce:
@@ -122,7 +124,8 @@ class datasource(PluginType):
                 broker.add_exception(reg_spec, te, te_tb)
             raise dr.SkipComponent()
         finally:
-            signal.alarm(0)
+            if HostContext in broker:
+                signal.alarm(0)
 
 
 class parser(PluginType):

--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -98,9 +98,9 @@ class datasource(PluginType):
 
     def invoke(self, broker):
         # Grab the timeout from the decorator, or use the default of 120.
-        self.timeout = getattr(self, "timeout", 120)
 
         if HostContext in broker:
+            self.timeout = getattr(self, "timeout", 120)
             signal.signal(signal.SIGALRM, self._handle_timeout)
             signal.alarm(self.timeout)
         try:

--- a/insights/tests/datasources/test_datasource_timeout.py
+++ b/insights/tests/datasources/test_datasource_timeout.py
@@ -1,6 +1,8 @@
 import time
 
+from insights.core import dr
 from insights.core.dr import run
+from insights.core.context import HostContext, SosArchiveContext
 from insights.core.plugins import TimeoutException, datasource, make_info, rule
 from insights.core.spec_factory import DatasourceProvider, RegistryPoint, SpecSet, foreach_execute
 
@@ -59,13 +61,17 @@ def timeout_foreach_datasource_hit(foreach_ds_to_1):
 
 
 def test_timeout_datasource_no_hit():
-    broker = run(timeout_datasource_no_timeout)
+    broker = dr.Broker()
+    broker[HostContext] = HostContext
+    broker = run(timeout_datasource_no_timeout, broker=broker)
     assert timeout_datasource_no_timeout in broker
     assert Specs.spec_ds_timeout_2 not in broker.exceptions
 
 
 def test_timeout_datasource_hit_def():
-    broker = run(timeout_datasource_hit)
+    broker = dr.Broker()
+    broker[HostContext] = HostContext
+    broker = run(timeout_datasource_hit, broker=broker)
     assert timeout_datasource_hit in broker
     assert Specs.spec_ds_timeout_1 in broker.exceptions
     exs = broker.exceptions[Specs.spec_ds_timeout_1]
@@ -73,8 +79,29 @@ def test_timeout_datasource_hit_def():
 
 
 def test_timeout_foreach_datasource_hit_def():
-    broker = run(timeout_foreach_datasource_hit)
+    broker = dr.Broker()
+    broker[HostContext] = HostContext
+    broker = run(timeout_foreach_datasource_hit, broker=broker)
     assert timeout_foreach_datasource_hit in broker
     assert Specs.spec_foreach_ds_timeout_1 in broker.exceptions
     exs = broker.exceptions[Specs.spec_foreach_ds_timeout_1]
     assert [ex for ex in exs if isinstance(ex, TimeoutException) and str(ex) == "Datasource spec insights.tests.datasources.test_datasource_timeout.foreach_ds_timeout_1 timed out after 1 seconds!"]
+
+
+def test_not_hostcontext_timeout_datasource_hit_def():
+    broker = dr.Broker()
+    broker[SosArchiveContext] = SosArchiveContext
+    broker = run(timeout_datasource_hit, broker=broker)
+    assert timeout_datasource_hit in broker
+    assert Specs.spec_ds_timeout_1 not in broker.exceptions
+    exs = broker.exceptions[Specs.spec_ds_timeout_1]
+    assert not [ex for ex in exs if isinstance(ex, TimeoutException) and str(ex) != "Datasource spec insights.tests.datasources.test_datasource_timeout.TestSpecs.spec_ds_timeout_1 timed out after 1 seconds!"]
+
+def test_not_hostcontext_timeout_foreach_datasource_hit_def():
+    broker = dr.Broker()
+    broker[SosArchiveContext] = SosArchiveContext
+    broker = run(timeout_foreach_datasource_hit, broker=broker)
+    assert timeout_foreach_datasource_hit in broker
+    assert Specs.spec_foreach_ds_timeout_1 not in broker.exceptions
+    exs = broker.exceptions[Specs.spec_foreach_ds_timeout_1]
+    assert not [ex for ex in exs if isinstance(ex, TimeoutException) and str(ex) != "Datasource spec insights.tests.datasources.test_datasource_timeout.foreach_ds_timeout_1 timed out after 1 seconds!"]

--- a/insights/tests/datasources/test_datasource_timeout.py
+++ b/insights/tests/datasources/test_datasource_timeout.py
@@ -97,6 +97,7 @@ def test_not_hostcontext_timeout_datasource_hit_def():
     exs = broker.exceptions[Specs.spec_ds_timeout_1]
     assert not [ex for ex in exs if isinstance(ex, TimeoutException) and str(ex) != "Datasource spec insights.tests.datasources.test_datasource_timeout.TestSpecs.spec_ds_timeout_1 timed out after 1 seconds!"]
 
+
 def test_not_hostcontext_timeout_foreach_datasource_hit_def():
     broker = dr.Broker()
     broker[SosArchiveContext] = SosArchiveContext


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:
* Since timeout signals are only needed when HostContext is used we only need to set the signal in that case, logic was change to skip when using any other context than Hostcontext.
* Changes were made to the pytest module to add HostContext object to the broker in present tests
* Additional pytests were added to test when not HostContext 

