### PR TITLE
Download malware rules into /var/lib/insights

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -63,7 +63,6 @@ filesystem_scan_exclude:
 - /net
 - /mnt
 - /media
-- /dev
 
 # filesystem_scan_since: scan files created or modified since X days ago or since the 'last' scan.
 # Valid values are integers >= 1 or the string 'last'.  For example:
@@ -611,8 +610,8 @@ class MalwareDetectionClient:
         # However it can happen that the rules file isn't removed for some reason, so remove any existing
         # rules files before beginning a new scan, otherwise they may show up as matches in the scan results.
         old_rules_files = sum([glob(os.path.join(path, rules))
-                               for path in ('/tmp', '/var/tmp', '/usr/tmp', gettempdir())
-                               for rules in ('.tmpmdsigs*', 'tmp_malware-detection-client_rules.*')], [])
+                               for path in ('/var/lib/insights', '/tmp', '/var/tmp', '/usr/tmp', gettempdir())
+                               for rules in ('malware-detection_yara_rules.*', '.tmpmdsigs*', 'tmp_malware-detection-client_rules.*')], [])
         for old_rules_file in old_rules_files:
             if os.path.exists(old_rules_file):
                 logger.debug("Removing old rules file %s", old_rules_file)
@@ -714,7 +713,8 @@ class MalwareDetectionClient:
                     self.cert_verify = self._get_config_option('ca_cert', ca_cert)
                     logger.debug("Trying cert_verify value %s ...", self.cert_verify)
 
-        self.temp_rules_file = NamedTemporaryFile(prefix='.tmpmdsigs', mode='wb', delete=True)
+        self.temp_rules_file = NamedTemporaryFile(prefix='malware-detection_yara_rules.',
+                                                  mode='wb', delete=True, dir='/var/lib/insights')
         self.temp_rules_file.write(response.content)
         self.temp_rules_file.flush()
         return self.temp_rules_file.name

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -35,7 +35,7 @@ RANDOM_STRING = ''.join(random.choice(string.ascii_lowercase) for _ in range(5))
 TEMP_TEST_DIR = "/tmp/malware-detection_test_dir_%s" % RANDOM_STRING
 
 FAKE_YARA = '/bin/yara'  # Need to fake yara for a number of tests
-RULES_FILE = os.path.join(TEMP_TEST_DIR, '.tmpmdsigs.yar')
+RULES_FILE = os.path.join(TEMP_TEST_DIR, 'malware-detection_yara_rules.yar')
 TEST_RULE_FILE = os.path.join(TEMP_TEST_DIR, 'test-rule.yar')
 TEST_RULE_SCRIPT = os.path.join(TEMP_TEST_DIR, 'test-rule_process_match.sh')
 MATCHING_ENTITY_FILE = os.path.join(TEMP_TEST_DIR, 'matching_entity')
@@ -49,8 +49,8 @@ CPUS = 1 if int(call('nproc').strip()) <= 2 else 2
 
 # Some of the toplevel directories that will be included/excluded by default when listing root (/)
 TLDS = ['/boot', '/dev', '/etc', '/home', '/opt', '/proc', '/root', '/sys', '/tmp', '/usr', '/var']
-INCLUDED_TLDS = ['/boot', '/etc', '/home', '/opt', '/root', '/tmp', '/usr', '/var']  # after removing exclude items
-DEFAULT_SCAN_EXCLUDE = ['/cgroup', '/dev', '/media', '/mnt', '/net', '/proc', '/selinux', '/sys']
+INCLUDED_TLDS = ['/boot', '/dev', '/etc', '/home', '/opt', '/root', '/tmp', '/usr', '/var']  # after removing exclude items
+DEFAULT_SCAN_EXCLUDE = ['/cgroup', '/media', '/mnt', '/net', '/proc', '/selinux', '/sys']
 
 # Various patch targets
 LOGGER_TARGET = "insights.client.apps.malware_detection.logger"
@@ -62,6 +62,7 @@ BUILD_YARA_COMMAND_TARGET = "insights.client.apps.malware_detection.MalwareDetec
 FINDMNT_TARGET = "insights.client.apps.malware_detection.MalwareDetectionClient._parse_exclude_network_filesystem_mountpoints_option"
 CALL_TARGET = "insights.client.apps.malware_detection.call"
 CONFIG_FILE_TARGET = "insights.client.apps.malware_detection.MALWARE_CONFIG_FILE"
