### PR TITLE
chore: use RHEL for os_release.release

### DIFF
--- a/insights/combiners/os_release.py
+++ b/insights/combiners/os_release.py
@@ -259,8 +259,7 @@ class OSRelease(object):
             ret.update(data)
             return ret
 
-        self._is_rhel = True
-        self._release = 'Red Hat Enterprise Linux'
+        self._release = 'RHEL'
         self._reasons = {}
         _dmesg = dmesg.linux_version if dmesg else dmesg
         if not list(filter(None, [uname, _dmesg, rpms])):
@@ -270,12 +269,10 @@ class OSRelease(object):
                 ret = _from_os_release(osr) if osr else dict()
                 ret.update(_from_redhat_release(rhr)) if rhr else None
                 if ret.get('other_linux', 'RHEL') != 'RHEL':
-                    self._is_rhel = False
                     self._release = ret['other_linux']
                     self._reasons = {'reason': 'NON-RHEL: os-release/redhat-release'}
             else:
                 # Nothing means NON-RHEL
-                self._is_rhel = False
                 self._release = 'Unknown'
                 self._reasons = {'reason': 'Nothing available to check'}
         else:
@@ -288,7 +285,6 @@ class OSRelease(object):
                                 result, _from_installed_rpms(rpms, uname)))
             # 'other_linux' means NON-RHEL
             if 'other_linux' in result and result['other_linux'] != 'RHEL':
-                self._is_rhel = False
                 self._release = result.pop('other_linux')
                 self._reasons = result
 
@@ -297,7 +293,7 @@ class OSRelease(object):
         """
         Returns True if it's RHEL, False for NON-RHEL.
         """
-        return self._is_rhel
+        return self._release == 'RHEL'
 
     @property
     def release(self):

--- a/insights/tests/combiners/test_os_release.py
+++ b/insights/tests/combiners/test_os_release.py
@@ -111,63 +111,63 @@ def test_is_rhel():
     uname = Uname(context_wrap(UNAME_91))
     result = OSRelease(uname, None, None, None, None)
     assert result.is_rhel is True
-    assert result.release == "Red Hat Enterprise Linux"
+    assert result.release == "RHEL"
     assert result.reasons == {}
 
     # RHEL, dmesg only
     dmesg = DmesgLineList(context_wrap(DMESG_REDHAT))
     result = OSRelease(None, dmesg, None, None, None)
     assert result.is_rhel is True
-    assert result.release == "Red Hat Enterprise Linux"
-    assert result.product == "Red Hat Enterprise Linux"
+    assert result.release == "RHEL"
+    assert result.product == "RHEL"
     assert result.reasons == {}
 
     # RHEL, dmesg and uname
     dmesg = DmesgLineList(context_wrap(DMESG_REDHAT))
     result = OSRelease(uname, dmesg, None, None, None)
     assert result.is_rhel is True
-    assert result.release == "Red Hat Enterprise Linux"
+    assert result.release == "RHEL"
     assert result.reasons == {}
 
     # RHEL, rpms only
     rpms = InstalledRpms(context_wrap(RPMS_JSON_91_WO_KERNEL))
     result = OSRelease(None, None, rpms, None, None)
     assert result.is_rhel is True
-    assert result.release == "Red Hat Enterprise Linux"
+    assert result.release == "RHEL"
     assert result.reasons == {}
 
     rpms = InstalledRpms(context_wrap(RPMS_JSON_91_W_KERNEL))
     result = OSRelease(None, None, rpms, None, None)
     assert result.is_rhel is True
-    assert result.release == "Red Hat Enterprise Linux"
+    assert result.release == "RHEL"
     assert result.reasons == {}
 
     # RHEL, rpms and uname
     rpms = InstalledRpms(context_wrap(RPMS_JSON_91_W_KERNEL))
     result = OSRelease(uname, None, rpms, None, None)
     assert result.is_rhel is True
-    assert result.release == "Red Hat Enterprise Linux"
+    assert result.release == "RHEL"
     assert result.reasons == {}
 
     # RHEL, rpms, dmesg and uname
     rpms = InstalledRpms(context_wrap(RPMS_JSON_91_W_KERNEL))
     result = OSRelease(uname, dmesg, rpms, None, None)
     assert result.is_rhel is True
-    assert result.release == "Red Hat Enterprise Linux"
+    assert result.release == "RHEL"
     assert result.reasons == {}
 
     # RHEL, os-release
     osr = OsRelease(context_wrap(OS_RELEASE_RH))
     result = OSRelease(None, None, None, osr, None)
     assert result.is_rhel is True
-    assert result.release == "Red Hat Enterprise Linux"
+    assert result.release == "RHEL"
     assert result.reasons == {}
 
     # RHEL, redhat-release
     rhr = RedhatRelease(context_wrap(REDHAT_RELEASE_86))
     result = OSRelease(None, None, None, None, rhr)
     assert result.is_rhel is True
-    assert result.release == "Red Hat Enterprise Linux"
+    assert result.release == "RHEL"
     assert result.reasons == {}
 
 


### PR DESCRIPTION
- instead of the lone format "Red Hat Enterprise Linux"

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

- tiny update to return "RHEL" when `is_rhel==True`