### PR TITLE
chore: discard the deprecation of LsBoot, LsDev and LsSysFirmware

### DIFF
--- a/insights/parsers/ls.py
+++ b/insights/parsers/ls.py
@@ -150,12 +150,23 @@ class FileListing(Parser, dict):
         >>> fp.perms_owner
         'rw-'
     """
+    __root_path = None
+    """
+    The root path of the dir when there is only one list target.  It only works
+    for the following specs/parsers that are compatible for sos-archives.
+    - :class:`insights.parsers.ls_boot.LsBoot`
+    - :class:`insights.parsers.ls_dev.LsDev`
+    - :class:`insights.parsers.ls_sys_firmware.LsSysFirmware`
+
+    None by default, for the new ```ls_*``` datasource specs
+    """
+
     def parse_content(self, content):
         """
         Called automatically to process the directory listing(s) contained in
         the content.
         """
-        self.update(ls_parser.parse(content))
+        self.update(ls_parser.parse(content, self.__root_path))
 
     def files_of(self, directory):
         """

--- a/insights/parsers/ls_boot.py
+++ b/insights/parsers/ls_boot.py
@@ -5,40 +5,12 @@ LsBoot - command ``ls -lanR /boot``
 The ``ls -lanR /boot`` command provides information for the listing of the
 ``/boot`` directory.
 
-See the ``FileListing`` class for a more complete description of the
-available features of the class.
+See :class:`insights.parsers.ls.FileListing` for more information.
 
-Sample directory listing::
-
-    /boot:
-    total 187380
-    dr-xr-xr-x.  3 0 0     4096 Mar  4 16:19 .
-    dr-xr-xr-x. 19 0 0     4096 Jul 14 09:10 ..
-    -rw-r--r--.  1 0 0   123891 Aug 25  2015 config-3.10.0-229.14.1.el7.x86_64
-
-    /boot/grub2:
-    total 36
-    drwxr-xr-x. 6 0 0  104 Mar  4 16:16 .
-    dr-xr-xr-x. 3 0 0 4096 Mar  4 16:19 ..
-    lrwxrwxrwx. 1 0 0     11 Aug  4  2014 menu.lst -> ./grub.conf
-    -rw-r--r--. 1 0 0   64 Sep 18  2015 device.map
-
-Examples:
-
-    >>> bootdir = shared[LsBoot]
-    >>> '/boot' in bootdir
-    True
-    >>> '/boot/grub' in bootdir
-    False
-    >>> bootdir.files_of('/boot')
-    ['config-3.10.0-229.14.1.el7.x86_64']
-    >>> bootdir.dirs_of('/boot')
-    ['.', '..', 'grub2']
-    >>> bootdir.dir_contains('/boot/grub2', 'menu.lst')
-    True
 """
 
-from insights import CommandParser, FileListing, parser
+from insights import CommandParser, parser
+from insights.parsers.ls import FileListing
 from insights.specs import Specs
 
 
@@ -52,5 +24,34 @@ class LsBoot(CommandParser, FileListing):
         For Insights Advisor Rules, it's recommended to use the
         :class:`insights.parsers.ls.LSlanR` and add the ``"/boot"`` to
         the filter list of `Specs.ls_lanR_dirs` instead.
+
+    Sample directory listing::
+
+        /boot:
+        total 187380
+        dr-xr-xr-x.  3 0 0     4096 Mar  4 16:19 .
+        dr-xr-xr-x. 19 0 0     4096 Jul 14 09:10 ..
+        -rw-r--r--.  1 0 0   123891 Aug 25  2015 config-3.10.0-229.14.1.el7.x86_64
+
+        /boot/grub2:
+        total 36
+        drwxr-xr-x. 6 0 0  104 Mar  4 16:16 .
+        dr-xr-xr-x. 3 0 0 4096 Mar  4 16:19 ..
+        lrwxrwxrwx. 1 0 0     11 Aug  4  2014 menu.lst -> ./grub.conf
+        -rw-r--r--. 1 0 0   64 Sep 18  2015 device.map
+
+    Examples:
+        >>> type(bootdir)
+        <class 'insights.parsers.ls_boot.LsBoot'>
+        >>> '/boot' in bootdir
+        True
+        >>> '/boot/grub' in bootdir
+        False
+        >>> bootdir.files_of('/boot')
+        ['config-3.10.0-229.14.1.el7.x86_64']
+        >>> bootdir.dirs_of('/boot')
+        ['.', '..', 'grub2']
+        >>> bootdir.dir_contains('/boot/grub2', 'menu.lst')
+        True
     """
