### PR TITLE
fix: Add unit tests for listdir spec factory

### DIFF
--- a/insights/tests/core/spec_factory/test_listdir.py
+++ b/insights/tests/core/spec_factory/test_listdir.py
@@ -1,0 +1,82 @@
+import os
+import pytest
+import tempfile
+
+from insights.core import dr
+from insights.core.context import HostContext
+from insights.core.spec_factory import listdir
+
+
+@pytest.fixture
+def sample_directory(scope="module"):
+    tmpdir = tempfile.mkdtemp()
+    os.mkdir(tmpdir + "/dir1")
+    os.mkdir(tmpdir + "/dir2")
+    for d in ["dir1", "dir2"]:
+        for f in ["file_a", "file_b"]:
+            fd = open(tmpdir + "/" + d + "/" + f, "w")
+            fd.close()
+    yield tmpdir
+    for d in ["dir1", "dir2"]:
+        for f in ["file_a", "file_b"]:
+            os.remove(tmpdir + "/" + d + "/" + f)
+    os.rmdir(tmpdir + "/dir1")
+    os.rmdir(tmpdir + "/dir2")
+    os.rmdir(tmpdir)
+
+
+def run_listdir_test(sample_directory, spec):
+    ctx = HostContext()
+    ctx.root = sample_directory
+    broker = dr.Broker()
+    broker[HostContext] = ctx
+    broker = dr.run([spec], broker)
+    return broker
+
+
+CASES_PATH_FORMAT = [
+    # default path_format, directory
+    (listdir("dir1/"), ["file_a", "file_b"]),
+    # default path_format, glob
+    (listdir("*/*"), ["file_a", "file_b", "file_a", "file_b"]),
+]
+
+
+CASES_IGNORE = [
+    # ignore filter works on basenames when listing a directory
+    (listdir("dir1", ignore=".*a"), ["file_b"]),
+    # ignore filter works ONLY on basenames paths when listing a directory (nothing is filtered out)
+    (listdir("dir1", ignore="dir1.*"), ["file_a", "file_b"]),
+    # ignore filter works on relative paths when matching a glob (keeps only files from dir2)
+    (listdir("*/*", ignore="dir1.*"), ["file_a", "file_b"]),
+    # ignore filter does not cause ContentException when listing a directory
+    (listdir("dir1", ignore="file"), []),
+    # ignore filter does not cause ContentException when matching a glob
+    (listdir("*/*", ignore="dir"), []),
+]
+
+
+@pytest.mark.parametrize(
+    "spec,result", CASES_PATH_FORMAT + CASES_IGNORE
+)
+def test_non_empty_results(sample_directory, spec, result):
+    broker = run_listdir_test(sample_directory, spec)
+    assert broker[spec] == result
+
+
+def test_ignore_uses_absolute_path_with_glob(sample_directory):
+    spec = listdir("*/*", ignore=sample_directory)
+    broker = run_listdir_test(sample_directory, spec)
+    assert broker[spec] == []
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        listdir("nothing/there"),
+        listdir("nothing/there/*"),
+    ]
+)
+def test_nothing_found(sample_directory, spec):
+    broker = run_listdir_test(sample_directory, spec)
+    assert spec not in broker


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

I am developing a rule that could use an [extension](https://github.com/RedHatInsights/insights-core/pull/3692) of the `listdir` spec factory. The current implementation turned out to be incredibly difficult to change while preserving 100% backwards compatibility.

I would like to use this PR to discuss which of the corner cases of the current implementation are intentional and which might be lifted. The final tests that get merged will declare the intended behavior of the spec factory that future extensions and/or refactoring should not change unintentionally.

There are three things that I would like to challenge:

#### `ignore` filter does not raise `ContentException` when the result is empty

How is the situation different from a directory being empty or a glob not matching anything? The whole spec defines a desired set of files and directories using a `path` and an `ignore` filter. The "nothing found" situation should be handled the same regardless of which part of the specification causes it.

The only case that might be worth distinguishing is the intention to list a non-existent directory. However, the implementation handles this case by considering `path` a glob, where this distinction doesn't make sense.

I see three ways to achieve a more consistent behavior:
1. Always return a list, possibly an empty one. This would be the preferred semantics from my point of view, but this would be a breaking change for the two existing `listdir` specs.
2. Always raise `ContentException` instead of returning an empty list. None of the two existing listdir specs uses an `ignore` filter so this change would be safe.
3. Split `listdir` and `listglob`, allowing for greater control of the "empty" corner cases for `listdir`. `ContentException` would be raised only if the directory didn't exist. However, it would still be a breaking change for the two existing `listdir` specs.

#### `ignore` filter works on absolute paths when the path is a glob

See the `test_ignore_uses_absolute_path_with_glob` test. Is it really the intended behavior? For comparison, the ignore filter works only on basenames when `path` is an existing directory (see the cases in `CASES_IGNORE`).

In my opinion, the filter should work with basenames when listing a directory and with paths relative to the execution context root when matching a glob.

This is another reason to split `listdir` and `listglob`, imho.

#### Returning basenames when matching a glob

As my [use case](https://github.com/openshift/insights-operator/blob/master/docs/gathered-data.md#configmaps) demonstrates, basenames are not necessarily enough when an application needs to use a glob.

Splitting `listdir` and `listglob` would solve this. It would also eliminate the need for the `path_format` argument that I drafted [here](https://github.com/RedHatInsights/insights-core/pull/3692).