### PR TITLE
chore: uniform the deprecation warnings and docstring

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -868,7 +868,7 @@ class Scannable(six.with_metaclass(ScanMeta, Parser)):
 
     """
     def __init__(self, *args, **kwargs):
-        deprecated(Scannable, "Please use the :class:`insights.core.Parser` instead", "3.2.25")
+        deprecated(Scannable, "Please use the :class:`insights.core.Parser` instead.", "3.3.0")
         super(Scannable, self).__init__(*args, **kwargs)
 
     @classmethod

--- a/insights/core/exceptions.py
+++ b/insights/core/exceptions.py
@@ -105,6 +105,6 @@ class SkipException(SkipComponent):
         deprecated(
             SkipException,
             "Please use the :class:`insights.core.exceptions.SkipComponent` instead.",
-            "3.2.25"
+            "3.3.0"
         )
         super(SkipException, self).__init__(msg)

--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -535,7 +535,8 @@ class make_response(Response):
                return make_response("BASH_BUG_123", bash=bash)
            return make_pass("BASH", bash=bash)
 
-    .. deprecated::
+    .. deprecated:: 1.x
+
         Use :class:`make_fail` instead.
     """
 

--- a/insights/parsers/azure_instance_plan.py
+++ b/insights/parsers/azure_instance_plan.py
@@ -55,7 +55,7 @@ class AzureInstancePlan(CommandParser):
         True
     """
     def __init__(self, *args, **kwargs):
-        deprecated(AzureInstancePlan, "Import AzureInstancePlan from insights.parsers.azure_instance instead", "3.2.25")
+        deprecated(AzureInstancePlan, "Import AzureInstancePlan from insights.parsers.azure_instance instead.", "3.3.0")
         super(AzureInstancePlan, self).__init__(*args, **kwargs)
 
     def parse_content(self, content):

--- a/insights/parsers/azure_instance_type.py
+++ b/insights/parsers/azure_instance_type.py
@@ -52,7 +52,7 @@ class AzureInstanceType(CommandParser):
         'Standard_L64s_v2'
     """
     def __init__(self, *args, **kwargs):
-        deprecated(AzureInstanceType, "Import AzureInstanceType from insights.parsers.azure_instance instead", "3.2.25")
+        deprecated(AzureInstanceType, "Import AzureInstanceType from insights.parsers.azure_instance instead.", "3.3.0")
         super(AzureInstanceType, self).__init__(*args, **kwargs)
 
     def parse_content(self, content):

--- a/insights/parsers/blacklisted.py
+++ b/insights/parsers/blacklisted.py
@@ -35,7 +35,7 @@ class BlacklistedSpecs(JSONParser):
         deprecated(
             BlacklistedSpecs,
             "Please use insights.parsers.client_metadata.BlacklistedSpecs instead.",
-            "3.3.25"
+            "3.4.0"
         )
         super(BlacklistedSpecs, self).__init__(*args, **kwargs)
 

--- a/insights/parsers/branch_info.py
+++ b/insights/parsers/branch_info.py
@@ -17,6 +17,6 @@ class BranchInfo(YAMLParser):
         deprecated(
             BranchInfo,
             "Please use insights.parsers.client_metadata.BranchInfo instead.",
-            "3.3.25"
+            "3.4.0"
         )
         super(BranchInfo, self).__init__(*args, **kwargs)

--- a/insights/parsers/cpuinfo.py
+++ b/insights/parsers/cpuinfo.py
@@ -270,11 +270,11 @@ class CpuInfo(LegacyItemAccess, Parser):
         int: Returns the total number of cores for the server if available, else None.
 
         .. warning::
