### PR TITLE
fix: OSRelease.release returns prepared OS Name

### DIFF
--- a/insights/combiners/os_release.py
+++ b/insights/combiners/os_release.py
@@ -100,6 +100,14 @@ THRESHOLD = 0.75
 """Threshold of the must-install packages to identify NON-RHEL"""
 
 
+def _get_release(names):
+    names = names if isinstance(names, list) else [names]
+    for rel in OTHER_LINUX_KEYS:
+        if any(rel.lower() in name.lower() for name in names):
+            return rel
+    return names[-1].split()[0]
+
+
 def _from_os_release(osr):
     """
     Identify RHEL by checking the `/etc/os-release`.
@@ -115,7 +123,8 @@ def _from_os_release(osr):
                                       osr.get('PRETTY_NAME')]))
         if names:
             # NON-RHEL: /etc/os-release
-            return dict(other_linux=names[-1], reason='NON-RHEL: os-release')
+            return dict(other_linux=_get_release(names),
+                        reason='NON-RHEL: os-release')
         return dict(other_linux='RHEL')
 
 
@@ -125,7 +134,8 @@ def _from_redhat_release(rhr):
     """
     if rhr:
         if not rhr.is_rhel:
-            return dict(other_linux=rhr.product, reason='NON-RHEL: redhat-release')
+            return dict(other_linux=_get_release(rhr.product),
+                        reason='NON-RHEL: redhat-release')
         return dict(other_linux='RHEL')
 
 
@@ -227,7 +237,7 @@ def _from_installed_rpms(rpms, uname):
             # try to get the release from kernel vendor
             if 'red hat' not in vendor.lower():
                 sep = ',' if ',' in vendor else ' '
-                release = vendor.split(sep)[0].strip()
+                release = _get_release(vendor.split(sep)[0].strip())
                 ret.update(other_linux=release)
         return ret
     return dict(other_linux='RHEL')
@@ -315,7 +325,8 @@ class OSRelease(object):
     @property
     def release(self):
         """
-        Returns the estimated release name of the running Linux.
+        Returns the estimated release name of the running Linux.  It's RHEL or
+        one key of the :const:`OTHER_LINUX_KEYS` when it's NON-RHEL.
         """
         return self._release
 
@@ -349,5 +360,7 @@ class OSRelease(object):
         return self._release
 
     def __repr__(self):
+        if self.is_rhel:
+            return "<release: {0}, name: {1}>".format(self.release, self.name)
         return "<release: {0}, name: {1}, reasons: {2}>".format(
                 self.release, self.name, self.reasons)

--- a/insights/combiners/os_release.py
+++ b/insights/combiners/os_release.py
@@ -2,7 +2,7 @@
 OSRelease
 =========
 The ``OSRelease`` combiner uses the following parsers to try to identify if the
-current host is installed with a "Red Hat Enterprise Linux" system.
+current host is installed with a "Red Hat Enterprise Linux" (RHEL) system.
 
     - :py:class:`insights.parsers.installed_rpms.InstalledRpms`
     - :py:class:`insights.parsers.uname.Uname`
@@ -10,15 +10,16 @@ current host is installed with a "Red Hat Enterprise Linux" system.
     - :py:class:`insights.parsers.os_release.OSRelease`
     - :py:class:`insights.parsers.redhat_release.RedhatRelease`
 
-It provides an attribute `is_rhel` that indicates if the host is "RHEL" or not.
+It provides an attribute `is_rhel` that indicates if the host is RHEL or not.
 It also provides an attribute `release` which returns the estimated OS release
 name of the system, "Unknown" will be returned by default when cannot identify
 the OS.
 
-* TODO:
-  The lists of keywords to identify NON-RHEL system of each sub-combiners are
-  based on our current knowledge, and maybe not sufficient. It needs to be
-  updated timely according to new found Linux distributions.
+* TODO::
+
+    The lists of keywords to identify NON-RHEL system of each sub-combiners are
+    based on our current knowledge, and may be not sufficient. It needs to be
+    updated timely according to new found Linux Distributions.
 """
 from insights.core.filters import add_filter
 from insights.core.plugins import combiner
@@ -60,6 +61,7 @@ OTHER_LINUX_KEYS = {
         ['suse', 'sles', 'novell'],
         ['sles-release', 'sles_es-release-server']),
 }
+"""Known NON-RHEL Linux Distributions."""
 # TODO:
 # Update the CONVERT2RHEL_SUPPORTED list when necessary
 CONVERT2RHEL_SUPPORTED = ['CentOS']
@@ -69,7 +71,7 @@ add_filter(DmesgLineList, DMESG_LINUX_BUILD_INFO)
 DmesgLineList.keep_scan("linux_version", DMESG_LINUX_BUILD_INFO, num=1)
 # Must-install packages for minimum RHEL system
 MINIMUM_RHEL_PKGS = [
-    # 'kernel' is must-install too, it's checked individually (booting kernel)
+    # 'kernel' is checked individually (booting kernel)
     'audit-libs',
     'basesystem',
     'bash',
@@ -97,7 +99,7 @@ MINIMUM_RHEL_PKGS = [
 ]
 """Must-install packages for minimum installed RHEL system."""
 THRESHOLD = 0.75
-"""Threshold of the must-install packages to identify NON-RHEL"""
+"""Threshold of the must-install packages to identify NON-RHEL."""
 
 
 def _get_release(names):
@@ -318,7 +320,7 @@ class OSRelease(object):
     @property
     def is_rhel_compatible(self):
         """
