### PR TITLE
fix: Fix bug of ls_parser when handling "major" and "minor" in e.g. "ls -lZ /dev"

### DIFF
--- a/insights/core/ls_parser.py
+++ b/insights/core/ls_parser.py
@@ -114,25 +114,31 @@ def parse_rhel8_selinux(parts):
     """
 
     links, owner, group, last = parts
-
-    selinux = parts[3].split(":")
-    lsel = len(selinux)
-    selinux, size, last = parts[-1].split(None, 2)
-    selinux = selinux.split(":")
-    date = last[:12]
-    path, link = parse_path(last[13:])
     result = {
         "links": int(links),
         "owner": owner,
         "group": group,
+    }
+    selinux, last = parts[-1].split(None, 1)
+    selinux = selinux.split(":")
+    lsel = len(selinux)
+    if "," in last:
+        major, minor, last = last.split(None, 2)
+        result['major'] = int(major.rstrip(","))
+        result['minor'] = int(minor)
+    else:
+        size, last = last.split(None, 1)
+        result['size'] = int(size)
+    date = last[:12]
+    path, link = parse_path(last[13:])
+    result.update({
         "se_user": selinux[0],
         "se_role": selinux[1] if lsel > 1 else None,
         "se_type": selinux[2] if lsel > 2 else None,
         "se_mls": selinux[3] if lsel > 3 else None,
-        "size": int(size),
         "name": path,
         "date": date,
-    }
+    })
     if link:
         result["link"] = link
     return result

--- a/insights/tests/parsers/test_ls.py
+++ b/insights/tests/parsers/test_ls.py
@@ -243,6 +243,24 @@ lrwxrwxrwx. root root    system_u:object_r:device_t:s0    stdout -> /proc/self/f
 lrwxrwxrwx. root root    system_u:object_r:device_t:s0    systty -> tty0
 """
 
+LS_LARZ_DEV_CONTENT1 = """
+/dev:
+total 0
+drwxr-xr-x. 19 root root    system_u:object_r:device_t:s0                  3180 May 10 09:54 .
+dr-xr-xr-x. 18 root root    system_u:object_r:root_t:s0                     235 May 27  2022 ..
+crw-r--r--.  1 root root    system_u:object_r:autofs_device_t:s0        10, 235 May 10 09:54 autofs
+drwxr-xr-x.  2 root root    system_u:object_r:device_t:s0                   140 Jun 15 16:11 block
+drwxr-xr-x.  3 root root    system_u:object_r:device_t:s0                    60 May 10 09:54 bus
+drwxr-xr-x.  2 root root    system_u:object_r:device_t:s0                  2680 May 10 09:55 char
+crw--w----.  1 root tty     system_u:object_r:console_device_t:s0        5,   1 May 10 09:54 console
+
+/dev/vfio:
+total 0
+drwxr-xr-x.  2 root root system_u:object_r:device_t:s0           60 May 10 09:54 .
+drwxr-xr-x. 19 root root system_u:object_r:device_t:s0         3180 May 10 09:54 ..
+crw-rw-rw-.  1 root root system_u:object_r:vfio_device_t:s0 10, 196 May 10 09:54 vfio -> false_link_2
+"""
+
 
 def test_ls_la():
     ls = LSla(context_wrap(LS_LA))
@@ -489,3 +507,20 @@ def test_ls_laZ():
     dev_listings = ls.listing_of('/dev')
     assert 'stderr' in dev_listings
     assert dev_listings["stderr"]['link'] == '/proc/self/fd/2'
+
+
+def test_ls_laZ_on_dev():
+    ls = LSlaRZ(context_wrap(LS_LARZ_DEV_CONTENT1))
+    assert '/dev' in ls
+    dev_listings = ls.listing_of('/dev')
+    assert "autofs" in dev_listings
+    assert 'se_type' in dev_listings["autofs"]
+    assert dev_listings["autofs"]['se_type'] == 'autofs_device_t'
+    assert dev_listings["autofs"]['major'] == 10
+    assert dev_listings["autofs"]['minor'] == 235
+    assert "block" in dev_listings
+    assert dev_listings['block']['size'] == 140
+
+    dev_listings = ls.listing_of('/dev/vfio')
+    assert 'vfio' in dev_listings
+    assert dev_listings["vfio"]['link'] == 'false_link_2'


### PR DESCRIPTION
Fixes https://github.com/RedHatInsights/insights-core/issues/3939
* The base class "FileListing" of parsers for "ls -xxx" specs raises the error "ValueError: invalid literal for int() with base 10: '10,'" when parsing the output like "ls -lZ /dev"

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?
