### PR TITLE
feat: Split listdir to listdir and listglob spec factories

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -690,14 +690,15 @@ class listdir(object):
     path.
 
     Args:
-        path (str): directory or glob pattern to list.
+        path (str): directory to list.
         context (ExecutionContext): the context under which the datasource
             should run.
-        ignore (str): regular expression defining paths to ignore.
+        ignore (str): regular expression defining names to ignore.
 
     Returns:
-        function: A datasource that returns the list of files and directories
-            in the directory specified by path
+        function: A datasource that returns a sorted list of file and directory
+            names in the directory specified by path. The list will be empty when
+            the directory is empty or all names get ignored.
     """
 
     def __init__(self, path, context=None, ignore=None, deps=[]):
@@ -712,11 +713,11 @@ class listdir(object):
         ctx = _get_context(self.context, broker)
         p = os.path.join(ctx.root, self.path.lstrip('/'))
         p = ctx.locate_path(p)
-        result = sorted(os.listdir(p)) if os.path.isdir(p) else sorted(glob(p))
-
-        if result:
-            return [os.path.basename(r) for r in result if not self.ignore_func(r)]
-        raise ContentException("Can't list %s or nothing there." % p)
+        try:
+            result = os.listdir(p)
+        except OSError as e:
+            raise ContentException(str(e))
+        return sorted([r for r in result if not self.ignore_func(r)])
 
 
 class simple_command(object):

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -720,6 +720,31 @@ class listdir(object):
         return sorted([r for r in result if not self.ignore_func(r)])
 
 
+class listglob(listdir):
+    """
+    List paths matching a glob pattern.
+
+    Args:
+        pattern (str): glob pattern to list.
+        context (ExecutionContext): the context under which the datasource
+            should run.
+        ignore (str): regular expression defining paths to ignore.
+
+    Returns:
+        function: A datasource that returns the list of paths that match
+            the given glob pattern. The list will be empty when nothing matches.
+    """
+    def __call__(self, broker):
+        ctx = _get_context(self.context, broker)
+        p = os.path.join(ctx.root, self.path.lstrip('/'))
+        p = ctx.locate_path(p)
+        result = glob(p)
+        # generator expression; we don't need the full list at this step
+        result = (os.path.relpath(r, start=ctx.root) for r in result)
+        result = sorted([r for r in result if not self.ignore_func(r)])
+        return result
+
+
 class simple_command(object):
     """
     Execute a simple command that has no dynamic arguments

--- a/insights/tests/core/spec_factory/test_listdir.py
+++ b/insights/tests/core/spec_factory/test_listdir.py
@@ -1,0 +1,82 @@
+import os
+import pytest
+import tempfile
+
+from insights.core import dr
+from insights.core.context import HostContext
+from insights.core.spec_factory import listdir
+
+
+@pytest.fixture
+def sample_directory(scope="module"):
+    tmpdir = tempfile.mkdtemp()
+    os.mkdir(tmpdir + "/dir1")
+    os.mkdir(tmpdir + "/dir2")
+    for d in ["dir1", "dir2"]:
+        for f in ["file_a", "file_b"]:
+            fd = open(tmpdir + "/" + d + "/" + f, "w")
+            fd.close()
+    yield tmpdir
+    for d in ["dir1", "dir2"]:
+        for f in ["file_a", "file_b"]:
+            os.remove(tmpdir + "/" + d + "/" + f)
+    os.rmdir(tmpdir + "/dir1")
+    os.rmdir(tmpdir + "/dir2")
+    os.rmdir(tmpdir)
+
+
+def run_listdir_test(sample_directory, spec):
+    ctx = HostContext()
+    ctx.root = sample_directory
+    broker = dr.Broker()
+    broker[HostContext] = ctx
+    broker = dr.run([spec], broker)
+    return broker
+
+
+CASES_PATH_TYPE = [
+    # directory
+    (listdir("dir1/"), ["file_a", "file_b"]),
+    # glob
+    (listdir("*/*"), ["file_a", "file_b", "file_a", "file_b"]),
+]
+
+
+CASES_IGNORE = [
+    # ignore filter works on basenames when listing a directory
+    (listdir("dir1", ignore=".*a"), ["file_b"]),
+    # ignore filter works ONLY on basenames paths when listing a directory (nothing is filtered out)
+    (listdir("dir1", ignore="dir1.*"), ["file_a", "file_b"]),
+    # ignore filter works on relative paths when matching a glob (keeps only files from dir2)
+    (listdir("*/*", ignore="dir1.*"), ["file_a", "file_b"]),
+    # ignore filter does not cause ContentException when listing a directory
+    (listdir("dir1", ignore="file"), []),
+    # ignore filter does not cause ContentException when matching a glob
+    (listdir("*/*", ignore="dir"), []),
+]
+
+
+@pytest.mark.parametrize(
+    "spec,result", CASES_PATH_TYPE + CASES_IGNORE
+)
+def test_non_empty_results(sample_directory, spec, result):
+    broker = run_listdir_test(sample_directory, spec)
+    assert broker[spec] == result
+
+
+def test_ignore_uses_absolute_path_with_glob(sample_directory):
+    spec = listdir("*/*", ignore=sample_directory)
+    broker = run_listdir_test(sample_directory, spec)
+    assert broker[spec] == []
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        listdir("nothing/there"),
+        listdir("nothing/there/*"),
+    ]
+)
+def test_nothing_found(sample_directory, spec):
+    broker = run_listdir_test(sample_directory, spec)
+    assert spec not in broker

