### PR TITLE
fix: update OSRelease.is_rhel more accurate 

### DIFF
--- a/insights/combiners/os_release.py
+++ b/insights/combiners/os_release.py
@@ -4,26 +4,33 @@ OSRelease
 The ``OSRelease`` combiner uses the following parsers to try to identify if the
 current host is installed with a "Red Hat Enterprise Linux" system.
 
-    - :py:class:`insights.parsers.os_release.OsRelease`
-    - :py:class:`insights.parsers.redhat_release.RedhatRelease`
+    - :py:class:`insights.parsers.uname.Uname`
+    - :py:class:`insights.parsers.dmesg.DmesgLineList`
     - :py:class:`insights.parsers.installed_rpms.InstalledRpms`
 
 It provides an attribute `is_rhel` that indicates if the host is "RHEL" or not.
-It also provides an attribute `product` which returns the estimated OS name of
-the system, "Unknown" will be returned by default when cannot identify the OS.
+It also provides an attribute `release` which returns the estimated OS release
+name of the system, "Unknown" will be returned by default when cannot identify
+the OS.
+
+* TODO:
+  The lists of keywords to identify NON-RHEL system of each sub-combiners are
+  based on our current knowledge, and maybe not sufficient. It needs to be
+  updated timely according to new found Linux distributions.
 """
+from insights.core.filters import add_filter
 from insights.core.plugins import combiner
+from insights.parsers.dmesg import DmesgLineList
 from insights.parsers.installed_rpms import InstalledRpm, InstalledRpms
-from insights.parsers.os_release import OsRelease
-from insights.parsers.redhat_release import RedhatRelease
 from insights.parsers.uname import Uname
 
-RHEL_STR = "Red Hat Enterprise Linux"
-RHEL_KEYS = ['rhel', 'red hat enterprise linux']
-"""Keywords in 'os-release' or 'redhat-release' that indicates an RHEL system."""
-NON_RHEL_KEYS = ['oracle', 'suse', 'sles', 'fedora', 'centos']
-"""Keywords in 'os-release' or 'redhat-release' that indicates a NON-RHEL system."""
-MIN_RHEL_PKGS = [
+# Get "Linux version" from `dmesg`
+DMESG_LINUX_BUILD_INFO = 'Linux version'
+add_filter(DmesgLineList, DMESG_LINUX_BUILD_INFO)
+DmesgLineList.keep_scan("linux_version", DMESG_LINUX_BUILD_INFO, num=1)
+# Must-install packages for minimum RHEL system
+MINIMUM_RHEL_PKGS = [
+    # 'kernel' is must-install too, it's checked individually (booting kernel)
     'audit-libs',
     'basesystem',
     'bash',
@@ -43,7 +50,7 @@ MIN_RHEL_PKGS = [
     'NetworkManager',
     'openssl-libs',
     'passwd',
-    'redhat-release',
+    'redhat-release',  # RHEL 8+
     'redhat-release-server',  # RHEL 6/7
     'systemd',  # RHEL 7+
     'util-linux',
@@ -51,74 +58,207 @@ MIN_RHEL_PKGS = [
 ]
 """Must-install packages for minimum installed RHEL system."""
 THRESHOLD = 0.7
-"""Threshold rate of the required "MIN_RHEL_PKGS" to identify RHEL system"""
+"""Threshold rate of the required "MINIMUM_RHEL_PKGS" to identify RHEL system"""
 
 
-@combiner(optional=[InstalledRpms, RedhatRelease, OsRelease, Uname])
+def _from_uname(uname):
+    """
+    Internal function to check the `uname -a` output.
+
+    1. Oracle kernels may contain 'uek' or 'ol' in the kernel NVR.
+    2. Fedora kernels contains 'fc' in the NVR.
+    3. RHEL kernels have '.el' in the NVR
+       CentOS/Oracle/RockyLinux kernels may also have the '.el' in the NVR,
+       but they are also checked in other sub-combiners.
+    4. Otherwise, flag it as an "Unknown"
+    """
+    LINUX_UNAME_KEYS = [
+        ('Oracle', ['uek', 'ol']),
+        ('Fedora', ['fc']),
+        ('RHEL', ['.el']),  # the last item
+    ]
+    kernel = uname.kernel
+    other_linux = 'Unknown'
+    for release, keys in LINUX_UNAME_KEYS:
+        if any(key in kernel for key in keys):
+            other_linux = release
+            break
+    if 'RHEL' != other_linux:
+        return dict(other_linux=other_linux, kernel=kernel)
+    # Not Sure
+    return dict()
+
+
+def _from_dmesg(dmesg):
+    """
+    Internal function to check the `dmesg` output.
+
+    The `dmesg` includes a line containing the kernel build information,
+    e.g. the build host and GCC version.
+    If this line doesn't contain 'redhat.com' then we can assume the kernel
+    wasn't built on a Red Hat machine and this should be flagged::
+
+        'centos'                    -> CentOS Linux
+        'oracle'                    -> Oracle Linux
+        'suse', 'sles', or 'novell' -> SUSE Linux
+        'fedora'                    -> Fedora Linux
+        'rockylinux'                -> Rocky Linux
+        others                      -> Unknown
+    """
+    OTHER_LINUX_KEYS = {
+        'Oracle': ['oracle'],
+        'Fedora': ['fedora'],
+        'CentOS': ['centos'],
+        'Rocky': ['rockylinux', 'rocky'],
+        'SUSE': ['suse', 'sles', 'novell'],
+    }
+    line = dmesg.linux_version[0]['raw_message']
+    low_line = line.lower()
+    if 'redhat.com' not in low_line:
+        other_linux = 'Unknown'
+        for release, keys in OTHER_LINUX_KEYS.items():
+            if any(kw in low_line for kw in keys):
+                other_linux = release
+                break
+        return dict(other_linux=other_linux, build_info=line)
+    # Not Sure
+    return dict()
+
+
+def _from_installed_rpms(rpms, uname):
+    """
+    Internal function to check the `rpm -qa ...` output.
+
+    Two parts are included, see below:
+    """
+    # Part-1 of RPMs
+    """
+    # Part-1: the following packages exists
+        'centos-release'        -> CentOS Linux
+        'centos-stream-release' -> CentOS Stream
+        'fedora-release'        -> Fedora
+        'enterprise-release'    -> Oracle
+        'oraclelinux-release'   -> Oracle
+        'rocky-release'         -> Rocky Linux,
+        'sl-release'            -> Scientific Linux
+        'sles-release'          -> SUSE
+    """
+    OTHER_LINUX_RELEASE_PKGS = {
+        'CentOS': ['centos-release', 'centos-stream-release'],
+        'Fedora': ['fedora-release'],
+        'Oracle': ['enterprise-release', 'oraclelinux-release'],
+        'Rocky': ['rocky-release'],
+        'Scientific': ['sl-release'],
+        'SUSE': ['sles-release'],
+    }
+    for release, pkgs in OTHER_LINUX_RELEASE_PKGS.items():
+        for pkg_name in pkgs:
+            pkg = rpms.newest(pkg_name)
+            if pkg:
+                return dict(other_linux=release, release=pkg.nvr)
+
+    # Part-2 of RPMs
+    """
+    # Part-2: too many must-install packages are not signed or provided by Red Hat
+    # - faulty_packages >= (THRESHOLD * must-install packages)
+    """
+    KERNEL_VENDORS = {
+        'Oracle': ['oracle'],
+        'Rocky': ['rocky'],
+        'SUSE': ['suse', 'novell'],
+    }
+    installed_packages = 0
+    vendor, _ng_pkgs = '', set()
+    if uname:
+        # check the booting 'kernel' first
+        installed_packages += 1
+        boot_kn = InstalledRpm.from_package('kernel-{0}'.format(uname.kernel))
+        for pkg in rpms.packages.get('kernel', []):
+            if pkg == boot_kn:
+                vendor = pkg.vendor
+                if not (pkg.redhat_signed and
+                        vendor and vendor == 'Red Hat, Inc.'):
+                    _ng_pkgs.add(pkg.nvr)
+                # check the booting kernel only
+                break
+    # check other packages
+    for pkg_name in MINIMUM_RHEL_PKGS:
+        pkg = rpms.newest(pkg_name)
+        if pkg:
+            # count the package only when it's installed
+            installed_packages += 1
+            if not (pkg.redhat_signed and
+                    pkg.vendor and pkg.vendor == 'Red Hat, Inc.'):
+                _ng_pkgs.add(pkg.nvr)
+    if len(_ng_pkgs) >= round(THRESHOLD * installed_packages) > 0:
+        # Unknown Linux: more than THRESHOLD packages are NOT from Red Hat
+        other_linux = 'Unknown'
+        for release, keys in KERNEL_VENDORS.items():
+            if any(kw in vendor.lower() for kw in keys):
+                # Known NON-RHEL from kernel vendor
+                other_linux = release
+                break
+        ret = dict(other_linux=other_linux, faulty_packages=sorted(_ng_pkgs))
+        ret.update(kernel_vendor=vendor) if vendor else None
+        return ret
+    # RHEL
+    return dict(other_linux='RHEL')
+
+
+@combiner(optional=[Uname, DmesgLineList, InstalledRpms])
 class OSRelease(object):
     """
