### PR TITLE
fix: sort the filters in the filters.yaml

### DIFF
--- a/insights/core/filters.py
+++ b/insights/core/filters.py
@@ -192,10 +192,10 @@ def load(stream=None):
 
 
 def dumps():
-    """Returns a string representation of the FILTERS dictionary."""
+    """Returns a string representation of the sorted FILTERS dictionary."""
     d = {}
     for k, v in FILTERS.items():
-        d[dr.get_name(k)] = list(v)
+        d[dr.get_name(k)] = sorted(v)
     return _dumps(d)
 
 

--- a/insights/tests/test_filters.py
+++ b/insights/tests/test_filters.py
@@ -32,7 +32,7 @@ def setup_function(func):
         filters.add_filter(DefaultSpecs.ps_aux, "MEM")
 
     if func is test_filter_dumps_loads:
-        filters.add_filter(Specs.ps_aux, "COMMAND")
+        filters.add_filter(Specs.ps_aux, ["PID", "COMMAND", "TEST"])
 
 
 def teardown_function(func):
@@ -62,7 +62,10 @@ def test_filter_dumps_loads():
     filters.loads(r)
 
     assert Specs.ps_aux in filters.FILTERS
-    assert filters.FILTERS[Specs.ps_aux] == set(["COMMAND"])
+    assert filters.FILTERS[Specs.ps_aux] == set(["PID", "COMMAND", "TEST"])
+
+    r2 = filters.dumps()
+    assert r2 == r  # 'filters' are in the same order in every dumps()
 
 
 def test_get_filter():


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

- The current filters were generated in random order and in each release, 
   it results in the MRs to the insights-core-assets containing a big change
   and difficult to check the actual changes.
- This MR sorted the list of filters in the `filter.yaml`
- See INSGHTCORE-206 for details