+NAMEDTMPFILE_TARGET = "insights.client.apps.malware_detection.NamedTemporaryFile"
 
 # Run these slowish tests?
 TEST_PROCESSES_SCAN_SINCE = getenv_bool("TEST_PROCESSES_SCAN_SINCE", False)
@@ -133,7 +134,7 @@ class TestsNotUtilizingYara:
         assert CONFIG['filesystem_scan_since'] is None
         assert CONFIG['processes_scan_since'] is None
         assert all([x in CONFIG['filesystem_scan_exclude']
-                    for x in ['/proc', '/sys', '/cgroup', '/selinux', '/net', '/mnt', '/media', '/dev']])
+                    for x in ['/proc', '/sys', '/cgroup', '/selinux', '/net', '/mnt', '/media']])
         assert CONFIG['processes_scan_exclude'] is None
         assert CONFIG['exclude_network_filesystem_mountpoints'] is True
 
@@ -393,7 +394,7 @@ class TestsUtilizingFakeYara:
             assert mdc.scan_fsobjects == []
             assert mdc.scan_pids == []
             assert mdc.filesystem_scan_since_dict == {'timestamp': None, 'datetime': None}
-            assert all([d in mdc.filesystem_scan_exclude_list for d in ['/proc', '/sys', '/mnt', '/media', '/dev']])
+            assert all([d in mdc.filesystem_scan_exclude_list for d in ['/proc', '/sys', '/mnt', '/media']])
             # filesystem_scan_* attributes will exist whereas processes_scan_* will not
             assert all([hasattr(mdc, 'filesystem_scan_' + attr) is True and hasattr(mdc, 'processes_scan_' + attr) is False
                         for attr in ('exclude_list', 'since_dict')])
@@ -1011,6 +1012,7 @@ class TestsUtilizingFakeYara:
             cmd.assert_called()
 
     # Use patch.object, just because I wanted to try using patch.object instead of using patch all the time :shrug:
+    @patch(NAMEDTMPFILE_TARGET)  # Mock NamedTemporaryFile so it doesn't try to create the temporary file
     @patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
     @patch.object(MalwareDetectionClient, '_parse_exclude_network_filesystem_mountpoints_option')
     @patch.object(InsightsConnection, 'get', return_value=Mock(status_code=200, content=b"Rule Content"))
@@ -1026,7 +1028,7 @@ class TestsUtilizingFakeYara:
 
         @patch.dict(os.environ, {'TEST_SCAN': 'true'})
         @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
-        def test_download_rules_cert_auth(self, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove):
+        def test_download_rules_cert_auth(self, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile):
             # Test the standard rules_location urls, but will result in cert auth being used to download the rules
             # Test with insights-config None, expect an error when trying to use the insights-config object
             with pytest.raises(SystemExit):
@@ -1063,7 +1065,7 @@ class TestsUtilizingFakeYara:
         @patch.dict(os.environ, {'TEST_SCAN': 'true'})
         @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
         @patch(LOGGER_TARGET)
-        def test_download_rules_basic_auth(self, log_mock, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove):
+        def test_download_rules_basic_auth(self, log_mock, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile):
             # Test the standard rules_location urls, with basic auth attempting to be used to download the rules
             # Basic auth is used by default, but needs to have a valid username and password for it to work
             # Without a username and password, then cert auth will be used
@@ -1097,7 +1099,7 @@ class TestsUtilizingFakeYara:
         @patch.dict(os.environ, {'TEST_SCAN': 'false'})
         @patch("os.path.exists", return_value=True)  # mock call to os.path.exists in _find_yara
         @patch(CALL_TARGET, return_value='4.2.1')  # mock call to 'yara --version'
-        def test_download_rules_versioned_files(self, version_mock, exists_mock, conf, cmd, disabled, session, proxies, get, findmnt, remove):
+        def test_download_rules_versioned_files(self, version_mock, exists_mock, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile):
             # Test downloading different signatures files depending on the yara version found on the system
             expected_rules_url = "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
             mdc = MalwareDetectionClient(InsightsConfig())
@@ -1128,7 +1130,7 @@ class TestsUtilizingFakeYara:
         @patch.dict(os.environ, {'TEST_SCAN': 'false'})
         @patch("os.path.exists", return_value=True)  # mock call to os.path.exists in _find_yara
         @patch(CALL_TARGET, return_value='4.2.0')  # mock call to 'yara --version'
