### PR TITLE
feat: add parser and combiner for IPA

### DIFF
--- a/docs/shared_combiners_catalog/ipa.rst
+++ b/docs/shared_combiners_catalog/ipa.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.combiners.ipa
+    :members:
+    :show-inheritance:

--- a/docs/shared_parsers_catalog/ipa_conf.rst
+++ b/docs/shared_parsers_catalog/ipa_conf.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.ipa_conf
+    :members:
+    :show-inheritance:

--- a/insights/combiners/ipa.py
+++ b/insights/combiners/ipa.py
@@ -69,13 +69,13 @@ class IPA(object):
                 "ipa_server_mode", "false"
             )
             if (
-                self._server_rpm
+                self._server_rpm and
                 # all servers are also clients
-                and self.is_client
+                self.is_client and
                 # only servers use LDAPI (LDAP over Unix socket)
-                and self._ipa_conf.ldap_uri.startswith("ldapi://")
+                self._ipa_conf.ldap_uri.startswith("ldapi://") and
                 # SSSD domain must be in server mode
-                and server_mode.lower() == "true"
+                server_mode.lower() == "true"
             ):
                 self._is_server = True
             else:

--- a/insights/combiners/ipa.py
+++ b/insights/combiners/ipa.py
@@ -29,6 +29,8 @@ class IPA(object):
             self._server_rpm = rpms.get_max("ipa-server")
         if self._client_rpm is None:
             raise SkipComponent("IPA client package is not installed")
+        self._is_client = None
+        self._is_server = None
 
     @property
     def ipa_conf(self):
@@ -48,26 +50,35 @@ class IPA(object):
     @property
     def is_client(self):
         """Is the host an IPA client?"""
-        if not self._client_rpm:
-            return False
-        cfg = self.sssd_domain_config
-        if not cfg.get("id_provider") == "ipa":
-            return False
-        return True
+        # IPAConfig validates that /etc/ipa/default.conf exists and is a
+        # valid IPA config file with all required values present.
+        if self._is_client is None:
+            id_provider = self.sssd_domain_config.get("id_provider")
+            if id_provider == "ipa":
+                self._is_client = True
+            else:
+                self._is_client = False
+
+        return self._is_client
 
     @property
     def is_server(self):
         """Is the host an IPA server?"""
-        if not self.is_client:
-            # all servers are also clients
-            return False
-        if not self._server_rpm:
-            return False
-        if not self._ipa_conf.ldap_uri.startswith("ldapi://"):
-            # only servers use LDAPI (LDAP over Unix socket)
-            return False
-        cfg = self.sssd_domain_config
-        if cfg.get("ipa_server_mode", "false").lower() != "true":
-            # all servers have ipa_server_mode enabled
-            return False
-        return True
+        if self._is_server is None:
+            server_mode = self.sssd_domain_config.get(
+                "ipa_server_mode", "false"
+            )
+            if (
+                self._server_rpm
+                # all servers are also clients
+                and self.is_client
+                # only servers use LDAPI (LDAP over Unix socket)
+                and self._ipa_conf.ldap_uri.startswith("ldapi://")
+                # SSSD domain must be in server mode
+                and server_mode.lower() == "true"
+            ):
+                self._is_server = True
+            else:
+                self._is_server = False
+
+        return self._is_server

