### PR TITLE
fix: DnfModuleList parser and collect dnf_module_list

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -176,6 +176,7 @@ class DefaultSpecs(Specs):
     dmsetup_status = simple_command("/usr/sbin/dmsetup status")
     dnf_conf = simple_file("/etc/dnf/dnf.conf")
     dnf_modules = glob_file("/etc/dnf/modules.d/*.module")
+    dnf_module_list = simple_command("/usr/bin/dnf -C --noplugins module list")
     docker_info = simple_command("/usr/bin/docker info")
     docker_list_containers = simple_command("/usr/bin/docker ps --all --no-trunc")
     docker_list_images = simple_command("/usr/bin/docker images --all --no-trunc --digests")

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -51,6 +51,7 @@ class InsightsArchiveSpecs(Specs):
     dig_edns = simple_file("insights_commands/dig_edns_0_._SOA")
     dig_noedns = simple_file("insights_commands/dig_noedns_._SOA")
     display_name = simple_file("display_name")
+    dnf_module_list = simple_file("insights_commands/dnf_-C_--noplugins_module_list")
     dmesg = simple_file("insights_commands/dmesg")
     dmidecode = simple_file("insights_commands/dmidecode")
     dmsetup_info = simple_file("insights_commands/dmsetup_info_-C")

--- a/insights/tests/parsers/test_dnf_module.py
+++ b/insights/tests/parsers/test_dnf_module.py
@@ -31,6 +31,8 @@ python36            3.6 [d][e]  common [d], build                         Python
 redis               5 [d]       common [d]                                Redis persistent key-value database
 rhn-tools           1.0 [d]     common [d]                                Red Hat Satellite 5 tools for RHEL
 ruby                2.5 [d]     common [d]                                An interpreter of object-oriented scripting language
+ruby                2.6 [e]     common [d]                                An interpreter of object-oriented scripting language
+ruby                2.7         common [d]                                An interpreter of object-oriented scripting language
 rust-toolset        rhel8 [d]   common [d]                                Rust
 satellite-5-client  1.0 [d]     common [d], gui                           Red Hat Satellite 5 client packages
 scala               2.10 [d]    common [d]                                A hybrid functional/object-oriented language for the JVM
@@ -48,6 +50,7 @@ Updating Subscription Management repositories.
 Name                Stream      Profiles                                  Summary
 389-ds              1.4                                                   389 Directory Server (base)
 ant                 1.10 [d]    common [d]                                Java build tool
+ant                 1.20        common [d]                                Java build tool
 
 Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled
 """.strip()
@@ -184,7 +187,30 @@ def test_dnf_module_list():
     module_list = DnfModuleList(context_wrap(DNF_MODULE_LIST))
     assert 'ant' in module_list
     assert module_list['httpd'].name == 'httpd'
-    assert module_list['httpd'].stream == '2.4 [d][e]'
+    assert module_list['httpd'].streams[0].stream == '2.4'
+    assert module_list['httpd'].streams[0].default
+    assert module_list['httpd'].streams[0].enabled
+    assert module_list['httpd'].streams[0].active
+    assert module_list['postgresql'].streams[0].stream == '10'
+    assert not module_list['postgresql'].streams[0].enabled
+    assert module_list['postgresql'].streams[0].active
+    assert module_list['postgresql'].streams[0].default
+    assert module_list['postgresql'].streams[1].stream == '9.6'
+    assert not module_list['postgresql'].streams[1].enabled
+    assert not module_list['postgresql'].streams[1].active
+    assert not module_list['postgresql'].streams[1].default
+    assert module_list['ruby'].streams[0].stream == '2.5'
+    assert module_list['ruby'].streams[0].default
+    assert not module_list['ruby'].streams[0].enabled
+    assert not module_list['ruby'].streams[0].active
+    assert module_list['ruby'].streams[1].stream == '2.6'
+    assert module_list['ruby'].streams[1].enabled
+    assert module_list['ruby'].streams[1].active
+    assert not module_list['ruby'].streams[1].default
+    assert module_list['ruby'].streams[2].stream == '2.7'
+    assert not module_list['ruby'].streams[2].enabled
+    assert not module_list['ruby'].streams[2].active
+    assert not module_list['ruby'].streams[2].default
 
 
 def test_dnf_module_list_exp():
@@ -202,9 +228,9 @@ def test_dnf_module_info():
     assert len(module_infos['httpd']) == 2
     assert module_infos['httpd'][0].name == 'httpd'
     assert module_infos['httpd'][0].version == '8000020190405071959'
-    assert len(module_infos['httpd'][0].profiles) == 3
+    assert len(module_infos['httpd'][0].streams[0].profiles) == 3
     assert module_infos['httpd'][0].default_profiles == 'common'
-    assert module_infos['httpd'][1].summary == 'Apache HTTP Server'
+    assert module_infos['httpd'][1].streams[0].summary == 'Apache HTTP Server'
     assert module_infos['httpd'][1].context == '9edba152'
     assert 'mod_http2-0:1.11.3-1.module+el8+2443+605475b7.x86_64' in module_infos['httpd'][1].artifacts
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
DnfModuleList parser stores only the last module:stream which is incorrect, to solve this we should
- store all streams for module
- assign list of profiles to individual streams
- assign summary to individual streams
- parse [e] [x] [d] [a] [i] module stream and profile flags
- collect `dnf module list` output

This is going to be a breaking change but I haven't found any app using this parser in RedHatInsights org. It will be used by vulnerability-engine and patchman-engine to fix evaluation of CVEs/errata for modular packages by using this parser in insights-puptoo https://github.com/RedHatInsights/insights-puptoo/pull/272