### PR TITLE
feat: beautify testcase deep_compare diff details

### DIFF
--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -86,6 +86,30 @@ DEFAULT_HOSTNAME = "hostname.example.com"
 MAKE_NONE_RESULT = make_none()
 
 
+def _beautify_deep_compare_diff(result, expected):
+    if not (isinstance(result, dict) and isinstance(expected, dict)):
+        return result
+
+    expected_keys = set(expected.keys())
+    result_keys = set(result.keys())
+    common_keys = set.intersection(result_keys, expected_keys)
+
+    diff = []
+    for k in result_keys - common_keys:
+        diff.append('\tMissing result key "{0}" not in expected;'.format(k))
+    for k in expected_keys - common_keys:
+        diff.append('\tExtra expected key "{0}" not in result;'.format(k))
+    for k in common_keys:
+        if not eq(result[k], expected[k]):
+            diff.append('\tUnequal value of "{0}":\n\t\tExpected: "{1}"\n\t\tResult: "{2}"'.format(
+                            k, expected[k], result[k]))
+    if not diff:
+        diff.append('\tUnrecognized unequal value in result layer one;')
+
+    diff.append('Result: "{0}"'.format(result))
+    return '\n' + '\n'.join(diff)
+
+
 def deep_compare(result, expected):
     """
     Deep compare rule reducer results when testing.
@@ -115,7 +139,7 @@ def deep_compare(result, expected):
         assert result["type"] == "skip", result
         return
 
-    assert eq(result, expected), result
+    assert eq(result, expected), _beautify_deep_compare_diff(result, expected)
 
 
 def run_input_data(component, input_data, store_skips=False):

--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -101,7 +101,7 @@ def _beautify_deep_compare_diff(result, expected):
         diff.append('\tExtra expected key "{0}" not in result;'.format(k))
     for k in common_keys:
         if not eq(result[k], expected[k]):
-            diff.append('\tUnequal value of "{0}":\n\t\tExpected: "{1}"\n\t\tResult: "{2}"'.format(
+            diff.append('\tUnequal value of "{0}":\n\t\tExpected: {1}\n\t\tResult: {2}'.format(
                             k, expected[k], result[k]))
     if not diff:
         diff.append('\tUnrecognized unequal value in result layer one;')

--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -90,21 +90,24 @@ def _beautify_deep_compare_diff(result, expected):
     if not (isinstance(result, dict) and isinstance(expected, dict)):
         return result
 
+    if result.get('type') == 'skip':
+        return result
+
     expected_keys = set(expected.keys())
     result_keys = set(result.keys())
     common_keys = set.intersection(result_keys, expected_keys)
 
     diff = []
     for k in result_keys - common_keys:
-        diff.append('\tMissing result key "{0}" not in expected;'.format(k))
+        diff.append('\tkey "{0}" not in Expected;'.format(k))
     for k in expected_keys - common_keys:
-        diff.append('\tExtra expected key "{0}" not in result;'.format(k))
+        diff.append('\tkey "{0}" not in Result;'.format(k))
     for k in common_keys:
         if not eq(result[k], expected[k]):
-            diff.append('\tUnequal value of "{0}":\n\t\tExpected: {1}\n\t\tResult: {2}'.format(
+            diff.append('\tkey "{0}" unequal values:\n\t\tExpected: {1}\n\t\tResult  : {2}'.format(
                             k, expected[k], result[k]))
     if not diff:
-        diff.append('\tUnrecognized unequal value in result layer one;')
+        diff.append('\tUnrecognized unequal values in result layer one;')
 
     diff.append('Result: "{0}"'.format(result))
     return '\n' + '\n'.join(diff)

--- a/insights/tests/test_util.py
+++ b/insights/tests/test_util.py
@@ -110,8 +110,8 @@ def test_beautify_deep_compare_diff():
         einfo = err.value
     elif hasattr(err, "message"):   # py2
         einfo = err.message
-    assert 'Missing result key "foo" not in expected;' in str(einfo)
-    assert 'Extra expected key "bar" not in result;' in str(einfo)
+    assert 'key "foo" not in Expected;' in str(einfo)
+    assert 'key "bar" not in Result;' in str(einfo)
 
     with pytest.raises(AssertionError) as err:
         deep_compare({"e": "k", "common": "left"}, {"e": "k", "common": "right"})
@@ -120,7 +120,7 @@ def test_beautify_deep_compare_diff():
         einfo = err.value
     elif hasattr(err, "message"):   # py2
         einfo = err.message
-    assert 'Unequal value of "common":' in str(einfo)
+    assert 'key "common" unequal values:' in str(einfo)
     assert 'Result: ' in str(einfo)
 
 

--- a/insights/tests/test_util.py
+++ b/insights/tests/test_util.py
@@ -102,57 +102,26 @@ def test_dict():
         deep_compare({"foo": 1, "bar": [1, 2, 3]}, {"foo": 1, "bar": [0, 1, 2]})
 
 
-def test_beautify_deep_compare_diff_py3():
+def test_beautify_deep_compare_diff():
     with pytest.raises(AssertionError) as err:
         deep_compare({"foo": "some foo"}, {"bar": "some bar"})
-    # print(err)
-    # print(dir(err))
-    # print(err.message)
-    # print(err.args)
-    # print(err.value)
-    # print(type(err.value))
-    # print(err.tb)
     einfo = None
-    if hasattr(err, "value"):
+    if hasattr(err, "value"):       # py3
         einfo = err.value
-    elif hasattr(err, "message"):
+    elif hasattr(err, "message"):   # py2
         einfo = err.message
-    # print(einfo)
-    # print(type(einfo))
-    # print(str(einfo))
-    # print(repr(einfo))
     assert 'Missing result key "foo" not in expected;' in str(einfo)
     assert 'Extra expected key "bar" not in result;' in str(einfo)
 
-
-def test_beautify_deep_compare_diff_args():
-    with pytest.raises(AssertionError) as err:
-        deep_compare({"foo": "some foo"}, {"bar": "some bar"})
-    # print(err)
-    # print(dir(err))
-    # print(err.message)
-    # print(err.args)
-    # print(err.value)
-    # print(type(err.value))
-    # print(err.tb)
-    einfo = None
-    if hasattr(err, "value"):
-        einfo = err.value
-    elif hasattr(err, "args"):
-        einfo = err.args[0]
-    # print(einfo)
-    # print(type(einfo))
-    # print(str(einfo))
-    # print(repr(einfo))
-    assert 'Missing result key "foo" not in expected;' in str(einfo)
-    assert 'Extra expected key "bar" not in result;' in str(einfo)
-
-
-def test_beautify_deep_compare_diff_py2():
     with pytest.raises(AssertionError) as err:
         deep_compare({"e": "k", "common": "left"}, {"e": "k", "common": "right"})
-    assert 'Unequal value of "common":' in str(err)
-    assert 'Result: ' in str(err)
+    einfo = None
+    if hasattr(err, "value"):       # py3
+        einfo = err.value
+    elif hasattr(err, "message"):   # py2
+        einfo = err.message
+    assert 'Unequal value of "common":' in str(einfo)
+    assert 'Result: ' in str(einfo)
 
 
 def test_deep_nest():

--- a/insights/tests/test_util.py
+++ b/insights/tests/test_util.py
@@ -102,6 +102,18 @@ def test_dict():
         deep_compare({"foo": 1, "bar": [1, 2, 3]}, {"foo": 1, "bar": [0, 1, 2]})
 
 
+def test_beautify_deep_compare_diff():
+    with pytest.raises(AssertionError) as err:
+        deep_compare({"foo": "some foo"}, {"bar": "some bar"})
+    assert 'Missing result key "foo" not in expected;' in str(err)
+    assert 'Extra expected key "bar" not in result;' in str(err)
+
+    with pytest.raises(AssertionError) as err:
+        deep_compare({"e": "k", "common": "left"}, {"e": "k", "common": "right"})
+    assert 'Unequal value of "common":' in str(err)
+    assert 'Result: ' in str(err)
+
+
 def test_deep_nest():
     a = {"error_key": "test1", "stuff": {"abba": [{"foo": 2}]}}
     b = {"error_key": "test1", "stuff": {"abba": [{"foo": 2}]}}

--- a/insights/tests/test_util.py
+++ b/insights/tests/test_util.py
@@ -102,12 +102,53 @@ def test_dict():
         deep_compare({"foo": 1, "bar": [1, 2, 3]}, {"foo": 1, "bar": [0, 1, 2]})
 
 
-def test_beautify_deep_compare_diff():
+def test_beautify_deep_compare_diff_py3():
     with pytest.raises(AssertionError) as err:
         deep_compare({"foo": "some foo"}, {"bar": "some bar"})
-    assert 'Missing result key "foo" not in expected;' in str(err)
-    assert 'Extra expected key "bar" not in result;' in str(err)
+    # print(err)
+    # print(dir(err))
+    # print(err.message)
+    # print(err.args)
+    # print(err.value)
+    # print(type(err.value))
+    # print(err.tb)
+    einfo = None
+    if hasattr(err, "value"):
+        einfo = err.value
+    elif hasattr(err, "message"):
+        einfo = err.message
+    # print(einfo)
+    # print(type(einfo))
+    # print(str(einfo))
+    # print(repr(einfo))
+    assert 'Missing result key "foo" not in expected;' in str(einfo)
+    assert 'Extra expected key "bar" not in result;' in str(einfo)
 
+
+def test_beautify_deep_compare_diff_args():
+    with pytest.raises(AssertionError) as err:
+        deep_compare({"foo": "some foo"}, {"bar": "some bar"})
+    # print(err)
+    # print(dir(err))
+    # print(err.message)
+    # print(err.args)
+    # print(err.value)
+    # print(type(err.value))
+    # print(err.tb)
+    einfo = None
+    if hasattr(err, "value"):
+        einfo = err.value
+    elif hasattr(err, "args"):
+        einfo = err.args[0]
+    # print(einfo)
+    # print(type(einfo))
+    # print(str(einfo))
+    # print(repr(einfo))
+    assert 'Missing result key "foo" not in expected;' in str(einfo)
+    assert 'Extra expected key "bar" not in result;' in str(einfo)
+
+
+def test_beautify_deep_compare_diff_py2():
     with pytest.raises(AssertionError) as err:
         deep_compare({"e": "k", "common": "left"}, {"e": "k", "common": "right"})
     assert 'Unequal value of "common":' in str(err)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
Beautify the deep_compare diff details for smooth rule test-cases development.

An example of the expanded AssertionError info looks like: 
```
>       assert eq(result, expected), _beautify_deep_compare_diff(result, expected)
E       AssertionError: 
E       	Missing result key "foo" not in expected;
E       	Extra expected key "bar_one" not in result;
E       	Extra expected key "bar_two" not in result;
E       	Unequal value of "common":
E       		Expected: "y"
E       		Result: "x"
E       Result: "RULE_ERROR_KEY:
E           foo            : None
E           common : "x"
E       "
```