### PR TITLE
feat: add collect_pcp_archive option

### DIFF
--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -466,6 +466,12 @@ DEFAULT_OPTS = {
         'const': True,
         'nargs': '?',
         'group': 'actions'
+    },
+    'collect_pcp_archive': {
+        'default': False,
+        'opt': ['--collect-pcp-archive'],
+        'help': 'Collect pcp log archives for Resource Optimization Service',
+        'action': 'store_true'
     }
 }
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

To collect pcp log archives when pcp-zeroconf package is installed, pcp services are running there should a flag. By default pcp log archives should not be collected and those should only be collected if this flag is True.
