### PR TITLE
fix: let 'get_filters' work for filterable=True specs only

### DIFF
--- a/insights/core/filters.py
+++ b/insights/core/filters.py
@@ -129,7 +129,7 @@ def get_filters(component):
     def inner(c, filters=None):
         filters = filters or set()
 
-        if hasattr(c, 'filterable') and getattr(c, 'filterable') is False:
+        if hasattr(c, 'filterable') and c.filterable is False:
             return filters
 
         if not ENABLED:

--- a/insights/core/filters.py
+++ b/insights/core/filters.py
@@ -128,6 +128,10 @@ def get_filters(component):
     """
     def inner(c, filters=None):
         filters = filters or set()
+
+        if hasattr(c, 'filterable') and getattr(c, 'filterable') is False:
+            return filters
+
         if not ENABLED:
             return filters
 


### PR DESCRIPTION
- fix: #3704

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
- fix: #3704