-    pass
+    __root_path = '/boot'

--- a/insights/parsers/ls_boot.py
+++ b/insights/parsers/ls_boot.py
@@ -38,20 +38,19 @@ Examples:
     True
 """
 
-from .. import FileListing, parser, CommandParser
+from insights import CommandParser, FileListing, parser
 from insights.specs import Specs
-from insights.util import deprecated
 
 
 @parser(Specs.ls_boot)
 class LsBoot(CommandParser, FileListing):
     """
-    .. warning::
-        This class is deprecated and will be removed from 3.5.0.
-        Please use the :class:`insights.parsers.ls.LSlanR` instead.
-
     Parse the /boot directory listing using a standard FileListing parser.
+
+    .. warning::
+
+        For Insights Advisor Rules, it's recommended to use the
+        :class:`insights.parsers.ls.LSlanR` and add the ``"/boot"`` to
+        the filter list of `Specs.ls_lanR_dirs` instead.
     """
-    def __init__(self, *args, **kwargs):
-        deprecated(LsBoot, "Please use the :class:`insights.parsers.ls.LSlanR` instead.", "3.5.0")
-        super(LsBoot, self).__init__(*args, **kwargs)
+    pass

--- a/insights/parsers/ls_dev.py
+++ b/insights/parsers/ls_dev.py
@@ -5,49 +5,8 @@ LsDev - Command ``ls -lanR /dev``
 The ``ls -lanR /dev`` command provides information for the listing of the
 ``/dev`` directory.
 
-Sample input is shown in the Examples. See ``FileListing`` class for
-additional information.
+See :class:`insights.parsers.ls.FileListing` for more information.
 
-Examples:
-    >>> LS_DEV = '''
-    ... /dev:
-    ... total 3
-    ... brw-rw----.  1 0  6 253,   0 Aug  4 16:56 dm-0
-    ... brw-rw----.  1 0  6 253,   1 Aug  4 16:56 dm-1
-    ... brw-rw----.  1 0  6 253,  10 Aug  4 16:56 dm-10
-    ... crw-rw-rw-.  1 0  5   5,   2 Aug  5  2016 ptmx
-    ... drwxr-xr-x.  2 0  0        0 Aug  4 16:56 pts
-    ... lrwxrwxrwx.  1 0  0       25 Oct 25 14:48 initctl -> /run/systemd/initctl/fifo
-    ...
-    ... /dev/rhel:
-    ... total 0
-    ... drwxr-xr-x.  2 0 0  100 Jul 25 10:00 .
-    ... drwxr-xr-x. 23 0 0 3720 Jul 25 12:43 ..
-    ... lrwxrwxrwx.  1 0 0    7 Jul 25 10:00 home -> ../dm-2
-    ... lrwxrwxrwx.  1 0 0    7 Jul 25 10:00 root -> ../dm-0
-    ... lrwxrwxrwx.  1 0 0    7 Jul 25 10:00 swap -> ../dm-1
-    ...'''
-    >>> ls_dev = LsDev(context_wrap(LS_DEV))
-    >>> ls_dev
-    <insights.parsers.ls_dev.LsDev object at 0x7f287406a1d0>
-    >>> "/dev/rhel" in ls_dev
-    True
-    >>> ls_dev.files_of("/dev/rhel")
-    ['home', 'root', 'swap']
-    >>> ls_dev.dirs_of("/dev/rhel")
-    ['.', '..']
-    >>> ls_dev.specials_of("/dev/rhel")
-    []
-    >>> ls_dev.listing_of("/dev/rhel").keys()
-    ['home', 'root', 'swap', '..', '.']
-    >>> ls_dev.dir_entry("/dev/rhel", "home")
-    {'group': '0', 'name': 'home', 'links': 1, 'perms': 'rwxrwxrwx.',
-    'raw_entry': 'lrwxrwxrwx.  1 0 0    7 Jul 25 10:00 home -> ../dm-2', 'owner': '0',
-    'link': '../dm-2', 'date': 'Jul 25 10:00', 'type': 'l', 'size': 7}
-    >>> ls_dev.listing_of('/dev/rhel')['.']['type'] == 'd'
-    True
-    >>> ls_dev.listing_of('/dev/rhel')['home']['link']
-    '../dm-2'
 """
 from insights import CommandParser, FileListing, parser
 from insights.specs import Specs
@@ -63,5 +22,41 @@ class LsDev(CommandParser, FileListing):
         For Insights Advisor Rules, it's recommended to use the
         :class:`insights.parsers.ls.LSlanR` and add the ``"/dev"`` to
         the filter list of `Specs.ls_lanR_dirs` instead.
