### PR TITLE
feat: Add store_skips argument to run_input_data

### DIFF
--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -105,13 +105,14 @@ def deep_compare(result, expected):
     assert eq(result, expected), result
 
 
-def run_input_data(component, input_data):
+def run_input_data(component, input_data, store_skips=False):
     broker = dr.Broker()
     for k, v in input_data.data.items():
         broker[k] = v
 
     graph = dr.get_dependency_graph(component)
     broker = dr.run(graph, broker=broker)
+    broker.store_skips = store_skips
     for v in broker.tracebacks.values():
         print(v)
     return broker


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

PR #3663 added a `Broker.store_skips` attribute that allows for storing `SkipComponent` exceptions in the broker. This commit makes the feature available in tests based on the `run_input_data` function.
