### PR TITLE
Feat: Add parser LsinitrdLvmConf

### DIFF
--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -111,7 +111,7 @@ insights.specs.datasources.kernel
 ---------------------------------
 
 .. automodule:: insights.specs.datasources.kernel
-    :members:  current_version
+    :members:  current_version, default_version
     :show-inheritance:
     :undoc-members:
 

--- a/insights/parsers/lsinitrd.py
+++ b/insights/parsers/lsinitrd.py
@@ -10,12 +10,16 @@ Lsinitrd - command ``lsinitrd``
 LsinitrdKdumpImage - command ``lsinitrd initramfs-<kernel-version>kdump.img``
 -----------------------------------------------------------------------------
 
+LsinitrdLvmConf - command ``/bin/lsinitrd -f /etc/lvm/lvm.conf --kver {default_kernel_version}``
+------------------------------------------------------------------------------------------------
+
 """
 
 from insights import parser, CommandParser
 from insights.core import ls_parser
 from insights.specs import Specs
 from insights.parsers import keyword_search
+from insights.parsers.lvm import LvmConf
 
 
 @parser(Specs.lsinitrd)
@@ -134,5 +138,23 @@ class LsinitrdKdumpImage(Lsinitrd):
         1
         >>> result_list[0].get('raw_entry')
         'crw-r--r--   1 root     root       1,   9 Aug  4  2020 dev/urandom'
+    """
+    pass
+
+
+@parser(Specs.lsinitrd_lvm_conf)
+class LsinitrdLvmConf(LvmConf):
+    """
+    Parses the ``/dev/lvm/lvm.conf`` file get from the default initramfs.
+
+    Sample Input::
+        # volume_list = [ "vg1", "vg2/lvol1", "@tag1", "@*" ]
+        volume_list = [ "vg2", "vg3/lvol3", "@tag2", "@*" ]
+
+    Examples:
+        >>> type(lsinitrd_lvm_conf)
+        <class 'insights.parsers.lsinitrd.LsinitrdLvmConf'>
+        >>> lsinitrd_lvm_conf.get("volume_list")
+        [ "vg2", "vg3/lvol3", "@tag2", "@*" ]
     """
     pass

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -359,7 +359,7 @@ class Specs(SpecSet):
     lscpu = RegistryPoint()
     lsinitrd = RegistryPoint(filterable=True)
     lsinitrd_kdump_image = RegistryPoint(filterable=True)
-    lsinitrd_lvm_conf = RegistryPoint()
+    lsinitrd_lvm_conf = RegistryPoint(filterable=True)
     lsmod = RegistryPoint()
     lsof = RegistryPoint(filterable=True)
     lspci = RegistryPoint()

--- a/insights/specs/datasources/kernel.py
+++ b/insights/specs/datasources/kernel.py
@@ -4,7 +4,9 @@ Custom datasource to get the current kernel version.
 
 from insights.core.context import HostContext
 from insights.core.plugins import datasource
+from insights.core.exceptions import SkipComponent
 from insights.parsers.uname import Uname
+from insights.specs import Specs
 
 
 @datasource(Uname, HostContext)
@@ -24,3 +26,28 @@ def current_version(broker):
     """
 
     return broker[Uname].kernel
+
+
+@datasource(Specs.grubby_default_kernel, HostContext)
+def default_version(broker):
+    """
+    This datasource provides the default kernel version.
+
+    Sample data returned::
+
+        '4.18.0-240.el8.x86_64'
+
+    Returns:
+        String: The default kernel version.
+
+    Raises:
+        SkipComponent: When output is empty or an error occurs
+    """
+    try:
+        content = broker[Specs.grubby_default_kernel].content
+        if len(content) == 1 and len(content[0].split()) == 1:
+            default_kernel = content[0]
+            return default_kernel.lstrip("/boot/vmlinuz-")
+    except Exception as e:
+        raise SkipComponent("Unexpected exception:{e}".format(e=str(e)))
+    raise SkipComponent

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -25,7 +25,7 @@ from insights.components.satellite import IsCapsule, IsSatellite611, IsSatellite
 from insights.specs import Specs
 from insights.specs.datasources import (
     aws, awx_manage, cloud_init, candlepin_broker, corosync as corosync_ds,
-    dir_list, ethernet, httpd, ipcs, kernel_module_list, leapp, lpstat,
+    dir_list, ethernet, httpd, ipcs, kernel, kernel_module_list, leapp, lpstat,
     machine_ids, md5chk, package_provides, ps as ps_datasource, rsyslog_confs, sap,
     satellite_missed_queues, semanage, ssl_certificate, sys_fs_cgroup_memory,
     sys_fs_cgroup_memory_tasks_number, rpm_pkgs, user_group, yum_updates,
@@ -319,6 +319,7 @@ class DefaultSpecs(Specs):
     lpfc_max_luns = simple_file("/sys/module/lpfc/parameters/lpfc_max_luns")
     lpstat_p = simple_command("/usr/bin/lpstat -p")
     lpstat_protocol_printers = lpstat.lpstat_protocol_printers_info
+    lsinitrd_lvm_conf = command_with_args("/bin/lsinitrd -f /etc/lvm/lvm.conf --kver %s", kernel.default_version)
     ls_R_var_lib_nova_instances = simple_command("/bin/ls -laR /var/lib/nova/instances")
     ls_boot = simple_command("/bin/ls -lanR /boot")
     ls_dev = simple_command("/bin/ls -lanR /dev")

--- a/insights/tests/datasources/test_kernel.py
+++ b/insights/tests/datasources/test_kernel.py
@@ -1,7 +1,12 @@
 import pytest
-from insights.specs.datasources.kernel import current_version
+
+from mock.mock import Mock
+
+from insights.core.exceptions import SkipComponent
+from insights.specs.datasources.kernel import current_version, default_version
 from insights.parsers.uname import Uname
 from insights.parsers import uname
+from insights.specs import Specs
 from insights.tests import context_wrap
 
 UNAME = """
