### PR TITLE
fix: correctly identify final segment of kernel version in uname

### DIFF
--- a/insights/parsers/uname.py
+++ b/insights/parsers/uname.py
@@ -253,7 +253,12 @@ class Uname(CommandParser):
             data['kernel'] = uname_parts[2]
             data['name'] = uname_parts[0]
             data['nodename'] = uname_parts[1]
-        has_arch = "el" not in data['kernel'].split(".")[-1]
+
+        # Check if the last segment of kernel version is the architecture (e.g. x86_64)
+        last_kernel_segment = data['kernel'].split(".")[-1]
+        # If the last segment contains "el" then we assume its the product indicator (e.g. el9_2)
+        # If the last segment contains more than just digits we assume its the architecture (e.g. x86_64)
+        has_arch = "el" not in last_kernel_segment and not last_kernel_segment.isdigit()
         try:
             data = self.parse_nvr(data['kernel'], data, arch=has_arch)
         except UnameError as error:

--- a/insights/tests/parsers/test_uname.py
+++ b/insights/tests/parsers/test_uname.py
@@ -260,6 +260,25 @@ def test_fixed_by_rhel5():
         assert expected == fixed_by
 
 
+def test_from_kernel_partial():
+    u = uname.Uname.from_kernel("5.14.0-284.13.1")
+    assert "284.13.1.0.0" == u._lv_release
+
+    u = uname.Uname.from_kernel("5.14.0-284")
+    assert "284.0.0.0.0" == u._lv_release
+
+    early_rhel9 = uname.Uname.from_uname_str("Linux example 5.14.0-70.22.1.el9_0.x86_64 #1 SMP Wed May 24 08:55:08 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux")
+    later_rhel9_1 = uname.Uname.from_kernel("5.14.0-162.18.1")
+    later_rhel9_2 = uname.Uname.from_kernel("5.14.0-284")
+
+    # Test comparison of full uname with partial kernel version
+    assert early_rhel9 < later_rhel9_1
+
+    # Test comparison of partial kernel versions
+    assert early_rhel9 < later_rhel9_2
+    assert later_rhel9_1 < later_rhel9_2
+
+
 def test_from_release():
     release = ("6", "4")
     from_release = uname.Uname.from_release(release)


### PR DESCRIPTION
Resolves issue with Uname parser where the last segment of kernel version was always assumed to be the architecture if it didn't contain "el". A check is added to see if the last segment is a digit and if so we assume its not architecture.

Further resolves https://github.com/RedHatInsights/insights-core/issues/3799 and complements PR https://github.com/RedHatInsights/insights-core/pull/3800

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

When the Uname parser is given a partial kernel version (e.g. `3.10.0-1161.1`) the final segment of the version is incorrectly interpreted as the architecture iff it does not contain the letters `el` (e.g. `3.10.0-1161.1` would have `.1` interpreted as the architecture). 

This PR adds an additional check in `parse_content` to further identify if the last segment of version is just digits or not. If the last segment of version does not contain `el` _and_ not only composed of digits then we assume its an architecture. 

cc @ryan-blakley 