### PR TITLE
feat: Azure public IP spec

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -26,6 +26,7 @@ class Specs(SpecSet):
     azure_instance_id = RegistryPoint()
     azure_instance_plan = RegistryPoint()
     azure_instance_type = RegistryPoint()
+    azure_load_balancer = RegistryPoint()
     bdi_read_ahead_kb = RegistryPoint(multi_output=True)
     bios_uuid = RegistryPoint()
     blacklisted_specs = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -100,6 +100,7 @@ class DefaultSpecs(Specs):
     azure_instance_id = simple_command("/usr/bin/curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/vmId?api-version=2021-12-13&format=text --connect-timeout 5", deps=[IsAzure])
     azure_instance_plan = simple_command("/usr/bin/curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/plan?api-version=2021-12-13&format=json --connect-timeout 5", deps=[IsAzure])
     azure_instance_type = simple_command("/usr/bin/curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-12-13&format=text --connect-timeout 5", deps=[IsAzure])
+    azure_load_balancer = simple_command("/usr/bin/curl -s -H Metadata:true http://169.254.169.254/metadata/loadbalancer?api-version=2021-12-13&format=json --connect-timeout 5", deps=[IsAzure])
     bdi_read_ahead_kb = glob_file("/sys/class/bdi/*/read_ahead_kb")
     bios_uuid = simple_command("/usr/sbin/dmidecode -s system-uuid")
     blkid = simple_command("/sbin/blkid -c /dev/null")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This patch adds Azure public IP address:

Refs ESSNTL-4679

Related to: https://github.com/RedHatInsights/insights-core/pull/3741

Test on an Azure instance:

```
# BYPASS_GPG=true EGG=/root/insights.zip insights-client --offline --no-upload --keep-archive --no-gpg

# cat insights-lzap-insights-client.bke4gskh30hejcgg4rxro51k3g.bx.internal.cloudapp.net-20230414121920/meta_data/insights.specs.Specs.azure_load_balancer.json | jq
{
  "name": "insights.specs.Specs.azure_load_balancer",
  "exec_time": 0.0001773834228515625,
  "errors": [],
  "results": {
    "type": "insights.core.spec_factory.CommandOutputProvider",
    "object": {
      "rc": null,
      "cmd": "/usr/bin/curl -s -H Metadata:true http://169.254.169.254/metadata/loadbalancer?api-version=2021-12-13&format=json --connect-timeout 5",
      "args": null,
      "relative_path": "insights_commands/curl_-s_-H_Metadata_true_http_..169.254.169.254.metadata.loadbalancer_api-version_2021-12-13_format_json_--connect-timeout_5"
    }
  },
  "ser_time": 0.017719268798828125
}

# cat insights-lzap-insights-client.bke4gskh30hejcgg4rxro51k3g.bx.internal.cloudapp.net-20230414121920/data/insights_commands/curl_-s_-H_Metadata_true_http_..169.254.169.254.metadata.loadbalancer_api-version_2021-12-13_format_json_--connect-timeout_5 | jq
{
  "loadbalancer": {
    "publicIpAddresses": [
      {
        "frontendIpAddress": "137.116.118.209",
        "privateIpAddress": "10.0.0.4"
      }
    ],
    "inboundRules": [],
    "outboundRules": []
  }
}
```

Not sure how to actually test spec parsing.