### PR TITLE
fix: uname pad release without el segment

### DIFF
--- a/insights/parsers/uname.py
+++ b/insights/parsers/uname.py
@@ -579,7 +579,7 @@ def pad_release(release_to_pad, num_sections=4):
     ``LooseVersion`` comparisons will be correct.
 
     Release versions with less than num_sections will
-    be padded in front of the last section with zeros.
+    padded with zeros where missing versions segments are.
 
     For example ::
 
@@ -589,7 +589,11 @@ def pad_release(release_to_pad, num_sections=4):
 
         pad_release("390.11.el6", 4)
 
-    will return ``390.11.0.el6``.
+    will return ``390.11.0.el6``. Finally, if no "el" is specified:
+
+        pad_release("390.11", 4)
+
+    will return ``390.11.0.0``.
 
     If the number of sections of the release to be padded is
     greater than num_sections, a ``ValueError`` will be raised.
@@ -602,4 +606,9 @@ def pad_release(release_to_pad, num_sections=4):
         ))
 
     pad_count = num_sections - len(parts)
-    return ".".join(parts[:-1] + ['0'] * pad_count + parts[-1:])
+    is_el_release = any(letter.isalpha() for letter in parts[-1])
+
+    if len(parts) > 1 and is_el_release:
+        return ".".join(parts[:-1] + ['0'] * pad_count + parts[-1:])
+    else:
+        return ".".join(parts + ['0'] * pad_count)

--- a/insights/tests/parsers/test_uname.py
+++ b/insights/tests/parsers/test_uname.py
@@ -220,6 +220,9 @@ def test_pad_release():
     assert "390.0.0.el6" == uname.pad_release("390.el6")
     assert "390.12.0.el6" == uname.pad_release("390.12.el6")
     assert "390.12.0.0.el6" == uname.pad_release("390.12.el6", 5)
+    assert "390.0.0.0" == uname.pad_release("390")
+    assert "390.12.0.0" == uname.pad_release("390.12")
+    assert "1160.71.1.0" == uname.pad_release("1160.71.1")
     with pytest.raises(ValueError):
         uname.pad_release('390.11.12.13.el6')
 


### PR DESCRIPTION
Changes behavior of Uname parser's `pad_release` such that a missing "el" segment of a release version results in the padded version having version numbers properly arranged.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The current behavior of the Uname parser's `pad_release` function is to unconditionally take the last segment of release version and place it at the end of padded version. This results in padded releases like below when no `el` segment is included (e.g. `el7`). 

- `0.0.0.0.1161`
- `1160.0.0.0.1`

This PR resolves this issue by first checking if the release string to be padded has a period to indicate multiple parts. If not, the release parts are simply joined with _trailing_ zeroes (instead of leading). If the release string _does_ have multiple parts and the last part contains alpha characters then we assume its an `el` part or some other product identifier. The resulting padded release is padded appropriately with the `el` part at the end.

cc @ryan-blakley 

Resolves https://github.com/RedHatInsights/insights-core/issues/3799