### PR TITLE
feat: logrotate client implementation

### DIFF
--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -84,6 +84,8 @@ class InsightsConstants(object):
     valid_compressors = ("gz", "xz", "bz2", "none")
     # RPM version in which core collection was released
     core_collect_rpm_version = '3.1.0'
+    # The last RPM version before logrotate was released
+    rpm_version_before_logrotate = '3.1.8'
     rhsm_facts_dir = os.path.join(os.sep, 'etc', 'rhsm', 'facts')
     rhsm_facts_file = os.path.join(os.sep, 'etc', 'rhsm', 'facts', 'insights-client.facts')
     # In MB

--- a/insights/tests/client/test_client.py
+++ b/insights/tests/client/test_client.py
@@ -1,10 +1,13 @@
 from contextlib import contextmanager
 from shutil import rmtree
+import logging
+import logging.handlers
 import sys
 import os
 import pytest
 
 from insights.client import InsightsClient
+from insights.client.client import get_file_handler
 from insights.client.archive import InsightsArchive
 from insights.client.config import InsightsConfig
 from insights import package_info
@@ -112,6 +115,32 @@ def _mock_no_register_files_machineid_present():
     finally:
         rmtree(TEMP_TEST_REG_DIR)
         rmtree(TEMP_TEST_REG_DIR2)
+
+
+@patch('insights.client.client.os.path.dirname')
+@patch('insights.client.client.get_version_info')
+def test_get_log_handler_by_client_version(get_version_info, mock_path_dirname):
+    '''
+    Verify that get_log_handler() returns
+    the correct file handler depending on
+    the client rpm version.
+    '''
+    mock_path_dirname.return_value = "mock_dirname"
+
+    # RPM version is older than 3.1.8
+    get_version_info.return_value = {'client_version': '3.1.0'}
+    conf = InsightsConfig(logging_file='/tmp/insights.log')
+    assert isinstance(get_file_handler(conf), logging.handlers.RotatingFileHandler) is True
+
+    # RPM version is 3.1.8
+    get_version_info.return_value = {'client_version': '3.1.8'}
+    conf = InsightsConfig(logging_file='/tmp/insights.log')
+    assert isinstance(get_file_handler(conf), logging.handlers.RotatingFileHandler) is True
+
+    # RPM version is newer than 3.1.8
+    get_version_info.return_value = {'client_version': '3.1.9'}
+    conf = InsightsConfig(logging_file='/tmp/insights.log')
+    assert isinstance(get_file_handler(conf), logging.FileHandler) is True
 
 
 @patch('insights.client.client.generate_machine_id')


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This patch updates the logging file handler to no longer use a `RotatingFileHandler`
to prepare for the logrotate feature implementation in insights-client.
**Associated insights-client changes:** [insights-client PR](https://gitlab.cee.redhat.com/insights-platform/insights-client/-/merge_requests/49)
