### PR TITLE
RHINENG-761: Handle Compliance tailoring file request

### DIFF
--- a/insights/client/apps/compliance/__init__.py
+++ b/insights/client/apps/compliance/__init__.py
@@ -109,8 +109,13 @@ class ComplianceClient:
             "https://{0}/compliance/profiles/{1}/tailoring_file".format(self.config.base_url, profile['id'])
         )
         logger.debug("Response code: {0}".format(response.status_code))
-        if response.content is None:
-            logger.info("Problem downloading tailoring file for {0} to {1}".format(profile['attributes']['ref_id'], tailoring_file_path))
+
+        if not response.ok:
+            logger.info("Something went wrong during downloading the tailoring file of {0}. The expected status code is 200, got {1}".format(profile['attributes']['ref_id'], response.status_code))
+            return None
+
+        if response.content is None or response.headers['Content-Type'] != "application/xml":
+            logger.info("Problem with the content of the downloaded tailoring file of {0}. The expected format is xml, got {1}".format(profile['attributes']['ref_id'], response.headers['Content-Type']))
             return None
 
         with open(tailoring_file_path, mode="w+b") as f:


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
**Closes** https://issues.redhat.com/browse/RHINENG-761 
In some situations our customers could  get TCP connection issue and then openscap parser fails to use tailoring file as instead of xml format we get json with error messages. We need better handling of tailoring file request.
