### PR TITLE
feat: add do_filter option to run_test for rule test

### DIFF
--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -158,8 +158,18 @@ def run_input_data(component, input_data, store_skips=False):
     return broker
 
 
-def run_test(component, input_data, expected=None, return_make_none=False):
-    if filters.ENABLED:
+def run_test(component, input_data,
+             expected=None, return_make_none=False, do_filter=True):
+    """
+    Arguments:
+        component: The insights component need to test.
+        input_data: The test data prepared for testing the component.
+        expected: The expected result need to compare.
+        return_make_none: Does it allow to return None?
+        do_filter: Does need to check dependency spec filter warning?
+            - it's not required to check the filters for sosreport
+    """
+    if do_filter and filters.ENABLED:
         mod = component.__module__
         sup_mod = '.'.join(mod.split('.')[:-1])
         rps = _get_registry_points(component)


### PR DESCRIPTION
- user can skip the check of filterable specs by
   setting "do_filter=False" when calling run_test 
   if the rule targets do not need to filter
- see INSGHTCORE-254

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
