### PR TITLE
Fix malware SSL error fix - make it more flexible

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -702,7 +702,7 @@ class MalwareDetectionClient:
                     logger.error("Unable to download rules from %s: %s", self.rules_location, str(e))
                     exit(constants.sig_kill_bad)
 
-                if 'CERTIFICATE_VERIFY_FAILED' in str(e):
+                if re.search('SSL.*verify.failed', str(e), re.IGNORECASE):
                     # SSL error occurred, possibly due to a custom CA cert, try using a CA bundle for cert verification
                     self.insights_config.cert_verify = self._get_config_option('ca_cert', ca_cert)
                     logger.debug("Trying cert_verify value %s ...", self.insights_config.cert_verify)

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -461,23 +461,26 @@ class TestGetRules:
         # Because we've set retries to 3, the last attempted retry will wait 4 seconds (= 2**2)
         log_mock.debug.assert_called_with("Trying again in %d seconds ...", 4)
 
-        # CERTIFICATE_VERIFY_FAILED SSL Errors will cause a different CA certificate bundle to be tried
+        # Certificate verify failed SSL Errors will cause a different CA certificate bundle to be tried
         ca_cert = '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'  # default ca cert bundle file to try
-        get.side_effect = SSLError("CERTIFICATE_VERIFY_FAILED")
+        ssl_error = "SSL Error: certificate verify failed"
+        get.side_effect = SSLError(ssl_error)
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(retries=2))
         get.assert_called_with(expected_rules_url, log_response_text=False, verify=ca_cert)
         log_mock.debug.assert_called_with("Trying cert_verify value %s ...", ca_cert)
-        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "CERTIFICATE_VERIFY_FAILED")
+        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, ssl_error)
 
         # CA certificate bundles can be specified in the config file or via env vars too
         ca_cert = '/some/cert/file.crt'
         os.environ['CA_CERT'] = ca_cert  # customers can specify their own ca bundle file via config/env vars
+        ssl_error = "SslError CERTIFICATE_VERIFY_FAILED"
+        get.side_effect = SSLError(ssl_error)
         with pytest.raises(SystemExit):
             MalwareDetectionClient(InsightsConfig(retries=2))
         get.assert_called_with(expected_rules_url, log_response_text=False, verify=ca_cert)
         log_mock.debug.assert_called_with("Trying cert_verify value %s ...", ca_cert)
-        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "CERTIFICATE_VERIFY_FAILED")
+        log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, ssl_error)
 
     @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': '//console.redhat.com/rules.yar'})
     @patch(FIND_YARA_TARGET, return_value=YARA)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

The malware SSL error fix lacked flexibility in detecting the SSL error.  This PR uses a regex to determine if the SSL error has occurred.  It probably needs a better way of determining an SSL error occurred other than string matching the SSL error message, but this seems to work well enough (for the time being). 