### PR TITLE
fix: Fix wrong filter reference to 'ls_*_filtered' Specs

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -336,9 +336,9 @@ class DefaultSpecs(Specs):
     lpstat_protocol_printers = lpstat.lpstat_protocol_printers_info
     # New `ls` Specs
     ls_la = command_with_args('/bin/ls -la %s', ls.list_with_la, keep_rc=True)
-    ls_la_filtered = command_with_args('/bin/ls -la %s', ls.list_with_la, keep_rc=True)  # Result is filtered
+    ls_la_filtered = command_with_args('/bin/ls -la %s', ls.list_with_la_filtered, keep_rc=True)  # Result is filtered
     ls_lan = command_with_args('/bin/ls -lan %s', ls.list_with_lan, keep_rc=True)
-    ls_lan_filtered = command_with_args('/bin/ls -lan %s', ls.list_with_lan, keep_rc=True)  # Result is filtered
+    ls_lan_filtered = command_with_args('/bin/ls -lan %s', ls.list_with_lan_filtered, keep_rc=True)  # Result is filtered
     ls_lanL = command_with_args('/bin/ls -lanL %s', ls.list_with_lanL, keep_rc=True)
     ls_lanR = command_with_args('/bin/ls -lanR %s', ls.list_with_lanR, keep_rc=True)
     ls_lanRL = command_with_args('/bin/ls -lanRl %s', ls.list_with_lanRL, keep_rc=True)


### PR DESCRIPTION
* Fix wrong filter reference in specs "ls_la_filtered" and "ls_lan_filtered"

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

