### PR TITLE
fix: do not load all config in malware_detection

### DIFF
--- a/insights/specs/datasources/malware_detection.py
+++ b/insights/specs/datasources/malware_detection.py
@@ -20,7 +20,9 @@ class MalwareDetectionSpecs(Specs):
 
         try:
             # Only run malware-detection if it was passed as an option to insights-client
-            insights_config = InsightsConfig().load_all()
+            insights_config = InsightsConfig()
+            insights_config._load_config_file()
+            insights_config._load_env()
             auto_config.try_auto_configuration(insights_config)
             if not (insights_config and hasattr(insights_config, 'app') and insights_config.app == 'malware-detection'):
                 raise SkipComponent("Only run malware-detection app when specifically requested via --collector option")


### PR DESCRIPTION
- calling the '_load_config_file' and '_load_env' is sufficent

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

- fix the following issues reported in the CI pipelines:
```
2023-02-02 21:07:50 INFO Starting to collect Insights data for rhiqe.d6aa1c71-fd9c-447f-a5bf-58b04d1a4f6c.iqe-insights-client-plugin
Unexpected exception in malware-detection app: list index out of range
Traceback (most recent call last):
  File "/iqe_venv/lib/python3.8/site-packages/insights/specs/datasources/malware_detection.py", line 23, in malware_detection_app
    insights_config = InsightsConfig().load_all()
  File "/iqe_venv/lib/python3.8/site-packages/insights/client/config.py", line 672, in load_all
    self._load_command_line(conf_only=True)
  File "/iqe_venv/lib/python3.8/site-packages/insights/client/config.py", line 592, in _load_command_line
    parser = argparse.ArgumentParser()
  File "/usr/local/lib/python3.8/argparse.py", line 1660, in __init__
    prog = _os.path.basename(_sys.argv[0])
IndexError: list index out of range
```