### PR TITLE
fix: soscleaner get relative_path safely - 2

### DIFF
--- a/insights/contrib/soscleaner.py
+++ b/insights/contrib/soscleaner.py
@@ -741,7 +741,7 @@ class SOSCleaner:
                         results = meta_data["results"]
                     else:
                         results = [meta_data["results"]]
-                    relative_paths = [result["object"]["relative_path"] for result in results if 'object' in result]
+                    relative_paths = [result["object"]["relative_path"] for result in results if result and 'object' in result]
                     excluded_files.extend(relative_paths) if relative_paths else None
         return excluded_files
 


### PR DESCRIPTION
- the previous update didn't fix this issue totally

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

- fix: 2078807
