### PR TITLE
Handle module router request response format

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -105,6 +105,9 @@ class InsightsClient(object):
         try:
             response = self.connection.get(url)
             if response.status_code == 200:
+                if 'application/json' not in response.headers.get('Content-Type', ''):
+                    logger.warning("Module update router response is not valid for %s. Expected json format but got %s. Defaulting to /release", url, response.headers.get('Content-Type', ''))
+                    return '/release'
                 return response.json()["url"]
             else:
                 raise ConnectionError("%s: %s" % (response.status_code, response.reason))


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
I catch the issue when was running insights-client against ephemeral environment. I don't have module-router-request application deployed there and registering host failed:
```
2023-07-04 04:02:14,506  NETWORK insights.client.connection GET https://env-ephemeral-ng0e91-gvcod9fw.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/api/module-update-router/v1/channel?module=insights-core
2023-07-04 04:02:14,615  NETWORK insights.client.connection HTTP Status: 200 OK
2023-07-04 04:02:14,615  NETWORK insights.client.connection HTTP Response Text: <!DOCTYPE html>
<html lang="en-US">

<head>
    <meta charset="UTF-8">
    <title>
        Hybrid Cloud Console
    </title>
    <meta http-equiv="Content-Security-Policy" content="default-src 'self' https: wss: data: blob: 'unsafe-inline' 'unsafe-eval' https://*.redhat.com/ https://www.redhat.com/  https://*.openshift.com/ https://api.stage.openshift.com/ https://identity.api.openshift.com/ https://www.youtube.com/ https://redhat.sc.omtrdc.net/ https://assets.adobedtm.com/ https://www.redhat.com/ https://*.storage.googleapis.com/ https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com https://stage.quay.io/ https://quay.io/;">
    <meta http-equiv="Pragma" content="no-cache">
    <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">
    <meta http-equiv="x-ua-compatible" content="ie=edge">
    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
    <link rel="icon" type="image/png" href="https://access.redhat.com/webassets/avalon/g/favicon.ico">
    <script type="text/javascript">
        window.insights = {
            chrome: {
                isChrome2: true
            }
        }
    </script>
    <script id="dpal" src="https://www.redhat.com/ma/dpal.js" type="text/javascript"></script>
<base href="/"><link href="/apps/chrome/js/main.1014b7422bbb96c7.css" rel="stylesheet"></head>

<body class="pf-m-redhat-font">
    <div id="chrome-entry"></div>
    <div id="consent_blackbar"></div>
<script defer src="/apps/chrome/js/chrome-root.1014b7422bbb96c7.js"></script><script defer src="/apps/chrome/js/chrome.1014b7422bbb96c7.js"></script></body>
</html>
```
The issue here is that response code is 200 but content is not in json format. So if it doesn't have correct format it has to point to `/release` the same way as if you have `ConnectionError`

Here you can find more context https://redhat-internal.slack.com/archives/C69UN1L4E/p1688455216595829 
