### PR TITLE
fix: provider of GCP should be 'gcp' but not 'google' 

### DIFF
--- a/insights/combiners/cloud_instance.py
+++ b/insights/combiners/cloud_instance.py
@@ -22,13 +22,6 @@ from insights.parsers.gcp_instance_type import GCPInstanceType
 from insights.parsers.subscription_manager import SubscriptionManagerFacts
 
 
-# "google" is used in class:`insights.combiners.cloud_provider.CloudProvider`.
-# but 'gcp' is outputted in "subscription-manager facts"
-rhsm_type_maps = {
-    "google": 'gcp'
-}
-
-
 @combiner(
     CloudProvider,
     [
@@ -84,8 +77,7 @@ class CloudInstance(object):
             self.type = gcp.raw
         # 2. Check the "subscription-manager facts"
         if self.id is None and facts:
-            cp_name = rhsm_type_maps.get(self.provider, self.provider)
-            key = "{0}_instance_id".format(cp_name)
+            key = "{0}_instance_id".format(self.provider)
             if key not in facts:
                 raise ContentException("Unmatched/unsupported types!")
             self.id = facts[key]

--- a/insights/combiners/cloud_provider.py
+++ b/insights/combiners/cloud_provider.py
@@ -193,8 +193,8 @@ class GoogleCloudProvider(CloudProviderInstance):
 
     Google CP can be identified by RPM and BIOS vendor/version
     """
-    _NAME = 'google'
-    _LONG_NAME = 'Google Cloud'
+    _NAME = 'gcp'
+    _LONG_NAME = 'Google Cloud Platform'
 
     def __init__(self, *args, **kwargs):
         super(GoogleCloudProvider, self).__init__(*args, **kwargs)

--- a/insights/tests/combiners/test_cloud_provider.py
+++ b/insights/tests/combiners/test_cloud_provider.py
@@ -598,7 +598,7 @@ def test_rpm_google():
     assert ret.cloud_provider == CloudProvider.GOOGLE
     assert 'google-rhui-client-5.1.100-1.el7' in ret.cp_rpms.get(CloudProvider.GOOGLE)
     assert 'google-rhui-client-5.1.100-1.el6' in ret.cp_rpms.get(CloudProvider.GOOGLE)
-    assert ret.long_name == 'Google Cloud'
+    assert ret.long_name == 'Google Cloud Platform'
 
 
 def test_rpm_aws():


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

For Google Cloud Platform the `"provider"` and hence the `"provider_type"` should be `gcp` but not `google`