+
+    Sample directory listing::
+        /dev:
+        total 3
+        brw-rw----.  1 0  6 253,   0 Aug  4 16:56 dm-0
+        brw-rw----.  1 0  6 253,   1 Aug  4 16:56 dm-1
+        brw-rw----.  1 0  6 253,  10 Aug  4 16:56 dm-10
+        crw-rw-rw-.  1 0  5   5,   2 Aug  5  2016 ptmx
+        drwxr-xr-x.  2 0  0        0 Aug  4 16:56 pts
+        lrwxrwxrwx.  1 0  0       25 Oct 25 14:48 initctl -> /run/systemd/initctl/fifo
+
+        /dev/rhel:
+        total 0
+        drwxr-xr-x.  2 0 0  100 Jul 25 10:00 .
+        drwxr-xr-x. 23 0 0 3720 Jul 25 12:43 ..
+        lrwxrwxrwx.  1 0 0    7 Jul 25 10:00 home -> ../dm-2
+        lrwxrwxrwx.  1 0 0    7 Jul 25 10:00 root -> ../dm-0
+        lrwxrwxrwx.  1 0 0    7 Jul 25 10:00 swap -> ../dm-1
+
+    Examples:
+        >>> type(ls_dev)
+        <class 'insights.parsers.ls_dev.LsDev'>
+        >>> "/dev/rhel" in ls_dev
+        True
+        >>> ls_dev.files_of("/dev/rhel")
+        ['home', 'root', 'swap']
+        >>> ls_dev.dirs_of("/dev/rhel")
+        ['.', '..']
+        >>> ls_dev.specials_of("/dev/rhel")
+        []
+        >>> sorted(ls_dev.listing_of("/dev/rhel").keys())
+        ['.', '..', 'home', 'root', 'swap']
+        >>> ls_dev.listing_of('/dev/rhel')['.']['type'] == 'd'
+        True
+        >>> ls_dev.listing_of('/dev/rhel')['home']['link']
+        '../dm-2'
     """
-    pass
+    __root_path = '/dev'

--- a/insights/parsers/ls_dev.py
+++ b/insights/parsers/ls_dev.py
@@ -49,20 +49,19 @@ Examples:
     >>> ls_dev.listing_of('/dev/rhel')['home']['link']
     '../dm-2'
 """
-from .. import parser, FileListing, CommandParser
+from insights import CommandParser, FileListing, parser
 from insights.specs import Specs
-from insights.util import deprecated
 
 
 @parser(Specs.ls_dev)
 class LsDev(CommandParser, FileListing):
     """
-    .. warning::
-        This class is deprecated and will be removed from 3.5.0.
-        Please use the :class:`insights.parsers.ls.LSlanR` instead.
-
     Parses output of ``ls -lanR /dev`` command.
+
+    .. warning::
+
+        For Insights Advisor Rules, it's recommended to use the
+        :class:`insights.parsers.ls.LSlanR` and add the ``"/dev"`` to
+        the filter list of `Specs.ls_lanR_dirs` instead.
     """
-    def __init__(self, *args, **kwargs):
-        deprecated(LsDev, "Please use the :class:`insights.parsers.ls.LSlanR` instead.", "3.5.0")
-        super(LsDev, self).__init__(*args, **kwargs)
+    pass

--- a/insights/parsers/ls_sys_firmware.py
+++ b/insights/parsers/ls_sys_firmware.py
@@ -37,21 +37,19 @@ Examples:
     >>> ls_sys_firmware.files_of("/sys/firmware/acpi")
     ['pm_profile']
 """
-from .. import parser
-from .. import FileListing, CommandParser
+from insights import CommandParser, FileListing, parser
 from insights.specs import Specs
-from insights.util import deprecated
 
 
 @parser(Specs.ls_sys_firmware)
 class LsSysFirmware(CommandParser, FileListing):
     """
-    .. warning::
-        This class is deprecated and will be removed from 3.5.0.
-        Please use the :class:`insights.parsers.ls.LSlanR` instead.
-
     Parses output of ``ls -lanR /sys/firmware`` command.
