### PR TITLE
Log malware tracebacks to the log file, not the console

### DIFF
--- a/insights/specs/datasources/malware_detection.py
+++ b/insights/specs/datasources/malware_detection.py
@@ -33,6 +33,8 @@ class MalwareDetectionSpecs(Specs):
         except SkipComponent as msg:
             raise SkipComponent("Skipping malware-detection app: {0}".format(str(msg)))
         except Exception as err:
+            from traceback import format_exc
             err_msg = "Unexpected exception in malware-detection app: {0}".format(str(err))
-            logger.exception(err_msg)
+            logger.error(err_msg)
+            logger.debug(format_exc())
             raise SkipComponent(err_msg)


### PR DESCRIPTION
* Helps integration tests to run smoothly

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

Hopefully this fixes an issue with the IQE tests where malware is displaying this error and causing problems with the tests:
```
2023-02-02 21:07:50 INFO Starting to collect Insights data for rhiqe.d6aa1c71-fd9c-447f-a5bf-58b04d1a4f6c.iqe-insights-client-plugin
Unexpected exception in malware-detection app: list index out of range
Traceback (most recent call last):
  File "/iqe_venv/lib/python3.8/site-packages/insights/specs/datasources/malware_detection.py", line 23, in malware_detection_app
    insights_config = InsightsConfig().load_all()
  File "/iqe_venv/lib/python3.8/site-packages/insights/client/config.py", line 672, in load_all
    self._load_command_line(conf_only=True)
  File "/iqe_venv/lib/python3.8/site-packages/insights/client/config.py", line 592, in _load_command_line
    parser = argparse.ArgumentParser()
  File "/usr/local/lib/python3.8/argparse.py", line 1660, in __init__
    prog = _os.path.basename(_sys.argv[0])
IndexError: list index out of range
```

Its a follow on from PR https://github.com/RedHatInsights/insights-core/pull/3698