### PR TITLE
fix: generate 'meta_data' for built-in files correctly

### DIFF
--- a/insights/client/archive.py
+++ b/insights/client/archive.py
@@ -200,13 +200,22 @@ class InsightsArchive(object):
             logger.debug("Deleting: " + self.archive_dir)
             shutil.rmtree(self.archive_dir, True)
 
-    def delete_archive_file(self):
+    def delete_archive_tmp_dir(self):
         """
         Delete the directory containing the constructed archive
         """
         if self.archive_tmp_dir:
             logger.debug("Deleting %s", self.archive_tmp_dir)
             shutil.rmtree(self.archive_tmp_dir, True)
+
+    def delete_archive_file(self, spec):
+        """
+        Delete the spec file in the archive dir
+        """
+        path = os.path.join(self.archive_dir, spec)
+        if self.archive_dir and os.path.isfile(path):
+            logger.debug("Deleting %s", path)
+            shutil.rmtree(path, True)
 
     def add_to_archive(self, spec):
         '''

--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -291,14 +291,14 @@ def collect(config):
 
     archive = InsightsArchive(config)
 
-    msg_name = determine_hostname(config.display_name)
+    hostname = determine_hostname(config.display_name)
     if config.core_collect:
         collection_rules = None
         dc = CoreCollector(config, archive)
     else:
         collection_rules = pc.get_conf_file()
-        dc = DataCollector(config, archive)
-    logger.info('Starting to collect Insights data for %s', msg_name)
+        dc = DataCollector(config, archive, hostname=hostname)
+    logger.info('Starting to collect Insights data for %s', hostname)
     dc.run_collection(collection_rules, rm_conf, branch_info, blacklist_report)
     output = dc.done(collection_rules, rm_conf)
     return output

--- a/insights/client/core_collector.py
+++ b/insights/client/core_collector.py
@@ -72,10 +72,13 @@ class CoreCollector(DataCollector):
         logger.debug('Collecting metadata...')
         no_persist = set()
         self._write_branch_info(branch_info)
-        self._write_display_name(no_persist)
-        self._write_ansible_host(no_persist)
+        if self._write_display_name() is False:
+            no_persist.add('display_name')
+        if self._write_ansible_host() is False:
+            no_persist.add('ansible_host')
         self._write_version_info()
-        self._write_tags(no_persist)
+        if self._write_tags() is False:
+            no_persist.add('tags')
         self._write_blacklist_report(blacklist_report)
         self._write_egg_release()
         logger.debug('Metadata collection finished.')

--- a/insights/client/core_collector.py
+++ b/insights/client/core_collector.py
@@ -2,14 +2,17 @@
 Collect all the interesting data for analysis - Core version
 """
 from __future__ import absolute_import
+import logging
 import os
 import six
-import logging
-from insights import collect
 
-from .constants import InsightsConstants as constants
-from .data_collector import DataCollector
-from .utilities import systemd_notify_init_thread
+from datetime import datetime
+
+from insights import collect
+from insights.client.constants import InsightsConstants as constants
+from insights.client.data_collector import DataCollector
+from insights.client.utilities import systemd_notify_init_thread
+from insights.util import fs
 
 APP_NAME = constants.app_name
 logger = logging.getLogger(__name__)
@@ -56,18 +59,34 @@ class CoreCollector(DataCollector):
                     manifest = f.read()
             else:
                 manifest = self.config.manifest
-        collected_data_path, exceptions = collect.collect(
-            manifest=manifest,
-            tmp_path=self.archive.tmp_dir,
-            rm_conf=core_blacklist,
-            client_timeout=self.config.cmd_timeout
-        )
 
-        # update the archive dir with the reported data location from Insights Core
-        if not collected_data_path:
-            raise RuntimeError('Error running collection: no output path defined.')
-        self.archive.archive_dir = collected_data_path
-        self.archive.archive_name = os.path.basename(collected_data_path)
+        suffix = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        relative_path = "insights-%s-%s" % (self.hostname, suffix)
+        output_path = os.path.join(self.archive.tmp_dir, relative_path)
+        fs.ensure_path(output_path)
+        fs.touch(os.path.join(output_path, "insights_archive.txt"))
+
+        self.archive.archive_dir = output_path
+        self.archive.archive_name = relative_path
+        # Collect the folloing metadata before collecting the Specs
+        logger.debug('Collecting metadata...')
+        no_persist = set()
+        self._write_branch_info(branch_info)
+        self._write_display_name(no_persist)
+        self._write_ansible_host(no_persist)
+        self._write_version_info()
+        self._write_tags(no_persist)
+        self._write_blacklist_report(blacklist_report)
+        self._write_egg_release()
+        logger.debug('Metadata collection finished.')
+
+        collect.collect(
+            manifest=manifest,
+            tmp_path=self.archive.archive_dir,
+            rm_conf=core_blacklist,
+            client_timeout=self.config.cmd_timeout,
+            no_persist=no_persist,
+        )
 
         if not six.PY3:
             # collect.py returns a unicode string, and these must be bytestrings
@@ -82,18 +101,8 @@ class CoreCollector(DataCollector):
             # fall back to hostname if hostname -f not available
             self.hostname_path = 'data/insights_commands/hostname'
 
+        self._write_blacklisted_specs()
+
         logger.debug('Collection finished.')
 
         self.redact(rm_conf)
-
-        # collect metadata
-        logger.debug('Collecting metadata...')
-        self._write_branch_info(branch_info)
-        self._write_display_name()
-        self._write_ansible_host()
-        self._write_version_info()
-        self._write_tags()
-        self._write_blacklist_report(blacklist_report)
-        self._write_blacklisted_specs()
-        self._write_egg_release()
-        logger.debug('Metadata collection finished.')

--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -2,26 +2,31 @@
 Collect all the interesting data for analysis
 """
 from __future__ import absolute_import
-import os
+import copy
 import errno
+import glob
 import json
 import logging
-import copy
-import glob
-import six
-import shlex
+import os
 import re
+import shlex
+import six
+
 from itertools import chain
 from subprocess import Popen, PIPE, STDOUT
 from tempfile import NamedTemporaryFile
 
+from insights.contrib.soscleaner import SOSCleaner
 from insights.core.blacklist import BLACKLISTED_SPECS
 from insights.util import mangle
-from ..contrib.soscleaner import SOSCleaner
-from .utilities import _expand_paths, get_version_info, systemd_notify_init_thread, get_tags
-from .constants import InsightsConstants as constants
-from .insights_spec import InsightsFile, InsightsCommand
-from .archive import InsightsArchive
+from insights.client.archive import InsightsArchive
+from insights.client.constants import InsightsConstants as constants
+from insights.client.insights_spec import InsightsFile, InsightsCommand
+from insights.client.utilities import (_expand_paths,
+                                       determine_hostname,
+                                       get_version_info,
+                                       systemd_notify_init_thread,
+                                       get_tags)
 
 APP_NAME = constants.app_name
 logger = logging.getLogger(__name__)
@@ -73,12 +78,13 @@ class DataCollector(object):
     Run commands and collect files
     '''
 