--- a/insights/combiners/ipa.py
+++ b/insights/combiners/ipa.py
@@ -1,0 +1,73 @@
+"""
+IPA - Combiner for RHEL IdM / FreeIPA information
+=================================================
+"""
+from insights.core.plugins import combiner
+from insights.core.exceptions import SkipComponent
+from insights.parsers.installed_rpms import InstalledRpms
+from insights.parsers.redhat_release import RedhatRelease
+from insights.parsers.ipa_conf import IPAConfig
+from insights.parsers.sssd_conf import SSSD_Config
+
+
+@combiner(IPAConfig, SSSD_Config, InstalledRpms, RedhatRelease)
+class IPA(object):
+    """Combiner for IPA, SSSD, and installed RPMs
+
+    Provides additional information, e.g. whether the host is an IPA server.
+    """
+
+    def __init__(self, ipa_conf, sssd_conf, rpms, release):
+        self._ipa_conf = ipa_conf
+        self._sssd_conf = sssd_conf
+        # IPA package names are different on Fedora
+        if release.is_fedora:
+            self._client_rpm = rpms.get_max("freeipa-client")
+            self._server_rpm = rpms.get_max("freeipa-server")
+        else:
+            self._client_rpm = rpms.get_max("ipa-client")
+            self._server_rpm = rpms.get_max("ipa-server")
+        if self._client_rpm is None:
+            raise SkipComponent("IPA client package is not installed")
+
+    @property
+    def ipa_conf(self):
+        """Get IPAConfig object"""
+        return self._ipa_conf
+
+    @property
+    def sssd_conf(self):
+        """Get SSSD_Config object"""
+        return self._sssd_conf
+
+    @property
+    def sssd_domain_config(self):
+        """Get SSSD domain configuration for host's IPA domain"""
+        return self._sssd_conf.domain_config(self._ipa_conf.domain)
+
+    @property
+    def is_client(self):
+        """Is the host an IPA client?"""
+        if not self._client_rpm:
+            return False
+        cfg = self.sssd_domain_config
+        if not cfg.get("id_provider") == "ipa":
+            return False
+        return True
+
+    @property
+    def is_server(self):
+        """Is the host an IPA server?"""
+        if not self.is_client:
+            # all servers are also clients
+            return False
+        if not self._server_rpm:
+            return False
+        if not self._ipa_conf.ldap_uri.startswith("ldapi://"):
+            # only servers use LDAPI (LDAP over Unix socket)
+            return False
+        cfg = self.sssd_domain_config
+        if cfg.get("ipa_server_mode", "false").lower() != "true":
+            # all servers have ipa_server_mode enabled
+            return False
+        return True

--- a/insights/parsers/ipa_conf.py
+++ b/insights/parsers/ipa_conf.py
@@ -1,0 +1,172 @@
+"""
+IPA config - file ``/etc/ipa/default.conf``
+===========================================
+"""
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
+
+from insights.core import IniConfigFile, NoOptionError
+from insights.core.exceptions import ParseException
+from insights.core.plugins import parser
+from insights.specs import Specs
+
+
+@parser(Specs.ipa_default_conf)
+class IPAConfig(IniConfigFile):
+    """Parse the IPA default configuration
+
+    The file ``/etc/ipa/default.conf`` contains settings for IPA client and
+    server such as domain and realm name. It is a standard ini file. The
+    ``global``  section must exist. It contains all IPA settings. Other
+    sections are unused.
+
+    The parser provides additional properties which implements the same
+    fallbacks as IPA's internal config system. For example the ``server``
+    property attempts to get the server name from ``[global] server``, then
+    falls back to the net location of ``xmlrpc_uri`` and ``jsonrpc_uri``.
+
+    Raises:
+        ParseException: When config is missing required section or options.
+
+    Sample configuration::
+        [global]
+        host = client.ipa.test
+        basedn = dc=ipa,dc=test
+        realm = IPA.TEST
+        domain = ipa.test
+        xmlrpc_uri = https://server.ipa.test/ipa/xml
+
+    Examples:
+        >>> type(ipaconfig)
+        <class 'insights.parsers.ipa_conf.IPAConfig'>
+        >>> ipaconfig.ipa_section
+        'global'
+        >>> ipaconfig.sections()
+        ['global']
+        >>> ipaconfig.server
+        'server.ipa.test'
+        >>> ipaconfig.domain
+        'ipa.test'
+        >>> ipaconfig.realm
+        'IPA.TEST'
+        >>> ipaconfig.basedn
+        'dc=ipa,dc=test'
+        >>> ipaconfig.xmlrpc_uri
+        'https://server.ipa.test/ipa/xml'
+        >>> ipaconfig.jsonrpc_uri
+        'https://server.ipa.test/ipa/json'
+
+    """
+
+    ipa_section = "global"
+    _server = None
+
+    def parse_content(self, content, allow_no_value=False):
+        super(IPAConfig, self).parse_content(content, allow_no_value)
+        # validate configuration
+        if self.ipa_section not in self:
+            raise ParseException(
+                "Missing '{0}' section".format(self.ipa_section)
+            )
+        try:
+            if not self.realm:
+                raise ValueError("invalid realm")
+            if not self.server:
+                raise ValueError("invalid server")
+        except ValueError as e:
+            raise ParseException(str(e))
+
+    @property
+    def server(self):
+        """IPA server FQDN
+
+        Falls back to ``xmlrpc_uri`` and ``jsonrpc_uri``
+        """
+        if self._server is not None:
+            return self._server
+
+        try:
+            server = self.get(self.ipa_section, "server")
+        except NoOptionError:
+            # fall back
+            try:
+                uri = self.get(self.ipa_section, "xmlrpc_uri")
+            except NoOptionError:
+                try:
+                    uri = self.get(self.ipa_section, "jsonrpc_uri")
+                except NoOptionError:
+                    raise ValueError(
+                        "server, xmlrpc_uri, and jsonrpc_uri missing"
+                    )
+            server = urlparse(uri).netloc
+
+        self._server = server
+        return server
+
+    @property
+    def realm(self):
+        """Kerberos realm name"""
+        try:
+            return self.get(self.ipa_section, "realm")
+        except NoOptionError:
+            # no fallback
+            raise ValueError("realm missing")
+
+    @property
+    def domain(self):
+        """Domain name
+
+        Falls back to lower-case Kerberos ``realm`` name
+        """
+        try:
+            return self.get(self.ipa_section, "domain")
+        except NoOptionError:
+            # fall back to lower realm name
+            return self.realm.lower()
+
+    @property
+    def basedn(self):
+        """LDAP base DN
+
+        Falls back to basedn from ``domain``'s domain components
+        """
+        try:
+            return self.get(self.ipa_section, "basedn")
+        except NoOptionError:
+            parts = self.domain.split(".")
+            return ",".join("dc={0}".format(part) for part in parts)
+
+    @property
+    def ldap_uri(self):
+        """LDAP server uri
+
+        Falls back to ``server`` to build an ``ldap://`` URI.
+        """
+        try:
+            return self.get(self.ipa_section, "ldap_uri")
+        except NoOptionError:
+            return "ldap://{0}".format(self.server)
+
+    @property
+    def xmlrpc_uri(self):
+        """XML-RPC uri
+
+        Falls back to ``server`` to build an ``https://`` URI.
+        """
+        try:
+            return self.get(self.ipa_section, "xmlrpc_uri")
+        except NoOptionError:
+            return "https://{0}/ipa/xml".format(self.server)
+
+    @property
+    def jsonrpc_uri(self):
+        """JSON-RPC uri
+
+        Falls back to ``server`` to build an ``https://`` URI.
+        """
+        try:
+            return self.get(self.ipa_section, "jsonrpc_uri")
+        except NoOptionError:
+            return "https://{0}/ipa/json".format(self.server)

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -271,6 +271,7 @@ class Specs(SpecSet):
     ip_netns_exec_namespace_lsof = RegistryPoint(multi_output=True, filterable=True)
     ip_route_show_table_all = RegistryPoint()
     ip_s_link = RegistryPoint()
