### PR TITLE
Better handle SSL cert verify errors when downloading malware rules

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -669,13 +669,26 @@ class MalwareDetectionClient:
             self.rules_location = self._get_test_rule_location(self.rules_location)
             log_rule_contents = True
 
+        # If a custom CA cert is being used, eg on a Satellite, then SSL errors may occur when downloading the rules
+        # The CA cert needs to be added to a CA bundle (with update-ca-trust) and the bundle used for cert verification
+        ca_cert = None
+        ca_bundles = ['/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem', '/etc/pki/tls/certs/ca-bundle.crt']
+        for ca_bundle in ca_bundles:
+            if os.path.isfile(ca_bundle):
+                ca_cert = ca_bundle
+                break
+
         logger.debug("Downloading rules from: %s", self.rules_location)
         self.insights_config.cert_verify = True
         conn = InsightsConnection(self.insights_config)
 
         for attempt in range(1, self.insights_config.retries + 1):
             try:
-                response = conn.get(self.rules_location, log_response_text=log_rule_contents)
+                response = conn.get(
+                    self.rules_location,
+                    log_response_text=log_rule_contents,
+                    verify=self.insights_config.cert_verify
+                )
                 if response.status_code != 200:
                     raise Exception("%s %s: %s" % (response.status_code, response.reason, response.text))
                 break
@@ -688,6 +701,11 @@ class MalwareDetectionClient:
                 else:
                     logger.error("Unable to download rules from %s: %s", self.rules_location, str(e))
                     exit(constants.sig_kill_bad)
+
+                if 'CERTIFICATE_VERIFY_FAILED' in str(e):
+                    # SSL error occurred, possibly due to a custom CA cert, try using a CA bundle for cert verification
+                    self.insights_config.cert_verify = self._get_config_option('ca_cert', ca_cert)
+                    logger.debug("Trying cert_verify value %s ...", self.insights_config.cert_verify)
 
         self.temp_rules_file = NamedTemporaryFile(prefix='.tmpmdsigs', mode='wb', delete=True)
         self.temp_rules_file.write(response.content)

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -267,13 +267,13 @@ class TestGetRules:
         assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
         assert mdc.rules_file.startswith('/tmp')  # rules will be saved into a temp file
         get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar",
-                               log_response_text=True)
+                               log_response_text=True, verify=True)
 
         # With authmethod=CERT, expect 'cert.' to be prefixed to the url
         mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
         assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
         get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar",
-                               log_response_text=True)
+                               log_response_text=True, verify=True)
 
         # With authmethod=BASIC and test scan false ...
         # Expect to still use cert auth because no username or password specified
@@ -281,12 +281,12 @@ class TestGetRules:
         mdc = MalwareDetectionClient(InsightsConfig(authmethod='BASIC'))
         assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
         get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar",
-                               log_response_text=False)
+                               log_response_text=False, verify=True)
 
         mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
         assert mdc.rules_location == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
         get.assert_called_with("https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar",
-                               log_response_text=False)
+                               log_response_text=False, verify=True)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true'})
     @patch(FIND_YARA_TARGET, return_value=YARA)
@@ -301,26 +301,26 @@ class TestGetRules:
         get.return_value = Mock(status_code=401, reason="Unauthorized", text="No can do")
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(username='user'))
-        get.assert_called_with(expected_rules_url, log_response_text=True)
+        get.assert_called_with(expected_rules_url, log_response_text=True, verify=True)
         log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "401 Unauthorized: No can do")
 
         # Test with just a password specified - expect basic auth to be used but fails
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(password='pass'))
-        get.assert_called_with(expected_rules_url, log_response_text=True)
+        get.assert_called_with(expected_rules_url, log_response_text=True, verify=True)
         log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "401 Unauthorized: No can do")
 
         # Test with 'incorrect' username and/or password - expect basic auth failure
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(username='user', password='badpass'))
-        get.assert_called_with(expected_rules_url, log_response_text=True)
+        get.assert_called_with(expected_rules_url, log_response_text=True, verify=True)
         log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "401 Unauthorized: No can do")
 
         # Test with 'correct' username and password - expect basic auth success
         get.return_value = Mock(status_code=200, content=b"Rule Content")
         mdc = MalwareDetectionClient(InsightsConfig(username='user', password='goodpass'))
         assert mdc.rules_location == expected_rules_url
-        get.assert_called_with(expected_rules_url, log_response_text=True)
+        get.assert_called_with(expected_rules_url, log_response_text=True, verify=True)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'false'})
     @patch("os.path.exists", return_value=True)  # mock call to os.path.exists in _find_yara
