### PR TITLE
Use the existing cert_verify value, if set

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -669,6 +669,7 @@ class MalwareDetectionClient:
             self.rules_location = self._get_test_rule_location(self.rules_location)
             log_rule_contents = True
 
+        # Shouldn't need this, but left here for insurance: https://access.redhat.com/solutions/6997170
         # If a custom CA cert is being used, eg on a Satellite, then SSL errors may occur when downloading the rules
         # The CA cert needs to be added to a CA bundle (with update-ca-trust) and the bundle used for cert verification
         ca_cert = None
@@ -679,7 +680,9 @@ class MalwareDetectionClient:
                 break
 
         logger.debug("Downloading rules from: %s", self.rules_location)
-        self.insights_config.cert_verify = True
+        if not self.insights_config.cert_verify:
+            self.insights_config.cert_verify = True
+        logger.debug("Using cert_verify value %s ...", self.insights_config.cert_verify)
         conn = InsightsConnection(self.insights_config)
 
         for attempt in range(1, self.insights_config.retries + 1):
@@ -695,15 +698,14 @@ class MalwareDetectionClient:
             except Exception as e:
                 if attempt < self.insights_config.retries:
                     logger.debug("Unable to download rules from %s: %s", self.rules_location, str(e))
-                    retry_delay = attempt ** 2
-                    logger.debug("Trying again in %d seconds ...", retry_delay)
-                    time.sleep(retry_delay)
+                    logger.debug("Trying again in %d seconds ...", attempt)
+                    time.sleep(attempt)
                 else:
                     logger.error("Unable to download rules from %s: %s", self.rules_location, str(e))
                     exit(constants.sig_kill_bad)
 
                 if re.search('SSL.*verify.failed', str(e), re.IGNORECASE):
-                    # SSL error occurred, possibly due to a custom CA cert, try using a CA bundle for cert verification
+                    # Kept as a fallback in case SSL errors still occur - add the custom CA cert to the trusted certs
                     self.insights_config.cert_verify = self._get_config_option('ca_cert', ca_cert)
                     logger.debug("Trying cert_verify value %s ...", self.insights_config.cert_verify)
 

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -1203,7 +1203,8 @@ class TestsUtilizingFakeYara:
                 MalwareDetectionClient(InsightsConfig(retries=1))
             log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "404 Not found: Nup")
             # Last call to logger.debug will be about downloading rules, not about retrying, which shows retrying wasn't invoked
-            log_mock.debug.assert_called_with('Downloading rules from: %s', expected_rules_url)
+            log_mock.debug.assert_called_with("Using cert_verify value %s ...", True)
+            log_mock.debug.assert_any_call("Downloading rules from: %s", expected_rules_url)
 
             # Set retries > 1 and now retrying happens
             with pytest.raises(SystemExit):
@@ -1217,8 +1218,8 @@ class TestsUtilizingFakeYara:
             with pytest.raises(SystemExit):
                 MalwareDetectionClient(InsightsConfig(retries=3))
             log_mock.error.assert_called_with("Unable to download rules from %s: %s", expected_rules_url, "Couldn't connect")
-            # Because we've set retries to 3, the last attempted retry will wait 4 seconds (= 2**2)
-            log_mock.debug.assert_called_with("Trying again in %d seconds ...", 4)
+            # Because we've set retries to 3, the last attempted retry will wait 2 seconds
+            log_mock.debug.assert_called_with("Trying again in %d seconds ...", 2)
 
             # Certificate verify failed SSL Errors will cause a different CA certificate bundle to be tried
             ca_cert = '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'  # default ca cert bundle file to try
@@ -1264,47 +1265,53 @@ class TestsUtilizingFakeYara:
         @patch(LOGGER_TARGET)
         def test_download_rules_via_satellite(self, log_mock, conf, cmd, session, proxies, get, findmnt, remove):
             # Test recognizing and handling of Satellite URLs.
-            # Satellite URLs have '/redhat_access/' in their path (which is how the Satellite knows to redirect the
-            # query to C.R.C).
+            # Satellite URLs have '/redhat_access/' in their path (so Satellite knows to redirect the query to C.R.C)
             # For malware-detection requests through a Satellite we append the malware-detection path and add https://
             satellite_url = 'satellite.example.com:443/redhat_access/r/insights/platform'
+            satellite_cert = '/etc/rhsm/ca/katello-server-ca.pem'
             expected_rules_url_prefix = "https://satellite.example.com:443/redhat_access/r/insights/platform/malware-detection/v1/"