@@ -26,3 +31,20 @@ def test_current_kernel_version_without_uname():
     with pytest.raises(uname.UnameError) as e_info:
         current_version({Uname: uname.Uname(context_wrap(UNAME_ERROR_BLANK))})
     assert 'Empty uname line' in str(e_info.value)
+
+
+def test_default_version():
+    grubby_command = Mock()
+    grubby_command.content = ['/boot/vmlinuz-4.18.0-305.el8.x86_64']
+    broker = {Specs.grubby_default_kernel: grubby_command}
+    result = default_version(broker)
+    assert result is not None
+    assert result == '4.18.0-305.el8.x86_64'
+
+
+def test_default_version_with_error():
+    grubby_command = Mock()
+    grubby_command.content = ['grep: /boot/grub2/grubenv: Permission denied']
+    broker = {Specs.grubby_default_kernel: grubby_command}
+    with pytest.raises(SkipComponent):
+        default_version(broker)

--- a/insights/tests/parsers/test_lsinitrd.py
+++ b/insights/tests/parsers/test_lsinitrd.py
@@ -176,6 +176,11 @@ drwxr-xr-x   2 root     root            0 Aug  4  2020 dev
 ========================================================================
 """.strip()
 
+LSINITRD_LVM_CONF = """
+# volume_list = [ "vg1", "vg2/lvol1", "@tag1", "@*" ]
+volume_list = [ "vg2", "vg3/lvol3", "@tag2", "@*" ]
+""".strip()
+
 
 def test_lsinitrd_empty():
     d = lsinitrd.Lsinitrd(context_wrap(LSINITRD_EMPTY))
@@ -226,9 +231,15 @@ def test_lsinitrd_kdump_image_valid():
     assert result_list[0].get('raw_entry') == '-rw-r--r--   1 root     root          126 Aug  4  2020 usr/lib/modules/4.18.0-240.el8.x86_64/modules.devname'
 
 
+def test_lsinitrd_lvm_conf():
+    lvm_conf = lsinitrd.LsinitrdLvmConf(context_wrap(LSINITRD_LVM_CONF))
+    assert lvm_conf["volume_list"] == ["vg2", "vg3/lvol3", "@tag2", "@*"]
+
+
 def test_lsinitrd_docs():
     failed_count, tests = doctest.testmod(
         globs={'ls': lsinitrd.Lsinitrd(context_wrap(LSINITRD_FILTERED)),
-               'lsinitrd_kdump_image': LsinitrdKdumpImage(context_wrap(LSINITRD_KDUMP_IMAGE_VALID_EXAMPLE))}
+               'lsinitrd_kdump_image': LsinitrdKdumpImage(context_wrap(LSINITRD_KDUMP_IMAGE_VALID_EXAMPLE)),
+               'lsinitrd_lvm_conf': lsinitrd.LsinitrdLvmConf(context_wrap(LSINITRD_LVM_CONF))}
     )
     assert failed_count == 0


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Add parser LsinitrdLvmConf, this parser is needed by RHINRULE-160.
When implementation:
1. Updated the existing ResistryPoint: lsinitrd_lvm_conf
2. Updated the existing parser LvmConf
