### PR TITLE
fix: py26 test: install libssl1.0-dev manually

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,6 @@ jobs:
     - name: apt-install python26
       run: |
         sudo add-apt-repository 'ppa:deadsnakes/ppa'
-        sudo echo "deb http://security.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends libssl1.0-dev
         sudo apt-get install python2.6  python2.6-dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
     - name: apt-install python26
       run: |
         sudo add-apt-repository 'ppa:deadsnakes/ppa'
-        echo "deb http://security.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
+        sudo echo "deb http://security.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends libssl1.0-dev
         sudo apt-get install python2.6  python2.6-dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,9 @@ jobs:
     - name: apt-install python26
       run: |
         sudo add-apt-repository 'ppa:deadsnakes/ppa'
+        echo "deb http://security.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
         sudo apt-get update
+        sudo apt-get install -y --no-install-recommends libssl1.0-dev
         sudo apt-get install python2.6  python2.6-dev
         sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.6 1
         sudo update-alternatives --set python /usr/bin/python2.6


### PR DESCRIPTION
Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
To fix the following issue raised in the CI test of py26:
``` python2.6-dev : Depends: libssl1.0-dev but it is not going to be installed```