### PR TITLE
fix: Add missing multi_output=True for dnf_modules spec

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -137,7 +137,7 @@ class Specs(SpecSet):
     dnf_conf = RegistryPoint(filterable=True)
     dnf_module_info = RegistryPoint()
     dnf_module_list = RegistryPoint()
-    dnf_modules = RegistryPoint()
+    dnf_modules = RegistryPoint(multi_output=True)
     dnsmasq_config = RegistryPoint(multi_output=True)
     docker_container_inspect = RegistryPoint(multi_output=True)
     docker_host_machine_id = RegistryPoint()


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
The spec dnf_modules is a glob spec, but didn't have the multi_output=True in the registry, so I added it.
