### PR TITLE
SPM-2113: allow re-generating dnf/yum cache on demand

### DIFF
--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -135,6 +135,13 @@ DEFAULT_OPTS = {
         'group': 'actions',
         'dest': 'manifest'
     },
+    'build_packagecache': {
+        'default': False,
+        'opt': ['--build-packagecache'],
+        'help': 'Refresh the system package manager cache',
+        'action': 'store_true',
+        'group': 'actions'
+    },
     'compliance': {
         'default': False,
         'opt': ['--compliance'],

--- a/insights/tests/datasources/test_yum_updates.py
+++ b/insights/tests/datasources/test_yum_updates.py
@@ -23,7 +23,8 @@ def test_yum_updates_runs_correctly():
                     ]
                 }
             },
-            "metadata_time": "2021-01-01T09:39:45Z"
+            "build_pkgcache": False,
+            "metadata_time": "2021-01-01T09:39:45Z",
     })
     # setup dnf mock
     with patch("insights.specs.datasources.yum_updates.UpdatesManager", yum_updates.DnfManager):


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

To support satellite systems in Patch application, insights client will provide a flag (--build-packagecache) that will regenerate DNF/YUM cache and collect all the installable errata from the satellite system (dnf updateinfo list). 
I also want to add an option to the insights-client so this flag can be setup from the .conf file.