+
+    .. warning::
+
+        For Insights Advisor Rules, it's recommended to use the
+        :class:`insights.parsers.ls.LSlanR` and add the ``"/sys/firmware"`` to
+        the filter list of `Specs.ls_lanR_dirs` instead.
     """
-    def __init__(self, *args, **kwargs):
-        deprecated(LsSysFirmware, "Please use the :class:`insights.parsers.ls.LSlanR` instead.", "3.5.0")
-        super(LsSysFirmware, self).__init__(*args, **kwargs)
+    pass

--- a/insights/parsers/ls_sys_firmware.py
+++ b/insights/parsers/ls_sys_firmware.py
@@ -5,38 +5,10 @@ LsSysFirmware - command ``ls /sys/firmware``
 The ``ls -lanR /sys/firmware`` command provides information for the listing of
 the ``/sys/firmware`` directory.
 
-Sample input is shown in the Examples. See ``FileListing`` class for
-additional information.
+See :class:`insights.parsers.ls.FileListing` for more information.
 
-Examples:
-    >>> LS_SYS_FIRMWARE = '''
-    ... /sys/firmware:
-    ... total 0
-    ... drwxr-xr-x.  5 0 0 0 Dec 22 17:56 .
-    ... dr-xr-xr-x. 13 0 0 0 Dec 22 17:56 ..
-    ... drwxr-xr-x.  5 0 0 0 Dec 22 17:56 acpi
-    ... drwxr-xr-x.  3 0 0 0 Dec 22 17:57 dmi
-    ... drwxr-xr-x. 10 0 0 0 Dec 22 17:57 memmap
-    ...
-    ... /sys/firmware/acpi:
-    ... total 0
-    ... drwxr-xr-x. 5 0 0    0 Dec 22 17:56 .
-    ... drwxr-xr-x. 5 0 0    0 Dec 22 17:56 ..
-    ... drwxr-xr-x. 6 0 0    0 Feb 10 15:54 hotplug
-    ... drwxr-xr-x. 2 0 0    0 Feb 10 15:54 interrupts
-    ... -r--r--r--. 1 0 0 4096 Feb 10 15:54 pm_profile
-    ... drwxr-xr-x. 3 0 0    0 Dec 22 17:56 tables
-    ... '''
-    >>> ls_sys_firmware = LsSysFirmware(context_wrap(LS_SYS_FIRMWARE))
-    >>> "acpi" in ls_sys_firmware
-    False
-    >>> "/sys/firmware/acpi" in ls_sys_firmware
-    True
-    >>> ls_sys_firmware.dirs_of("/sys/firmware")
-    ['.', '..', 'acpi', 'dmi', 'memmap']
-    >>> ls_sys_firmware.files_of("/sys/firmware/acpi")
-    ['pm_profile']
 """
+
 from insights import CommandParser, FileListing, parser
 from insights.specs import Specs
 
@@ -51,5 +23,36 @@ class LsSysFirmware(CommandParser, FileListing):
         For Insights Advisor Rules, it's recommended to use the
         :class:`insights.parsers.ls.LSlanR` and add the ``"/sys/firmware"`` to
         the filter list of `Specs.ls_lanR_dirs` instead.
