### PR TITLE
Disable datasource timeout alarm for the malware-detection app

### DIFF
--- a/insights/specs/datasources/malware_detection.py
+++ b/insights/specs/datasources/malware_detection.py
@@ -9,7 +9,8 @@ from insights.specs import Specs
 
 
 class MalwareDetectionSpecs(Specs):
-    @datasource(HostContext)
+    # timeout=0 disables the datasource timeout alarm, allowing malware-detection to run for as long as necessary
+    @datasource(HostContext, timeout=0)
     def malware_detection_app(broker):
         """
         Custom datasource to collects content for malware scanner if a scanner is present on the system


### PR DESCRIPTION
Signed-off-by: Mark Huth <mhuth@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

The new datasource timeout mechanism was causing malware-detection scans to be terminated after just 120 seconds, which isn't enough time to scan a system's filesystem.  This PR disables the datasource timeout alarm allowing malware-detection scans run for as long as necessary.