### PR TITLE
fix: don't initiate InsighsConfig in dup_machine_id_info

### DIFF
--- a/insights/specs/datasources/machine_ids.py
+++ b/insights/specs/datasources/machine_ids.py
@@ -7,11 +7,9 @@ from insights.core.plugins import datasource
 from insights.core.spec_factory import DatasourceProvider
 from insights.core.filters import get_filters
 from insights.core.context import HostContext
-from insights.client.config import InsightsConfig
-from insights.client.connection import InsightsConnection
 from insights.core.exceptions import SkipComponent
+from insights.client.client import get_connection
 from insights.specs import Specs
-from insights.client.auto_config import try_auto_configuration
 
 
 @datasource(HostContext, Specs.machine_id)
@@ -38,12 +36,9 @@ def dup_machine_id_info(broker):
     if len(machine_id_obj.content) == 1:
         machine_id = str(machine_id_obj.content[0].strip())
         if machine_id in filters:
-            config = InsightsConfig()
-            config._load_config_file()
-            config._load_env()
-            try_auto_configuration(config)
-            conn = InsightsConnection(config)
+            config = broker.get('client_config')
             try:
+                conn = get_connection(config)
                 if config.legacy_upload:
                     url = conn.base_url + '/platform/inventory/v1/hosts?insights_id=' + machine_id
                 else:

--- a/insights/tests/datasources/test_machine_ids.py
+++ b/insights/tests/datasources/test_machine_ids.py
@@ -1,28 +1,19 @@
 import json
-from mock.mock import patch
 import pytest
 
-from insights.tests import context_wrap
-from insights.core.spec_factory import DatasourceProvider
-from insights.specs.datasources.machine_ids import dup_machine_id_info
+from mock.mock import patch
+
+from insights.client.config import InsightsConfig
 from insights.core import filters
 from insights.core.exceptions import SkipComponent
+from insights.core.spec_factory import DatasourceProvider
 from insights.specs import Specs
-
-
-class MockInsightsConfig(object):
-    def __init__(self):
-        self.legacy_upload = False
-
-    def _load_config_file(self):
-        pass
-
-    def _load_env(self):
-        pass
+from insights.specs.datasources.machine_ids import dup_machine_id_info
+from insights.tests import context_wrap
 
 
 class MockInsightsConnection(object):
-    def __init__(self, config):
+    def __init__(self, config=None):
         self.config = config
         self.base_url = ''
         self.inventory_url = ''
@@ -104,61 +95,78 @@ def setup_function(func):
         filters.add_filter(Specs.duplicate_machine_id, [])
 
 
-def mock_try_autoconfig(config):
-    return
+@patch('insights.specs.datasources.machine_ids.get_connection',
+       return_value=MockInsightsConnection())
+def test_duplicate(conn):
+    broker = {
+        Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsdeff']),
+        'client_config': InsightsConfig(legacy_upload=False)
+    }
+    result = dup_machine_id_info(broker)
+    expected = DatasourceProvider(content=["dc194312-8cdd-4e75-8cf1-2094bfsfsdeff hostname1.compute.internal,hostname2.compute.internal"], relative_path='insights_commands/duplicate_machine_id_info')
+    assert expected.content == result.content
+    assert expected.relative_path == result.relative_path
 
