### PR TITLE
Fix: write all data to sys_fs_cgroup_uniq_memory_swappiness

### DIFF
--- a/insights/specs/datasources/sys_fs_cgroup_memory.py
+++ b/insights/specs/datasources/sys_fs_cgroup_memory.py
@@ -41,4 +41,5 @@ def sys_fs_cgroup_uniq_memory_swappiness(broker):
     data_list = []
     for value, count in data.items():
         data_list.append("{0}   {1}".format(value, count))
-        return DatasourceProvider(content="\n".join(data_list), relative_path='insights_commands/sys_fs_cgroup_uniq_memory_swappiness')
+
+    return DatasourceProvider(content="\n".join(data_list), relative_path='insights_commands/sys_fs_cgroup_uniq_memory_swappiness')

--- a/insights/tests/datasources/test_sys_fs_cgroup_memory.py
+++ b/insights/tests/datasources/test_sys_fs_cgroup_memory.py
@@ -5,12 +5,16 @@ from insights.core.spec_factory import DatasourceProvider
 from insights.specs.datasources.sys_fs_cgroup_memory import sys_fs_cgroup_uniq_memory_swappiness
 
 RELATIVE_PATH = 'insights_commands/sys_fs_cgroup_uniq_memory_swappiness'
-EXPECTED_RESULT = "60  3"
+EXPECTED_RESULT_1 = "60  3"
+EXPECTED_RESULT_2 = """
+60   1
+10   2
+""".strip()
 
 
 @patch('insights.specs.datasources.sys_fs_cgroup_memory.open', new_callable=mock_open, read_data='60')
 @patch('insights.specs.datasources.sys_fs_cgroup_memory.os.walk')
-def test_sys_fs_cgroup_uniq_memory_swappiness(mock_walk, mock_ds_open):
+def test_sys_fs_cgroup_uniq_memory_swappiness_single_line(mock_walk, mock_ds_open):
     mock_walk.return_value = [
         ("/sys/fs/cgroup/memory", (), ("memory.swappiness", "test",)),
         ("/sys/fs/cgroup/memory/test_1", (), ("memory.swappiness", "test",)),
@@ -21,9 +25,30 @@ def test_sys_fs_cgroup_uniq_memory_swappiness(mock_walk, mock_ds_open):
     result = sys_fs_cgroup_uniq_memory_swappiness(broker)
     assert result is not None
     assert isinstance(result, DatasourceProvider)
-    expected = DatasourceProvider(content=EXPECTED_RESULT, relative_path=RELATIVE_PATH)
+    expected = DatasourceProvider(content=EXPECTED_RESULT_1, relative_path=RELATIVE_PATH)
     assert len(result.content) == len(expected.content) == 1
     assert result.content[0].split() == expected.content[0].split()
+    assert result.relative_path == expected.relative_path
+
+
+@patch('insights.specs.datasources.sys_fs_cgroup_memory.open', new_callable=mock_open, read_data='60')
+@patch('insights.specs.datasources.sys_fs_cgroup_memory.os.walk')
+def test_sys_fs_cgroup_uniq_memory_swappiness_multi_lines(mock_walk, mock_ds_open):
+    mock_walk.return_value = [
+        ("/sys/fs/cgroup/memory", (), ("memory.swappiness", "test",)),
+        ("/sys/fs/cgroup/memory/test_1", (), ("memory.swappiness", "test",)),
+        ("/sys/fs/cgroup/memory/test_2", (), ("memory.swappiness", "test",)),
+    ]
+
+    mock_ds_open.side_effect = (mock_ds_open.return_value, mock_open(read_data="10").return_value, mock_open(read_data="10").return_value,)
+
+    broker = {}
+    result = sys_fs_cgroup_uniq_memory_swappiness(broker)
+    assert result is not None
+    assert isinstance(result, DatasourceProvider)
+    expected = DatasourceProvider(content=EXPECTED_RESULT_2, relative_path=RELATIVE_PATH)
+    assert len(result.content) == len(expected.content) == 2
+    assert result.content[1].split() == expected.content[1].split()
     assert result.relative_path == expected.relative_path
 
 


### PR DESCRIPTION
…datasource into archive

Signed-off-by: Qin Ping <piqin@redhat.com>

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
With this enhancement, all the data can be written to the archive when the `sys_fs_cgroup_uniq_memory_swappiness` datasource gets multiple records.
