### PR TITLE
fix: default and disabled module cannot be active

### DIFF
--- a/insights/parsers/dnf_module.py
+++ b/insights/parsers/dnf_module.py
@@ -167,7 +167,7 @@ class DnfModuleList(CommandParser, dict):
                 # we have no `active` stream because no stream is `enabled`
                 # mark `default` module as `active`
                 for stream in module_brief.streams:
-                    if stream.default:
+                    if stream.default and not stream.disabled:
                         stream.active = True
                         module_brief._has_active_stream = True
                         break

--- a/insights/tests/parsers/test_dnf_module.py
+++ b/insights/tests/parsers/test_dnf_module.py
@@ -41,6 +41,7 @@ subversion          1.10 [d]    common [d], server                        Apache
 swig                3.0 [d]     common [d], complete                      Connects C/C++/Objective C to some high-level programming languages
 varnish             6 [d]       common [d]                                Varnish HTTP cache
 virt                rhel [d]    common [d]                                Virtualization module
+default_disabled    1.0 [d][x]                                            Default module which is disabled
 
 Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled
 """.strip()
@@ -211,6 +212,11 @@ def test_dnf_module_list():
     assert not module_list['ruby'].streams[2].enabled
     assert not module_list['ruby'].streams[2].active
     assert not module_list['ruby'].streams[2].default
+    assert module_list['default_disabled'].streams[0].stream == '1.0'
+    assert module_list['default_disabled'].streams[0].default
+    assert module_list['default_disabled'].streams[0].disabled
+    assert not module_list['default_disabled'].streams[0].enabled
+    assert not module_list['default_disabled'].streams[0].active
 
 
 def test_dnf_module_list_exp():


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
While implementing https://github.com/RedHatInsights/insights-puptoo/pull/272 I noticed I made a bug in DnfModuleList parser. When a module is `default` and `disabled`, it can't be `active`
