### PR TITLE
Clarify logic when normalizing snippets

### DIFF
--- a/insights/client/apps/ansible/playbook_verifier/__init__.py
+++ b/insights/client/apps/ansible/playbook_verifier/__init__.py
@@ -223,10 +223,10 @@ def normalizeSnippet(snippet):
             for item in value:
                 if isinstance(item, six.text_type):
                     new_sequence.append(item.encode('ascii', 'ignore'))
-                if not isinstance(item, CommentedMap):
-                    new_sequence.append(item)
-                else:
+                elif isinstance(item, CommentedMap):
                     new_sequence.append(normalizeSnippet(item))
+                else:
+                    new_sequence.append(item)
             new[key] = new_sequence
         elif isinstance(value, six.text_type):
             new[key] = value.encode('ascii', 'ignore')


### PR DESCRIPTION
Fixes a bug in the normalizeSnippet function that can inadvertently process elements in a CommendedSeq twice when iterating over elements in the sequence.

Fixes: ESSNTL-4354