### PR TITLE
fix: Correct parser examples and tests

### DIFF
--- a/insights/parsers/blacklisted.py
+++ b/insights/parsers/blacklisted.py
@@ -13,7 +13,7 @@ class BlacklistedSpecs(JSONParser):
     Parses the blacklisted_specs.txt file generated on archive creation.
 
     Typical output::
-        "{"specs": ["insights.specs.default.DefaultSpecs.dmesg", "insights.specs.default.DefaultSpecs.fstab"]}"
+        "{"specs": ["dmesg", "fstab"]}"
 
     Attributes:
         specs (list): List of blacklisted specs.
@@ -21,7 +21,7 @@ class BlacklistedSpecs(JSONParser):
     Examples:
         >>> type(specs)
         <class 'insights.parsers.blacklisted.BlacklistedSpecs'>
-        >>> result = ['insights.specs.default.DefaultSpecs.dmesg', 'insights.specs.default.DefaultSpecs.fstab']
+        >>> result = ['dmesg', 'fstab']
         >>> specs.specs == result
         True
     """

--- a/insights/tests/parsers/test_blacklisted.py
+++ b/insights/tests/parsers/test_blacklisted.py
@@ -7,7 +7,7 @@ from insights.parsers.blacklisted import BlacklistedSpecs
 from insights.tests import context_wrap
 
 
-SPECS = '{"specs": ["insights.specs.default.DefaultSpecs.dmesg", "insights.specs.default.DefaultSpecs.fstab"]}'
+SPECS = '{"specs": ["dmesg", "fstab"]}'
 
 
 def test_blacklisted_doc_examples():
@@ -24,6 +24,6 @@ def test_skip():
     assert "Empty output." in str(ex)
 
 
-def test_blacklist_specs():
+def test_blacklisted_specs():
     bs = BlacklistedSpecs(context_wrap(SPECS))
-    assert bs.specs[0] == "insights.specs.default.DefaultSpecs.dmesg"
+    assert bs.specs[0] == "dmesg"


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
I forgot to change the tests and examples to only be the spec name instead of the full module path name that I had initially used. Renamed the test file to match the parser's file name.