--- a/insights/tests/core/spec_factory/test_listdir.py
+++ b/insights/tests/core/spec_factory/test_listdir.py
@@ -4,22 +4,25 @@ import tempfile
 
 from insights.core import dr
 from insights.core.context import HostContext
+from insights.core.exceptions import ContentException
 from insights.core.spec_factory import listdir
 
 
 @pytest.fixture
 def sample_directory(scope="module"):
+    def touch(fpath):
+        fd = open(fpath, "w")
+        fd.close()
+
+    # Python2 does not have tempfile.TemporaryDirectory
     tmpdir = tempfile.mkdtemp()
     os.mkdir(tmpdir + "/dir1")
     os.mkdir(tmpdir + "/dir2")
-    for d in ["dir1", "dir2"]:
-        for f in ["file_a", "file_b"]:
-            fd = open(tmpdir + "/" + d + "/" + f, "w")
-            fd.close()
+    touch(tmpdir + "/dir1/file_a")
+    touch(tmpdir + "/dir1/file_b")
     yield tmpdir
-    for d in ["dir1", "dir2"]:
-        for f in ["file_a", "file_b"]:
-            os.remove(tmpdir + "/" + d + "/" + f)
+    os.remove(tmpdir + "/dir1/file_a")
+    os.remove(tmpdir + "/dir1/file_b")
     os.rmdir(tmpdir + "/dir1")
     os.rmdir(tmpdir + "/dir2")
     os.rmdir(tmpdir)
@@ -34,49 +37,43 @@ def run_listdir_test(sample_directory, spec):
     return broker
 
 
