### PR TITLE
fix: correct parse_content in JSONParser

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -786,8 +786,6 @@ class JSONParser(Parser, LegacyItemAccess):
                 self.data = json.loads('\n'.join(content))
             else:
                 self.data = json.loads(content)
-            if self.data is None:
-                raise SkipComponent("There is no data")
         except:
             # If content is empty then raise a skip exception instead of a parse exception.
             if not content:
@@ -798,6 +796,10 @@ class JSONParser(Parser, LegacyItemAccess):
                 name = ".".join([cls.__module__, cls.__name__])
                 msg = "%s couldn't parse json." % name
                 six.reraise(ParseException, ParseException(msg), tb)
+        # Kept for backwards compatibility;
+        # JSONParser used to raise an exception for valid "null" JSON string
+        if self.data is None:
+            raise SkipComponent("Empty input")
 
 
 class ScanMeta(type):

--- a/insights/tests/test_json_parser.py
+++ b/insights/tests/test_json_parser.py
@@ -1,7 +1,7 @@
 import pytest
 
 from insights.core import JSONParser
-from insights.core.exceptions import ParseException
+from insights.core.exceptions import ParseException, SkipComponent
 from insights.tests import context_wrap
 
 
@@ -28,3 +28,11 @@ def test_json_parser_failure():
         MyJsonParser(ctx)
 
     assert "MyJsonParser" in ex.value.args[0]
+
+
+def test_json_parser_null_value():
+    ctx = context_wrap("null")
+    with pytest.raises(SkipComponent) as ex:
+        MyJsonParser(ctx)
+
+    assert "Empty input" == ex.value.args[0]


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

The parse_content method raised ParseException on valid json string "null". To work with this data the raising SkipComponent part was moved outside the try/except block