+    ipa_default_conf = RegistryPoint()
     ipaupgrade_log = RegistryPoint(filterable=True)
     ipcs_m = RegistryPoint()
     ipcs_m_p = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -288,6 +288,7 @@ class DefaultSpecs(Specs):
     ip_addresses = simple_command("/bin/hostname -I")
     ip_route_show_table_all = simple_command("/sbin/ip route show table all")
     ip_s_link = simple_command("/sbin/ip -s -d link")
+    ipa_default_conf = simple_file("/etc/ipa/default.conf")
     ipaupgrade_log = simple_file("/var/log/ipaupgrade.log")
     ipcs_m = simple_command("/usr/bin/ipcs -m")
     ipcs_m_p = simple_command("/usr/bin/ipcs -m -p")

--- a/insights/tests/client/apps/test_playbook_verifier.py
+++ b/insights/tests/client/apps/test_playbook_verifier.py
@@ -169,7 +169,7 @@ def test_revoked_playbook(call_1, call_2):
     assert revoked_error in str(error.value)
 
 
-@pytest.mark.skipif(sys.version_info.major != 2 and sys.version_info.minor != 7, reason='normalizeSnippet is only run with Python 2.7')
+@pytest.mark.skipif(sys.version_info[:2] != (2, 7), reason='normalizeSnippet is only run with Python 2.7')
 def test_normalize_snippet():
     playbook = '''task:
   when:

--- a/insights/tests/combiners/test_ipa.py
+++ b/insights/tests/combiners/test_ipa.py
@@ -1,0 +1,118 @@
+from insights.combiners.ipa import IPA
+from insights.parsers.installed_rpms import InstalledRpms
+from insights.parsers.ipa_conf import IPAConfig
+from insights.parsers.redhat_release import RedhatRelease
+from insights.parsers.sssd_conf import SSSD_Config
+
+from insights.tests import context_wrap
+
+REDHAT_RELEASE_RHEL = """
+Red Hat Enterprise Linux release 9.2 (Plow)
+"""
+
+IPA_RPMS_CLIENT = """
+ipa-client-4.10.1-6.el9.x86_64
+"""
+
+IPA_RPMS_SERVER = """
+ipa-client-4.10.1-6.el9.x86_64
+ipa-server-4.10.1-6.el9.x86_64
+"""
+
+SSSD_CONF_SERVER = """
+[domain/ipa.test]
+id_provider = ipa
+ipa_server_mode = True
+ipa_server = server.ipa.test
+ipa_domain = ipa.test
+ipa_hostname = server.ipa.test
+auth_provider = ipa
+chpass_provider = ipa
+access_provider = ipa
+cache_credentials = True
+ldap_tls_cacert = /etc/ipa/ca.crt
+krb5_store_password_if_offline = True
+sudo_provider = ipa
+autofs_provider = ipa
+subdomains_provider = ipa
+session_provider = ipa
+hostid_provider = ipa
+
+[sssd]
+domains = ipa.test
+"""
+
+IPA_DEFAULT_CONF_SERVER = """
+[global]
+host = server.ipa.test
+basedn = dc=ipahcc,dc=test
+realm = ipa.test
+domain = ipa.test
+xmlrpc_uri = https://server.ipa.test/ipa/xml
+ldap_uri = ldapi://%2Frun%2Fslapd-IPAHCC-TEST.socket
+mode = production
+enable_ra = True
+ra_plugin = dogtag
+dogtag_version = 10
+"""
+
+SSSD_CONF_CLIENT = """
+[domain/ipa.test]
+id_provider = ipa
+ipa_server = _srv_, server.ipa.test
+ipa_domain = ipa.test
+ipa_hostname = client91.ipa.test
+auth_provider = ipa
+chpass_provider = ipa
+access_provider = ipa
+cache_credentials = True
+ldap_tls_cacert = /etc/ipa/ca.crt
+krb5_store_password_if_offline = True
+
+[sssd]
+domains = ipa.test
+"""
+
+IPA_DEFAULT_CONF_CLIENT = """
+[global]
+basedn = dc=ipahcc,dc=test
+realm = ipa.test
+domain = ipa.test
+server = server.ipa.test
+host = client91.ipa.test
+xmlrpc_uri = https://server.ipa.test/ipa/xml
+enable_ra = True
+"""
+
+
+def test_ipa():
+    redhat_release = RedhatRelease(context_wrap(REDHAT_RELEASE_RHEL))
+
+    rpms_client = InstalledRpms(context_wrap(IPA_RPMS_CLIENT))
+    sssd_conf_client = SSSD_Config(context_wrap(SSSD_CONF_CLIENT))
+    ipa_conf_client = IPAConfig(context_wrap(IPA_DEFAULT_CONF_CLIENT))
+
+    rpms_server = InstalledRpms(context_wrap(IPA_RPMS_SERVER))
+    sssd_conf_server = SSSD_Config(context_wrap(SSSD_CONF_SERVER))
+    ipa_conf_server = IPAConfig(context_wrap(IPA_DEFAULT_CONF_SERVER))
+
+    ipa_client = IPA(
+        ipa_conf_client, sssd_conf_client, rpms_client, redhat_release
+    )
+    assert ipa_client.sssd_conf.domains == [ipa_client.ipa_conf.domain]
+    assert ipa_client.is_client
+    assert not ipa_client.is_server
+
+    ipa_server = IPA(
+        ipa_conf_server, sssd_conf_server, rpms_server, redhat_release
+    )
+    assert ipa_server.sssd_conf.domains == [ipa_server.ipa_conf.domain]
+    assert ipa_server.is_client
+    assert ipa_server.is_server
+
+    ipa_mixed = IPA(
+        ipa_conf_client, sssd_conf_server, rpms_client, redhat_release
+    )
+    assert ipa_mixed.sssd_conf.domains == [ipa_mixed.ipa_conf.domain]
+    assert ipa_mixed.is_client
+    assert not ipa_mixed.is_server

--- a/insights/tests/combiners/test_ipa.py
+++ b/insights/tests/combiners/test_ipa.py
@@ -100,8 +100,12 @@ def test_ipa():
         ipa_conf_client, sssd_conf_client, rpms_client, redhat_release
     )
     assert ipa_client.sssd_conf.domains == [ipa_client.ipa_conf.domain]
+    assert ipa_client._is_client is None
+    assert ipa_client._is_server is None
     assert ipa_client.is_client
+    assert ipa_client._is_client
     assert not ipa_client.is_server
+    assert not ipa_client._is_server
 
     ipa_server = IPA(
         ipa_conf_server, sssd_conf_server, rpms_server, redhat_release

--- a/insights/tests/parsers/test_ipa_conf.py
+++ b/insights/tests/parsers/test_ipa_conf.py
@@ -1,0 +1,67 @@
+import doctest
+
+import pytest
+
+from insights.core.exceptions import ParseException
+from insights.parsers import ipa_conf
+from insights.tests import context_wrap
+
+IPA_DEFAULT_CONF = """
+[global]
+host = client.ipa.test
+basedn = dc=ipa,dc=test
+realm = IPA.TEST
+domain = ipa.test
+xmlrpc_uri = https://server.ipa.test/ipa/xml
+"""
+
+IPA_DEFAULT_MINIMAL = """
+[global]
+realm = IPA.TEST
+server = server.ipa.test
+"""
+
+
+def test_doc_examples():
+    env = {
+        "ipaconfig": ipa_conf.IPAConfig(context_wrap(IPA_DEFAULT_CONF)),
+    }
+    failed, total = doctest.testmod(ipa_conf, globs=env)
+    assert failed == 0
+
+
+def test_ipa_default_conf():
+    cfg = ipa_conf.IPAConfig(context_wrap(IPA_DEFAULT_CONF))
+
+    assert cfg.ipa_section == "global"
+    assert cfg.get("global", "host") == "client.ipa.test"
+
+    assert cfg.server == "server.ipa.test"
+    assert cfg.domain == "ipa.test"
+    assert cfg.realm == "IPA.TEST"
+    assert cfg.basedn == "dc=ipa,dc=test"
+    assert cfg.ldap_uri == "ldap://server.ipa.test"
+    assert cfg.xmlrpc_uri == "https://server.ipa.test/ipa/xml"
+    assert cfg.jsonrpc_uri == "https://server.ipa.test/ipa/json"
+
+
+def test_ipa_default_minimal():
+    cfg = ipa_conf.IPAConfig(context_wrap(IPA_DEFAULT_MINIMAL))
+
+    assert cfg.server == "server.ipa.test"
+    assert cfg.domain == "ipa.test"
+    assert cfg.realm == "IPA.TEST"
+    assert cfg.basedn == "dc=ipa,dc=test"
+    assert cfg.ldap_uri == "ldap://server.ipa.test"
+    assert cfg.xmlrpc_uri == "https://server.ipa.test/ipa/xml"
+    assert cfg.jsonrpc_uri == "https://server.ipa.test/ipa/json"
+
+
+def test_ipa_missing_section():
+    with pytest.raises(ParseException):
+        ipa_conf.IPAConfig(context_wrap("[invalid]"))
+
+
+def test_ipa_missing_settings():
+    with pytest.raises(ParseException):
+        ipa_conf.IPAConfig(context_wrap("[global]"))


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

``insights.parsers.ipa_conf.IPAConfig`` parses the IPA client and server config file ``/etc/ipa/default.conf``. The config file contains information such as domain, realm, and server URIs. The parser implements the same fallback logic as IPA's internal config parser.

``insights.combiners.ipa.IPA`` combines information from ``IPAConfig``, ``SSSDConfig``, and ``InstalledRpms`` to detect whether a system is an IPA server.

See: HMS-1285

This is an alternative take on PR #3764. It does not have spec and parser for ``/var/lib/ipa/sysrestore/sysrestore.state``. Instead it uses a combiner to check ``IPAConfig``, ``SSSD_Config``, and ``InstalledRpms`` whether a system is an IPA server. In addition it raises a ``ParserException`` when ``/etc/ipa/default.conf`` is invalid.

`/etc/ipa/default.conf` is readable by insights-client
```
# ls -laZ /etc/ipa/default.conf
-rw-r--r--. 1 root root unconfined_u:object_r:etc_t:s0         279 Mar 14 11:20 /etc/ipa/default.conf
```