### PR TITLE
fix(yum_updates): releasever and basearch

### DIFF
--- a/insights/tests/datasources/test_yum_updates.py
+++ b/insights/tests/datasources/test_yum_updates.py
@@ -28,10 +28,12 @@ def test_yum_updates_runs_correctly():
     # setup dnf mock
     with patch("insights.specs.datasources.yum_updates.UpdatesManager", yum_updates.DnfManager):
         yum_updates.dnf = MagicMock()
+        yum_updates.dnf.cli = MagicMock()
         yum_updates.hawkey = MagicMock()
         yum_updates.dnf.VERSION = "4.7.0"
         yum_updates.dnf.rpm.detect_releasever.return_value = "8"
         yum_updates.dnf.rpm.basearch.return_value = "x86_64"
+        yum_updates.dnf.base.Base().conf.substitutions = {"releasever": "8"}
         repo = MagicMock()
         repo._repo.getTimestamp.return_value = 1609493985
         yum_updates.dnf.base.Base().repos.iter_enabled.return_value = [repo]


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Take releasever and basearch from dnf config substitutions after loading them from variables.  It utilizes dnf.cli to load vars correctly.

RHINENG-985
