### PR TITLE
fix: use LC_ALL=C.UTF-8 for subscription-manager

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -600,8 +600,10 @@ class DefaultSpecs(Specs):
     sshd_config = simple_file("/etc/ssh/sshd_config")
     sshd_config_perms = simple_command("/bin/ls -lH /etc/ssh/sshd_config")
     sssd_config = simple_file("/etc/sssd/sssd.conf")
-    subscription_manager_facts = simple_command("/usr/sbin/subscription-manager facts")
-    subscription_manager_id = simple_command("/usr/sbin/subscription-manager identity")  # use "/usr/sbin" here, BZ#1690529
+    subscription_manager_facts = simple_command("/usr/sbin/subscription-manager facts",
+                                                override_env={"LC_ALL": "C.UTF-8"})
+    subscription_manager_id = simple_command("/usr/sbin/subscription-manager identity",  # use "/usr/sbin" here, BZ#1690529
+                                             override_env={"LC_ALL": "C.UTF-8"})
     subscription_manager_installed_product_ids = simple_command("/usr/bin/find /etc/pki/product-default/ /etc/pki/product/ -name '*pem' -exec rct cat-cert --no-content '{}' \;")
     sudoers = glob_file(["/etc/sudoers", "/etc/sudoers.d/*"])
     swift_object_expirer_conf = first_file(["/var/lib/config-data/puppet-generated/swift/etc/swift/object-expirer.conf", "/etc/swift/object-expirer.conf"])


### PR DESCRIPTION
Signed-off-by: Pino Toscano <ptoscano@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The default environment for `simple_command` includes `LC_ALL=C`, which means ASCII (and not unicode); in case the language of the system is set to a non-English locale that uses unicode characters (e.g. non-Latin1 languages), then `subscription-manager` will fail to output that with encoding issues (e.g. [1]).

As a simple solution, enforce an unicode English locale for `subscription-manager`, which should avoid those encoding issues.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2074745