+
+    Sample directory listing::
+
+        /sys/firmware:
+        total 0
+        drwxr-xr-x.  5 0 0 0 Dec 22 17:56 .
+        dr-xr-xr-x. 13 0 0 0 Dec 22 17:56 ..
+        drwxr-xr-x.  5 0 0 0 Dec 22 17:56 acpi
+        drwxr-xr-x.  3 0 0 0 Dec 22 17:57 dmi
+        drwxr-xr-x. 10 0 0 0 Dec 22 17:57 memmap
+
+        /sys/firmware/acpi:
+        total 0
+        drwxr-xr-x. 5 0 0    0 Dec 22 17:56 .
+        drwxr-xr-x. 5 0 0    0 Dec 22 17:56 ..
+        drwxr-xr-x. 6 0 0    0 Feb 10 15:54 hotplug
+        drwxr-xr-x. 2 0 0    0 Feb 10 15:54 interrupts
+        -r--r--r--. 1 0 0 4096 Feb 10 15:54 pm_profile
+        drwxr-xr-x. 3 0 0    0 Dec 22 17:56 tables
+
+    Examples:
+        >>> type(ls_sys_firmware)
+        <class 'insights.parsers.ls_sys_firmware.LsSysFirmware'>
+        >>> "acpi" in ls_sys_firmware
+        False
+        >>> "/sys/firmware/acpi" in ls_sys_firmware
+        True
+        >>> ls_sys_firmware.dirs_of("/sys/firmware")
+        ['.', '..', 'acpi', 'dmi', 'memmap']
+        >>> ls_sys_firmware.files_of("/sys/firmware/acpi")
+        ['pm_profile']
     """
-    pass
+    __root_path = '/sys/firmware'

--- a/insights/tests/parsers/test_ls_boot.py
+++ b/insights/tests/parsers/test_ls_boot.py
@@ -1,3 +1,6 @@
+import doctest
+
+from insights.parsers import ls_boot
 from insights.parsers.ls_boot import LsBoot
 from insights.tests import context_wrap
 
@@ -53,3 +56,9 @@ def test_boot_links():
     assert 'initrd' in boot_files
     assert 'vmlinuz' in boot_files
     assert 'vmlinuz-2.6.32-504.el6.x86_64' in boot_files
+
+
+def test_doc_examples():
+    env = {'bootdir': LsBoot(context_wrap(LS_BOOT))}
+    failed, total = doctest.testmod(ls_boot, globs=env)
+    assert failed == 0

--- a/insights/tests/parsers/test_ls_dev.py
+++ b/insights/tests/parsers/test_ls_dev.py
@@ -1,3 +1,6 @@
+import doctest
+
+from insights.parsers import ls_dev
 from insights.parsers.ls_dev import LsDev
 from insights.tests import context_wrap
 
@@ -32,8 +35,8 @@ lrwxrwxrwx.  1 0 0       7 Jul 25 10:00 rhel-swap -> ../dm-1
 
 
 def test_ls_dev():
-    ls_dev = LsDev(context_wrap(LS_DEV))
-    assert ls_dev.listing_of("/dev/rhel") == {
+    lsdev = LsDev(context_wrap(LS_DEV))
+    assert lsdev.listing_of("/dev/rhel") == {
         'home': {'group': '0', 'name': 'home', 'links': 1, 'perms': 'rwxrwxrwx.',
                  'raw_entry': 'lrwxrwxrwx.  1 0 0    7 Jul 25 10:00 home -> ../dm-2',
                  'owner': '0', 'link': '../dm-2', 'date': 'Jul 25 10:00',
@@ -54,7 +57,13 @@ def test_ls_dev():
               'raw_entry': 'drwxr-xr-x.  2 0 0  100 Jul 25 10:00 .', 'owner': '0',
               'date': 'Jul 25 10:00', 'type': 'd', 'size': 100, 'dir': '/dev/rhel'}}
     expected = ['docker-253:0-1443032-pool', 'rhel-home', 'rhel-root', 'rhel-swap']
-    actual = ls_dev.listings.get("/dev/mapper")['files']
+    actual = lsdev.listings.get("/dev/mapper")['files']
     assert actual == expected
 
-    assert ls_dev.listings.get("/dev/mapper")['entries']['rhel-home']['link'] == "../dm-2"
+    assert lsdev.listings.get("/dev/mapper")['entries']['rhel-home']['link'] == "../dm-2"
+
+
+def test_doc_examples():
+    env = {'ls_dev': LsDev(context_wrap(LS_DEV))}
+    failed, total = doctest.testmod(ls_dev, globs=env)
+    assert failed == 0

--- a/insights/tests/parsers/test_ls_sys_firmware.py
+++ b/insights/tests/parsers/test_ls_sys_firmware.py
@@ -1,3 +1,6 @@
+import doctest
+
+from insights.parsers import ls_sys_firmware
 from insights.parsers.ls_sys_firmware import LsSysFirmware
 from insights.tests import context_wrap
 
@@ -23,8 +26,14 @@ drwxr-xr-x. 3 0 0    0 Dec 22 17:56 tables
 
 
 def test_ls_sys_firmware():
-    ls_sys_firmware = LsSysFirmware(context_wrap(LS_SYS_FIRMWARE))
-    assert "acpi" not in ls_sys_firmware
-    assert "/sys/firmware/acpi" in ls_sys_firmware
-    assert ls_sys_firmware.dirs_of("/sys/firmware") == ['.', '..', 'acpi', 'dmi', 'memmap']
-    assert ls_sys_firmware.files_of("/sys/firmware/acpi") == ['pm_profile']
+    ls = LsSysFirmware(context_wrap(LS_SYS_FIRMWARE))
+    assert "acpi" not in ls
+    assert "/sys/firmware/acpi" in ls
+    assert ls.dirs_of("/sys/firmware") == ['.', '..', 'acpi', 'dmi', 'memmap']
+    assert ls.files_of("/sys/firmware/acpi") == ['pm_profile']
+
+
+def test_doc_examples():
+    env = {'ls_sys_firmware': LsSysFirmware(context_wrap(LS_SYS_FIRMWARE))}
+    failed, total = doctest.testmod(ls_sys_firmware, globs=env)
+    assert failed == 0


### PR DESCRIPTION
- They are used by gss rules and other apps
   See the latest comment to #3833

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
