### PR TITLE
feat: Capture blacklisted specs inside archive

### DIFF
--- a/docs/shared_parsers_catalog/blacklisted.rst
+++ b/docs/shared_parsers_catalog/blacklisted.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.blacklisted
+   :members:
+   :show-inheritance:

--- a/insights/collect.py
+++ b/insights/collect.py
@@ -9,6 +9,7 @@ runs all datasources in ``insights.specs.Specs`` and
 """
 from __future__ import print_function
 import argparse
+import json
 import logging
 import os
 import sys
@@ -19,6 +20,7 @@ from datetime import datetime
 
 from insights import apply_configs, apply_default_enabled, get_pool
 from insights.core import blacklist, dr, filters
+from insights.core.blacklist import BLACKLISTED_SPECS
 from insights.core.exceptions import CalledProcessError
 from insights.core.serde import Hydration
 from insights.util import fs
@@ -402,6 +404,7 @@ def collect(manifest=default_manifest, tmp_path=None, compress=False, rm_conf=No
             log.warning('WARNING: Unknown component in blacklist: %s' % component)
         else:
             dr.set_enabled(component, enabled=False)
+            BLACKLISTED_SPECS.append(component.split('.')[-1])
             log.warning('WARNING: Skipping component: %s', component)
 
     to_persist = get_to_persist(client.get("persist", set()))
@@ -438,6 +441,11 @@ def collect(manifest=default_manifest, tmp_path=None, compress=False, rm_conf=No
         broker.add_observer(h.make_persister(to_persist))
         dr.run_all(broker=broker, pool=pool)
 
+    if BLACKLISTED_SPECS:
+        _write_out_blacklisted_specs(output_path)
+        # Delete the list so the specs aren't written again by the client.
+        del BLACKLISTED_SPECS[:]
+
     collect_errors = _parse_broker_exceptions(broker, EXCEPTIONS_TO_REPORT)
 
     if compress:
@@ -471,6 +479,41 @@ def _parse_broker_exceptions(broker, exceptions_to_report):
     except Exception as e:
         log.warning("Could not parse exceptions from the broker.: %s", str(e))
     return errors
+
+
+def _write_out_blacklisted_specs(output_path):
+    """
+    Write out the blacklisted specs to blacklisted_specs.txt, and create
+    a meta-data file for this file. That way it can be loaded when the
+    archive is processed.
+
+    Args:
+        output_path (str): Path of the output directory.
+    """
+    if os.path.exists(os.path.join(output_path, "meta_data")):
+        output_path_root = os.path.join(output_path, "data")
+    else:
+        output_path_root = output_path
+
+    with open(os.path.join(output_path_root, "blacklisted_specs.txt"), "w") as of:
+        json.dump({"specs": BLACKLISTED_SPECS}, of)
+
+    doc = {
+        "name": "insights.specs.Specs.blacklisted_specs",
+        "exec_time": 0.0,
+        "errors": [],
+        "results": {
+            "type": "insights.core.spec_factory.DatasourceProvider",
+            "object": {
+                "relative_path": "blacklisted_specs.txt"
+            }
+        },
+        "ser_time": 0.0
+    }
+
+    meta_path = os.path.join(os.path.join(output_path, "meta_data"), "insights.specs.Specs.blacklisted_specs")
+    with open(meta_path, "w") as of:
+        json.dump(doc, of)
 
 
 def main():

--- a/insights/core/blacklist.py
+++ b/insights/core/blacklist.py
@@ -1,6 +1,7 @@
 import re
 
 
+BLACKLISTED_SPECS = []
 _FILE_FILTERS = set()
 _COMMAND_FILTERS = set()
 _PATTERN_FILTERS = set()

--- a/insights/core/exceptions.py
+++ b/insights/core/exceptions.py
@@ -1,6 +1,13 @@
 from insights.util import deprecated
 
 
+class BlacklistedSpec(Exception):
+    """
+    Exception to be thrown when a blacklisted spec is found.
+    """
+    pass
+
+
 class CalledProcessError(Exception):
     """
     Raised if call fails.

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -14,7 +14,7 @@ from subprocess import call
 
 from insights.core import blacklist, dr
 from insights.core.context import ExecutionContext, FSRoots, HostContext
-from insights.core.exceptions import ContentException, SkipComponent
+from insights.core.exceptions import BlacklistedSpec, ContentException, SkipComponent
 from insights.core.filters import _add_filter, get_filters
 from insights.core.plugins import component, datasource, is_datasource
 from insights.core.serde import deserializer, serializer
