### PR TITLE
fix: store_skips argument of run_input_data has no effect (#3928)

### DIFF
--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -147,12 +147,12 @@ def deep_compare(result, expected):
 
 def run_input_data(component, input_data, store_skips=False):
     broker = dr.Broker()
+    broker.store_skips = store_skips
     for k, v in input_data.data.items():
         broker[k] = v
 
     graph = dr.get_dependency_graph(component)
     broker = dr.run(graph, broker=broker)
-    broker.store_skips = store_skips
     for v in broker.tracebacks.values():
         logger.warning(v)
     return broker

--- a/insights/tests/test_run_input_data.py
+++ b/insights/tests/test_run_input_data.py
@@ -1,0 +1,20 @@
+import pytest
+
+from insights.core.plugins import component
+from insights.core.exceptions import SkipComponent
+from insights.tests import InputData
+from insights.tests import run_input_data
+
+
+@component()
+def some_component():
+    raise SkipComponent
+
+
+@pytest.mark.parametrize(
+    "store_skips, exceptions_count",
+    ((False, 0), (True, 1)),
+)
+def test_store_skips_false(store_skips, exceptions_count):
+    broker = run_input_data(some_component, InputData(), store_skips=store_skips)
+    assert len(broker.exceptions) == exceptions_count


### PR DESCRIPTION
The Broker.store_skips property needs to be set before the dependency graph execution in run_input_data().

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

See #3928