-            This method is deprecated, and will be removed after 3.2.25. Please use
+            This method is deprecated, and will be removed from 3.3.0. Please use
             :py:class:`insights.parsers.lscpu.LsCPU` class attribute
             ``info['Cores per socket']`` and ``info['Sockets']`` values instead.
         """
-        warnings.warn("`is_hypervisor` is deprecated and will be removed after 3.2.25: Use `virt_what.VirtWhat` which uses the command `virt-what` to check the hypervisor type.", DeprecationWarning)
+        warnings.warn("`is_hypervisor` is deprecated and will be removed from 3.3.0: Use `virt_what.VirtWhat` which uses the command `virt-what` to check the hypervisor type.", DeprecationWarning)
         if self.data and 'cpu_cores' in self.data:
             # I guess we can't get this fancey on older versions of RHEL
             # return sum({e['sockets']: int(e['cpu_cores']) for e in self}.values())

--- a/insights/parsers/docker_inspect.py
+++ b/insights/parsers/docker_inspect.py
@@ -32,7 +32,7 @@ class DockerInspect(CommandParser, dict):
         deprecated(
             DockerInspect,
             "Please use the :class:`insights.parsers.containers_inspect.ContainersInspect` instead.",
-            "3.2.25"
+            "3.3.0"
         )
         super(DockerInspect, self).__init__(*args, **kwargs)
 
@@ -118,6 +118,6 @@ class DockerInspectContainer(DockerInspect):
         deprecated(
             DockerInspectContainer,
             "Please use the :class:`insights.parsers.containers_inspect.ContainersInspect` instead.",
-            "3.2.25"
+            "3.3.0"
         )
         super(DockerInspectContainer, self).__init__(*args, **kwargs)

--- a/insights/parsers/engine_log.py
+++ b/insights/parsers/engine_log.py
@@ -39,5 +39,5 @@ class EngineLog(LogFileOutput):
     Provide access to ovirt engine logs using the LogFileOutput parser class.
     """
     def __init__(self, *args, **kwargs):
-        deprecated(EngineLog, "Import EngineLog from insights.parsers.ovirt_engine_log instead", "3.2.25")
+        deprecated(EngineLog, "Import EngineLog from insights.parsers.ovirt_engine_log instead.", "3.3.0")
         super(EngineLog, self).__init__(*args, **kwargs)

--- a/insights/parsers/installed_rpms.py
+++ b/insights/parsers/installed_rpms.py
@@ -146,12 +146,12 @@ class RpmList(object):
     def is_hypervisor(self):
         """
         .. warning::
-           This method is deprecated, and will be removed after 3.2.25. Please use
+           This method is deprecated, and will be removed from 3.3.0. Please use
            :py:class:`insights.parsers.virt_what.VirtWhat` which uses the command `virt-what` to check the hypervisor type.
 
         bool: True if ".el[6|7]ev" exists in "vdsm".release, else False.
         """
-        warnings.warn("`is_hypervisor` is deprecated and will be removed after 3.2.25: Use `virt_what.VirtWhat` which uses the command `virt-what` to check the hypervisor type.", DeprecationWarning)
+        warnings.warn("`is_hypervisor` is deprecated and will be removed from 3.3.0: Use `virt_what.VirtWhat` which uses the command `virt-what` to check the hypervisor type.", DeprecationWarning)
         rpm = self.get_max("vdsm")
         return (True if rpm and rpm.release.endswith((".el6ev", ".el7ev")) else
                 False)

--- a/insights/parsers/ovs_vsctl_list_bridge.py
+++ b/insights/parsers/ovs_vsctl_list_bridge.py
@@ -63,6 +63,6 @@ class OVSvsctlListBridge(OVSvsctlList):
         deprecated(
             OVSvsctlListBridge,
             "Please use the :class:`insights.ovs_vsctl.OVSvsctlListBridge` instead.",
-            "3.2.25"
+            "3.3.0"
         )
         super(OVSvsctlListBridge, self).__init__(*args, **kwargs)

--- a/insights/parsers/podman_inspect.py
+++ b/insights/parsers/podman_inspect.py
@@ -32,7 +32,7 @@ class PodmanInspect(CommandParser, dict):
         deprecated(
             PodmanInspect,
             "Please use the :class:`insights.parsers.containers_inspect.ContainersInspect` instead.",
-            "3.2.25"
+            "3.3.0"
         )
         super(PodmanInspect, self).__init__(*args, **kwargs)
 
