### PR TITLE
fix: Malware fix to handle cert_verify set in conf file

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -680,9 +680,12 @@ class MalwareDetectionClient:
                 break
 
         logger.debug("Downloading rules from: %s", self.rules_location)
-        if not self.insights_config.cert_verify:
-            self.insights_config.cert_verify = True
-        logger.debug("Using cert_verify value %s ...", self.insights_config.cert_verify)
+        cert_verify = self.insights_config.cert_verify
+        if cert_verify is None or cert_verify == '':
+            cert_verify = True
+        elif cert_verify.lower() in ('true', 'false'):
+            cert_verify = cert_verify.lower() == 'true'
+        logger.debug("Using cert_verify value %s ...", cert_verify)
         conn = InsightsConnection(self.insights_config)
 
         for attempt in range(1, self.insights_config.retries + 1):
@@ -690,7 +693,7 @@ class MalwareDetectionClient:
                 response = conn.get(
                     self.rules_location,
                     log_response_text=log_rule_contents,
-                    verify=self.insights_config.cert_verify
+                    verify=cert_verify
                 )
                 if response.status_code != 200:
                     raise Exception("%s %s: %s" % (response.status_code, response.reason, response.text))
@@ -706,8 +709,8 @@ class MalwareDetectionClient:
 
                 if re.search('SSL.*verify.failed', str(e), re.IGNORECASE):
                     # Kept as a fallback in case SSL errors still occur - add the custom CA cert to the trusted certs
-                    self.insights_config.cert_verify = self._get_config_option('ca_cert', ca_cert)
-                    logger.debug("Trying cert_verify value %s ...", self.insights_config.cert_verify)
+                    cert_verify = self._get_config_option('ca_cert', ca_cert)
+                    logger.debug("Trying cert_verify value %s ...", cert_verify)
 
         self.temp_rules_file = NamedTemporaryFile(prefix='.tmpmdsigs', mode='wb', delete=True)
         self.temp_rules_file.write(response.content)

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -1114,29 +1114,30 @@ class TestsUtilizingFakeYara:
         @patch("insights.client.apps.malware_detection.call", return_value='4.2.0')  # mock call to 'yara --version'
         def test_download_rules_from_stage(self, version_mock, exists_mock, conf, cmd, session, proxies, get, findmnt, remove):
             # Test downloading signatures files from the stage environment
+            # cert_verify is set to 'False' (string) for stage - check its changed to False (boolean)
 
             base_url = "cert.console.stage.example.com:443/r/insights"
             expected_rules_url = "https://cert.console.stage.example.com/api/malware-detection/v1/signatures.yar?yara_version=4.2.0"
-            mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url))
+            mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url, cert_verify='False'))
             assert mdc.yara_version == '4.2.0'
             assert mdc.rules_location == expected_rules_url
-            get.assert_called_with(expected_rules_url, log_response_text=False, verify=True)
+            get.assert_called_with(expected_rules_url, log_response_text=False, verify=False)
 
             for base_url in ('cert.console.stage.example.com/r/insights', 'cert.console.stage.example.com'):
-                mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url))
+                mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url, cert_verify='false'))
                 assert mdc.rules_location == expected_rules_url
-                get.assert_called_with(expected_rules_url, log_response_text=False, verify=True)
+                get.assert_called_with(expected_rules_url, log_response_text=False, verify=False)
 
             base_url = "https://cert.console.stage.example.com:443/r/insights"
             expected_rules_url = "https://cert.console.stage.example.com:443/api/malware-detection/v1/signatures.yar?yara_version=4.2.0"
-            mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url))
+            mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url, cert_verify='True'))
             assert mdc.rules_location == expected_rules_url
             get.assert_called_with(expected_rules_url, log_response_text=False, verify=True)
 
             os.environ['TEST_SCAN'] = 'true'
             base_url = "cloud.stage.example.com"
             expected_rules_url = "https://cloud.stage.example.com/api/malware-detection/v1/test-rule.yar"
-            mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url))
+            mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url, cert_verify=''))
             assert mdc.rules_location == expected_rules_url
             get.assert_called_with(expected_rules_url, log_response_text=True, verify=True)
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

When downloading the malware signatures file from stage, the insights-config.conf file usually has the entry cert_verify = False.  This caused malware-detection to fail to download the signatures file because it wasn't treating False as a string.  This fix treats False as a string and converts it to a boolean before trying to use it. *sigh*