@@ -178,7 +178,7 @@ class FileProvider(ContentProvider):
     def validate(self):
         if not blacklist.allow_file("/" + self.relative_path):
             log.warning("WARNING: Skipping file %s", "/" + self.relative_path)
-            raise SkipComponent()
+            raise BlacklistedSpec()
 
         if not os.path.exists(self.path):
             raise ContentException("%s does not exist." % self.path)
@@ -333,7 +333,7 @@ class CommandOutputProvider(ContentProvider):
     def validate(self):
         if not blacklist.allow_command(self.cmd):
             log.warning("WARNING: Skipping command %s", self.cmd)
-            raise SkipComponent()
+            raise BlacklistedSpec()
 
         cmd = shlex.split(self.cmd)[0]
         if not which(cmd, env=self._env):

--- a/insights/parsers/blacklisted.py
+++ b/insights/parsers/blacklisted.py
@@ -1,0 +1,30 @@
+"""
+BlacklistedSpecs - File ``blacklisted_specs.txt``
+=================================================
+"""
+from insights.core import JSONParser
+from insights.core.plugins import parser
+from insights.specs import Specs
+
+
+@parser(Specs.blacklisted_specs)
+class BlacklistedSpecs(JSONParser):
+    """
+    Parses the blacklisted_specs.txt file generated on archive creation.
+
+    Typical output::
+        "{"specs": ["insights.specs.default.DefaultSpecs.dmesg", "insights.specs.default.DefaultSpecs.fstab"]}"
+
+    Attributes:
+        specs (list): List of blacklisted specs.
+
+    Examples:
+        >>> type(specs)
+        <class 'insights.parsers.blacklisted.BlacklistedSpecs'>
+        >>> result = ['insights.specs.default.DefaultSpecs.dmesg', 'insights.specs.default.DefaultSpecs.fstab']
+        >>> specs.specs == result
+        True
+    """
+    @property
+    def specs(self):
+        return self.data['specs']

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -25,6 +25,7 @@ class Specs(SpecSet):
     azure_instance_type = RegistryPoint()
     bdi_read_ahead_kb = RegistryPoint(multi_output=True)
     bios_uuid = RegistryPoint()
+    blacklisted_specs = RegistryPoint()
     blkid = RegistryPoint()
     bond = RegistryPoint(multi_output=True)
     bond_dynamic_lb = RegistryPoint(multi_output=True)

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -24,6 +24,7 @@ class InsightsArchiveSpecs(Specs):
     azure_instance_type = simple_file("insights_commands/python_-m_insights.tools.cat_--no-header_azure_instance_type")
     azure_instance_plan = simple_file("insights_commands/python_-m_insights.tools.cat_--no-header_azure_instance_plan")
     bios_uuid = simple_file("insights_commands/dmidecode_-s_system-uuid")
+    blacklisted_specs = simple_file("blacklisted_specs.txt")
     blkid = simple_file("insights_commands/blkid_-c_.dev.null")
     brctl_show = simple_file("insights_commands/brctl_show")
     ceph_df_detail = first_file(["insights_commands/ceph_df_detail_-f_json-pretty", "insights_commands/ceph_df_detail_-f_json"])

--- a/insights/tests/parsers/test_blacklist.py
+++ b/insights/tests/parsers/test_blacklist.py
@@ -1,0 +1,29 @@
+import doctest
+import pytest
+
+from insights.core.exceptions import SkipComponent
+from insights.parsers import blacklisted
+from insights.parsers.blacklisted import BlacklistedSpecs
+from insights.tests import context_wrap
+
+
+SPECS = '{"specs": ["insights.specs.default.DefaultSpecs.dmesg", "insights.specs.default.DefaultSpecs.fstab"]}'
+
+
+def test_blacklisted_doc_examples():
+    env = {
+        "specs": BlacklistedSpecs(context_wrap(SPECS)),
+    }
+    failed, total = doctest.testmod(blacklisted, globs=env)
+    assert failed == 0
+
+
+def test_skip():
+    with pytest.raises(SkipComponent) as ex:
+        BlacklistedSpecs(context_wrap(""))
+    assert "Empty output." in str(ex)
+
+
+def test_blacklist_specs():
+    bs = BlacklistedSpecs(context_wrap(SPECS))
+    assert bs.specs[0] == "insights.specs.default.DefaultSpecs.dmesg"


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
Capture the name of blacklisted specs, and dump them to a file in the archive. Added parser and spec to parse the blacklisted specs and use in rules.