### PR TITLE
fix: Enhance datasource kernel_module_filters to check the loaded modules

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -204,8 +204,8 @@ plugins:
         - name: insights.components.virtualization.IsBareMetal
           enabled: true
 
-    # needed for the 'pre-check' of the 'ss' spec
-        - name: insights.parsers.lsmod
+    # needed for the 'pre-check' of the 'ss' spec and the 'modinfo_filtered_modules' spec
+        - name: insights.parsers.lsmod.LsMod
           enabled: true
 
     # needed for the 'pre-check' of the 'is_satellite_server' spec
@@ -258,10 +258,6 @@ plugins:
           enabled: true
 
         - name: insights.components.cryptsetup
-          enabled: true
-
-    # needed for the 'modinfo_filtered_modules' spec
-        - name: insights.parsers.lsmod.LsMod
           enabled: true
 """.strip()
 

--- a/insights/collect.py
+++ b/insights/collect.py
@@ -259,6 +259,10 @@ plugins:
 
         - name: insights.components.cryptsetup
           enabled: true
+
+    # needed for the 'modinfo_filtered_modules' spec
+        - name: insights.parsers.lsmod.LsMod
+          enabled: true
 """.strip()
 
 EXCEPTIONS_TO_REPORT = set([

--- a/insights/specs/datasources/kernel_module_list.py
+++ b/insights/specs/datasources/kernel_module_list.py
@@ -5,10 +5,11 @@ from insights.core.context import HostContext
 from insights.core.exceptions import SkipComponent
 from insights.core.filters import get_filters
 from insights.core.plugins import datasource
+from insights.parsers.lsmod import LsMod
 from insights.specs import Specs
 
 
-@datasource(HostContext)
+@datasource(LsMod, HostContext)
 def kernel_module_filters(broker):
     """
     Return a string of a list of modules from the spec filter,
@@ -16,5 +17,9 @@ def kernel_module_filters(broker):
     """
     filters = sorted((get_filters(Specs.modinfo_modules)))
     if filters:
-        return ' '.join(filters)
+        new_modules = []
+        for item in filters:
+            if item in broker[LsMod]:
+                new_modules.append(item)
+        return ' '.join(new_modules)
     raise SkipComponent

--- a/insights/specs/datasources/kernel_module_list.py
+++ b/insights/specs/datasources/kernel_module_list.py
@@ -17,9 +17,11 @@ def kernel_module_filters(broker):
     """
     filters = sorted((get_filters(Specs.modinfo_modules)))
     if filters:
-        new_modules = []
+        loaded_modules = []
         for item in filters:
             if item in broker[LsMod]:
-                new_modules.append(item)
-        return ' '.join(new_modules)
+                loaded_modules.append(item)
+        if loaded_modules:
+            return ' '.join(loaded_modules)
+        raise SkipComponent
     raise SkipComponent

--- a/insights/tests/datasources/test_kernel_module_list.py
+++ b/insights/tests/datasources/test_kernel_module_list.py
@@ -20,6 +20,11 @@ binfmt_misc            69632  0
 udp_diag               18632  0
 """.strip()
 
+LSMOD_NO_LOADED = """
+Module                  Size  Used by
+tcp_diag               16384  0
+""".strip()
+
 
 def setup_function(func):
     if Specs.modinfo_modules in filters._CACHE:
@@ -28,6 +33,8 @@ def setup_function(func):
         del filters.FILTERS[Specs.modinfo_modules]
 
     if func is test_module_filters:
+        filters.add_filter(Specs.modinfo_modules, ["udp_diag", "binfmt_misc", "wireguard"])
+    if func is test_module_no_loaded_modules:
         filters.add_filter(Specs.modinfo_modules, ["udp_diag", "binfmt_misc", "wireguard"])
     if func is test_module_filters_empty:
         filters.add_filter(Specs.modinfo_modules, [])
@@ -42,6 +49,13 @@ def test_module_filters():
 
 def test_module_filters_empty():
     lsmod_info = LsMod(context_wrap(LSMOD))
+    broker = {LsMod: lsmod_info}
+    with pytest.raises(SkipComponent):
+        kernel_module_filters(broker)
+
+
+def test_module_no_loaded_modules():
+    lsmod_info = LsMod(context_wrap(LSMOD_NO_LOADED))
     broker = {LsMod: lsmod_info}
     with pytest.raises(SkipComponent):
         kernel_module_filters(broker)

--- a/insights/tests/datasources/test_kernel_module_list.py
+++ b/insights/tests/datasources/test_kernel_module_list.py
@@ -2,8 +2,23 @@ import pytest
 
 from insights.core import filters
 from insights.core.exceptions import SkipComponent
+from insights.parsers.lsmod import LsMod
 from insights.specs import Specs
 from insights.specs.datasources.kernel_module_list import kernel_module_filters
+from insights.tests import context_wrap
+
+LSMOD = """
+Module                  Size  Used by
+igb                   249856  0
+i2c_algo_bit           16384  1 igb
+dca                    16384  1 igb
+binfmt_misc            20480  1
+tcp_diag               16384  0
+udp_diag               16384  0
+inet_diag              24576  2 tcp_diag,udp_diag
+binfmt_misc            69632  0
+udp_diag               18632  0
+""".strip()
 
 
 def setup_function(func):
@@ -13,18 +28,20 @@ def setup_function(func):
         del filters.FILTERS[Specs.modinfo_modules]
 
     if func is test_module_filters:
-        filters.add_filter(Specs.modinfo_modules, ["udp_diag", "binfmt_misc"])
+        filters.add_filter(Specs.modinfo_modules, ["udp_diag", "binfmt_misc", "wireguard"])
     if func is test_module_filters_empty:
         filters.add_filter(Specs.modinfo_modules, [])
 
 
 def test_module_filters():
-    broker = {}
+    lsmod_info = LsMod(context_wrap(LSMOD))
+    broker = {LsMod: lsmod_info}
     result = kernel_module_filters(broker)
     assert 'binfmt_misc udp_diag' == result
 
 
 def test_module_filters_empty():
-    broker = {}
+    lsmod_info = LsMod(context_wrap(LSMOD))
+    broker = {LsMod: lsmod_info}
     with pytest.raises(SkipComponent):
         kernel_module_filters(broker)


### PR DESCRIPTION
Signed-off-by: jiazhang <jiazhang@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
The issue is https://github.com/RedHatInsights/insights-core/issues/3671

My first resolution is to add `keep_rc=True` into the spec:

~~~
modinfo_filtered_modules = command_with_args('modinfo %s', kernel_module_list.kernel_module_filters, `keep_rc=True`)
~~~
After updating, the spec can collect all of the output like this:

~~~
modinfo: ERROR: Module cvblk not found.
modinfo: ERROR: Module drbd not found.
modinfo: ERROR: Module emcpioc not found.
modinfo: ERROR: Module filepath not found.
filename:       /lib/modules/4.18.0-240.22.1.el8_3.x86_64/kernel/drivers/net/ethernet/intel/i40e/i40e.ko.xz
version:        2.8.20-k
...
~~~

However, the problem is that `modinfo: ERROR: Module XXX not found` can break the normal format:

~~~
alias:          pci:v00008086d000015ABsv*sd*bc*sc*i*
almodinfo: ERROR: Module krg_621845_imRH8_K2S_smp64 not found.
modinfo: ERROR: Module oracleafd not found.
ias:          pci:v00008086d000015B0sv*sd*bc*sc*i*
alias:          pci:v00008086d000015AAsv*sd*bc*sc*i*
...
name:           oracleasm
vermagic:       4.18.0-2modinfo: ERROR: Module oracleoks not found.
modinfo: ERROR: Module twnotify not found.
modinfo: ERROR: Module veeamsnap not found.
40.14.1.el8_3.x86_64 SMP mod_unload modversions
sig_id:         PKCS#7
~~~

We can modify the parser `KernelModulesInfo` to fix this issue, however, the broke format is not fixed, I am afraid that it is hard to avoid all the situations.

The second resolution is to update the datasource to only check the loaded modules:

~~~
cat insights/specs/datasources/kernel_module_list.py

@datasource(LsMod, HostContext)
def kernel_module_filters(broker):
    """
    Return a string of a list of modules from the spec filter,
    separated with space.
    """
    filters = sorted((get_filters(Specs.modinfo_modules)))
    if filters:
        new_modules = []
        for item in filters:
            if item in broker[LsMod]:
                new_modules.append(item)
        return ' '.join(new_modules)
    raise SkipComponent
~~~
