### PR TITLE
fix: don't redact ls_systemd_units to avoid issue#3858

### DIFF
--- a/insights/client/data_collector.py
+++ b/insights/client/data_collector.py
@@ -458,7 +458,8 @@ class DataCollector(object):
                             'etc/insights-client/machine-id',
                             'etc/insights-client/.exp.sed',  # INSPEC-414
                             'etc/machine-id',
-                            'insights_commands/subscription-manager_identity'
+                            'insights_commands/subscription-manager_identity',
+                            'insights_commands/ls_-lanRL_.etc.systemd_.run.systemd_.usr.lib.systemd_.usr.local.lib.systemd_.usr.local.share.systemd_.usr.share.systemd',  # issue #3858
                         )
                 )):
                     # do not redact the ID files

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -131,7 +131,10 @@ class InsightsArchiveSpecs(Specs):
     ls_osroot = simple_file("insights_commands/ls_-lan")
     ls_R_var_lib_nova_instances = simple_file("insights_commands/ls_-laR_.var.lib.nova.instances")
     ls_sys_firmware = simple_file("insights_commands/ls_-lanR_.sys.firmware")
-    ls_systemd_units = simple_file("insights_commands/ls_-lanRL_.etc.systemd_.run.systemd_.usr.lib.systemd_.usr.local.lib.systemd")
+    ls_systemd_units = first_file([
+        "insights_commands/ls_-lanRL_.etc.systemd_.run.systemd_.usr.lib.systemd_.usr.local.lib.systemd_.usr.local.share.systemd_.usr.share.systemd",
+        "insights_commands/ls_-lanRL_.etc.systemd_.run.systemd_.usr.lib.systemd_.usr.local.lib.systemd"
+    ])
     ls_tmp = simple_file("insights_commands/ls_-la_.tmp")
     ls_usr_bin = simple_file("insights_commands/ls_-lan_.usr.bin")
     ls_usr_lib64 = simple_file("insights_commands/ls_-lan_.usr.lib64")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
- fix: #3858 (workaround)
- and fix its incorrect file path in the `insights_archive.py`
