### PR TITLE
fix: fix test playbook by using no named tuples

### DIFF
--- a/insights/tests/client/apps/test_playbook_verifier.py
+++ b/insights/tests/client/apps/test_playbook_verifier.py
@@ -169,7 +169,7 @@ def test_revoked_playbook(call_1, call_2):
     assert revoked_error in str(error.value)
 
 
-@pytest.mark.skipif(sys.version_info.major != 2 and sys.version_info.minor != 7, reason='normalizeSnippet is only run with Python 2.7')
+@pytest.mark.skipif(sys.version_info[:2] != (2, 7), reason='normalizeSnippet is only run with Python 2.7')
 def test_normalize_snippet():
     playbook = '''task:
   when:


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
sys.version_info named tuples were introducing with python 2.7. Test for lower version are failing because of that.
https://docs.python.org/2/library/sys.html#sys.version_info