### PR TITLE
feat: improve temp directories

### DIFF
--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -78,8 +78,9 @@ class InsightsConstants(object):
     sig_kill_bad = 101
     cached_branch_info = os.path.join(default_conf_dir, '.branch_info')
     pidfile = os.path.join(os.sep, 'var', 'run', 'insights-client.pid')
-    insights_tmp_path = os.path.join(os.sep, 'var', 'tmp', 'insights-client')
-    egg_release_file = os.path.join(insights_tmp_path, 'insights-client-egg-release')
+    insights_tmp_path = os.path.join(os.sep, 'var', 'tmp')
+    insights_tmp_prefix = 'insights-client'
+    egg_release_file = os.path.join(os.sep, insights_tmp_path, insights_tmp_prefix, 'insights-client-egg-release')
     ppidfile = os.path.join(os.sep, 'tmp', 'insights-client.ppid')
     valid_compressors = ("gz", "xz", "bz2", "none")
     # RPM version in which core collection was released

--- a/insights/tests/client/apps/test_compliance.py
+++ b/insights/tests/client/apps/test_compliance.py
@@ -20,7 +20,7 @@ def test_oscap_scan(config, ssg_version, assert_rpms):
     compliance_client.get_profiles_matching_os = lambda: []
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
     compliance_client.run_scan = lambda ref_id, policy_xml, output_path, tailoring_file_path: None
-    compliance_client.archive.archive_tmp_dir = '/tmp'
+    compliance_client.archive.tmp_dir = '/tmp'
     compliance_client.archive.archive_name = 'insights-compliance-test'
     archive, content_type = compliance_client.oscap_scan()
     assert archive == '/tmp/insights-compliance-test.tar.gz'
@@ -71,7 +71,7 @@ def test_oscap_scan_with_obfuscation(config, ssg_version, assert_rpms, tmpdir):
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
     compliance_client._results_file = lambda archive_dir, profile: str(results_file)
     compliance_client.run_scan = lambda ref_id, policy_xml, output_path, tailoring_file_path: None
-    compliance_client.archive.archive_tmp_dir = '/tmp'
+    compliance_client.archive.tmp_dir = '/tmp'
     compliance_client.archive.archive_name = 'insights-compliance-test'
     archive, content_type = compliance_client.oscap_scan()
     assert archive == '/tmp/insights-compliance-test.tar.gz'
@@ -137,7 +137,7 @@ def test_oscap_scan_with_hostname_obfuscation(config, ssg_version, assert_rpms, 
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
     compliance_client._results_file = lambda archive_dir, profile: str(results_file)
     compliance_client.run_scan = lambda ref_id, policy_xml, output_path, tailoring_file_path: None
-    compliance_client.archive.archive_tmp_dir = '/tmp'
+    compliance_client.archive.tmp_dir = '/tmp'
     compliance_client.archive.archive_name = 'insights-compliance-test'
     archive, content_type = compliance_client.oscap_scan()
     assert archive == '/tmp/insights-compliance-test.tar.gz'
@@ -178,7 +178,7 @@ def test_oscap_scan_with_results_repaired(config, assert_rpms, tmpdir):
     compliance_client.find_scap_policy = lambda ref_id: '/usr/share/xml/scap/foo.xml'
     compliance_client._results_file = lambda archive_dir, profile: str(results_file)
     compliance_client.run_scan = lambda ref_id, policy_xml, output_path, tailoring_file_path: None
-    compliance_client.archive.archive_tmp_dir = '/tmp'
+    compliance_client.archive.tmp_dir = '/tmp'
     compliance_client.archive.archive_name = 'insights-compliance-test'
     archive, content_type = compliance_client.oscap_scan()
     assert archive == '/tmp/insights-compliance-test.tar.gz'


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This commit improve the use of temporary directories:

- The temporary directory will have a random name: `/var/tmp/insights-client-<random characters>`.
- It checks that the directory is not being in use before using it. If it existed, it will clean that directory and create a new one.
- Remove unused temporary directory and the function that used it: `archive_tmp_directory`.
- Change the cleanup mechanisms to be align with this change.
- Change the tests to be align with this change.
- Refactor the constants used.




