### PR TITLE
Use SIGTERM for dnf command

### DIFF
--- a/insights/client/insights_spec.py
+++ b/insights/client/insights_spec.py
@@ -55,6 +55,9 @@ class InsightsCommand(InsightsSpec):
 
         # use TERM for rpm/yum commands, KILL for everything else
         if (self.command.startswith('/bin/rpm') or
+           self.command.startswith('dnf') or
+           self.command.startswith('/bin/dnf') or
+           self.command.startswith('/usr/bin/dnf') or
            self.command.startswith('yum') or
            self.command.startswith('/usr/bin/yum')):
             signal = 'TERM'

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -182,7 +182,7 @@ class DefaultSpecs(Specs):
     dmsetup_status = simple_command("/usr/sbin/dmsetup status")
     dnf_conf = simple_file("/etc/dnf/dnf.conf")
     dnf_modules = glob_file("/etc/dnf/modules.d/*.module")
-    dnf_module_list = simple_command("/usr/bin/dnf -C --noplugins module list")
+    dnf_module_list = simple_command("/usr/bin/dnf -C --noplugins module list", signum=signal.SIGTERM)
     docker_info = simple_command("/usr/bin/docker info")
     docker_list_containers = simple_command("/usr/bin/docker ps --all --no-trunc")
     docker_list_images = simple_command("/usr/bin/docker images --all --no-trunc --digests")


### PR DESCRIPTION
Fix a regression of bugzilla 1935846, to also apply to dnf.

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

https://bugzilla.redhat.com/show_bug.cgi?id=1935846 was an issue that killed rpm and yum with SIGKILL on timeout, giving it no chance to clear their lock on the rpm database. This was fixed in #2974 by sending SIGTERM for yum and rpm. When these processes receive SIGTERM, they do have a chance to clear their locks.

Yum has been replaced by dnf in RHEL8. This PR adds dnf to the SIGTERM list.