-        def test_download_rules_from_stage(self, version_mock, exists_mock, conf, cmd, disabled, session, proxies, get, findmnt, remove):
+        def test_download_rules_from_stage(self, version_mock, exists_mock, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile):
             # Test downloading signatures files from the stage environment
             # cert_verify is set to 'False' (string) for stage - check its changed to False (boolean)
 
@@ -1159,7 +1161,7 @@ class TestsUtilizingFakeYara:
 
         @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': 'console.redhat.com/rules.yar'})
         @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
-        def test_get_rules_missing_protocol(self, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove):
+        def test_get_rules_missing_protocol(self, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile):
             # Non-standard rules URLS - without https:// at the start and not signatures.yar
             # test-scan true and BASIC auth by default expect test-rule.yar and no 'cert.' in URL
             mdc = MalwareDetectionClient(InsightsConfig(username='user', password='pass'))
@@ -1177,7 +1179,7 @@ class TestsUtilizingFakeYara:
         @patch.dict(os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'http://localhost/rules.yar'})
         @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
         @patch(LOGGER_TARGET)
-        def test_download_failures(self, log_mock, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove):
+        def test_download_failures(self, log_mock, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile):
             from requests.exceptions import ConnectionError, Timeout
             # Test various problems downloading rules
             expected_rules_url = os.environ['RULES_LOCATION']
@@ -1211,7 +1213,7 @@ class TestsUtilizingFakeYara:
         @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
         @patch("os.path.isfile", return_value=True)
         @patch(LOGGER_TARGET)
-        def test_download_failure_retries(self, log_mock, isfile, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove):
+        def test_download_failure_retries(self, log_mock, isfile, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile):
             from requests.exceptions import ConnectionError, SSLError
             # Testing the download failure retry logic
             expected_rules_url = os.environ['RULES_LOCATION']
@@ -1264,7 +1266,7 @@ class TestsUtilizingFakeYara:
         @patch.dict(os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': '//console.redhat.com/rules.yar'})
         @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
         @patch("os.path.isfile", return_value=True)
-        def test_get_rules_location_as_file(self, isfile, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove):
+        def test_get_rules_location_as_file(self, isfile, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile):
             # Test using files for rules_location, esp irregular file names
             # rules_location that starts with a '/' is assumed to be a file, even if its a double '//'
             # Re-writing the rule to be test-rule.yar doesn't apply to local files
@@ -1282,7 +1284,7 @@ class TestsUtilizingFakeYara:
 
         @patch.dict(os.environ, {'TEST_SCAN': 'true'})
         @patch(LOGGER_TARGET)
-        def test_download_rules_via_satellite(self, log_mock, conf, cmd, disabled, session, proxies, get, findmnt, remove):
+        def test_download_rules_via_satellite(self, log_mock, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile):
             # Test recognizing and handling of Satellite URLs.
             # Satellite URLs have '/redhat_access/' in their path (so Satellite knows to redirect the query to C.R.C)
             # For malware-detection requests through a Satellite we append the malware-detection path and add https://
@@ -1332,6 +1334,7 @@ class TestsUtilizingFakeYara:
             log_mock.debug.assert_called_with("Using cert_verify value %s ...", True)
             log_mock.debug.assert_any_call("Downloading rules from: %s", expected_rules_url)
 
+    @patch(NAMEDTMPFILE_TARGET)  # Mock NamedTemporaryFile so it doesn't try to create the temporary file
     @patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
     @patch(FINDMNT_TARGET)  # Don't run the command
     @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
@@ -1341,7 +1344,7 @@ class TestsUtilizingFakeYara:
         """ Testing the _get_disabled_rules method """
 
         @patch.dict(os.environ)
-        def test_skip_getting_disabled_rules(self, conf, cmd, yara, findmnt, remove):
+        def test_skip_getting_disabled_rules(self, conf, cmd, yara, findmnt, remove, tmpfile):
             # Skip getting disabled rules if doing a test scan
             os.environ['TEST_SCAN'] = 'true'
             with patch(GET_RULES_TARGET, return_value=RULES_FILE):
@@ -1360,7 +1363,7 @@ class TestsUtilizingFakeYara:
         @patch.object(InsightsConnection, 'get_proxies')
         @patch.object(InsightsConnection, '_init_session', return_value=Mock())
         @patch.dict(os.environ, {'TEST_SCAN': 'false'})
-        def test_get_disabled_rules(self, session, proxies, get, post, conf, cmd, yara, findmnt, remove):
+        def test_get_disabled_rules(self, session, proxies, get, post, conf, cmd, yara, findmnt, remove, tmpfile):
             # Test with no disabled rules
             rules_location = "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
             expected_graphql_url = "https://cert.console.redhat.com/api/malware-detection/v1/graphql"
@@ -1398,7 +1401,7 @@ class TestsUtilizingFakeYara:
         @patch.object(InsightsConnection, '_init_session', return_value=Mock())
         @patch.dict(os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'localhost/rules.yar'})
         @patch(LOGGER_TARGET)