-    This combiner can be used to identify if the host an RHEL host by
-    checking the following parsers:
+    A Combiner identifies whether the current Linux a Red Hat Enterprise Linux
+    or not.
 
-        - :py:class:`insights.parsers.os_release.OsRelease`
-        - :py:class:`insights.parsers.redhat_release.RedhatRelease`
-        - :py:class:`insights.parsers.installed_rpms.InstalledRpms`
-
-    If none of the above parsers is available, NON-RHEL will be returned.
-
-    The :py:class:`insights.parsers.uname.Uname` parser is used to get the
-    booting kernel package.
+    Examples:
+        >>> type(osr)
+        <class 'insights.combiners.os_release.OSRelease'>
+        >>> osr.is_rhel
+        False
+        >>> osr.release == "Oracle"
+        True
+        >>> sorted(osr.reasons.keys())
+        ['build_info', 'faulty_packages', 'kernel', 'kernel_vendor']
+        >>> 'Linux version kernel-4.18.0-372' in osr.reasons['build_info']
+        True
+        >>> osr.reasons['kernel']
+        '4.18.0-372.19.1.el8_6uek.x86_64'
+        >>> osr.reasons['kernel_vendor'] == 'Oracle America'
+        True
+        >>> 'glibc-2.28-211.el8' in osr.reasons['faulty_packages']
+        True
     """
-    def __init__(self, rpms, rhr, osr, uname):
-        self._is_rhel = False
-        self._product = "Unknown"
-        self._ng_pkgs = set()
-        if osr:
-            names = list(filter(None,
-                                [osr.get('ID'), osr.get('NAME'),
-                                 osr.get('PRETTY_NAME')]))
-            if names and any(nr in nm.lower() for nm in names
-                                              for nr in NON_RHEL_KEYS):
-                self._product = names[-1]
-                # NON-RHEL Assertion 1: NG /etc/os-release
-                return
-        if rhr and any(nr in rhr.raw.lower() for nr in NON_RHEL_KEYS):
-            self._product = rhr.product
-            # NON-RHEL Assertion 2: NG /etc/redhat-release
-            return
-        if rpms and rpms.packages:
-            installed_packages = 1  # kernel is must-installed
-            # check the booting 'kernel' first
-            boot_kn = InstalledRpm.from_package(
-                    'kernel-{0}'.format(uname.kernel)) if uname else None
-            if boot_kn:
-                # check the booting kernel only when Uname is available
-                for pkg in rpms.packages.get('kernel', []):
-                    if pkg == boot_kn:
-                        if not (pkg.redhat_signed and
-                                pkg.vendor and pkg.vendor == 'Red Hat, Inc.'):
-                            self._ng_pkgs.add(pkg.nvr)
-                        break
-            # check other packages
-            for pkg_name in MIN_RHEL_PKGS:
-                pkg = rpms.newest(pkg_name)
-                if pkg:
-                    installed_packages += 1  # count the package only when it's installed
-                    if not (pkg.redhat_signed and
-                            pkg.vendor and pkg.vendor == 'Red Hat, Inc.'):
-                        self._ng_pkgs.add(pkg.nvr)
-            if len(self._ng_pkgs) < round(THRESHOLD * installed_packages):
-                # RHEL: less than THRESHOLD packages are NOT from Red Hat
-                self._is_rhel = True
-                self._product = RHEL_STR
-        elif ((rhr and rhr.is_rhel) or
-                (osr and names and
-                 any(k in v.lower() for k in RHEL_KEYS for v in names))):
-            # backup plan when "rpm" command is corrupt or blocked
-            # RHEL: when `os-release` *OR* `redhat-release` are for RHEL
-            self._is_rhel = True
-            self._product = RHEL_STR
-        # else: Unknown OS Product
+    def __init__(self, uname, dmesg, rpms):
+        def _update_other_linux(ret, data):
+            if data.get('other_linux') == 'Unknown' and 'other_linux' in ret:
+                # Do not update the 'other_linux' if it's identified already
+                data.pop('other_linux')
+            ret.update(data)
+            return ret
+
+        self._is_rhel = True
+        self._release = 'Red Hat Enterprise Linux'
+        self._reasons = {}
+        _dmesg = dmesg.linux_version if dmesg else dmesg
+        if not list(filter(None, [uname, _dmesg, rpms])):
+            # Nothing means NON-RHEL
+            self._is_rhel = False
+            self._release = 'Unknown'
+            self._reasons = {'reason': 'Nothing to check'}
+        else:
+            # Uname -> Dmesg -> RPMs
+            result = _from_uname(uname) if uname else dict()
+            if dmesg and dmesg.linux_version:
+                result.update(_update_other_linux(result, _from_dmesg(dmesg)))
+            if rpms:
+                result.update(_update_other_linux(
+                                result, _from_installed_rpms(rpms, uname)))
+            # 'other_linux' means NON-RHEL
+            if 'other_linux' in result and result['other_linux'] != 'RHEL':
+                self._is_rhel = False
+                self._release = result.pop('other_linux')
+                self._reasons = result
 
     @property
     def is_rhel(self):
@@ -128,16 +268,27 @@ class OSRelease(object):
         return self._is_rhel
 
     @property
-    def product(self):
+    def release(self):
         """
