### PR TITLE
fix: improve temporary directory

### DIFF
--- a/insights/client/constants.py
+++ b/insights/client/constants.py
@@ -79,8 +79,9 @@ class InsightsConstants(object):
     cached_branch_info = os.path.join(default_conf_dir, '.branch_info')
     pidfile = os.path.join(os.sep, 'var', 'run', 'insights-client.pid')
     insights_tmp_path = os.path.join(os.sep, 'var', 'tmp')
+    cache_dir = os.path.join(os.sep, 'var', 'cache', 'insights-client')
     insights_tmp_prefix = 'insights-client'
-    egg_release_file = os.path.join(os.sep, insights_tmp_path, insights_tmp_prefix, 'insights-client-egg-release')
+    egg_release_file = os.path.join(os.sep, cache_dir, 'insights-client-egg-release')
     ppidfile = os.path.join(os.sep, 'tmp', 'insights-client.ppid')
     valid_compressors = ("gz", "xz", "bz2", "none")
     # RPM version in which core collection was released


### PR DESCRIPTION
insights-client was using /var/tmp to store the egg release file.

This commit changes the temporary directory to /var/cache/insights-client.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