-
-@patch('insights.specs.datasources.machine_ids.InsightsConnection', MockInsightsConnection)
-@patch('insights.specs.datasources.machine_ids.try_auto_configuration', mock_try_autoconfig)
-@patch('insights.specs.datasources.machine_ids.InsightsConfig', MockInsightsConfig)
-def test_duplicate():
-    broker = {Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsdeff'])}
+    broker = {
+        Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsdeff']),
+        'client_config': InsightsConfig(legacy_upload=True)
+    }
     result = dup_machine_id_info(broker)
     expected = DatasourceProvider(content=["dc194312-8cdd-4e75-8cf1-2094bfsfsdeff hostname1.compute.internal,hostname2.compute.internal"], relative_path='insights_commands/duplicate_machine_id_info')
     assert expected.content == result.content
     assert expected.relative_path == result.relative_path
 
 
-@patch('insights.specs.datasources.machine_ids.InsightsConnection', MockInsightsConnection)
-@patch('insights.specs.datasources.machine_ids.try_auto_configuration', mock_try_autoconfig)
-@patch('insights.specs.datasources.machine_ids.InsightsConfig', MockInsightsConfig)
-def test_non_duplicate():
-    broker = {Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bf45678'])}
+@patch('insights.specs.datasources.machine_ids.get_connection',
+       return_value=MockInsightsConnection())
+def test_non_duplicate(conn):
+    broker = {
+        Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bf45678']),
+        'client_config': InsightsConfig(legacy_upload=False)
+    }
     with pytest.raises(SkipComponent):
         dup_machine_id_info(broker)
 
 
-@patch('insights.specs.datasources.machine_ids.InsightsConnection', MockInsightsConnection)
-@patch('insights.specs.datasources.machine_ids.try_auto_configuration', mock_try_autoconfig)
-@patch('insights.specs.datasources.machine_ids.InsightsConfig', MockInsightsConfig)
-def test_module_filters_empty():
-    broker = {Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsdeff'])}
+@patch('insights.specs.datasources.machine_ids.get_connection',
+       return_value=MockInsightsConnection())
+def test_module_filters_empty(conn):
+    broker = {
+        Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsdeff']),
+        'client_config': InsightsConfig(legacy_upload=False)
+    }
     with pytest.raises(SkipComponent):
         dup_machine_id_info(broker)
 
 
-@patch('insights.specs.datasources.machine_ids.InsightsConnection', MockInsightsConnection)
-@patch('insights.specs.datasources.machine_ids.try_auto_configuration', mock_try_autoconfig)
-@patch('insights.specs.datasources.machine_ids.InsightsConfig', MockInsightsConfig)
-def test_wrong_machine_id_content():
-    broker = {Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsdeff', 'dc194312-8cdd-4e75-8cf1-2094bfsf45678'])}
+@patch('insights.specs.datasources.machine_ids.get_connection',
+       return_value=MockInsightsConnection())
+def test_wrong_machine_id_content(conn):
+    broker = {
+        Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsdeff', 'dc194312-8cdd-4e75-8cf1-2094bfsf45678']),
+        'client_config': InsightsConfig(legacy_upload=False)
+    }
     with pytest.raises(SkipComponent):
         dup_machine_id_info(broker)
 
 
-@patch('insights.specs.datasources.machine_ids.InsightsConnection', MockInsightsConnection)
-@patch('insights.specs.datasources.machine_ids.try_auto_configuration', mock_try_autoconfig)
-@patch('insights.specs.datasources.machine_ids.InsightsConfig', MockInsightsConfig)
-def test_machine_id_not_in_filters():
-    broker = {Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsabc'])}
+@patch('insights.specs.datasources.machine_ids.get_connection',
+       return_value=MockInsightsConnection())
+def test_machine_id_not_in_filters(conn):
+    broker = {
+        Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsabc']),
+        'client_config': InsightsConfig(legacy_upload=False)
+    }
     with pytest.raises(SkipComponent):
         dup_machine_id_info(broker)
 
 
-@patch('insights.specs.datasources.machine_ids.InsightsConnection', MockInsightsConnection)
-@patch('insights.specs.datasources.machine_ids.try_auto_configuration', mock_try_autoconfig)
-@patch('insights.specs.datasources.machine_ids.InsightsConfig', MockInsightsConfig)
-def test_api_result_not_in_json_format():
-    broker = {Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfwrong'])}
+@patch('insights.specs.datasources.machine_ids.get_connection',
+       return_value=MockInsightsConnection("wrong"))
+def test_api_result_not_in_json_format(conn):
+    broker = {
+        Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfwrong']),
+        'client_config': InsightsConfig(legacy_upload=False)
+    }
     with pytest.raises(SkipComponent):
         dup_machine_id_info(broker)


### PR DESCRIPTION
- since the config is stored in `broker`, load it from `broker` instead of initiating a new one
- use client.get_connenction instead of InsightsConnection

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

