### PR TITLE
fix: update Uname parser to fix LooseVersion comparision error

### DIFF
--- a/insights/tests/parsers/test_uname.py
+++ b/insights/tests/parsers/test_uname.py
@@ -239,30 +239,46 @@ def test_fixed_by():
     assert ['2.6.33-100.el6'] == u.fixed_by('2.6.33-100.el6')
     assert ['2.6.32-600.el6'] == u.fixed_by('2.6.32-220.1.el6', '2.6.32-600.el6')
 
-    # For all remaining tests, cause the warnings to always be caught
-    warnings.simplefilter("always")
-    warning_msg = "Comparison of distribution part will be ingored"
 
+def test_fixed_by_warning():
+    # For all remaining tests, cause the comparation warnings
+    # to always be caught, and ignore other warnings.
+    warning_msg = "Comparison of distribution part will be ingored"
+    warnings.simplefilter("ignore")
+    warnings.filterwarnings("always", message=warning_msg)
     with warnings.catch_warnings(record=True) as w:
+
+        u = uname.Uname.from_uname_str("Linux qqhrycsq2 2.6.32-504.el6.x86_64 #1 SMP Wed Jun 13 18:24:36 EDT 2012 x86_64 x86_64 x86_64 GNU/Linux")
+        # should be no comparation warning reported
+        assert [] == u.fixed_by('2.6.32-220.1.el6', '2.6.32-504.el6')
+        assert len(w) == 0
+
         # fixes without distribution part
         assert [] == u.fixed_by('2.6.32-504')
+        assert len(w) == 1
 
         # fixes only has kernel version part
         assert [] == u.fixed_by('2.6.32-')
+        assert len(w) == 2
 
         # introduce without distribution part
         assert ['2.6.32-600.el6'] == u.fixed_by('2.6.32-600.el6', introduced_in='2.6.32-504')
+        assert len(w) == 3
 
         # introduce only has kernel version part
         assert ['2.6.32-600.el6'] == u.fixed_by('2.6.32-600.el6', introduced_in='2.6.32-')
+        assert len(w) == 4
 
-        assert any([warning_msg in str(ww.message) for ww in w])
+        rt_u = uname.Uname.from_uname_str("Linux qqhrycsq2 4.18.0-305.rt7.72.el8.x86_64 #1 SMP Wed Jun 13 18:24:36 EDT 2012 x86_64 x86_64 x86_64 GNU/Linux")
+        # fixes without distribution part
+        assert [] == rt_u.fixed_by('4.18.0-305.rt7.72')
+        assert len(w) == 5
 
-    rt_u = uname.Uname.from_uname_str("Linux qqhrycsq2 4.18.0-305.rt7.72.el8.x86_64 #1 SMP Wed Jun 13 18:24:36 EDT 2012 x86_64 x86_64 x86_64 GNU/Linux")
-    # fixes without distribution part
-    assert [] == rt_u.fixed_by('4.18.0-305.rt7.72')
-    # introduce without distribution part
-    assert ['4.18.0-307.rt7.72.el8'] == rt_u.fixed_by('4.18.0-307.rt7.72.el8', introduced_in='4.18.0-305.rt7.72')
+        # introduce without distribution part
+        assert ['4.18.0-307.rt7.72.el8'] == rt_u.fixed_by('4.18.0-307.rt7.72.el8', introduced_in='4.18.0-305.rt7.72')
+        assert len(w) == 6
+
+    warnings.resetwarnings()
 
 
 def test_unknown_release():

--- a/insights/tests/parsers/test_uname.py
+++ b/insights/tests/parsers/test_uname.py
@@ -236,19 +236,32 @@ def test_fixed_by():
     assert ['2.6.33-100.el6'] == u.fixed_by('2.6.33-100.el6')
     assert ['2.6.32-600.el6'] == u.fixed_by('2.6.32-220.1.el6', '2.6.32-600.el6')
 
+    # fixes without distribution part
+    assert [] == u.fixed_by('2.6.32-504')
+    # fixes only has kernel version part
+    assert [] == u.fixed_by('2.6.32-')
+    # introduce without distribution part
+    assert ['2.6.32-600.el6'] == u.fixed_by('2.6.32-600.el6', introduced_in='2.6.32-504')
+    # introduce only has kernel version part
+    assert ['2.6.32-600.el6'] == u.fixed_by('2.6.32-600.el6', introduced_in='2.6.32-')
+
+    rt_u = uname.Uname.from_uname_str("Linux qqhrycsq2 4.18.0-305.rt7.72.el8.x86_64 #1 SMP Wed Jun 13 18:24:36 EDT 2012 x86_64 x86_64 x86_64 GNU/Linux")
+    # fixes without distribution part
+    assert [] == rt_u.fixed_by('4.18.0-305.rt7.72')
+    # introduce without distribution part
+    assert ['4.18.0-307.rt7.72.el8'] == rt_u.fixed_by('4.18.0-307.rt7.72.el8', introduced_in='4.18.0-305.rt7.72')
+
 
 def test_unknown_release():
     u = uname.Uname.from_kernel("2.6.23-504.23.3.el6.revertBZ1169225")
     assert "504.23.3.0.el6" == u._lv_release
-    fixed_by = u.fixed_by("2.6.18-128.39.1.el5", "2.6.18-238.40.1.el5", "2.6.18-308.13.1.el5", "2.6.18-348.el5")
-    assert [] == fixed_by
 
 
 def test_fixed_by_rhel5():
     test_kernels = [
         (uname.Uname.from_uname_str("Linux oprddb1r5.example.com 2.6.18-348.el5 #1 SMP Wed Nov 28 21:22:00 EST 2012 x86_64 x86_64 x86_64 GNU/Linux"), []),
         (uname.Uname.from_uname_str("Linux srspidr1-3.example2.com 2.6.18-402.el5 #1 SMP Thu Jan 8 06:22:34 EST 2015 x86_64 x86_64 x86_64 GNU/Linux"), []),
-        (uname.Uname.from_uname_str("Linux PVT-Dev1.pvtsolar.local 2.6.18-398.el5xen #1 SMP Tue Aug 12 06:30:31 EDT 2014 x86_64 x86_64 x86_64 GNU/Linux"), []),
+        (uname.Uname.from_uname_str("Linux PVT-Dev1.pvtsolar.local 2.6.18-398.el5 #1 SMP Tue Aug 12 06:30:31 EDT 2014 x86_64 x86_64 x86_64 GNU/Linux"), []),
         (uname.Uname.from_kernel("2.6.18-194.el5"),
             ["2.6.18-238.40.1.el5", "2.6.18-308.13.1.el5", "2.6.18-348.el5"]),
         (uname.Uname.from_kernel("2.6.18-128.el5"),


### PR DESCRIPTION
Detailed error is:
TypeError: '<' not supported between instances of 'str' and 'int'

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
The issue is: https://github.com/RedHatInsights/insights-core/issues/3815