-    def __init__(self, config, archive_=None, mountpoint=None):
+    def __init__(self, config, archive_=None, mountpoint=None, hostname=None):
         self.config = config
         self.archive = archive_ if archive_ else InsightsArchive(config)
         self.mountpoint = '/'
         if mountpoint:
             self.mountpoint = mountpoint
+        self.hostname = hostname or determine_hostname(config.display_name)
         self.hostname_path = None
 
     def _write_branch_info(self, branch_info):
@@ -86,17 +92,23 @@ class DataCollector(object):
         self.archive.add_metadata_to_archive(
             json.dumps(branch_info), '/branch_info')
 
-    def _write_display_name(self):
+    def _write_display_name(self, no_persist=None):
         if self.config.display_name:
             logger.debug("Writing display_name to archive...")
             self.archive.add_metadata_to_archive(
                 self.config.display_name, '/display_name')
+        else:
+            if no_persist:
+                no_persist.add('display_name')
 
-    def _write_ansible_host(self):
+    def _write_ansible_host(self, no_persist=None):
         if self.config.ansible_host:
             logger.debug("Writing ansible_host to archive...")
             self.archive.add_metadata_to_archive(
                 self.config.ansible_host, '/ansible_host')
+        else:
+            if no_persist:
+                no_persist.add('ansible_host')
 
     def _write_version_info(self):
         logger.debug("Writing version information to archive...")
@@ -104,8 +116,7 @@ class DataCollector(object):
         self.archive.add_metadata_to_archive(
             json.dumps(version_info), '/version_info')
 
-    def _write_tags(self):
-        logger.debug("Writing tags to archive...")
+    def _write_tags(self, no_persist=None):
         tags = get_tags()
         if tags is not None:
             def f(k, v):
@@ -121,12 +132,16 @@ class DataCollector(object):
                     return list(chain.from_iterable(col))
                 else:
                     return [{"key": k, "value": v, "namespace": constants.app_name}]
