### PR TITLE
Feat: Add identity domain combiner

### DIFF
--- a/docs/shared_combiners_catalog/identity_domain.rst
+++ b/docs/shared_combiners_catalog/identity_domain.rst
@@ -1,0 +1,7 @@
+.. automodule:: insights.combiners.identity_domain
+
+.. autoclass:: insights.combiners.identity_domain.DomainInfo
+
+.. autoclass:: insights.combiners.identity_domain.IdentityDomain
+    :members:
+    :show-inheritance:

--- a/insights/combiners/identity_domain.py
+++ b/insights/combiners/identity_domain.py
@@ -1,0 +1,289 @@
+"""
+Identity Domain - Combiner for domain enrollment
+================================================
+
+The combiner detects enrollment into identity domains such as IPA,
+Active Directory, generic Kerberos realm, and generic LDAP. It parses
+domains and realms from SSSD, KRB5, IPA, and Samba configuration.
+
+Supported domain types
+----------------------
+
+* IPA (RHEL IdM, FreeIPA)
+* Active Directory (SSSD)
+* Active Directory (Samba winbind)
+* generic LDAP domain (SSSD)
+* generic LDAP domain with Kerberos authentication (SSSD)
+* generic Kerberos realm (from ``krb5.conf``)
+
+The combiner cannot detect generic Kerberos realms that solely rely upon
+DNS realm lookup (``dns_lookup_realm``).
+
+Examples::
+
+    DomainInfo(
+        name="ipa.test",
+        domain_type="IPA",
+        server_software="IPA",
+        client_software="SSSD",
+        domain="ipa.test",
+        realm="IPA.TEST",
+        workgroup=None,
+        ipa_mode="client",
+    )
+
+    DomainInfo(
+        name="ad-winbind.test",
+        domain_type="Active Directory (winbind)",
+        server_software="Active Directory",
+        client_software="winbind",
+        domain="ad-winbind.test",
+        realm="AD-WINBIND.TEST",
+        workgroup="AD-WINBIND",
+        ipa_mode=None,
+    )
+"""
+import collections
+
+from insights.core.exceptions import SkipComponent
+from insights.core.plugins import combiner
+from insights.combiners.ipa import IPA
+from insights.parsers.samba import SambaConfigs
+from insights.parsers.sssd_conf import SSSD_Config
+from insights.combiners.krb5 import AllKrb5Conf
+
+
+class DomainTypes(object):
+    """Human readable domain type"""
+
+    # SSSD domain types
+    IPA = "IPA"
+    AD_SSSD = "Active Directory (SSSD)"
+    LDAP = "LDAP"
+    LDAP_KRB5 = "LDAP/Kerberos"
+    # krb5.conf but not in sssd.conf
+    KRB5 = "Kerberos"
+    # Samba winbind
+    AD_WINBIND = "Active Directory (winbind)"
+
+
+class ServerSoftware(object):
+    """Server software"""
+
+    IPA = "IPA"
+    AD = "Active Directory"
+    LDAP = "generic LDAP"
+    LDAP_KRB5 = "generic LDAP/Kerberos"
+    KRB5 = "generic Kerberos"
+
+
+class ClientSoftware(object):
+    """Client software"""
+
+    SSSD = "SSSD"
+    WINBIND = "winbind"
+    KRB5 = "Kerberos"
+
+
+class IPAMode(object):
+    """IPA mode (server or client-only)"""
+
+    IPA_CLIENT = "client"
+    IPA_SERVER = "server"
+
+
+DomainInfo = collections.namedtuple(
+    "DomainInfo",
+    [
+        "name",
+        "domain_type",
+        "server_software",
+        "client_software",
+        "domain",
+        "realm",
+        "workgroup",
+        "ipa_mode",
+    ],
+)
+"""Identity domain information
+
+Attributes:
+    name (str): user-friendly name
+        either SSSD's domain name, domain name, or lower-case realm name
+    domain_type (str): domain type, e.g. ``IPA`` or ``Active Directory (SSSD)``
+    server_software (str): name of the server software, e.g. ``Active Directory``
+    client_software (str): name of the client software, e.g. ``SSSD`` or ``winbind``
+    domain (str, None): name of the identity domain,
+        not set for generic Kerberos or LDAP
+    realm (str, None): Kerberos realm name,
+        not set for generic LDAP
+    workgroup (str, None): workgroup name,
+        only set for AD with winbind
+    ipa_mode (str, None): IPA mode (server or client),
+        only set for IPA
+"""
+
+
+@combiner(optional=[SSSD_Config, AllKrb5Conf, IPA, SambaConfigs])
+class IdentityDomain(object):
+    """
+    A combiner for identity domains.
+
+    Raises:
+        SkipComponent: When no identity domains are detected.
+
+    Attributes:
+        domains (list): List of the namedtuple `DomainInfo`
+        default_realm (str, None): default realm name (if configured)
+        dns_lookup_realm (bool): is Kerberos realm DNS lookup enabled?
+        dns_lookup_kdc (bool): is Kerberos KDC DNS lookup enabled?
+    """
+
+    def __init__(self, sssd=None, krb5=None, ipa=None, smb=None):
+        if sssd is None and krb5 is None and smb is None:
+            # ipa depends on sssd
+            raise SkipComponent("KRB5, SSSD, and Samba are not configured")
+
+        self.domains = []
+        self._realms = set()
+
+        if krb5 is not None:
+            self.default_realm = krb5.default_realm
+            self.dns_lookup_realm = krb5.dns_lookup_realm
+            self.dns_lookup_kdc = krb5.dns_lookup_kdc
+        else:
+            self.default_realm = None
+            # krb5.conf default is True
+            self.dns_lookup_realm = True
+            self.dns_lookup_kdc = True
+
+        if sssd is not None:
+            self._parse_sssd(sssd, ipa)
+        if smb is not None:
+            self._parse_smb(smb)
+        if krb5 is not None:
+            # parse /etc/krb5.conf last to skip SSSD and Samba realms
+            self._parse_krb5(krb5)
+
+        if not self.domains:
+            raise SkipComponent("No identity domains detected")
+
+    def _add_domaininfo(
+        self, name, dtype, srv, clnt, domain, realm, workgroup=None, ipa_mode=None
+    ):
+        if realm is not None:
+            if realm in self._realms:
+                # already configured
+                return
+            self._realms.add(realm)
+
+        di = DomainInfo(name, dtype, srv, clnt, domain, realm, workgroup, ipa_mode)
+        self.domains.append(di)
+
+    def _parse_sssd(self, sssd, ipa):
+        """Extract domains from sssd.conf
+
+        Supports id_providers "ad", "ipa", and "ldap".
+        """
+        id_auth_providers = set(["ldap", "krb5", "ipa", "ad", "proxy"])
+        for name in sssd.domains:
+            if "/" in name:
+                # Ignore trusted domain (subdomain) configuration. Subdomain
+                # settings are configured as
+                # `[domain/parent.example/subdomain.example]`.
+                continue
+            conf = sssd.domain_config(name)
+            id_provider = conf.get("id_provider")
+            ipa_mode = None
+
+            auth_provider = conf.get("auth_provider")
+            if auth_provider is None and id_provider in id_auth_providers:
+                # most id providers are also an auth providers
+                auth_provider = id_provider
+            elif auth_provider == "none":
+                auth_provider = None
+
+            if id_provider == "ad":
+                dtype = DomainTypes.AD_SSSD
+                srv = ServerSoftware.AD
+                domain = conf.get("ad_domain", name)
+                realm = conf.get("krb5_domain", domain.upper())
+            elif id_provider == "ipa":
+                if ipa is None or not ipa.is_client:
+                    # unsupported configuration
+                    continue
+                dtype = DomainTypes.IPA
+                srv = ServerSoftware.IPA
+                domain = conf.get("ipa_domain", name)
+                realm = conf.get("krb5_domain", domain.upper())
+                ipa_mode = IPAMode.IPA_SERVER if ipa.is_server else IPAMode.IPA_CLIENT
+            elif id_provider == "ldap":
+                if auth_provider == "ldap":
+                    dtype = DomainTypes.LDAP
+                    srv = ServerSoftware.LDAP
+                    domain = None
+                    realm = None
+                elif auth_provider == "krb5":
+                    dtype = DomainTypes.LDAP_KRB5
+                    srv = ServerSoftware.LDAP_KRB5
+                    domain = None
+                    # krb5_domain is required
+                    realm = conf.get("krb5_realm", name.upper())
+                else:
+                    # unsupported configuration
+                    continue
+            elif id_provider in ("proxy", "files"):
+                # not an identity domain
+                continue
+            else:
+                # unsupported configuration
+                continue
+
+            self._add_domaininfo(
+                name, dtype, srv, ClientSoftware.SSSD, domain, realm, ipa_mode=ipa_mode
+            )
+
+    def _parse_smb(self, smb):
+        """Parse smb.conf to detect AD with winbind
+
+        We ignore IPA DC here as the information is already provided by
+        `sssd.conf`. IPA DC has either server role `ROLE_IPA_DC`
+        (Samba >= 4.16.0) or `ROLE_DOMAIN_PDC`, and always
+        `security=user`.
+        """
+        if (
+            smb.server_role != "ROLE_DOMAIN_MEMBER" or
+            not smb.has_option("global", "security") or
+            smb.get("global", "security").upper() != "ADS" or
+            not smb.has_option("global", "realm")
+        ):
+            return
+        realm = smb.get("global", "realm")
+        domain = realm.lower()
+
+        if smb.has_option("global", "workgroup"):
+            workgroup = smb.get("global", "workgroup")
+        else:
+            workgroup = realm.split(".", 1)[0]
+
+        self._add_domaininfo(
+            domain,
+            DomainTypes.AD_WINBIND,
+            ServerSoftware.AD,
+            ClientSoftware.WINBIND,
+            domain,
+            realm,
+            workgroup,
+        )
+
+    def _parse_krb5(self, krb5):
+        """Parse krb5.conf to detect additional generic Kerberos realms"""
+        for realm in krb5.realms:
+            self._add_domaininfo(
+                realm.lower(),
+                DomainTypes.KRB5,
+                ServerSoftware.KRB5,
+                ClientSoftware.KRB5,
+                None,
+                realm,
+            )

