### PR TITLE
fix: Enhance spec "satellite_settings" and parser to support satellite 6.14

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -210,6 +210,10 @@ plugins:
           enabled: true
         - name: insights.components.satellite.IsSatellite
           enabled: true
+        - name: insights.components.satellite.IsSatellite614AndLater
+          enabled: true
+        - name: insights.components.satellite.IsSatelliteLessThan614
+          enabled: true
 
     # needed for the 'pre-check' of the 'is_satellite_capsule' spec
         - name: insights.combiners.satellite_version.CapsuleVersion

--- a/insights/components/satellite.py
+++ b/insights/components/satellite.py
@@ -91,3 +91,33 @@ class IsSatellite611(IsSatellite):
     """
     def __init__(self, sat):
         super(IsSatellite611, self).__init__(sat, 6, 11)
+
+
+@component(SatelliteVersion)
+class IsSatellite614AndLater(object):
+    """
+    This component uses ``SatelliteVersion`` combiner
+    to determine the Satellite version. It checks if the Satellite version is 6.14 and later,
+    and raises ``SkipComponent`` when it isn't.
+
+    Raises:
+        SkipComponent: When the Satellite version is earlier than 6.14.
+    """
+    def __init__(self, sat):
+        if sat.major == 6 and sat.minor < 14:
+            raise SkipComponent
+
+
+@component(SatelliteVersion)
+class IsSatelliteLessThan614(object):
+    """
+    This component uses ``SatelliteVersion`` combiner
+    to determine the Satellite version. It checks if the Satellite version is less than 6.14,
+    and raises ``SkipComponent`` when it isn't.
+
+    Raises:
+        SkipComponent: When the Satellite version is 6.14 and later.
+    """
+    def __init__(self, sat):
+        if sat.major == 6 and sat.minor >= 14:
+            raise SkipComponent

--- a/insights/components/satellite.py
+++ b/insights/components/satellite.py
@@ -104,7 +104,7 @@ class IsSatellite614AndLater(object):
         SkipComponent: When the Satellite version is earlier than 6.14.
     """
     def __init__(self, sat):
-        if (sat.major < 6 or sat.major == 6 and sat.minor < 14):
+        if (sat.major < 6 or (sat.major == 6 and sat.minor < 14)):
             raise SkipComponent
 
 

--- a/insights/components/satellite.py
+++ b/insights/components/satellite.py
@@ -104,7 +104,7 @@ class IsSatellite614AndLater(object):
         SkipComponent: When the Satellite version is earlier than 6.14.
     """
     def __init__(self, sat):
-        if sat.major == 6 and sat.minor < 14:
+        if (sat.major < 6 or sat.major == 6 and sat.minor < 14):
             raise SkipComponent
 
 
@@ -112,12 +112,13 @@ class IsSatellite614AndLater(object):
 class IsSatelliteLessThan614(object):
     """
     This component uses ``SatelliteVersion`` combiner
-    to determine the Satellite version. It checks if the Satellite version is less than 6.14,
+    to determine the Satellite version. It checks if the Satellite version is 6.x and less than 6.14,
     and raises ``SkipComponent`` when it isn't.
 
     Raises:
-        SkipComponent: When the Satellite version is 6.14 and later.
+        SkipComponent: When the Satellite version isn't 6.x or it's 6.14 and later.
     """
     def __init__(self, sat):
-        if sat.major == 6 and sat.minor >= 14:
-            raise SkipComponent
+        if sat.major == 6 and sat.minor < 14:
+            return
+        raise SkipComponent

--- a/insights/tests/parsers/test_satellite_postgresql_query.py
+++ b/insights/tests/parsers/test_satellite_postgresql_query.py
@@ -25,6 +25,10 @@ SATELLITE_POSTGRESQL_WRONG_5 = '''
 name,default,value
 '''.strip()
 
+SATELLITE_POSTGRESQL_WRONG_6 = '''
+name,value
+'''.strip()
+
 SATELLITE_SETTINGS_1 = '''
 name,value,default
 unregister_delete_host,"--- true
@@ -49,6 +53,20 @@ unregister_delete_host,"--- false
 ..."
 destroy_vm_on_host_delete,"--- false
 ...","--- true
+..."
+'''
+
+SATELLITE_SETTINGS_4 = '''
+name,value
+destroy_vm_on_host_delete,
+unregister_delete_host,
+'''
+
+SATELLITE_SETTINGS_5 = '''
+name,value
+destroy_vm_on_host_delete,"--- true
+..."
+unregister_delete_host,"--- true
 ..."
 '''
 
@@ -87,13 +105,6 @@ foreman_tasks_sync_task_timeout,,"--- 120
 ..."
 foreman_tasks_proxy_action_retry_count,,"--- 4
 ..."
-'''
-
-SATELLITE_SETTINGS_BAD_1 = '''
-name,value
-unregister_delete_host,"--- true
-..."
-destroy_vm_on_host_delete,
 '''
 
 SATELLITE_SETTINGS_BAD_2 = '''
@@ -259,6 +270,8 @@ def test_basic_output_with_satellite_admin_setting():
         satellite_postgresql_query.SatelliteAdminSettings(context_wrap(SATELLITE_POSTGRESQL_WRONG_4))
     with pytest.raises(SkipComponent):
         satellite_postgresql_query.SatelliteAdminSettings(context_wrap(SATELLITE_POSTGRESQL_WRONG_5))
+    with pytest.raises(SkipComponent):
+        satellite_postgresql_query.SatelliteAdminSettings(context_wrap(SATELLITE_POSTGRESQL_WRONG_6))
 
 
 def test_satellite_admin_settings():
@@ -272,6 +285,17 @@ def test_satellite_admin_settings():
     assert not settings.get_setting('unregister_delete_host')
     assert not settings.get_setting('destroy_vm_on_host_delete')
     assert settings.get_setting('non_exist_column') is None
+
+    settings = satellite_postgresql_query.SatelliteAdminSettings(context_wrap(SATELLITE_SETTINGS_4))
+    assert (len(settings)) == 2
+    assert not settings.get_setting('unregister_delete_host')
+    assert not settings.get_setting('destroy_vm_on_host_delete')
+    assert settings.get_setting('non_exist_column') is None
+
+    settings = satellite_postgresql_query.SatelliteAdminSettings(context_wrap(SATELLITE_SETTINGS_5))
+    assert (len(settings)) == 2
+    assert settings.get_setting('unregister_delete_host')
+    assert settings.get_setting('destroy_vm_on_host_delete')
 
     table = satellite_postgresql_query.SatelliteAdminSettings(context_wrap(SATELLITE_SETTINGS_WITH_DIFFERENT_TYPES))
     setting_value = table.get_setting('ignored_interface_identifiers')
@@ -289,8 +313,6 @@ def test_satellite_admin_settings():
 
 
 def test_satellite_admin_settings_exception():
-    with pytest.raises(ValueError):
-        satellite_postgresql_query.SatelliteAdminSettings(context_wrap(SATELLITE_SETTINGS_BAD_1))
     with pytest.raises(ParseException):
         satellite_postgresql_query.SatelliteAdminSettings(context_wrap(SATELLITE_SETTINGS_BAD_2))
 


### PR DESCRIPTION

* Since satellite 6.14, the column "default" has been deleted from the satellite_settings table.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?