-CASES_PATH_TYPE = [
-    # directory
+CASES_RETURNS_LIST = [
+    # directory with files, no filter
     (listdir("dir1/"), ["file_a", "file_b"]),
-    # glob
-    (listdir("*/*"), ["file_a", "file_b", "file_a", "file_b"]),
-]
-
-
-CASES_IGNORE = [
-    # ignore filter works on basenames when listing a directory
+    # empty directory, no filter
+    (listdir("dir2/"), []),
+    # ignore filter works on basenames
     (listdir("dir1", ignore=".*a"), ["file_b"]),
-    # ignore filter works ONLY on basenames paths when listing a directory (nothing is filtered out)
+    # ignore filter works ONLY on basenames (nothing is filtered out here)
     (listdir("dir1", ignore="dir1.*"), ["file_a", "file_b"]),
-    # ignore filter works on relative paths when matching a glob (keeps only files from dir2)
-    (listdir("*/*", ignore="dir1.*"), ["file_a", "file_b"]),
-    # ignore filter does not cause ContentException when listing a directory
+    # empty list is returned when the ignore filter matches all basenames
     (listdir("dir1", ignore="file"), []),
-    # ignore filter does not cause ContentException when matching a glob
-    (listdir("*/*", ignore="dir"), []),
 ]
 
 
 @pytest.mark.parametrize(
-    "spec,result", CASES_PATH_TYPE + CASES_IGNORE
+    "spec,result", CASES_RETURNS_LIST
 )
-def test_non_empty_results(sample_directory, spec, result):
+def test_returns_list(sample_directory, spec, result):
     broker = run_listdir_test(sample_directory, spec)
     assert broker[spec] == result
-
-
-def test_ignore_uses_absolute_path_with_glob(sample_directory):
-    spec = listdir("*/*", ignore=sample_directory)
-    broker = run_listdir_test(sample_directory, spec)
-    assert broker[spec] == []
 
 
 @pytest.mark.parametrize(
     "spec",
     [
+        # directory does not exist
         listdir("nothing/there"),
-        listdir("nothing/there/*"),
+        # path is not a directory
+        listdir("dir1/file_a"),
     ]
 )
-def test_nothing_found(sample_directory, spec):
+def test_raises_content_exception(sample_directory, spec):
     broker = run_listdir_test(sample_directory, spec)
     assert spec not in broker
+    # PluginType masks ContentException as a new SkipComponent even though
+    # ContentException is a SkipComponet instance; it is not possible to test
+    # that a component raises ContentException using the broker even with
+    # broker.store_skips == True
+    with pytest.raises(ContentException):
+        spec(broker)

--- a/insights/tests/core/spec_factory/test_listglob.py
+++ b/insights/tests/core/spec_factory/test_listglob.py
@@ -1,0 +1,60 @@
+import os
+import pytest
+import tempfile
+
+from insights.core import dr
+from insights.core.context import HostContext
+from insights.core.spec_factory import listglob
+
+
+@pytest.fixture
+def sample_directory(scope="module"):
+    tmpdir = tempfile.mkdtemp()
+    os.mkdir(tmpdir + "/dir1")
+    os.mkdir(tmpdir + "/dir2")
+    for d in ["dir1", "dir2"]:
+        for f in ["file_a", "file_b"]:
+            fd = open(tmpdir + "/" + d + "/" + f, "w")
+            fd.close()
+    yield tmpdir
+    for d in ["dir1", "dir2"]:
+        for f in ["file_a", "file_b"]:
+            os.remove(tmpdir + "/" + d + "/" + f)
+    os.rmdir(tmpdir + "/dir1")
+    os.rmdir(tmpdir + "/dir2")
+    os.rmdir(tmpdir)
+
+
+def run_listglob_test(sample_directory, spec):
+    ctx = HostContext()
+    ctx.root = sample_directory
+    broker = dr.Broker()
+    broker[HostContext] = ctx
+    broker = dr.run([spec], broker)
+    return broker
+
+
+@pytest.mark.parametrize(
+    "spec,result",
+    [
+        # return empty list if nothing matches
+        (listglob("nothing/there"), []),
+        (listglob("nothing/there/*"), []),
+        (listglob("dir1/*", ignore="file"), []),
+        # matching starts at the execution context root
+        (listglob("*"), ["dir1", "dir2"]),
+        # a more complex glob
+        (listglob("*/*"), ["dir1/file_a", "dir1/file_b", "dir2/file_a", "dir2/file_b"]),
+        # ignore filter works on paths relative to the execution context root
+        (listglob("*/*", ignore="dir1.*"), ["dir2/file_a", "dir2/file_b"]),
+    ]
+)
+def test_match_results(sample_directory, spec, result):
+    broker = run_listglob_test(sample_directory, spec)
+    assert broker[spec] == result
+
+
+def test_ignore_does_not_use_absolute_paths(sample_directory):
+    spec = listglob("dir1/file_a", ignore=sample_directory)
+    broker = run_listglob_test(sample_directory, spec)
+    assert broker[spec] == ["dir1/file_a"]


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The exact behavior of specs created using the listdir spec factory was difficult to predict because it depended on a number of subtle details:

- ContentException was raised instead of an empty list in some cases, an empty list was returned in other cases.
- The ignore filter was applied to returned values in some cases and to absolute paths in other cases.
- The specs returned only basenames of files and directories even for a complex glob (e.g. `some/*/file`) where returning relative paths makes more sense.

A dedicated `listglob` spec factory can have a more predictable behavior while keeping the implementation simple. In most cases, users will know if they want to list a directory or a glob pattern. An amphibious spec factory is not necessary.
    
This MR:

- Removes support for globs from `listdir` (no known specs rely on this functionality)
- Updates `listdir` to raise `ContentException` only if the specificed path is not an existing directory; an empty list will be returned for empty directories (SkipComponent will be raised one step later for known listdir specs; the change should not affect any rules).
- Adds a `listglob` spec factory with behavior optimized for listing globs