### PR TITLE
Exclude malware-detection rules files in /var/tmp (and other locations)

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -7,7 +7,7 @@ from sys import exit
 import logging
 from glob import glob
 from datetime import datetime
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, gettempdir
 try:
     # python 2
     from urllib import quote as urlencode
@@ -605,11 +605,12 @@ class MalwareDetectionClient:
         # However it can happen that the rules file isn't removed for some reason, so remove any existing
         # rules files before beginning a new scan, otherwise they may show up as matches in the scan results.
         old_rules_files = sum([glob(os.path.join(path, rules))
-                               for path in ('/tmp', '/var/tmp')
+                               for path in ('/tmp', '/var/tmp', '/usr/tmp', gettempdir())
                                for rules in ('.tmpmdsigs*', 'tmp_malware-detection-client_rules.*')], [])
         for old_rules_file in old_rules_files:
-            logger.debug("Removing old rules file %s", old_rules_file)
-            os.remove(old_rules_file)
+            if os.path.exists(old_rules_file):
+                logger.debug("Removing old rules file %s", old_rules_file)
+                os.remove(old_rules_file)
 
         self.rules_location = self._get_config_option('rules_location', '')
 
@@ -742,8 +743,16 @@ class MalwareDetectionClient:
             return False
 
         # Exclude the rules file and insights-client log files, unless they are things we specifically want to scan
-        if self.rules_file not in self.scan_fsobjects:
-            self.filesystem_scan_exclude_list.append(self.rules_file)
+        # Get a list of potential rules files locations,eg /tmp, /var/tmp, /usr/tmp and gettempdir()
+        # eg customers may have /tmp linked to /var/tmp so both must be checked for excluding the downloaded rules
+        rules_file_name = os.path.basename(self.rules_file)
+        potential_tmp_dirs = set([gettempdir(), '/tmp', '/var/tmp', '/usr/tmp'])
+        potential_rules_files = set(list(map(lambda d: os.path.join(d, rules_file_name), potential_tmp_dirs)) + [self.rules_file])
+        rules_files = list(filter(lambda f: os.path.isfile(f), potential_rules_files))
+        for rules_file in rules_files:
+            if rules_file not in self.scan_fsobjects:
+                self.filesystem_scan_exclude_list.append(rules_file)
+                logger.debug("Excluding rules file: %s", rules_file)
         insights_log_files = glob(constants.default_log_file + '*')
         self.filesystem_scan_exclude_list.extend(list(set(insights_log_files) - set(self.scan_fsobjects)))
 


### PR DESCRIPTION
Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

Customers who have /tmp linked to /var/tmp will get false positives from the downloaded rules file in /var/tmp because we only check for the rules file in /tmp.  /facepalm ... D'oh ... crikey ... sheesh ... good lord ....  Anyway, this PR makes sure we check /tmp, /var/tmp, /usr/tmp and tempfile.gettempdir() for the downloaded rules file so we can ignore it in all those locations.