@@ -331,24 +331,24 @@ class TestGetRules:
         mdc = MalwareDetectionClient(InsightsConfig())
         assert mdc.yara_version == '4.2.1'
         assert mdc.rules_location == expected_rules_url + "?yara_version=4.2.1"
-        get.assert_called_with(expected_rules_url + "?yara_version=4.2.1", log_response_text=False)
+        get.assert_called_with(expected_rules_url + "?yara_version=4.2.1", log_response_text=False, verify=True)
 
         version_mock.return_value = '4.1.0'
         mdc = MalwareDetectionClient(InsightsConfig())
         assert mdc.rules_location == expected_rules_url + "?yara_version=4.1.0"
-        get.assert_called_with(expected_rules_url + "?yara_version=4.1.0", log_response_text=False)
+        get.assert_called_with(expected_rules_url + "?yara_version=4.1.0", log_response_text=False, verify=True)
 
         version_mock.return_value = '10.100'
         mdc = MalwareDetectionClient(InsightsConfig())
         assert mdc.rules_location == expected_rules_url + "?yara_version=10.100"
-        get.assert_called_with(expected_rules_url + "?yara_version=10.100", log_response_text=False)
+        get.assert_called_with(expected_rules_url + "?yara_version=10.100", log_response_text=False, verify=True)
 
         # Bypass the _find_yara method so self.yara_version isn't set
         with patch(FIND_YARA_TARGET, return_value=YARA):
             mdc = MalwareDetectionClient(InsightsConfig())
         assert not hasattr(mdc, 'yara_version')
         assert mdc.rules_location == expected_rules_url
-        get.assert_called_with(expected_rules_url, log_response_text=False)
+        get.assert_called_with(expected_rules_url, log_response_text=False, verify=True)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'false'})
     @patch("os.path.exists", return_value=True)  # mock call to os.path.exists in _find_yara
@@ -361,25 +361,25 @@ class TestGetRules:
         mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url))
         assert mdc.yara_version == '4.2.0'
         assert mdc.rules_location == expected_rules_url
-        get.assert_called_with(expected_rules_url, log_response_text=False)
+        get.assert_called_with(expected_rules_url, log_response_text=False, verify=True)
 
         for base_url in ('cert.console.stage.redhat.com/r/insights', 'cert.console.stage.redhat.com'):
             mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url))
             assert mdc.rules_location == expected_rules_url
-            get.assert_called_with(expected_rules_url, log_response_text=False)
+            get.assert_called_with(expected_rules_url, log_response_text=False, verify=True)
 
         base_url = "https://cert.console.stage.redhat.com:443/r/insights"
         expected_rules_url = "https://cert.console.stage.redhat.com:443/api/malware-detection/v1/signatures.yar?yara_version=4.2.0"
         mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url))
         assert mdc.rules_location == expected_rules_url
-        get.assert_called_with(expected_rules_url, log_response_text=False)
+        get.assert_called_with(expected_rules_url, log_response_text=False, verify=True)
 
         os.environ['TEST_SCAN'] = 'true'
         base_url = "cloud.stage.redhat.com"
         expected_rules_url = "https://cloud.stage.redhat.com/api/malware-detection/v1/test-rule.yar"
         mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url))
         assert mdc.rules_location == expected_rules_url
-        get.assert_called_with(expected_rules_url, log_response_text=True)
+        get.assert_called_with(expected_rules_url, log_response_text=True, verify=True)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': 'console.redhat.com/rules.yar'})
     @patch(FIND_YARA_TARGET, return_value=YARA)
@@ -388,13 +388,13 @@ class TestGetRules:
         # test-scan true and BASIC auth by default expect test-rule.yar and no 'cert.' in URL
         mdc = MalwareDetectionClient(InsightsConfig(username='user', password='pass'))
         assert mdc.rules_location == "https://console.redhat.com/test-rule.yar"
-        get.assert_called_with("https://console.redhat.com/test-rule.yar", log_response_text=True)
+        get.assert_called_with("https://console.redhat.com/test-rule.yar", log_response_text=True, verify=True)
 
         # test-scan false and CERT auth - expect 'cert.' prefixed to the URL and not test-rule.yar
         os.environ['TEST_SCAN'] = 'false'
         mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
         assert mdc.rules_location == "https://cert.console.redhat.com/rules.yar"
-        get.assert_called_with("https://cert.console.redhat.com/rules.yar", log_response_text=False)
+        get.assert_called_with("https://cert.console.redhat.com/rules.yar", log_response_text=False, verify=True)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'http://localhost/rules.yar'})
     @patch(FIND_YARA_TARGET, return_value=YARA)
