### PR TITLE
feat: logrotate client implementation

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -8,13 +8,15 @@ import logging.handlers
 import os
 import time
 import six
+from distutils.version import LooseVersion
 
 from .utilities import (generate_machine_id,
                         write_to_disk,
                         write_registered_file,
                         write_unregistered_file,
                         delete_cache_files,
-                        determine_hostname)
+                        determine_hostname,
+                        get_version_info)
 from .collection_rules import InsightsUploadConf
 from .data_collector import DataCollector
 from .core_collector import CoreCollector
@@ -34,14 +36,25 @@ def do_log_rotation():
 
 
 def get_file_handler(config):
+    '''
+    Sets up the logging file handler.
+    Returns:
+        RotatingFileHandler - client rpm version is older than 3.2.0.
+        FileHandler - client rpm version is 3.2.0 or newer.
+    '''
     log_file = config.logging_file
     log_dir = os.path.dirname(log_file)
     if not log_dir:
         log_dir = os.getcwd()
     elif not os.path.exists(log_dir):
         os.makedirs(log_dir, 0o700)
-    file_handler = logging.handlers.RotatingFileHandler(
-        log_file, backupCount=3)
+    # ensure the legacy rotating file handler is only used in older client versions
+    # or if there is a problem retrieving the rpm version.
+    rpm_version = get_version_info()['client_version']
+    if not rpm_version or (LooseVersion(rpm_version) < LooseVersion(constants.rpm_version_before_logrotate)):
+        file_handler = logging.handlers.RotatingFileHandler(log_file, backupCount=3)
+    else:
+        file_handler = logging.FileHandler(log_file)
     file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
     return file_handler
 

--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -84,6 +84,8 @@ class InsightsConstants(object):
     valid_compressors = ("gz", "xz", "bz2", "none")
     # RPM version in which core collection was released
     core_collect_rpm_version = '3.1.0'
+    # RPM version in which logrotate was released
+    rpm_version_before_logrotate = '3.2.0'
     rhsm_facts_dir = os.path.join(os.sep, 'etc', 'rhsm', 'facts')
     rhsm_facts_file = os.path.join(os.sep, 'etc', 'rhsm', 'facts', 'insights-client.facts')
     # In MB

--- a/insights/tests/client/test_client.py
+++ b/insights/tests/client/test_client.py
@@ -1,10 +1,13 @@
 from contextlib import contextmanager
 from shutil import rmtree
+import logging
+import logging.handlers
 import sys
 import os
 import pytest
 
 from insights.client import InsightsClient
+from insights.client.client import get_file_handler
 from insights.client.archive import InsightsArchive
 from insights.client.config import InsightsConfig
 from insights import package_info
@@ -112,6 +115,32 @@ def _mock_no_register_files_machineid_present():
     finally:
         rmtree(TEMP_TEST_REG_DIR)
         rmtree(TEMP_TEST_REG_DIR2)
+
+
+@patch('insights.client.client.os.path.dirname')
+@patch('insights.client.client.get_version_info')
+def test_get_log_handler_by_client_version(get_version_info, mock_path_dirname):
+    '''
+    Verify that get_log_handler() returns
+    the correct file handler depending on
+    the client rpm version.
+    '''
+    mock_path_dirname.return_value = "mock_dirname"
+
+    # RPM version is older than 3.2.0
+    get_version_info.return_value = {'client_version': '3.1.8'}
+    conf = InsightsConfig(logging_file='/tmp/insights.log')
+    assert isinstance(get_file_handler(conf), logging.handlers.RotatingFileHandler) is True
+
+    # RPM version is 3.2.0
+    get_version_info.return_value = {'client_version': '3.2.0'}
+    conf = InsightsConfig(logging_file='/tmp/insights.log')
+    assert isinstance(get_file_handler(conf), logging.FileHandler) is True
+
+    # RPM version is newer than 3.2.0
+    get_version_info.return_value = {'client_version': '3.2.1'}
+    conf = InsightsConfig(logging_file='/tmp/insights.log')
+    assert isinstance(get_file_handler(conf), logging.FileHandler) is True
 
 
 @patch('insights.client.client.generate_machine_id')


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
This patch updates the logging file handler to no longer use a `RotatingFileHandler`
to prepare for the logrotate feature implementation in insights-client.
The legacy `RotatingFileHandler` will still be used for versions of insights-client preceding 
the implementation of logrotate.

**Associated insights-client changes:** [insights-client PR](https://gitlab.cee.redhat.com/insights-platform/insights-client/-/merge_requests/49)