+            logger.debug("Writing tags to archive...")
             t = []
             for k, v in tags.items():
                 iv = f(k, v)
                 t.append(iv)
             t = list(chain.from_iterable(t))
             self.archive.add_metadata_to_archive(json.dumps(t), '/tags.json')
+        else:
+            if no_persist:
+                no_persist.add('tags')
 
     def _write_blacklist_report(self, blacklist_report):
         logger.debug("Writing blacklist report to archive...")
@@ -134,11 +149,15 @@ class DataCollector(object):
             json.dumps(blacklist_report), '/blacklist_report')
 
     def _write_blacklisted_specs(self):
-        logger.debug("Writing blacklisted specs to archive...")
-
         if BLACKLISTED_SPECS:
+            logger.debug("Writing blacklisted specs to archive...")
             self.archive.add_metadata_to_archive(
                 json.dumps({"specs": BLACKLISTED_SPECS}), '/blacklisted_specs')
+        else:
+            # TODO: spec name should not be hard-coded
+            # - insights.core.serde.Hydration.ser_name
+            spec = 'meta_data/insights.specs.Specs.blacklisted_specs.json'
+            self.archive.delete_archive_file(spec)
 
     def _write_egg_release(self):
         logger.debug("Writing egg release to archive...")

--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -92,23 +92,23 @@ class DataCollector(object):
         self.archive.add_metadata_to_archive(
             json.dumps(branch_info), '/branch_info')
 
-    def _write_display_name(self, no_persist=None):
+    def _write_display_name(self):
         if self.config.display_name:
             logger.debug("Writing display_name to archive...")
             self.archive.add_metadata_to_archive(
                 self.config.display_name, '/display_name')
         else:
-            if no_persist:
-                no_persist.add('display_name')
+            # Return False to exclude it from no_persist
+            return False
 
-    def _write_ansible_host(self, no_persist=None):
+    def _write_ansible_host(self):
         if self.config.ansible_host:
             logger.debug("Writing ansible_host to archive...")
             self.archive.add_metadata_to_archive(
                 self.config.ansible_host, '/ansible_host')
         else:
-            if no_persist:
-                no_persist.add('ansible_host')
+            # Return False to exclude it from no_persist
+            return False
 
     def _write_version_info(self):
         logger.debug("Writing version information to archive...")
@@ -116,7 +116,7 @@ class DataCollector(object):
         self.archive.add_metadata_to_archive(
             json.dumps(version_info), '/version_info')
 
-    def _write_tags(self, no_persist=None):
+    def _write_tags(self):
         tags = get_tags()
         if tags is not None:
             def f(k, v):
@@ -140,8 +140,8 @@ class DataCollector(object):
             t = list(chain.from_iterable(t))
             self.archive.add_metadata_to_archive(json.dumps(t), '/tags.json')
         else:
-            if no_persist:
-                no_persist.add('tags')
+            # Return False to exclude it from no_persist
+            return False
 
     def _write_blacklist_report(self, blacklist_report):
         logger.debug("Writing blacklist report to archive...")

--- a/insights/collect.py
+++ b/insights/collect.py
@@ -15,12 +15,9 @@ import sys
 import tempfile
 import yaml
 
-from datetime import datetime
-
 from insights import apply_configs, apply_default_enabled, get_pool
 from insights.core import blacklist, dr, filters
 from insights.core.blacklist import BLACKLISTED_SPECS
-from insights.core.exceptions import CalledProcessError
 from insights.core.serde import Hydration
 from insights.util import fs
 from insights.util.subproc import call
@@ -317,7 +314,7 @@ def create_context(ctx):
     return ctx_cls(**ctx_args)
 
 
-def get_to_persist(persisters):
+def get_to_persist(persisters, no_persisters=None):
     """
     Given a specification of what to persist, generates the corresponding set
     of components.
@@ -328,14 +325,14 @@ def get_to_persist(persisters):
                 yield p["name"], p.get("enabled", True)
             else:
                 yield p, True
-
+    no_persisters = tuple(no_persisters) if no_persisters else tuple()
     components = sorted(dr.DELEGATES, key=dr.get_name)
     names = dict((c, dr.get_name(c)) for c in components)
 
     results = set()
     for p, e in specs():
         for c in components:
-            if names[c].startswith(p):
+            if names[c].startswith(p) and not names[c].endswith(no_persisters):
                 if e:
                     results.add(c)
                 elif c in results:
@@ -360,7 +357,8 @@ def create_archive(path, remove_path=True):
     return archive_path
 
 
-def collect(manifest=default_manifest, tmp_path=None, compress=False, rm_conf=None, client_timeout=None):
+def collect(manifest=default_manifest, tmp_path=None, compress=False,
+            rm_conf=None, client_timeout=None, no_persist=None):
     """
     This is the collection entry point. It accepts a manifest, a temporary
     directory in which to store output, and a boolean for optional compression.