-        def test_get_disabled_rules_failure(self, log, session, proxies, get, post, conf, cmd, yara, findmnt, remove):
+        def test_get_disabled_rules_failure(self, log, session, proxies, get, post, conf, cmd, yara, findmnt, remove, tmpfile):
             from requests.exceptions import ConnectionError, Timeout
             expected_graphql_url = 'https://localhost/graphql'
 
@@ -2323,7 +2326,7 @@ if REAL_YARA:
                 assert mdc.scan_fsobjects == []
                 assert mdc.scan_pids == []
                 assert mdc.filesystem_scan_since_dict == {'timestamp': None, 'datetime': None}
-                assert all([d in mdc.filesystem_scan_exclude_list for d in ['/proc', '/sys', '/mnt', '/media', '/dev']])
+                assert all([d in mdc.filesystem_scan_exclude_list for d in ['/proc', '/sys', '/mnt', '/media']])
 
             def test_scan_only_option(self, create_test_files_real_yara, caplog):
                 # Test various combinations of scan_only and the scan_filesystem and scan_processes options
@@ -3678,6 +3681,7 @@ if REAL_YARA:
                 assert scan_me_file in sources
                 assert scan_me_too_file in sources
 
+        @patch(NAMEDTMPFILE_TARGET)
         @patch.object(InsightsConnection, 'get', return_value=Mock(status_code=200, content=b"Rule Content"))
         @patch.object(InsightsConnection, 'get_proxies')
         @patch.object(InsightsConnection, '_init_session', return_value=Mock())
@@ -3686,7 +3690,7 @@ if REAL_YARA:
         class TestGetRules:
 
             @patch.dict(os.environ)
-            def test_get_regular_rules_location_urls(self, disabled, init_session, get_proxies, get, caplog):
+            def test_get_regular_rules_location_urls(self, disabled, init_session, get_proxies, get, tmpfile, caplog):
                 # Test the standard rules_location urls, depending on whether test rule or cert auth is set
                 # With test scan true, expect to download test-rule.yar
                 test_rule_url = "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
@@ -3719,7 +3723,7 @@ if REAL_YARA:
                 get.assert_called_with(signatures_url, log_response_text=False, verify=True, stream=True)
                 assert signatures_url in caplog.text
 
-            def test_get_irregular_rules_location_urls(self, disabled, init_session, get_proxies, get, create_test_files_real_yara, caplog):
+            def test_get_irregular_rules_location_urls(self, disabled, init_session, get_proxies, get, tmpfile, create_test_files_real_yara, caplog):
                 # Non-standard rules URLs
                 # Without https:// at the start and not signatures.yar
                 logger.setLevel('DEBUG')
@@ -3742,7 +3746,7 @@ if REAL_YARA:
                                        log_response_text=False, verify=True, stream=True)
                 assert "https://cert.console.redhat.com/rules.yar" in caplog.text
 
-            def test_get_rules_location_files(self, disabled, init_session, get_proxies, get, create_test_files_real_yara, caplog):
+            def test_get_rules_location_files(self, disabled, init_session, get_proxies, get, tmpfile, create_test_files_real_yara, caplog):
                 # Test using files for rules_location, esp irregular file names
                 # Re-writing the rule to be test-rule.yar doesn't apply to local files
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):


### PR DESCRIPTION
* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

This PR renames the malware rules file that is downloaded onto hosts to be scanned and puts it in /var/lib/insights.  This is to make the file more obvious as to its purpose and less likely for it to be flagged as malware itself.
