### PR TITLE
Make malware-detection app more resilient to unexpected errors

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -187,6 +187,7 @@ class MalwareDetectionClient:
         self.add_metadata = self._get_config_option('add_metadata', False)
 
         self.matches = 0
+        self.potential_matches = 0
 
     def run(self):
         # Start the scans and record the time they were started
@@ -202,7 +203,11 @@ class MalwareDetectionClient:
 
             # Write a message to user informing them if there were matches or not and what to do next
             if self.matches == 0:
-                logger.info("No rule matches found.\n")
+                if self.potential_matches == 0:
+                    logger.info("No rule matches found.\n")
+                else:
+                    logger.info("Rule matches potentially found but problems encountered parsing them, so no match data to upload.")
+                    logger.info("Please contact support.\n")
             else:
                 logger.info("Found %d rule match%s.", self.matches, 'es' if self.matches > 1 else '')
                 if not self.test_scan:
@@ -805,7 +810,12 @@ class MalwareDetectionClient:
                 logger.debug("Unable to scan %s: %s", toplevel_dir, cpe.output.strip())
                 continue
 
-            self.parse_scan_output(output.strip())
+            try:
+                self.parse_scan_output(output.strip())
+            except Exception as e:
+                self.potential_matches += 1
+                logger.exception("Rule match(es) potentially found in %s but problems encountered parsing the results: %s.  Skipping ...",
+                                 toplevel_dir, str(e))
 
             dir_scan_end = time.time()
             logger.info("Scan time for %s: %d seconds", toplevel_dir, (dir_scan_end - dir_scan_start))
@@ -872,7 +882,12 @@ class MalwareDetectionClient:
                 logger.debug("Unable to scan process %s: %s", scan_pid, cpe.output.strip())
                 continue
 
-            self.parse_scan_output(output)
+            try:
+                self.parse_scan_output(output)
+            except Exception as e:
+                self.potential_matches += 1
+                logger.exception("Rule match(es) potentially found in process %s but problems encountered parsing the results: %s.  Skipping ...",
+                                 scan_pid, str(e))
 
             pid_scan_end = time.time()
             logger.info("Scan time for process %s: %d seconds", scan_pid, (pid_scan_end - pid_scan_start))
@@ -979,11 +994,15 @@ class MalwareDetectionClient:
                 rule_match['matches'] = [rule_match_dict]
 
             if self.add_metadata:
-                # Add extra data to each rule match, beyond what yara provides
-                # Eg, for files: line numbers & context, checksums; for processes: process name
-                # TODO: find more pythonic ways of doing this stuff instead of using system commands
-                metadata_func = self._add_file_metadata if source_type == 'file' else self._add_process_metadata
-                metadata_func(rule_match['matches'])
+                try:
+                    # Add extra data to each rule match, beyond what yara provides
+                    # Eg, for files: line numbers & context, checksums; for processes: process name
+                    # TODO: find more pythonic ways of doing this stuff instead of using system commands
+                    metadata_func = self._add_file_metadata if source_type == 'file' else self._add_process_metadata
+                    metadata_func(rule_match['matches'])
+                except Exception as e:
+                    logger.error("Error adding metadata to rule match %s in %s %s: %s.  Skipping ...",
+                                 rule_name, source_type, source, str(e))
 
             self.matches += 1
             logger.info("Matched rule %s in %s %s", rule_name, source_type, source)

--- a/insights/specs/datasources/malware_detection.py
+++ b/insights/specs/datasources/malware_detection.py
@@ -6,6 +6,8 @@ from insights.client import auto_config
 from insights.client.apps.malware_detection import MalwareDetectionClient
 from insights.client.config import InsightsConfig
 from insights.specs import Specs
+import logging
+logger = logging.getLogger(__name__)
 
 
 class MalwareDetectionSpecs(Specs):
@@ -20,12 +22,16 @@ class MalwareDetectionSpecs(Specs):
             insights_config = InsightsConfig().load_all()
             auto_config.try_auto_configuration(insights_config)
             if not (insights_config and hasattr(insights_config, 'app') and insights_config.app == 'malware-detection'):
-                raise SkipComponent
+                raise SkipComponent("Only run malware-detection app when specifically requested via --collector option")
             mdc = MalwareDetectionClient(insights_config)
             scan_results = mdc.run()
             if scan_results:
                 return DatasourceProvider(content=scan_results, relative_path="malware-detection-results.json")
             else:
-                raise SkipComponent
-        except Exception:
-            raise SkipComponent
+                raise SkipComponent("No scan results were produced")
+        except SkipComponent as msg:
+            raise SkipComponent("Skipping malware-detection app: {0}".format(str(msg)))
+        except Exception as err:
+            err_msg = "Unexpected exception in malware-detection app: {0}".format(str(err))
+            logger.exception(err_msg)
+            raise SkipComponent(err_msg)


### PR DESCRIPTION
* And make log messages more informative when things go wrong

Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

The malware-detection app can fail silently when things go wrong unexpectedly.  This also causes it to not upload results archives leaving customers confused as to why it failed and why they don't see any results in the UI.  This PR adds a few more try/except blocks around code sections where problems could occur and adds more helpful error messages ... however it doesn't fix the problem so I've still go more work to do there :/  

It also displays an error when the malware-detection app component unexpectedly fails as a whole which at least gives us a starting point for debugging the problem.