+            insights_config = InsightsConfig(base_url=satellite_url, verbose=True, cert_verify=satellite_cert)
 
             # Firstly try with test-rule
             expected_rules_url = expected_rules_url_prefix + "test-rule.yar"
             with patch(FIND_YARA_TARGET, return_value=FAKE_YARA):
-                mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
+                mdc = MalwareDetectionClient(insights_config)
             assert mdc.rules_location == expected_rules_url
-            get.assert_called_with(expected_rules_url, log_response_text=True, verify=True)
-            log_mock.debug.assert_called_with("Downloading rules from: %s", expected_rules_url)
+            get.assert_called_with(expected_rules_url, log_response_text=True, verify=satellite_cert)
+            log_mock.debug.assert_called_with("Using cert_verify value %s ...", satellite_cert)
+            log_mock.debug.assert_any_call("Downloading rules from: %s", expected_rules_url)
 
             # Then with the actual rules file
             os.environ['TEST_SCAN'] = 'false'
             expected_rules_url = expected_rules_url_prefix + "signatures.yar"
             with patch(FIND_YARA_TARGET, return_value=FAKE_YARA):
-                mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
+                mdc = MalwareDetectionClient(insights_config)
             assert mdc.rules_location == expected_rules_url
-            get.assert_called_with(expected_rules_url, log_response_text=False, verify=True)
-            log_mock.debug.assert_called_with("Downloading rules from: %s", expected_rules_url)
+            get.assert_called_with(expected_rules_url, log_response_text=False, verify=satellite_cert)
+            log_mock.debug.assert_called_with("Using cert_verify value %s ...", satellite_cert)
+            log_mock.debug.assert_any_call("Downloading rules from: %s", expected_rules_url)
 
             expected_rules_url += '?yara_version=4.1'
             with patch('os.path.exists', return_value=True):
                 with patch("insights.client.apps.malware_detection.call", return_value='4.1'):
-                    mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
+                    mdc = MalwareDetectionClient(insights_config)
             assert mdc.rules_location == expected_rules_url
-            get.assert_called_with(expected_rules_url, log_response_text=False, verify=True)
-            log_mock.debug.assert_called_with("Downloading rules from: %s", expected_rules_url)
+            get.assert_called_with(expected_rules_url, log_response_text=False, verify=satellite_cert)
+            log_mock.debug.assert_called_with("Using cert_verify value %s ...", satellite_cert)
+            log_mock.debug.assert_any_call("Downloading rules from: %s", expected_rules_url)
 
             # Test a Satellite URL with 'cloud.stage.' in its name - expect to still download from Satellite
+            # Also test using cert_verify=None in the InsightsConfig and check it changes to cert_verify=True
             satellite_url = 'satellite.cloud.stage.example.com:443/redhat_access/r/insights/platform'
             expected_rules_url = "https://satellite.cloud.stage.example.com:443/redhat_access/r/insights/platform/malware-detection/v1/"
             expected_rules_url += 'signatures.yar?yara_version=4.1'
             with patch('os.path.exists', return_value=True):
                 with patch("insights.client.apps.malware_detection.call", return_value='4.1'):
-                    mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True))
+                    mdc = MalwareDetectionClient(InsightsConfig(base_url=satellite_url, verbose=True, cert_verify=None))
             assert mdc.rules_location == expected_rules_url
             get.assert_called_with(expected_rules_url, log_response_text=False, verify=True)
-            log_mock.debug.assert_called_with("Downloading rules from: %s", expected_rules_url)
+            log_mock.debug.assert_called_with("Using cert_verify value %s ...", True)
+            log_mock.debug.assert_any_call("Downloading rules from: %s", expected_rules_url)
 
     @patch(GET_RULES_TARGET, return_value=RULES_FILE)
     @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)


### PR DESCRIPTION
- The cert_verify value may be set outside the malware-detection app Use its value if set, otherwise set it to True

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

Malware-detection had problems downloading rules via a Satellite.  Long story short, we weren't checking the cert_verify value from the InsightsConfig object and just blindly setting cert_verify to True.  This is ok with the customer portal, but with Satellites that use their own CA cert, then the cert_verify value should be /etc/rhsm/ca/katello-server-ca.pem.  This is what insights-client uses, but I failed to notice this and kept setting it to True, which meant downloading the malware rule via a Satellite didn't work correctly.

This PR checks the cert_verify value in the InsightsConfig and uses its value (if its set).  Only if its None do we change it to True.