### PR TITLE
Enhance datasource kernel_module_list

### DIFF
--- a/insights/specs/datasources/kernel_module_list.py
+++ b/insights/specs/datasources/kernel_module_list.py
@@ -19,8 +19,9 @@ def kernel_module_filters(broker):
     if filters:
         loaded_modules = []
         for item in filters:
-            if item in broker[LsMod]:
-                loaded_modules.append(item)
+            module_list = [module for module in broker[LsMod].data if item in module]
+            if module_list:
+                loaded_modules.extend(module_list)
         if loaded_modules:
             return ' '.join(loaded_modules)
         raise SkipComponent

--- a/insights/tests/datasources/test_kernel_module_list.py
+++ b/insights/tests/datasources/test_kernel_module_list.py
@@ -18,6 +18,8 @@ udp_diag               16384  0
 inet_diag              24576  2 tcp_diag,udp_diag
 binfmt_misc            69632  0
 udp_diag               18632  0
+mfe_aac_100713183      23360   0
+mfe_aac_100712495       3360   0
 """.strip()
 
 LSMOD_NO_LOADED = """
@@ -34,6 +36,8 @@ def setup_function(func):
 
     if func is test_module_filters:
         filters.add_filter(Specs.modinfo_modules, ["udp_diag", "binfmt_misc", "wireguard"])
+    if func is test_module_filters_2:
+        filters.add_filter(Specs.modinfo_modules, ["mfe_aac"])
     if func is test_module_no_loaded_modules:
         filters.add_filter(Specs.modinfo_modules, ["udp_diag", "binfmt_misc", "wireguard"])
     if func is test_module_filters_empty:
@@ -45,6 +49,13 @@ def test_module_filters():
     broker = {LsMod: lsmod_info}
     result = kernel_module_filters(broker)
     assert 'binfmt_misc udp_diag' == result
+
+
+def test_module_filters_2():
+    lsmod_info = LsMod(context_wrap(LSMOD))
+    broker = {LsMod: lsmod_info}
+    result = kernel_module_filters(broker)
+    assert 'mfe_aac_100713183 mfe_aac_100712495' == result
 
 
 def test_module_filters_empty():


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
modinfo_filtered_modules can only get the module which is same to the filter key words. Update it to get the modules which starts with the filter key words, so that we can get the information of all modules of mfe_aac_* (like mfe_aac_100713183, mfe_aac_100710368 and mfe_aac_100708119) with one filter ('mfe_aac'), rather than adding all modules full name to filter.