@@ -431,9 +431,10 @@ class TestGetRules:
                                'Use TEST_DOWNLOAD_FAILURE_RETRIES=True to enable test')
     @patch.dict(os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'http://localhost/rules.yar'})
     @patch(FIND_YARA_TARGET, return_value=YARA)
+    @patch("os.path.isfile", return_value=True)
     @patch(LOGGER_TARGET)
-    def test_download_failure_retries(self, log_mock, yara, conf, cmd, session, proxies, get, findmnt, remove):
-        from requests.exceptions import ConnectionError
+    def test_download_failure_retries(self, log_mock, isfile, yara, conf, cmd, session, proxies, get, findmnt, remove):
+        from requests.exceptions import ConnectionError, SSLError
         # Testing the download failure retry logic
         expected_rules_url = os.environ['RULES_LOCATION']
 
@@ -459,6 +460,24 @@ class TestGetRules:
         log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "Couldn't connect")
         # Because we've set retries to 3, the last attempted retry will wait 4 seconds (= 2**2)
         log_mock.debug.assert_called_with("Trying again in %d seconds ...", 4)
+
+        # CERTIFICATE_VERIFY_FAILED SSL Errors will cause a different CA certificate bundle to be tried
+        ca_cert = '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'  # default ca cert bundle file to try
+        get.side_effect = SSLError("CERTIFICATE_VERIFY_FAILED")
+        with pytest.raises(SystemExit):
+            MalwareDetectionClient(InsightsConfig(retries=2))
+        get.assert_called_with(expected_rules_url, log_response_text=False, verify=ca_cert)
+        log_mock.debug.assert_called_with("Trying cert_verify value %s ...", ca_cert)
+        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "CERTIFICATE_VERIFY_FAILED")
+
+        # CA certificate bundles can be specified in the config file or via env vars too
+        ca_cert = '/some/cert/file.crt'
+        os.environ['CA_CERT'] = ca_cert  # customers can specify their own ca bundle file via config/env vars
+        with pytest.raises(SystemExit):
+            MalwareDetectionClient(InsightsConfig(retries=2))
+        get.assert_called_with(expected_rules_url, log_response_text=False, verify=ca_cert)
+        log_mock.debug.assert_called_with("Trying cert_verify value %s ...", ca_cert)
+        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "CERTIFICATE_VERIFY_FAILED")
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': '//console.redhat.com/rules.yar'})
     @patch(FIND_YARA_TARGET, return_value=YARA)
@@ -494,7 +513,7 @@ class TestGetRules:
         with patch(FIND_YARA_TARGET, return_value=YARA):
             mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
         assert mdc.rules_location == expected_rules_url
-        get.assert_called_with(expected_rules_url, log_response_text=True)
+        get.assert_called_with(expected_rules_url, log_response_text=True, verify=True)
         log_mock.debug.assert_called_with("Downloading rules from: %s", expected_rules_url)
 
         # Then with the actual rules file
@@ -503,7 +522,7 @@ class TestGetRules:
         with patch(FIND_YARA_TARGET, return_value=YARA):
             mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
         assert mdc.rules_location == expected_rules_url
-        get.assert_called_with(expected_rules_url, log_response_text=False)
+        get.assert_called_with(expected_rules_url, log_response_text=False, verify=True)
         log_mock.debug.assert_called_with("Downloading rules from: %s", expected_rules_url)
 
         expected_rules_url += '?yara_version=4.1'
@@ -511,7 +530,7 @@ class TestGetRules:
             with patch("insights.client.apps.malware_detection.call", return_value='4.1'):
                 mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
         assert mdc.rules_location == expected_rules_url
-        get.assert_called_with(expected_rules_url, log_response_text=False)
+        get.assert_called_with(expected_rules_url, log_response_text=False, verify=True)
         log_mock.debug.assert_called_with("Downloading rules from: %s", expected_rules_url)
 
         # Test a Satellite URL with 'stage.redhat.com' in its name - expect to still download from Satellite
@@ -522,7 +541,7 @@ class TestGetRules:
             with patch("insights.client.apps.malware_detection.call", return_value='4.1'):
                 mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
         assert mdc.rules_location == expected_rules_url
-        get.assert_called_with(expected_rules_url, log_response_text=False)
+        get.assert_called_with(expected_rules_url, log_response_text=False, verify=True)
         log_mock.debug.assert_called_with("Downloading rules from: %s", expected_rules_url)
 
 


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

Customer had their own self signed Satellite certificates.  Malware-detection couldn't download rules from the backend because it wasn't aware to use the custom CA certificates to verify the Satellite certificates.  This PR allows malware-detection to try different ca-cert/ca-bundle files to find the custom certificate and hence allow the rules to be downloaded successfully.

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2168808
Related Kbase: https://access.redhat.com/solutions/6997170