### PR TITLE
Add warning to yum_log exclusion

### DIFF
--- a/insights/contrib/soscleaner.py
+++ b/insights/contrib/soscleaner.py
@@ -83,7 +83,7 @@ class SOSCleaner:
             "insights.specs.Specs.installed_rpms",
             "insights.specs.Specs.dnf_modules",
             "insights.specs.Specs.yum_list_available",
-            "insights.specs.Specs.yum_log",
+            "insights.specs.Specs.yum_log",  # Potentially insecure.
             "insights.specs.Specs.yum_updateinfo",
             "insights.specs.Specs.yum_updates"
         ]


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The _yum.log_ file collected by the _yum_log_ spec can in theory leak sensitive information. A RAT scan on the real customer data show that in reality this does not happen. The warning calls for caution when adding items to the list of excluded specs.

YUM plugins can write arbitrary information to the log file, potentially creating lines containing both a filter keyword (_Erased:_, _Installed:_, _Updated:_) and an IP address, e.g. a repository URL. Also, log files are persisted in their localized form, so they can contain various strings that are separate from the code and out of developer control.
