### PR TITLE
fix: OSRelease when both os_release and redhat_release avaiable

### DIFF
--- a/insights/combiners/os_release.py
+++ b/insights/combiners/os_release.py
@@ -274,7 +274,8 @@ class OSRelease(object):
             if osr or rhr:
                 # Use 'os-release' and 'redhat-release
                 ret = _from_os_release(osr) if osr else dict()
-                ret.update(_from_redhat_release(rhr)) if rhr else None
+                if ret.get('other_linux', 'RHEL') == 'RHEL':
+                    ret.update(_from_redhat_release(rhr)) if rhr else None
                 if ret.get('other_linux', 'RHEL') != 'RHEL':
                     self._release = ret['other_linux']
                     self._reasons = {'reason': 'NON-RHEL: os-release/redhat-release'}

--- a/insights/tests/combiners/test_os_release.py
+++ b/insights/tests/combiners/test_os_release.py
@@ -389,7 +389,7 @@ def test_not_rhel():
     assert result.name == "Oracle"  # the same to self.release when '/etc/os-release' is unavailable
     assert result.is_rhel_compatible is False
 
-    # RHEL, Bad os-release only
+    # RHEL, os-release only
     osr = OsRelease(context_wrap(OS_RELEASE_UNKNOWN))
     result = OSRelease(None, None, None, osr, None)
     assert result.is_rhel is False
@@ -406,7 +406,7 @@ def test_not_rhel():
     assert result.name == "Oracle Linux Server"
     assert result.is_rhel_compatible is False
 
-    # RHEL, redhat-release
+    # RHEL, redhat-release only
     rhr = RedhatRelease(context_wrap(REDHAT_RELEASE_FEDORA))
     result = OSRelease(None, None, None, None, rhr)
     assert result.is_rhel is False
@@ -421,6 +421,26 @@ def test_not_rhel():
     assert result.release == "Test OS"
     assert result.reasons == {'reason': 'NON-RHEL: os-release/redhat-release'}
     assert result.name == "Test OS"
+    assert result.is_rhel_compatible is False
+
+    # RHEL, BAD os-release + GOOD redhat-release
+    osr = OsRelease(context_wrap(OS_RELEASE_OL))
+    rhr = RedhatRelease(context_wrap(REDHAT_RELEASE_86))
+    result = OSRelease(None, None, None, osr, rhr)
+    assert result.is_rhel is False
+    assert result.release == "Oracle Linux Server"
+    assert result.reasons == {'reason': 'NON-RHEL: os-release/redhat-release'}
+    assert result.name == "Oracle Linux Server"
+    assert result.is_rhel_compatible is False
+
+    # RHEL, GOOD os-release + BAD redhat-release
+    osr = OsRelease(context_wrap(OS_RELEASE_RH))
+    rhr = RedhatRelease(context_wrap(REDHAT_RELEASE_FEDORA))
+    result = OSRelease(None, None, None, osr, rhr)
+    assert result.is_rhel is False
+    assert result.release == "Fedora"
+    assert result.reasons == {'reason': 'NON-RHEL: os-release/redhat-release'}
+    assert result.name == "Red Hat Enterprise Linux"
     assert result.is_rhel_compatible is False
 
 


### PR DESCRIPTION
- Identify non-rhel when one of them is non-rhel

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

- fix the following issue:
   E.g. when `os_release` is non-rhel, but `redhat_release` is rhel, it will be identified as RHEL incorrectly.