--- a/insights/parsers/krb5.py
+++ b/insights/parsers/krb5.py
@@ -73,6 +73,21 @@ def _handle_key_value(t_dict, key, value):
     return value
 
 
+def _handle_krb5_bool(value):
+    """
+    Convert krb5.conf boolean
+    """
+    # see lib/krb5/krb/libdef_parse.c _krb5_conf_boolean()
+    if value in set(["y", "yes", "true", "t", "1", "on"]):
+        return True
+    elif value in set(["n", "no", "false", "nil", "0", "off"]):
+        return False
+    else:
+        # _krb5_conf_boolean() treats any other value as "False". Return
+        # "None" so caller can identify this case.
+        return None
+
+
 @parser(Specs.krb5)
 class Krb5Configuration(Parser, LegacyItemAccess):
     """
@@ -179,3 +194,11 @@ class Krb5Configuration(Parser, LegacyItemAccess):
         if section not in self.data:
             return False
         return option in self.data[section]
+
+    def getboolean(self, section, option):
+        """Parse option as bool
+
+        Returns None is not a krb5.conf boolean string.
+        """
+        value = self.data[section][option]
+        return _handle_krb5_bool(value)

--- a/insights/parsers/sssd_conf.py
+++ b/insights/parsers/sssd_conf.py
@@ -88,7 +88,7 @@ class SSSD_Config(IniConfigFile):
         if self.has_option('sssd', 'domains'):
             domains = self.get('sssd', 'domains')
             if domains:
-                return domains.split(',')
+                return [domain.strip() for domain in domains.split(',')]
 
         # Return a blank list if no domains.
         return []

--- a/insights/tests/combiners/test_identity_domain.py
+++ b/insights/tests/combiners/test_identity_domain.py
@@ -1,0 +1,239 @@
+import pytest
+
+from insights.core.exceptions import SkipComponent
+from insights.combiners.krb5 import AllKrb5Conf
+from insights.combiners.identity_domain import (
+    IdentityDomain,
+    DomainInfo,
+    DomainTypes,
+    ClientSoftware,
+    ServerSoftware,
+    IPAMode,
+)
+from insights.combiners.ipa import IPA
+from insights.parsers.installed_rpms import InstalledRpms
+from insights.parsers.ipa_conf import IPAConfig
+from insights.parsers.krb5 import Krb5Configuration
+from insights.parsers.redhat_release import RedhatRelease
+from insights.parsers.samba import SambaConfigs
+from insights.parsers.sssd_conf import SSSD_Config
+from insights.tests import context_wrap
+
+KRB5_CONF = """
+[libdefaults]
+    dns_lookup_realm = false
+    default_realm = IPA.TEST
+    dns_canonicalize_hostname = false
+    ticket_lifetime = 24h
+    renew_lifetime = 7d
+    rdns = false
+
+[realms]
+    IPA.TEST = {
+        pkinit_anchors = FILE:/var/lib/ipa-client/pki/kdc-ca-bundle.pem
+        pkinit_pool = FILE:/var/lib/ipa-client/pki/ca-bundle.pem
+    }
+    KERBEROS-LDAP.TEST = {
+        kdc = kdc.kerberos-ldap.test
+    }
+
+    KERBEROS.TEST = {
+        kdc = kdc.kerberos.test
+    }
+
+    # "realm join" for AD  does not add an entry to krb5.conf.
+    # AD-WINBIND.TEST = {}
+    # AD-SSSD.TEST = {}
+
+[domain_realm]
+  .ipa.test = IPA.TEST
+  ipa.test = IPA.TEST
+"""
+
+SMB_CONF_WINBIND = """
+# output of testparm -s
+Server role: ROLE_DOMAIN_MEMBER
+
+[global]
+    realm = AD-WINBIND.TEST
+    security = ADS
+    template homedir = /home/%U@%D
+    template shell = /bin/bash
+    winbind offline logon = Yes
+    winbind refresh tickets = Yes
+    workgroup = AD-WINBIND
+    idmap config * : range = 10000-999999
+    idmap config sub1 : backend = rid
+    idmap config sub1 : range = 2000000-2999999
+    idmap config * : backend = tdb
+"""
+
+REDHAT_RELEASE_RHEL = """
+Red Hat Enterprise Linux release 9.2 (Plow)
+"""
+
+IPA_RPMS_CLIENT = """
+ipa-client-4.10.1-6.el9.x86_64
+"""
+
+IPA_DEFAULT_CONF = """
+[global]
+basedn = dc=ipa,dc=test
+realm = IPA.TEST
+domain = ipa.test
+server = server.ipa.test
+xmlrpc_uri = https://server.ipa.test/ipa/xml
+enable_ra = True
+"""
+
+SSSD_CONF = """
+[sssd]
+domains = ad-sssd.test, ipa.test, kerberos-ldap, ldap
+config_file_version = 2
+services = nss, pam
+
+[domain/ad-sssd.test]
+default_shell = /bin/bash
+krb5_store_password_if_offline = True
+cache_credentials = True
+krb5_realm = AD-SSSD.TEST
+realmd_tags = manages-system joined-with-adcli
+id_provider = ad
+fallback_homedir = /home/%u@%d
+ad_domain = ad-sssd.test
+use_fully_qualified_names = True
+ldap_id_mapping = True
+access_provider = ad
+
+[domain/ipa.test]
+id_provider = ipa
+ipa_server = _srv_, server.ipa.test
+ipa_domain = ipa.test
+ipa_hostname = client91.ipa.test
+auth_provider = ipa
+chpass_provider = ipa
+access_provider = ipa
+cache_credentials = True
+ldap_tls_cacert = /etc/ipa/ca.crt
+krb5_store_password_if_offline = True
+
+[domain/kerberos-ldap]
+id_provider = ldap
+ldap_uri = ldap://ldap.kerberos-ldap.test
+ldap_search_base = dc=kerberos-ldap,dc=test
+auth_provider = krb5
+krb5_server = kdc.kerberos-ldap.test
+krb5_realm = KERBEROS-LDAP.TEST
+
+[domain/ldap]
+id_provider = ldap
+ldap_uri = ldap://ldap.ldap.test
+ldap_search_base = dc=ldap,dc=test?subtree?
+cache_credentials = true
+"""
+
+IPA_DOMAIN = DomainInfo(
+    "ipa.test",
+    DomainTypes.IPA,
+    ServerSoftware.IPA,
+    ClientSoftware.SSSD,
+    "ipa.test",
+    "IPA.TEST",
+    None,
+    IPAMode.IPA_CLIENT,
+)
+
+KERBEROS_LDAP_DOMAIN = DomainInfo(
+    "kerberos-ldap",
+    DomainTypes.LDAP_KRB5,
+    ServerSoftware.LDAP_KRB5,
+    ClientSoftware.SSSD,
+    None,
+    "KERBEROS-LDAP.TEST",
+    None,
+    None,
+)
+
+LDAP_DOMAIN = DomainInfo(
+    "ldap",
+    DomainTypes.LDAP,
+    ServerSoftware.LDAP,
+    ClientSoftware.SSSD,
+    None,
+    None,
+    None,
+    None,
+)
+
+AD_SSSD_DOMAIN = DomainInfo(
+    "ad-sssd.test",
+    DomainTypes.AD_SSSD,
+    ServerSoftware.AD,
+    ClientSoftware.SSSD,
+    "ad-sssd.test",
+    "AD-SSSD.TEST",
+    None,
+    None,
+)
+
+KERBEROS_DOMAIN = DomainInfo(
+    "kerberos.test",
+    DomainTypes.KRB5,
+    ServerSoftware.KRB5,
+    ClientSoftware.KRB5,
+    None,
+    "KERBEROS.TEST",
+    None,
+    None,
+)
+
+AD_WINBIND_DOMAIN = DomainInfo(
+    "ad-winbind.test",
+    DomainTypes.AD_WINBIND,
+    ServerSoftware.AD,
+    ClientSoftware.WINBIND,
+    "ad-winbind.test",
+    "AD-WINBIND.TEST",
+    "AD-WINBIND",
+    None,
+)
+
+
+def test_identity_domain_sssd():
+    krb5 = AllKrb5Conf(
+        [Krb5Configuration(context_wrap(KRB5_CONF, path="/etc/krb5.conf"))]
+    )
+    sssd = SSSD_Config(context_wrap(SSSD_CONF, path="/etc/sssd/sssd.conf"))
+    redhat_release = RedhatRelease(context_wrap(REDHAT_RELEASE_RHEL))
+    rpms_client = InstalledRpms(context_wrap(IPA_RPMS_CLIENT))
+    ipa_conf = IPAConfig(context_wrap(IPA_DEFAULT_CONF, path="/etc/ipa/default.conf"))
+    ipa = IPA(ipa_conf, sssd, rpms_client, redhat_release)
+
+    identity_domain = IdentityDomain(sssd, krb5, ipa, None)
+
+    assert identity_domain.domains == [
+        AD_SSSD_DOMAIN,
+        IPA_DOMAIN,
+        KERBEROS_LDAP_DOMAIN,
+        LDAP_DOMAIN,
+        KERBEROS_DOMAIN,
+    ]
+
+    assert identity_domain.default_realm == "IPA.TEST"
+    assert identity_domain.dns_lookup_kdc is True
+    assert identity_domain.dns_lookup_realm is False
+
+
+def test_identity_domain_samba():
+    smbwb = SambaConfigs(context_wrap(SMB_CONF_WINBIND, path="/etc/samba/smb.conf"))
+    identity_domain = IdentityDomain(None, None, None, smbwb)
+    assert identity_domain.domains == [AD_WINBIND_DOMAIN]
+
+    assert identity_domain.default_realm is None
+    assert identity_domain.dns_lookup_kdc is True
+    assert identity_domain.dns_lookup_realm is True
+
+
+def test_identity_domain_empty():
+    with pytest.raises(SkipComponent):
+        IdentityDomain(None, None, None, None)

--- a/insights/tests/parsers/test_krb5.py
+++ b/insights/tests/parsers/test_krb5.py
@@ -108,6 +108,7 @@ KRB5_DCONF_PATH = "etc/krb5.conf.d/test.conf"
 def test_krb5configuration():
     common_conf_info = krb5.Krb5Configuration(context_wrap(KRB5CONFIG, path=KRB5_CONF_PATH))
     assert common_conf_info["libdefaults"]["dnsdsd"] == "false"
+    assert common_conf_info.getboolean("libdefaults", "dnsdsd") is False
     assert "renew_lifetime" not in common_conf_info.data.keys()
     assert common_conf_info["realms"]["EXAMPLE.COM"]["kdc"] == "kerberos.example.com"
     assert common_conf_info["realms"]["default_ccache_name"] == "KEYRING:persistent:%{uid}"
@@ -127,6 +128,8 @@ def test_krb5configuration():
     common_conf_info = krb5.Krb5Configuration(context_wrap(KRB5CONFIG3, path=KRB5_CONF_PATH))
     assert len(common_conf_info.sections()) == 4
     assert common_conf_info.has_section('domain_realm') is True
+    assert common_conf_info.getboolean("libdefaults", "forwardable") is True
+    assert common_conf_info.getboolean("libdefaults", "renew_lifetime") is None
     assert sorted(common_conf_info.options('logging')) == sorted(['default', 'kdc', 'admin_server'])
     assert common_conf_info.has_option('libdefaults', 'dns_lookup_realm') is True
     assert common_conf_info.has_option('domain_realm', 'example.com') is False
@@ -144,3 +147,14 @@ def test_krb5Dconfiguration():
     assert common_conf_info["realms"]["EXAMPLE.COM"]["kdc"] == ['kerberos.example.com', 'test2.example.com', 'test3.example.com']
     assert common_conf_info.has_option("logging", "admin_server")
     assert common_conf_info["logging"]["kdc"] == "FILE:/var/log/krb5kdc.log"
+
+
+def test_handle_krb5_bool():
+    assert krb5._handle_krb5_bool("yes") is True
+    assert krb5._handle_krb5_bool("1") is True
+    assert krb5._handle_krb5_bool("on") is True
+    assert krb5._handle_krb5_bool("no") is False
+    assert krb5._handle_krb5_bool("false") is False
+    assert krb5._handle_krb5_bool("0") is False
+    assert krb5._handle_krb5_bool("unknown") is None
+    assert krb5._handle_krb5_bool("") is None


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The new `IdentityDomain` combiner detects enrollment into identity domains such as IPA, Active Directory, and generic Kerberos/LDAP. The plugin combines information from `SSSD_Conf`, `AllKrb5Conf`, `SambaConfigs`, and `IPA`.

Also improves `AllKrb5Conf` combiner to parse a list of realm names and some `libdefault` settings like default realm and DNS lookup.

Also fixes issues with Kerberos tests. Kerberos realms are configured in `[realms]` section, not `[libdefaults]` section.

Also fixes an issue with `SSSD_Config.domains` property. The `domains` setting can contain white space.

See: HMS-1285