@@ -378,6 +376,7 @@ def collect(manifest=default_manifest, tmp_path=None, compress=False, rm_conf=No
             "commands", "files", and "keywords", to be injected
             into the manifest blacklist.
         client_timeout (int): Client-provided command timeout value
+        no_persist (list): Specs that no need to persist
     Returns:
         (str, dict): The full path to the created tar.gz or workspace.
         And a dictionary with relevant exceptions captured by the broker during
@@ -412,7 +411,7 @@ def collect(manifest=default_manifest, tmp_path=None, compress=False, rm_conf=No
             BLACKLISTED_SPECS.append(component.split('.')[-1])
             log.warning('WARNING: Skipping component: %s', component)
 
-    to_persist = get_to_persist(client.get("persist", set()))
+    to_persist = get_to_persist(client.get("persist", set()), no_persisters=no_persist)
 
     try:
         filters.load()
@@ -423,18 +422,6 @@ def collect(manifest=default_manifest, tmp_path=None, compress=False, rm_conf=No
         # problem parsing the filters
         log.debug("Could not parse filters: %s", str(e))
 
-    try:
-        hostname = call("hostname -f", env=SAFE_ENV).strip()
-    except CalledProcessError:
-        # problem calling hostname -f
-        hostname = call("hostname", env=SAFE_ENV).strip()
-    suffix = datetime.utcnow().strftime("%Y%m%d%H%M%S")
-    relative_path = "insights-%s-%s" % (hostname, suffix)
-    tmp_path = tmp_path or tempfile.gettempdir()
-    output_path = os.path.join(tmp_path, relative_path)
-    fs.ensure_path(output_path)
-    fs.touch(os.path.join(output_path, "insights_archive.txt"))
-
     broker = dr.Broker()
     ctx = create_context(client.get("context", {}))
     broker[ctx.__class__] = ctx
@@ -442,15 +429,15 @@ def collect(manifest=default_manifest, tmp_path=None, compress=False, rm_conf=No
     parallel = run_strategy.get("name") == "parallel"
     pool_args = run_strategy.get("args", {})
     with get_pool(parallel, "insights-collector-pool", pool_args) as pool:
-        h = Hydration(output_path, pool=pool)
+        h = Hydration(tmp_path, pool=pool)
         broker.add_observer(h.make_persister(to_persist))
         dr.run_all(broker=broker, pool=pool)
 
     collect_errors = _parse_broker_exceptions(broker, EXCEPTIONS_TO_REPORT)
 
     if compress:
-        return create_archive(output_path), collect_errors
-    return output_path, collect_errors
+        return create_archive(tmp_path), collect_errors
+    return tmp_path, collect_errors
 
 
 def _parse_broker_exceptions(broker, exceptions_to_report):

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -187,7 +187,8 @@ class MetadataProvider(FileProvider):
             return [l.rstrip("\n") for l in f]
 
     def write(self, dst):
-        # TODO: the metadata files can also be collected via core collection
+        # TODO: the built-ine metadata files can also be collected via
+        #       core-collection
         pass
 
 
@@ -1288,6 +1289,8 @@ def deserialize_datasource_provider(_type, data, root):
 
 @serializer(MetadataProvider)
 def serialize_metadata_provider(obj, root):
+    # Built-in metadata files are under root directory, but not '/data'
+    root = os.path.dirname(root) if os.path.basename(root) == 'data' else root
     dst = os.path.join(root, obj.relative_path.lstrip("/"))
     fs.ensure_path(os.path.dirname(dst))
     obj.write(dst)
@@ -1296,7 +1299,7 @@ def serialize_metadata_provider(obj, root):
 
 @deserializer(MetadataProvider)
 def deserialize_metadata_provider(_type, data, root):
-    # metadata files are put in the root directory instead of '/data'
+    # Built-in metadata files are under root directory, but not '/data'
     root = os.path.dirname(root) if os.path.basename(root) == 'data' else root
     return SerializedOutputProvider(data["relative_path"], root)
 


### PR DESCRIPTION
- fix: #3739
- write the built-in files before collecting the specs but except for the 'blacklisted_specs', it requires the BLACKLISTED_SPECS
- move the generating of the archive name out from the `collect()` to ensure wrapping the above built-in files and specs data in the same archive dir
- update the 'to_persist' list to remove the skipped built-in files

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

