### PR TITLE
fix: correct the initialization of ParserException in PHPConf

### DIFF
--- a/insights/parsers/php_ini.py
+++ b/insights/parsers/php_ini.py
@@ -144,8 +144,8 @@ class PHPConf(ConfigParser):
         except SkipComponent:
             raise
         except:
-            raise ParseException(ParseException("Could not parse content: '{0}'".
-                                                format(content)))
+            raise ParseException("Could not parse content: '{0}'".
+                                                format(content))
 
     def parse_content(self, content):
         super(PHPConf, self).parse_content(content)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

To fix the ParserException initialization in php_ini parser, this should be one typo.