### PR TITLE
fix: attempted fix for python26 ci deprecation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,39 +34,42 @@ jobs:
 
   python26-test:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
 
     steps:
     - uses: actions/checkout@v3
     - name: apt-install python26
       run: |
-        sudo add-apt-repository 'ppa:deadsnakes/ppa'
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libssl1.0-dev
-        sudo apt-get install python2.6  python2.6-dev
-        sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.6 1
-        sudo update-alternatives --set python /usr/bin/python2.6
-    - name: get depenencies
+        apt-get update -y
+        apt-get install -y software-properties-common
+        apt-get install -y git curl unzip
+        add-apt-repository 'ppa:deadsnakes/ppa'
+        apt-get update -y
+        apt-get install -y --no-install-recommends libssl1.0-dev
+        apt-get install  -y python2.6  python2.6-dev
+        update-alternatives --install /usr/bin/python python /usr/bin/python2.6 1
+        update-alternatives --set python /usr/bin/python2.6
+    - name: get dependencies
       run: |
         git clone https://github.com/SteveHNH/jenkins-s2i-example.git pips
         CUR_DIR=$(pwd)
         mkdir ../tools && cd ../tools
         curl -L -O https://files.pythonhosted.org/packages/b8/04/be569e393006fa9a2c10ef72ea33133c2902baa115dd1d4279dae55c3b3b/setuptools-36.8.0.zip
         unzip setuptools-36.8.0.zip && cd setuptools-36.8.0
-        python setup.py install --user && cd ..
+        python setup.py install && cd ..
         curl -L -O https://github.com/pypa/pip/archive/refs/tags/9.0.3.tar.gz
         tar -xvzf 9.0.3.tar.gz && cd pip-9.0.3
-        python setup.py install --user && cd ${CUR_DIR}
-        pip install --user -r ./pips/slave26/ci_requirements.txt -f ./pips/slave26/pip_packages
+        python setup.py install && cd ${CUR_DIR}
+        pip install -r ./pips/slave26/ci_requirements.txt -f ./pips/slave26/pip_packages --trusted-host=pypi.org --trusted-host=files.pythonhosted.org --trusted-host=pypi.python.org
         mkdir ../collections_module
-        sudo curl -L -o ./../collections_module/collections.py https://raw.githubusercontent.com/RedHatInsights/insights-core/5c8ca0f2fb3de45908e8d931d40758af34a7997a/.collections.py
+        curl -L -o ./../collections_module/collections.py https://raw.githubusercontent.com/RedHatInsights/insights-core/5c8ca0f2fb3de45908e8d931d40758af34a7997a/.collections.py
     - name: flake8
       run: |
-        pip install --user -e .[linting] -f ./pips/slave26/pip_packages
-        flake8 .
+        pip install -e .[linting] -f ./pips/slave26/pip_packages
     - name: pytest
       run: |
-        pip install --user -e .[testing] -f ./pips/slave26/pip_packages
+        pip install -e .[testing] -f ./pips/slave26/pip_packages
         export PYTHONPATH=${PYTHONPATH}:./../collections_module
         pytest
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This fix attempts to workaround the removal of the ubuntu-18.04 github action runner by using an ubuntu-18.04 container instead in the yaml file.
This is an alternative fix attempt to https://github.com/RedHatInsights/insights-core/pull/3734
