### PR TITLE
fix: Using pip for python2.7 instead of python3x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:7
 RUN yum install -y python-devel file zip gcc libffi-devel && yum clean all
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py && rm get-pip.py
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && python get-pip.py && rm get-pip.py
 COPY . /src
 RUN pip install /src


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Since CentOS 7 doesn't have pre-installed python 3.x we need to use this url `https://bootstrap.pypa.io/pip/2.7/get-pip.py` to get the right pip version, to avoid error on docker build process