-        Returns the estimated product name of this host. "Unknown" by default.
+        Returns the estimated release name of the running Linux.
         """
-        return self._product
+        return self._release
 
     @property
-    def issued_packages(self):
+    def reasons(self):
         """
-        Returns the list of issued must-install packages that are not signed
-        by Red Hat or not provided by Red Hat.
+        Returns a dict indicating why the host is a NON-RHEL.  Empty when
+        it's an RHEL. The keys include::
+
+            kernel (str): the kernel package
+            build_info (str): the kernel build information
+            release (str): the release package
+            faulty_packages (list): the packages that are not signed or provided by Red Hat
+            reason (str): a string when nothing is available to check
         """
-        return sorted(self._ng_pkgs)
+        return self._reasons
+
+    @property
+    def product(self):
+        """ Alias of `release`. Keep backward compatible """
+        return self._release

--- a/insights/tests/combiners/test_os_release.py
+++ b/insights/tests/combiners/test_os_release.py
@@ -1,12 +1,17 @@
-from insights.combiners.os_release import OSRelease, RHEL_STR
+import doctest
+
+from insights.combiners import os_release
+from insights.combiners.os_release import OSRelease
+from insights.parsers.dmesg import DmesgLineList
 from insights.parsers.installed_rpms import InstalledRpms
-from insights.parsers.os_release import OsRelease
-from insights.parsers.redhat_release import RedhatRelease
 from insights.parsers.uname import Uname
 from insights.tests import context_wrap
 
 UNAME_86 = "Linux vm-123 4.18.0-372.19.1.el8_6.x86_64 #1 SMP Mon Jul 18 11:14:02 EDT 2022 x86_64 x86_64 x86_64 GNU/Linux"
 UNAME_91 = "Linux vm-123 5.14.0-162.6.1.el9_1.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Sep 30 07:36:03 EDT 2022 x86_64 x86_64 x86_64 GNU/Linux"
+UNAME_ORACLE = "Linux atlnfs4testd 4.18.0-372.19.1.el8_6uek.x86_64 #1 SMP Thu Nov 7 17:01:44 PST 2013 x86_64 x86_64 x86_64 GNU/Linux"
+UNAME_FEDORA = "Linux sironote.home.local 3.17.8-200.fc20.x86_64 #1 SMP Thu Jan 8 23:26:57 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux"
+UNAME_UNKNOWN = "Linux eslinb24.emea.nsn-net.net 2.6.39.4-9.NSN.kiuas #1 SMP Thu Feb 13 08:58:31 EET 2014 x86_64 x86_64 x86_64 GNU/Linux"
 
 RPMS_JSON_91_WO_KERNEL = '''
 {"name":"systemd", "epoch":"(none)", "version":"250", "release":"12.el9_1", "arch":"x86_64", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Thu 29 Sep 2022 05:02:47 PM CST, Key ID 199e2f91fd431d51"}
@@ -25,17 +30,16 @@ RPMS_JSON_91_WO_KERNEL = '''
 {"name":"dracut", "epoch":"(none)", "version":"057", "release":"13.git20220816.el9", "arch":"x86_64", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Wed Aug 17 08:06:56 2022, Key ID 199e2f91fd431d51"}
 {"name":"firewalld", "epoch":"(none)", "version":"1.1.1", "release":"3.el9", "arch":"noarch", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Mon Aug  8 21:31:26 2022, Key ID 199e2f91fd431d51"}
 '''.strip()
-
 RPMS_JSON_91_W_KERNEL = RPMS_JSON_91_WO_KERNEL + """
 {"name":"kernel", "epoch":"(none)", "version":"5.14.0", "release":"70.13.1.el9_0", "arch":"x86_64", "vendor":"RH, Inc.", "sigpgp":"RSA/SHA256, Mon 05 Sep 2022 09:55:09 PM CST, Key ID 199e2f91fd431d51"}
 {"name":"kernel", "epoch":"(none)", "version":"5.14.0", "release":"162.6.1.el9_1", "arch":"x86_64", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Mon 03 Oct 2022 04:18:36 PM CST, Key ID 199e2f91fd431d51"}"""
-
 RPMS_JSON_8_NG = '''
-{"name":"kernel", "epoch":"(none)", "version":"4.18.0", "release":"425.3.1.el8", "arch":"x86_64", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Tue Nov  8 18:10:54 2022, Key ID 199e2f91fd431d51"}
-{"name":"kernel", "epoch":"(none)", "version":"4.18.0", "release":"372.19.1.el8_6", "arch":"x86_64", "vendor":"RH, Inc.", "sigpgp":"RSA/SHA256, Wed Sep 15 17:11:22 2021, Key ID 199e2f91fd431d51"}
+{"name":"kernel", "epoch":"(none)", "version":"4.18.0", "release":"425.3.1.el8", "arch":"x86_64", "vendor":"RH, Inc.", "sigpgp":"RSA/SHA256, Tue Nov  8 18:10:54 2022, Key ID 199e2f91fd431d51"}
+{"name":"kernel", "epoch":"(none)", "version":"4.18.0", "release":"372.19.1.el8_6uek", "arch":"x86_64", "vendor":"Oracle America", "sigpgp":"RSA/SHA256, Wed Sep 15 17:11:22 2021, Key ID 199e2f91fd431d51"}
+{"name":"kernel", "epoch":"(none)", "version":"4.18.0", "release":"372.19.1.el8_6", "arch":"x86_64", "vendor":"suse, Inc.", "sigpgp":"RSA/SHA256, Wed Sep 15 17:11:22 2021, Key ID 199e2f91fd431d51"}
 {"name":"libselinux", "epoch":"(none)", "version":"2.9", "release":"6.el8", "arch":"i686", "vendor":"RH, Inc.", "sigpgp":"RSA/SHA256, Mon 15 Aug 2022 08:55:09 PM CST, Key ID 199e2f91fd431d51"}
-{"name":"dbus", "epoch":"1", "version":"1.12.8", "release":"23.el8", "arch":"x86_64", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Wed 07 Sep 2022 04:08:12 AM CST, Key ID 199e2f91fd431d51"}
-{"name":"dracut", "epoch":"(none)", "version":"049", "release":"209.git20220815.el8", "arch":"x86_64", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Mon 15 Aug 2022 09:56:58 PM CST, Key ID 199e2f91fd431d51"}
+{"name":"dbus", "epoch":"1", "version":"1.12.8", "release":"23.el8", "arch":"x86_64", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Wed 07 Sep 2022 04:08:12 AM CST, Key ID 99e2f91fd431d51"}
+{"name":"dracut", "epoch":"(none)", "version":"049", "release":"209.git20220815.el8", "arch":"x86_64", "vendor":"RH, Inc.", "sigpgp":"RSA/SHA256, Mon 15 Aug 2022 09:56:58 PM CST, Key ID 199e2f91fd431d51"}
 {"name":"libgcc", "epoch":"(none)", "version":"8.5.0", "release":"15.el8", "arch":"x86_64", "vendor":"RH, Inc.", "sigpgp":"RSA/SHA256, Thu 21 Jul 2022 05:36:25 PM CST, Key ID 199e2f91fd431d51"}
 {"name":"policycoreutils", "epoch":"(none)", "version":"2.9", "release":"20.el8", "arch":"x86_64", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Mon 15 Aug 2022 08:51:06 PM CST, Key ID 199e2f91fd431d51"}
 {"name":"glibc", "epoch":"(none)", "version":"2.28", "release":"211.el8", "arch":"x86_64", "vendor":"RH, Inc.", "sigpgp":"RSA/SHA256, Mon 29 Aug 2022 04:13:20 PM CST, Key ID 199e2f91fd431d51"}
@@ -47,149 +51,233 @@ RPMS_JSON_8_NG = '''
 {"name":"coreutils", "epoch":"(none)", "version":"8.30", "release":"13.el8", "arch":"x86_64", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Thu 16 Jun 2022 12:18:02 PM CST, Key ID 09e2f91fd431d51"}
 {"name":"firewalld", "epoch":"(none)", "version":"0.9.3", "release":"13.el8", "arch":"noarch", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Fri 25 Feb 2022 09:40:17 PM CST, Key ID 09e2f91fd431d51"}
 {"name":"filesystem", "epoch":"(none)", "version":"3.8", "release":"6.el8", "arch":"x86_64", "vendor":"RH, Inc.", "sigpgp":"RSA/SHA256, Mon 21 Jun 2021 07:17:43 PM CST, Key ID 199e2f91fd431d51"}
-{"name":"gmp", "epoch":"1", "version":"6.1.2", "release":"10.el8", "arch":"x86_64", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Fri 14 Jun 2019 04:58:39 PM CST, Key ID 199e2f91fd431d51"}
+{"name":"gmp", "epoch":"1", "version":"6.1.2", "release":"10.el8", "arch":"x86_64", "vendor":"RH, Inc.", "sigpgp":"RSA/SHA256, Fri 14 Jun 2019 04:58:39 PM CST, Key ID 199e2f91fd431d51"}
 {"name":"basesystem", "epoch":"(none)", "version":"11", "release":"5.el8", "arch":"noarch", "vendor":"RH, Inc.", "sigpgp":"RSA/SHA256, Sat 15 Dec 2018 05:49:21 AM CST, Key ID 09e2f91fd431d51"}
 {"name":"dmidecode", "epoch":"1", "version":"3.3", "release":"4.el8", "arch":"x86_64", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Mon 14 Mar 2022 02:13:06 PM CST, Key ID 99e2f91fd431d51"}
 '''.strip()
+RPMS_JSON_ROCKY = '''
+{"name":"rocky-release", "epoch":"1", "version":"3.3", "release":"4.el8", "arch":"x86_64", "vendor":"Red Hat, Inc.", "sigpgp":"RSA/SHA256, Mon 14 Mar 2022 02:13:06 PM CST, Key ID 99e2f91fd431d51"}
+'''.strip()
 
-REDHAT_RELEASE_86 = """
-Red Hat Enterprise Linux release 8.6 (Ootpa)
+DMESG_ORACLE = """
+Linux version kernel-4.18.0-372.19.1.el8_6uek.x86_64 (mockbuild@ca-build56.us.oracle.com) (gcc version 4.1.2 20080704 (Red Hat 4.1.2-54)) #1 SMP Mon Sep 30 16:46:32 PDT 2013
 """.strip()
-
-REDHAT_RELEASE_91 = """
-Red Hat Enterprise Linux release 9.1 (Plow)
+DMESG_CENTOS = """
+[    0.000000] Linux version 4.18.0-240.el8.x86_64 (mockbuild@kbuilder.bsys.centos.org) (gcc version 8.4.1 20200928 (Red Hat 8.4.1-1) (GCC)) #1 SMP Tue Apr 13 16:24:22 UTC 2021
 """.strip()
-
-REDHAT_RELEASE_FEDORA = """
-Fedora release 23 (Twenty Three)
+DMESG_SUSE = """
+Linux version 2.6.32-431.23.3.el6.x86_64 (sandman@ceph01t6) (gcc version 4.4.7 20120313 (Novell 4.4.7-4) (GCC) ) #1 SMP Tue Jul 29 17:05:14 EDT 2014
 """.strip()
-
-OS_RELEASE_RH = """
-NAME="Red Hat Enterprise Linux"
-ID="rhel"
+DMESG_UNKNOWN = """
+Linux version 2.6.32-431.17.1.el6.x86_64 (mockbuild@lxdist01) (gcc version 4.4.7 20120313 (Red Hat 4.4.7-4) (GCC) ) #1 SMP Thu May 8 08:33:50 CEST 2014
 """.strip()
-
-OS_RELEASE_OL = """
-NAME="Oracle Linux Server"
-ID="ol"
+DMESG_NG = """
+Initializing cgroup subsys cpu
+Command line: ro root=/dev/vg00/lvol1
 """.strip()
-
-REDHAT_RELEASE_UNKNOWN = """
-Test OS
-""".strip()
-
-OS_RELEASE_UNKNOWN = """
-NAME="Test OS"
-ID="test"
-PRETTY_NAME="Test OS"
+DMESG_REDHAT = """
+[    0.000000] Linux version 5.14.0-162.6.1.el9_1.x86_64 (mockbuild@x86-vm-07.build.eng.bos.redhat.com) (gcc (GCC) 11.3.1 20220421 (Red Hat 11.3.1-2), GNU ld version 2.35.2-24.el9) #1 SMP PREEMPT_DYNAMIC Tue Dec 20 06:06:30 EST 2022
 """.strip()
 
 
 # RHEL Test
 def test_is_rhel():
-    # RHEL: redhat-release only
-    rhr = RedhatRelease(context_wrap(REDHAT_RELEASE_91))
-    result = OSRelease(None, rhr, None, None)
-    assert result.is_rhel is True
-    assert result.product == RHEL_STR
-    assert result.issued_packages == []
-
-    # RHEL: os-release only
-    osr = OsRelease(context_wrap(OS_RELEASE_RH))
-    result = OSRelease(None, None, osr, None)
-    assert result.is_rhel is True
-    assert result.product == RHEL_STR
-    assert result.issued_packages == []
-
-    # RHEL 9, rpms only
-    rpms = InstalledRpms(context_wrap(RPMS_JSON_91_WO_KERNEL))
-    result = OSRelease(rpms, None, None, None)
-    assert result.is_rhel is True
-    assert result.product == RHEL_STR
-    assert result.issued_packages == []
-
-    # RHEL 9, rpms and uname
-    rpms = InstalledRpms(context_wrap(RPMS_JSON_91_WO_KERNEL))
+    # RHEL, uname only
     uname = Uname(context_wrap(UNAME_91))
-    result = OSRelease(rpms, None, None, uname)
+    result = OSRelease(uname, None, None)
     assert result.is_rhel is True
-    assert result.product == RHEL_STR
-    assert result.issued_packages == []
+    assert result.release == "Red Hat Enterprise Linux"
+    assert result.reasons == {}
+
+    # RHEL, dmesg only
+    dmesg = DmesgLineList(context_wrap(DMESG_REDHAT))
+    result = OSRelease(None, dmesg, None)
+    assert result.is_rhel is True
+    assert result.release == "Red Hat Enterprise Linux"
+    assert result.product == "Red Hat Enterprise Linux"
+    assert result.reasons == {}
+
+    # RHEL, dmesg and uname
+    dmesg = DmesgLineList(context_wrap(DMESG_REDHAT))
+    result = OSRelease(uname, dmesg, None)
+    assert result.is_rhel is True
+    assert result.release == "Red Hat Enterprise Linux"
+    assert result.reasons == {}
+
+    # RHEL, rpms only
+    rpms = InstalledRpms(context_wrap(RPMS_JSON_91_WO_KERNEL))
+    result = OSRelease(None, None, rpms)
+    assert result.is_rhel is True
+    assert result.release == "Red Hat Enterprise Linux"
+    assert result.reasons == {}
+
+    # RHEL, rpms and uname
+    rpms = InstalledRpms(context_wrap(RPMS_JSON_91_WO_KERNEL))
+    result = OSRelease(uname, None, rpms)
+    assert result.is_rhel is True
+    assert result.release == "Red Hat Enterprise Linux"
+    assert result.reasons == {}
 
     rpms = InstalledRpms(context_wrap(RPMS_JSON_91_W_KERNEL))
-    result = OSRelease(rpms, None, None, uname)
+    result = OSRelease(uname, None, rpms)
     assert result.is_rhel is True
-    assert result.product == RHEL_STR
-    assert result.issued_packages == []
+    assert result.release == "Red Hat Enterprise Linux"
+    assert result.reasons == {}
+
+    # RHEL, rpms, dmesg and uname
+    rpms = InstalledRpms(context_wrap(RPMS_JSON_91_W_KERNEL))
+    result = OSRelease(uname, dmesg, rpms)
+    assert result.is_rhel is True
+    assert result.release == "Red Hat Enterprise Linux"
+    assert result.reasons == {}
 
 
 def test_not_rhel():
     # NON-RHEL: Nothing
-    result = OSRelease(None, None, None, None)
+    result = OSRelease(None, None, None)
     assert result.is_rhel is False
-    assert result.product == "Unknown"
-    assert result.issued_packages == []
+    assert result.release == "Unknown"
+    assert result.reasons.get('reason') == "Nothing to check"
 
-    # NON-RHEL: uname only
-    uname = Uname(context_wrap(UNAME_91))
-    result = OSRelease(None, None, None, uname)
+    # NON-RHEL: BAD rpms
+    rpms = InstalledRpms(context_wrap(RPMS_JSON_ROCKY))
+    result = OSRelease(None, None, rpms)
     assert result.is_rhel is False
-    assert result.product == "Unknown"
-    assert result.issued_packages == []
+    assert result.release == "Rocky"
+    assert result.reasons['release'] == 'rocky-release-3.3-4.el8'
 
-    # NON-RHEL: BAD redhat-release
-    rhr = RedhatRelease(context_wrap(REDHAT_RELEASE_FEDORA))
-    result = OSRelease(None, rhr, None, None)
-    assert result.is_rhel is False
-    assert result.product == "Fedora"
-    assert result.issued_packages == []
-
-    # NON-RHEL: BAD os-release
-    osr = OsRelease(context_wrap(OS_RELEASE_OL))
-    result = OSRelease(None, None, osr, None)
-    assert result.is_rhel is False
-    assert result.product == "Oracle Linux Server"
-    assert result.issued_packages == []
-
-    # NON-RHEL: BAD redhat-release, Good rpms
-    rpms = InstalledRpms(context_wrap(RPMS_JSON_91_W_KERNEL))
-    rhr = RedhatRelease(context_wrap(REDHAT_RELEASE_FEDORA))
-    osr = OsRelease(context_wrap(OS_RELEASE_RH))
-    uname = Uname(context_wrap(UNAME_91))
-    result = OSRelease(rpms, rhr, osr, uname)
-    assert result.is_rhel is False
-    assert result.product == "Fedora"
-    assert result.issued_packages == []
-
-    # NON-RHEL: BAD os-release, Good rpms
-    rpms = InstalledRpms(context_wrap(RPMS_JSON_91_W_KERNEL))
-    rhr = RedhatRelease(context_wrap(REDHAT_RELEASE_91))
-    osr = OsRelease(context_wrap(OS_RELEASE_OL))
-    uname = Uname(context_wrap(UNAME_91))
-    result = OSRelease(rpms, rhr, osr, uname)
-    assert result.is_rhel is False
-    assert result.product == "Oracle Linux Server"
-    assert result.issued_packages == []
-
-    # NON-RHEL: BAD rpms, Good others
     rpms = InstalledRpms(context_wrap(RPMS_JSON_8_NG))
-    rhr = RedhatRelease(context_wrap(REDHAT_RELEASE_86))
-    osr = OsRelease(context_wrap(OS_RELEASE_RH))
-    uname = Uname(context_wrap(UNAME_86))
-    result = OSRelease(rpms, rhr, osr, uname)
+    result = OSRelease(None, None, rpms)
     assert result.is_rhel is False
-    assert result.product == "Unknown"
-    assert result.issued_packages == [
-            'basesystem-11-5.el8', 'bash-4.4.20-4.el8_6',
-            'coreutils-8.30-13.el8', 'dmidecode-3.3-4.el8',
-            'filesystem-3.8-6.el8', 'firewalld-0.9.3-13.el8',
-            'glibc-2.28-211.el8', 'kernel-4.18.0-372.19.1.el8_6',
-            'libgcc-8.5.0-15.el8', 'libselinux-2.9-6.el8']
+    assert result.release == "Unknown"
+    assert result.reasons['faulty_packages'] == [
+        'basesystem-11-5.el8', 'bash-4.4.20-4.el8_6',
+        'coreutils-8.30-13.el8', 'dbus-1.12.8-23.el8',
+        'dmidecode-3.3-4.el8', 'dracut-049-209.git20220815.el8',
+        'filesystem-3.8-6.el8', 'firewalld-0.9.3-13.el8',
+        'glibc-2.28-211.el8', 'gmp-6.1.2-10.el8',
+        'libgcc-8.5.0-15.el8', 'libselinux-2.9-6.el8']
 
-    # NON-RHEL: NO rpms, both os-release  and redhat-release are NG
-    rhr = RedhatRelease(context_wrap(REDHAT_RELEASE_UNKNOWN))
-    osr = OsRelease(context_wrap(OS_RELEASE_UNKNOWN))
-    result = OSRelease(None, rhr, osr, None)
+    # NON-RHEL: BAD rpms with uname
+    uname = Uname(context_wrap(UNAME_86))
+    result = OSRelease(uname, None, rpms)
     assert result.is_rhel is False
-    assert result.product == "Unknown"
-    assert result.issued_packages == []
+    assert result.release == "SUSE"
+    assert result.reasons['kernel_vendor'] == 'suse, Inc.'
+    assert result.reasons['faulty_packages'] == [
+        'basesystem-11-5.el8', 'bash-4.4.20-4.el8_6',
+        'coreutils-8.30-13.el8', 'dbus-1.12.8-23.el8',
+        'dmidecode-3.3-4.el8', 'dracut-049-209.git20220815.el8',
+        'filesystem-3.8-6.el8', 'firewalld-0.9.3-13.el8',
+        'glibc-2.28-211.el8', 'gmp-6.1.2-10.el8',
+        'kernel-4.18.0-372.19.1.el8_6', 'libgcc-8.5.0-15.el8',
+        'libselinux-2.9-6.el8']
+
+    # NON-RHEL: BAD dmesg
+    dmesg = DmesgLineList(context_wrap(DMESG_NG))
+    result = OSRelease(None, dmesg, None)
+    assert result.is_rhel is False
+    assert result.release == "Unknown"
+    assert result.reasons.get('reason') == "Nothing to check"
+
+    dmesg = DmesgLineList(context_wrap(DMESG_SUSE))
+    result = OSRelease(None, dmesg, None)
+    assert result.is_rhel is False
+    assert result.release == "SUSE"
+    assert result.reasons['build_info'] == DMESG_SUSE
+
+    dmesg = DmesgLineList(context_wrap(DMESG_CENTOS))
+    result = OSRelease(None, dmesg, None)
+    assert result.is_rhel is False
+    assert result.release == "CentOS"
+    assert result.reasons['build_info'] == DMESG_CENTOS
+
+    dmesg = DmesgLineList(context_wrap(DMESG_UNKNOWN))
+    result = OSRelease(None, dmesg, None)
+    assert result.is_rhel is False
+    assert result.release == "Unknown"
+    assert result.reasons['build_info'] == DMESG_UNKNOWN
+
+    # NON-RHEL: BAD uname
+    uname = Uname(context_wrap(UNAME_ORACLE))
+    result = OSRelease(uname, None, None)
+    assert result.is_rhel is False
+    assert result.release == "Oracle"
+    assert result.reasons.get('kernel') == "4.18.0-372.19.1.el8_6uek.x86_64"
+
+    uname = Uname(context_wrap(UNAME_FEDORA))
+    result = OSRelease(uname, None, None)
+    assert result.is_rhel is False
+    assert result.release == "Fedora"
+    assert result.reasons.get('kernel') == "3.17.8-200.fc20.x86_64"
+
+    uname = Uname(context_wrap(UNAME_UNKNOWN))
+    result = OSRelease(uname, None, None)
+    assert result.is_rhel is False
+    assert result.release == "Unknown"
+    assert result.reasons.get('kernel') == "2.6.39.4-9.NSN.kiuas"
+
+    # NON-RHEL: Bad Uname + Dmesg
+    dmesg = DmesgLineList(context_wrap(DMESG_NG))
+    uname = Uname(context_wrap(UNAME_ORACLE))
+    result = OSRelease(uname, dmesg, None)
+    assert result.is_rhel is False
+    assert result.release == "Oracle"
+    assert result.reasons['kernel'] == "4.18.0-372.19.1.el8_6uek.x86_64"
+
+    dmesg = DmesgLineList(context_wrap(DMESG_ORACLE))
+    result = OSRelease(uname, dmesg, None)
+    assert result.is_rhel is False
+    assert result.release == "Oracle"
+    assert result.reasons['build_info'] == DMESG_ORACLE
+    assert result.reasons['kernel'] == "4.18.0-372.19.1.el8_6uek.x86_64"
+    assert 'kernel_vendor' not in result.reasons  # No RPMs
+
+    # NON-RHEL: Bad Uname + Dmesg + RPMs
+    dmesg = DmesgLineList(context_wrap(DMESG_ORACLE))
+    uname = Uname(context_wrap(UNAME_86))
+    rpms = InstalledRpms(context_wrap(RPMS_JSON_8_NG))
+    result = OSRelease(uname, dmesg, rpms)
+    assert result.is_rhel is False
+    assert result.release == "SUSE"  # from Dmesg first then updated by RPMS
+    assert result.reasons['build_info'] == DMESG_ORACLE  # from Dmesg
+    assert 'kernel' not in result.reasons  # Uname is OK
+    assert result.reasons['kernel_vendor'] == "suse, Inc."
+
+    dmesg = DmesgLineList(context_wrap(DMESG_ORACLE))
+    uname = Uname(context_wrap(UNAME_UNKNOWN))
+    rpms = InstalledRpms(context_wrap(RPMS_JSON_8_NG))
+    result = OSRelease(uname, dmesg, rpms)
+    assert result.is_rhel is False
+    assert result.release == "Oracle"  # from Dmesg
+    assert result.reasons['build_info'] == DMESG_ORACLE  # from Dmesg
+    assert result.reasons.get('kernel') == "2.6.39.4-9.NSN.kiuas"
+    assert 'kernel_vendor' not in result.reasons  # running kernel not in RPMs
+
+    dmesg = DmesgLineList(context_wrap(DMESG_ORACLE))
+    uname = Uname(context_wrap(UNAME_ORACLE))
+    result = OSRelease(uname, dmesg, rpms)
+    assert result.is_rhel is False
+    assert result.release == "Oracle"
+    assert result.reasons['build_info'] == DMESG_ORACLE
+    assert result.reasons['kernel'] == "4.18.0-372.19.1.el8_6uek.x86_64"
+    assert result.reasons['kernel_vendor'] == "Oracle America"
+    assert result.reasons['faulty_packages'] == [
+        'basesystem-11-5.el8', 'bash-4.4.20-4.el8_6',
+        'coreutils-8.30-13.el8', 'dbus-1.12.8-23.el8',
+        'dmidecode-3.3-4.el8', 'dracut-049-209.git20220815.el8',
+        'filesystem-3.8-6.el8', 'firewalld-0.9.3-13.el8',
+        'glibc-2.28-211.el8', 'gmp-6.1.2-10.el8',
+        'kernel-4.18.0-372.19.1.el8_6uek',
+        'libgcc-8.5.0-15.el8', 'libselinux-2.9-6.el8']
+
+
+def test_osr_doc():
+    dmesg = DmesgLineList(context_wrap(DMESG_ORACLE))
+    uname = Uname(context_wrap(UNAME_ORACLE))
+    rpms = InstalledRpms(context_wrap(RPMS_JSON_8_NG))
+    env = {
+        'osr': OSRelease(uname, dmesg, rpms),
+    }
+    failed, total = doctest.testmod(os_release, globs=env)
+    assert failed == 0


### PR DESCRIPTION
- It's not good for the old OSRelease depends on the 'redhat-release'
  and 'os-release' which can be easily modified
- Introduce the `dmesg` and update the logic of `uname` and `rpms`
  processing
- Add one more property 'reasons' to return the reasons why it's not
  RHEL

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

- fixed the "OSRelease.product" returns "Red Hat Enterprise Linux" when `is_rhel==False`
