### PR TITLE
Improve logging for disabled rule matches

### DIFF
--- a/insights/client/apps/malware_detection/__init__.py
+++ b/insights/client/apps/malware_detection/__init__.py
@@ -30,6 +30,7 @@ MALWARE_APP_URL = 'https://console.redhat.com/insights/malware'
 MALWARE_CONFIG_FILE = os.path.join(constants.default_conf_dir, "malware-detection-config.yml")
 LAST_FILESYSTEM_SCAN_FILE = os.path.join(constants.default_conf_dir, '.last_malware-detection_filesystem_scan')
 LAST_PROCESSES_SCAN_FILE = os.path.join(constants.default_conf_dir, '.last_malware-detection_processes_scan')
+RULE_DOWNLOAD_DIR = constants.insights_core_lib_dir
 DEFAULT_MALWARE_CONFIG = """
 # Configuration file for the Red Hat Insights Malware Detection Client app
 # File format is YAML
@@ -610,7 +611,7 @@ class MalwareDetectionClient:
         # However it can happen that the rules file isn't removed for some reason, so remove any existing
         # rules files before beginning a new scan, otherwise they may show up as matches in the scan results.
         old_rules_files = sum([glob(os.path.join(path, rules))
-                               for path in ('/var/lib/insights', '/tmp', '/var/tmp', '/usr/tmp', gettempdir())
+                               for path in (RULE_DOWNLOAD_DIR, '/tmp', '/var/tmp', '/usr/tmp', gettempdir())
                                for rules in ('malware-detection_yara_rules.*', '.tmpmdsigs*', 'tmp_malware-detection-client_rules.*')], [])
         for old_rules_file in old_rules_files:
             if os.path.exists(old_rules_file):
@@ -714,7 +715,7 @@ class MalwareDetectionClient:
                     logger.debug("Trying cert_verify value %s ...", self.cert_verify)
 
         self.temp_rules_file = NamedTemporaryFile(prefix='malware-detection_yara_rules.',
-                                                  mode='wb', delete=True, dir='/var/lib/insights')
+                                                  mode='wb', delete=True, dir=RULE_DOWNLOAD_DIR)
         self.temp_rules_file.write(response.content)
         self.temp_rules_file.flush()
         return self.temp_rules_file.name
@@ -982,13 +983,12 @@ class MalwareDetectionClient:
         def skip_string_data_lines(string_data_lines):
             # Skip the 0x... lines containing string match data
             while string_data_lines and string_data_lines[0].startswith('0x'):
-                logger.debug("Skipping string data line '%s'", string_data_lines[0])
                 string_data_lines.pop(0)
 
         output_lines = output.split("\n")
         while output_lines:
             if 'error scanning ' in output_lines[0]:
-                logger.debug(output_lines[0])
+                logger.debug("Skipping yara output line: %s", output_lines[0])
                 output_lines.pop(0)  # Skip the error scanning line
                 # Skip any string match lines after the error scanning line
                 skip_string_data_lines(output_lines)
@@ -998,7 +998,7 @@ class MalwareDetectionClient:
                 rule_name, source = output_lines[0].rstrip().split(" ", 1)
             except ValueError as err:
                 # Hopefully shouldn't happen but log it and continue processing
-                logger.debug("Error parsing rule match '%s': %s", output_lines[0], err)
+                logger.debug("Error parsing rule match '%s': %s", output_lines[0], str(err))
                 output_lines.pop(0)  # Skip the erroneous line
                 # Skip any string match lines afterwards until we get to the next rule match line
                 skip_string_data_lines(output_lines)
@@ -1007,11 +1007,6 @@ class MalwareDetectionClient:
             # All good so far, skip over the line containing the rule name and matching source file/pid
             output_lines.pop(0)
 
-            # If the rule is disabled, then skip over its scan matches until the next rule match
-            if rule_name.lower() in self.disabled_rules:
-                skip_string_data_lines(output_lines)
-                continue
-
             # Check if the rule name contains a ':' or doesn't start with a char/string
             # It shouldn't and its likely to be due to a malformed string_offset line
             # Skip any further scan matches until the next rule match
@@ -1019,10 +1014,16 @@ class MalwareDetectionClient:
                 skip_string_data_lines(output_lines)
                 continue
 
-            rule_match = {'rule_name': rule_name, 'matches': []}
             source_type = "process" if source.isdigit() else "file"
 
+            # If the rule is disabled, then skip over its scan matches until the next rule match
+            if rule_name.lower() in self.disabled_rules:
+                logger.debug("Skipping matches for disabled rule %s in %s %s", rule_name, source_type, source)
+                skip_string_data_lines(output_lines)
+                continue
+
             # Parse the string match data for the remaining lines in the set
+            rule_match = {'rule_name': rule_name, 'matches': []}
             string_matches = 0
             while output_lines and output_lines[0].startswith('0x'):
                 if string_matches < self.string_match_limit:

--- a/insights/tests/client/apps/test_malware_detection.py
+++ b/insights/tests/client/apps/test_malware_detection.py
@@ -2132,7 +2132,8 @@ class TestsUtilizingFakeYara:
             assert metadata['source_type'] == 'process'
             assert all([key not in ['process_name', 'file_type', 'md5sum', 'line_number'] for key in metadata.keys()])
 
-        def test_contrived_scan_output_with_disabled_rules(self, conf, yara, disabled, rules, cmd, findmnt):
+        @patch(LOGGER_TARGET)
+        def test_contrived_scan_output_with_disabled_rules(self, log_mock, conf, yara, disabled, rules, cmd, findmnt):
             # Parse the CONTRIVED_SCAN_OUTPUT but with a number of disabled rules
             # Disable 3 of the rules in CONTRIVED_SCAN_OUTPUT, expect 2 matching rules
             disabled.return_value = ['this', 'rule', 'another_matching_rule']
@@ -2142,8 +2143,14 @@ class TestsUtilizingFakeYara:
             assert mdc.matches == 2
             assert all(list(map(lambda x: x not in ['this', 'Rule', 'another_matching_rule'], mdc.host_scan)))
             assert all(list(map(lambda x: x in ['Iyamtho', 'n_m3_t00'], mdc.host_scan)))
+            log_mock.debug.assert_any_call('Skipping matches for disabled rule %s in %s %s', 'this', 'file', ANY)
+            log_mock.debug.assert_any_call('Skipping matches for disabled rule %s in %s %s', 'Rule', 'file', ANY)
+            log_mock.info.assert_any_call('Matched rule %s in %s %s', 'Iyamtho', 'file', ANY)
+            log_mock.info.assert_any_call('Matched rule %s in %s %s', 'n_m3_t00', 'file', ANY)
 
             # disable all rules except 'Rule', because it isn't excluded
+            log_mock.debug.reset_mock()
+            log_mock.info.reset_mock()
             disabled.return_value = ['this', 'rool', 'another_matching_rule', 'iyamtho', 'n_m3_t00']
             mdc = MalwareDetectionClient(None)
             mdc.parse_scan_output(CONTRIVED_SCAN_OUTPUT)
@@ -2151,6 +2158,8 @@ class TestsUtilizingFakeYara:
             assert mdc.matches == 3
             sources = set(map(lambda x: x['source'], mdc.host_scan['Rule']))
             assert len(sources) == 3
+            log_mock.debug.assert_any_call('Skipping matches for disabled rule %s in %s %s', 'Iyamtho', 'file', ANY)
+            log_mock.info.assert_any_call('Matched rule %s in %s %s', 'Rule', 'file', ANY)
 
         def test_random_output(self, conf, yara, disabled, rules, cmd, findmnt):
             mdc = MalwareDetectionClient(None)
@@ -2168,7 +2177,8 @@ class TestsUtilizingFakeYara:
             assert rule_match[0]['string_identifier'] == ''
             assert rule_match[0]['string_offset'] == -1
 
-        def test_random_output_with_disabled_rules(self, conf, yara, disabled, rules, cmd, findmnt):
+        @patch(LOGGER_TARGET)
+        def test_random_output_with_disabled_rules(self, log_mock, conf, yara, disabled, rules, cmd, findmnt):
             # Test various disabled rules with parsing RANDOM_OUTPUT
             # Disable 'Lorem' rule (and others) and expect just to match the 'Dictum' rule
             disabled.return_value = ['random', 'rules', 'and', 'lorem']
@@ -2176,13 +2186,17 @@ class TestsUtilizingFakeYara:
             mdc.parse_scan_output(RANDOM_OUTPUT)
             assert mdc.matches == 1
             assert list(mdc.host_scan) == ['Dictum']
+            log_mock.debug.assert_any_call('Skipping matches for disabled rule %s in %s %s', 'Lorem', 'file', ANY)
 
             # Disable both 'Lorem' and 'Dictum' rules and expect to have no matches
+            log_mock.debug.reset_mock()
             disabled.return_value = ['dictum', 'lorem']
             mdc = MalwareDetectionClient(None)
             mdc.parse_scan_output(RANDOM_OUTPUT)
             assert mdc.matches == 0
             assert mdc.host_scan == {}
+            log_mock.debug.assert_any_call('Skipping matches for disabled rule %s in %s %s', 'Dictum', 'file', ANY)
+            log_mock.debug.assert_any_call('Skipping matches for disabled rule %s in %s %s', 'Lorem', 'file', ANY)
 
             # Disable rules other than 'Lorem' and 'Dictum' and expect match both those rules
             disabled.return_value = ['dictumm', 'lore', 'and', 'other', 'rules']
@@ -2190,6 +2204,8 @@ class TestsUtilizingFakeYara:
             mdc.parse_scan_output(RANDOM_OUTPUT)
             assert mdc.matches == 2
             assert sorted(mdc.host_scan) == ['Dictum', 'Lorem']
+            log_mock.info.assert_any_call('Matched rule %s in %s %s', 'Dictum', 'file', ANY)
+            log_mock.info.assert_any_call('Matched rule %s in %s %s', 'Lorem', 'file', ANY)
 
 
 ################################################################################################################
@@ -3382,6 +3398,7 @@ if REAL_YARA:
             def test_contrived_scan_output_with_disabled_rules(self, disabled, rules, create_test_files_real_yara, caplog):
                 # Parse the CONTRIVED_SCAN_OUTPUT but with a number of disabled rules
                 # Disable 3 of the rules in CONTRIVED_SCAN_OUTPUT, expect 2 matching rules
+                logger.setLevel('DEBUG')
                 disabled.return_value = ['this', 'rule', 'another_matching_rule']
                 mdc = MalwareDetectionClient(None)
                 assert mdc.disabled_rules == ['this', 'rule', 'another_matching_rule']
@@ -3389,8 +3406,14 @@ if REAL_YARA:
                 assert mdc.matches == 2
                 assert all(list(map(lambda x: x not in ['this', 'Rule', 'another_matching_rule'], mdc.host_scan)))
                 assert all(list(map(lambda x: x in ['Iyamtho', 'n_m3_t00'], mdc.host_scan)))
+                assert 'Skipping matches for disabled rule this in file' in caplog.text
+                assert 'Skipping matches for disabled rule Rule in file' in caplog.text
+                assert 'Skipping matches for disabled rule another_matching_rule in file' in caplog.text
+                assert 'Matched rule Iyamtho in file' in caplog.text
+                assert 'Matched rule n_m3_t00 in file' in caplog.text
 
                 # disable all rules except 'Rule', because it isn't excluded
+                caplog.clear()
                 disabled.return_value = ['this', 'rool', 'another_matching_rule', 'iyamtho', 'n_m3_t00']
                 mdc = MalwareDetectionClient(None)
                 mdc.parse_scan_output(CONTRIVED_SCAN_OUTPUT)
@@ -3398,6 +3421,8 @@ if REAL_YARA:
                 assert mdc.matches == 3
                 sources = set(map(lambda x: x['source'], mdc.host_scan['Rule']))
                 assert len(sources) == 3
+                assert 'Skipping matches for disabled rule Rule in file' not in caplog.text
+                assert 'Matched rule Rule in file' in caplog.text
 
             def test_error_scan_output(self, disabled, rules, create_test_files_real_yara, caplog):
                 logger.setLevel('DEBUG')
@@ -3433,28 +3458,38 @@ if REAL_YARA:
                 assert rule_match[0]['string_identifier'] == ''
                 assert rule_match[0]['string_offset'] == -1
 
-            def test_random_output_with_disabled_rules(self, disabled, rules, create_test_files_real_yara):
+            def test_random_output_with_disabled_rules(self, disabled, rules, create_test_files_real_yara, caplog):
                 # Test various disabled rules with parsing RANDOM_OUTPUT
                 # Disable 'Lorem' rule (and others) and expect just to match the 'Dictum' rule
+                logger.setLevel('DEBUG')
                 disabled.return_value = ['random', 'rules', 'and', 'lorem']
                 mdc = MalwareDetectionClient(None)
                 mdc.parse_scan_output(RANDOM_OUTPUT)
                 assert mdc.matches == 1
                 assert list(mdc.host_scan) == ['Dictum']
+                assert 'Skipping matches for disabled rule Lorem in file' in caplog.text
 
                 # Disable both 'Lorem' and 'Dictum' rules and expect to have no matches
+                caplog.clear()
                 disabled.return_value = ['dictum', 'lorem']
                 mdc = MalwareDetectionClient(None)
                 mdc.parse_scan_output(RANDOM_OUTPUT)
                 assert mdc.matches == 0
                 assert mdc.host_scan == {}
+                assert 'Skipping matches for disabled rule Dictum in file' in caplog.text
+                assert 'Skipping matches for disabled rule Lorem in file' in caplog.text
 
                 # Disable rules other than 'Lorem' and 'Dictum' and expect match both those rules
+                caplog.clear()
                 disabled.return_value = ['dictumm', 'lore', 'and', 'other', 'rules']
                 mdc = MalwareDetectionClient(None)
                 mdc.parse_scan_output(RANDOM_OUTPUT)
                 assert mdc.matches == 2
                 assert sorted(mdc.host_scan) == ['Dictum', 'Lorem']
+                assert 'Skipping matches for disabled rule Dictum in file' not in caplog.text
+                assert 'Skipping matches for disabled rule Lorem in file' not in caplog.text
+                assert 'Matched rule Dictum in file' in caplog.text
+                assert 'Matched rule Lorem in file' in caplog.text
 
         @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
         class TestFilesystemIncludeExcludeProcessing:


### PR DESCRIPTION
- And use a constant for the rules download directory

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

This PR uses constants.insights_core_lib_dir for the directory into which malware rules are downloaded, rather than hardcoding the /var/lib/insights directory.  It also improves the logging for matched disabled rules by logging the rule and the file/PID it was matched in.  Even though the rule is disabled, it would be nice to know which files/PIDs it still matches (if any).