@@ -111,6 +111,6 @@ class PodmanInspectContainer(PodmanInspect):
         deprecated(
             PodmanInspectContainer,
             "Please use the :class:`insights.parsers.containers_inspect.ContainersInspect` instead.",
-            "3.2.25"
+            "3.3.0"
         )
         super(PodmanInspectContainer, self).__init__(*args, **kwargs)

--- a/insights/parsers/rpm_pkgs.py
+++ b/insights/parsers/rpm_pkgs.py
@@ -39,7 +39,7 @@ class RpmPkgs(Parser):
         deprecated(
             RpmPkgs,
             "Please use the `RpmPkgsWritable` instead.",
-            "3.2.25"
+            "3.3.0"
         )
         super(RpmPkgs, self).__init__(*args, **kwargs)
 

--- a/insights/parsers/tags.py
+++ b/insights/parsers/tags.py
@@ -16,6 +16,6 @@ class Tags(JSONParser):
         deprecated(
             Tags,
             "Please use insights.parsers.client_metadata.Tags instead.",
-            "3.3.25"
+            "3.4.0"
         )
         super(Tags, self).__init__(*args, **kwargs)

--- a/insights/parsers/version_info.py
+++ b/insights/parsers/version_info.py
@@ -45,7 +45,7 @@ class VersionInfo(JSONParser):
         deprecated(
             VersionInfo,
             "Please use insights.parsers.client_metadata.VersionInfo instead.",
-            "3.3.25"
+            "3.4.0"
         )
         super(VersionInfo, self).__init__(*args, **kwargs)
 

--- a/insights/parsers/yumlog.py
+++ b/insights/parsers/yumlog.py
@@ -67,23 +67,23 @@ class YumLog(Parser, list):
     """
     ERASED = 'Erased'
     """
-    .. deprecated:: 3.3.0
+    .. deprecated:: 3.2.0
 
-       Use string "Erased" instead.
+       Will be removed from 3.4.0.  Use string "Erased" instead.
     """
 
     INSTALLED = 'Installed'
     """
-    .. deprecated:: 3.3.0
+    .. deprecated:: 3.2.0
 
-       Use string "Installed" instead.
+       Will be removed from 3.4.0.  Use string "Installed" instead.
     """
 
     UPDATED = 'Updated'
     """
-    .. deprecated:: 3.3.0
+    .. deprecated:: 3.2.0
 
-       Use string "Updated" instead.
+       Will be removed from 3.4.0.  Use string "Updated" instead.
     """
 
     STATES = set(["Erased", "Installed", "Updated"])
@@ -145,18 +145,18 @@ class YumLog(Parser, list):
     @property
     def pkgs(self):
         """
-        .. deprecated:: 3.3.0
+        .. deprecated:: 3.2.0
 
-           Just keep backward compatibility
+           Will be removed from 3.4.0.
         """
         return dict(self._pkgs)
 
     @property
     def data(self):
         """
-        .. deprecated:: 3.3.0
+        .. deprecated:: 3.2.0
 
-           Just keep backward compatibility
+           Will be removed from 3.4.0.
         """
         return self
 

--- a/insights/tests/parsers/__init__.py
+++ b/insights/tests/parsers/__init__.py
@@ -50,7 +50,7 @@ def skip_exception_check(parser_obj, output_str=""):
     deprecated(
         skip_component_check,
         "Please use the :method:`skip_component_check` instead.",
-        "3.2.25"
+        "3.3.0"
     )
 
     from insights.core.exceptions import SkipComponent

--- a/insights/util/__init__.py
+++ b/insights/util/__init__.py
@@ -168,7 +168,7 @@ def deprecated(func, solution, version=None):
     src, line_no = inspect.getsourcelines(func)
     name = get_name_line(src) or "Unknown"
     if version:
-        the_msg = "<{c}> at {p}:{l} is deprecated: {s} This function will be removed after version: {v}.".format(
+        the_msg = "<{c}> at {p}:{l} is deprecated: {s} This function will be removed from version: {v}.".format(
             c=name, p=path, l=line_no, s=solution, v=version
         )
     else:


### PR DESCRIPTION
- Use 'removed from `3.#+1.0`' instead of 'removed after `3.#.25`'. 
   Since sometimes the minor version would be greater than `25`.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?