### PR TITLE
fix: py3.9 test error: 'HTTPResponse' object has no attribute 'strict'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
         flake8 .
     - name: pytest
       run: |
+        pip install 'urllib3<2'
         pip install -e .[testing]
         pytest
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

- fix the following errors in the py3.9 CI test:
```
>               u"strict": response.strict,
                u"decode_content": response.decode_content,
            }
        }
E       AttributeError: 'HTTPResponse' object has no attribute 'strict
```
- See https://github.com/ionrock/cachecontrol/issues/292