### PR TITLE
feat: add try/except in jinja2 content rendering

### DIFF
--- a/insights/formats/__init__.py
+++ b/insights/formats/__init__.py
@@ -154,11 +154,20 @@ def get_content(obj, val):
 
 try:
     from jinja2 import Template
+    from jinja2 import exceptions as jinja2Exceptions
 
     def format_rule(comp, val):
         content = get_content(comp, val)
         if content and val.get("type") != "skip":
-            return Template(content).render(val)
+            try:
+                text = Template(content).render(val)
+            except jinja2Exceptions.UndefinedError as err:
+                text = '\n'.join([str(val),
+                                content,
+                                "Failed to render the Content above:",
+                                "    " + str(err)])
+            finally:
+                return text
         return str(val)
 
     RENDERERS[rule] = format_rule

--- a/insights/formats/__init__.py
+++ b/insights/formats/__init__.py
@@ -163,6 +163,8 @@ try:
                 text = Template(content).render(val)
             except jinja2Exceptions.UndefinedError as err:
                 text = '\n'.join([str(val),
+                                "CONTENT:",
+                                "--------",
                                 content,
                                 "Failed to render the Content above:",
                                 "    " + str(err)])

--- a/insights/tests/test_formats.py
+++ b/insights/tests/test_formats.py
@@ -37,6 +37,7 @@ def test_human_readable():
     data = output.read()
     assert "foo" in data
     assert "bar" in data
+    assert "CONTENT:" in data
     assert "The content of this rule:" in data
     assert "Failed to render the Content above:" in data
     assert "'FakeKey' is undefined" in data

--- a/insights/tests/test_formats.py
+++ b/insights/tests/test_formats.py
@@ -15,6 +15,13 @@ SL_CMD = "Command Line - "
 SL_ARCHIVE = "Real Archive Path - "
 SL_PATH = "/insights/core"
 
+CONTENT = """
+The content of this rule:
+    {% for key, val in FakeKey.items() -%}
+        {{key}}: {{val}}
+    {% endfor %}
+"""
+
 
 @rule()
 def report():
@@ -30,6 +37,9 @@ def test_human_readable():
     data = output.read()
     assert "foo" in data
     assert "bar" in data
+    assert "The content of this rule:" in data
+    assert "Failed to render the Content above:" in data
+    assert "'FakeKey' is undefined" in data
 
 
 def test_json_format():


### PR DESCRIPTION
Resolve INSGHTCORE-36 
  
  When there is a typo in the rule's CONTENT attribute, an
  UndefinedError exception would be raised during the jinja2
  rendering process. This exception halts the rest of the processing,
  so other, unrelated rule results are not output.

  This feature adds try/except around individual CONTENT rendering,
  so one "bad" rule has little to no impact on other rules.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
See commit msg above.

Example before the fix: 
```
[INFO] shared_rules.sysmgmt.rhel_lifecycle_display.report
---------------------------------------------------------
Traceback (most recent call last):
  File "/Users/joy/Work/gss-rules/venv/bin/insights-run", line 33, in <module>
    sys.exit(load_entry_point('insights-core', 'console_scripts', 'insights-run')())
  File "/Users/joy/Work/insights-core/insights/__init__.py", line 475, in main
    run(print_summary=True)
  File "/Users/joy/Work/insights-core/insights/__init__.py", line 417, in run
    formatter.postprocess(broker)
  File "/Users/joy/Work/insights-core/insights/formats/text.py", line 266, in postprocess
    self.formatter.postprocess()
  File "/Users/joy/Work/insights-core/insights/formats/text.py", line 219, in postprocess
    self.show_description()
  File "/Users/joy/Work/insights-core/insights/formats/text.py", line 202, in show_description
    printit(c, v)
  File "/Users/joy/Work/insights-core/insights/formats/text.py", line 185, in printit
    print(render(c, v), file=self.stream)
  File "/Users/joy/Work/insights-core/insights/formats/__init__.py", line 172, in render
    return func(comp, val) if func else str(val)
  File "/Users/joy/Work/insights-core/insights/formats/__init__.py", line 161, in format_rule
    return Template(content).render(val)
  File "/Users/joy/Work/gss-rules/venv/lib/python3.10/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/Users/joy/Work/gss-rules/venv/lib/python3.10/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 5, in top-level template code
  File "/Users/joy/Work/gss-rules/venv/lib/python3.10/site-packages/jinja2/environment.py", line 485, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'FakeLifeCCcycleInfo' is undefined
```

After the fix:
```
[INFO] shared_rules.sysmgmt.rhel_lifecycle_display.report
---------------------------------------------------------
Links:
    jira:
        https://issues.redhat.com/browse/CEECBA-4979
    kcs:
        https://access.redhat.com/articles/3078

RHEL_LIFECYCLE:
    LifecycleInfo : {'ELS': '31 May 2035',
                     'GA': '18 May 2022',
                     'Phase1': '31 May 2027',
                     'Phase2': 'N/A',
                     'Phase3': '31 May 2032'}
    ProductName   : 'Red Hat Enterprise Linux'
    ProductVersion: '9.1'

CONTENT:
--------
This system is running on {{ProductName}} {{ProductVersion}}

LifeCycle Dates for current system:
    {% for key, val in FakeLifeCCcycleInfo.items() -%}
        {{key}}: {{val}}
    {% endfor %}

Read article https://access.redhat.com/support/policy/updates/errata for detail information about RHEL Life Cycle.

Failed to render the Content above:
    'FakeLifeCCcycleInfo' is undefined

----------------------
Rule Execution Summary
----------------------
Missing Deps: 1598
Passed      : 0
Failed      : 8
Info        : 9
Ret'd None  : 551
Metadata    : 0
Metadata Key: 0
Fingerprint : 0
Exceptions  : 51
```
