### PR TITLE
fix: Suspend the data collection for xfs_db command

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -737,8 +737,11 @@ class DefaultSpecs(Specs):
     x86_ibrs_enabled = simple_file("sys/kernel/debug/x86/ibrs_enabled")
     x86_pti_enabled = simple_file("sys/kernel/debug/x86/pti_enabled")
     x86_retp_enabled = simple_file("sys/kernel/debug/x86/retp_enabled")
-    xfs_db_frag = foreach_execute(mount_ds.xfs_devices, "/usr/sbin/xfs_db -r -c frag %s")
-    xfs_db_freesp = foreach_execute(mount_ds.xfs_devices, "/usr/sbin/xfs_db -r -c freesp %s")
+    # Suspend the collection for xfsprogs bug INSGHTCORE-257
+    # xfs_db_frag = foreach_execute(mount_ds.xfs_devices, "/usr/sbin/xfs_db -r -c frag %s")
+    # xfs_db_freesp = foreach_execute(mount_ds.xfs_devices, "/usr/sbin/xfs_db -r -c freesp %s")
+    xfs_db_frag = foreach_execute(mount_ds.xfs_devices, "/usr/sbin/xfs_db_suspend -r -c frag %s")
+    xfs_db_freesp = foreach_execute(mount_ds.xfs_devices, "/usr/sbin/xfs_db_suspend -r -c freesp %s")
     xfs_info = foreach_execute(mount_ds.xfs_mounts, "/usr/sbin/xfs_info %s")  # INSPEC-409
     xfs_quota_state = simple_command("/sbin/xfs_quota -x -c 'state -gu'")
     xinetd_conf = glob_file(["/etc/xinetd.conf", "/etc/xinetd.d/*"])

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -740,8 +740,6 @@ class DefaultSpecs(Specs):
     # Suspend the collection for xfsprogs bug INSGHTCORE-257
     # xfs_db_frag = foreach_execute(mount_ds.xfs_devices, "/usr/sbin/xfs_db -r -c frag %s")
     # xfs_db_freesp = foreach_execute(mount_ds.xfs_devices, "/usr/sbin/xfs_db -r -c freesp %s")
-    xfs_db_frag = foreach_execute(mount_ds.xfs_devices, "/usr/sbin/xfs_db_suspend -r -c frag %s")
-    xfs_db_freesp = foreach_execute(mount_ds.xfs_devices, "/usr/sbin/xfs_db_suspend -r -c freesp %s")
     xfs_info = foreach_execute(mount_ds.xfs_mounts, "/usr/sbin/xfs_info %s")  # INSPEC-409
     xfs_quota_state = simple_command("/sbin/xfs_quota -x -c 'state -gu'")
     xinetd_conf = glob_file(["/etc/xinetd.conf", "/etc/xinetd.d/*"])


### PR DESCRIPTION
Due to a bug in xfsprogs, suspend the data collection for xfs_db command first.

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
The related jira card is: https://issues.redhat.com/browse/INSGHTCORE-257