-        Returns True if convert2rhel could convert
+        Returns True if Convert2RHEL could convert
         """
         return self._release in CONVERT2RHEL_SUPPORTED
 
@@ -333,9 +335,9 @@ class OSRelease(object):
     @property
     def name(self):
         """
-        Returns the name of the OS. Generally it's the "NAME" of the
-        '/etc/os-release' file, or it's the same as the `release` when
-        the '/etc/os-release' is not available.
+        Returns the name of the OS. Generally it's the ``NAME`` of the
+        `/etc/os-release` file, or it's the same as the `release` when
+        the `/etc/os-release` is not available.
         """
         return self._name
 

--- a/insights/tests/combiners/test_os_release.py
+++ b/insights/tests/combiners/test_os_release.py
@@ -98,6 +98,11 @@ NAME="Oracle Linux Server"
 ID="ol"
 PRETTY_NAME="Red Hat Enterprise Linux"
 """.strip()
+OS_RELEASE_CENTOS = """
+NAME="CentOS Stream"
+ID="centos"
+PRETTY_NAME="CentOS Stream 9"
+""".strip()
 OS_RELEASE_UNKNOWN = """
 NAME="Test OS"
 ID="test"
@@ -277,7 +282,7 @@ def test_not_rhel():
     assert result.name == "SUSE"  # the same to self.release when '/etc/os-release' is unavailable
     assert result.is_rhel_compatible is False
 
-    # NON-RHEL: SUSE dmesg only
+    # NON-RHEL: CentOS dmesg only
     dmesg = DmesgLineList(context_wrap(DMESG_CENTOS))
     result = OSRelease(None, dmesg, None, None, None)
     assert result.is_rhel is False
@@ -411,15 +416,23 @@ def test_not_rhel():
     osr = OsRelease(context_wrap(OS_RELEASE_UNKNOWN))
     result = OSRelease(None, None, None, osr, None)
     assert result.is_rhel is False
-    assert result.release == "Test OS"
+    assert result.release == "Test"
     assert result.reasons == {'reason': 'NON-RHEL: os-release'}
     assert result.name == "Test OS"
     assert result.is_rhel_compatible is False
 
+    osr = OsRelease(context_wrap(OS_RELEASE_CENTOS))
+    result = OSRelease(None, None, None, osr, None)
+    assert result.is_rhel is False
+    assert result.release == "CentOS"
+    assert result.reasons == {'reason': 'NON-RHEL: os-release'}
+    assert result.name == "CentOS Stream"
+    assert result.is_rhel_compatible is True
+
     osr = OsRelease(context_wrap(OS_RELEASE_OL))
     result = OSRelease(None, None, None, osr, None)
     assert result.is_rhel is False
-    assert result.release == "Oracle Linux Server"
+    assert result.release == "Oracle"
     assert result.reasons == {'reason': 'NON-RHEL: os-release'}
     assert result.name == "Oracle Linux Server"
     assert result.is_rhel_compatible is False
@@ -436,9 +449,9 @@ def test_not_rhel():
     rhr = RedhatRelease(context_wrap(REDHAT_RELEASE_UNKNOWN))
     result = OSRelease(None, None, None, None, rhr)
     assert result.is_rhel is False
-    assert result.release == "Test OS"
+    assert result.release == "Test"
     assert result.reasons == {'reason': 'NON-RHEL: redhat-release'}
-    assert result.name == "Test OS"
+    assert result.name == "Test"
     assert result.is_rhel_compatible is False
 
     # RHEL, Oracle os-release + RHEL redhat-release
@@ -446,7 +459,7 @@ def test_not_rhel():
     rhr = RedhatRelease(context_wrap(REDHAT_RELEASE_86))
     result = OSRelease(None, None, None, osr, rhr)
     assert result.is_rhel is False
-    assert result.release == "Oracle Linux Server"
+    assert result.release == "Oracle"
     assert result.reasons == {'reason': 'NON-RHEL: os-release'}
     assert result.name == "Oracle Linux Server"
     assert result.is_rhel_compatible is False


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
- In fact, this is not to fix an issue but to update the `release`
   as per the requirement of puptoo
