### PR TITLE
Fix: Fix LogRotateConfPEG cannot handle '='

### DIFF
--- a/insights/combiners/logrotate_conf.py
+++ b/insights/combiners/logrotate_conf.py
@@ -169,7 +169,7 @@ class LogRotateConfTree(ConfigCombiner):
     def find_matches(self, confs, pattern):
         results = []
         for c in confs:
-            if os.path.isdir(pattern) and c.file_path.startswith(pattern):
+            if c.file_path.startswith(pattern) and len(c.file_path.split(pattern)[-1].lstrip('/').split('/')) == 1:
                 results.append(c)
             elif fnmatch(c.file_path, pattern):
                 results.append(c)

--- a/insights/parsers/logrotate_conf.py
+++ b/insights/parsers/logrotate_conf.py
@@ -14,7 +14,7 @@ from insights.core import ConfigParser, LegacyItemAccess, Parser
 from insights.core.exceptions import ParseException
 from insights.core.plugins import parser
 from insights.parsers import get_active_lines
-from insights.parsr import (AnyChar, Choice, EOF, EOL, Forward, LeftCurly, LineEnd,
+from insights.parsr import (AnyChar, Choice, EOF, EOL, Forward, InSet, LeftCurly, LineEnd,
                             Literal, Many, Number, OneLineComment, Opt, PosMarker,
                             QuotedString, RightCurly, String, WS, WSChar, skip_none)
 from insights.parsr.query import Directive, Entry, Section
@@ -158,7 +158,7 @@ class DocParser(object):
         scripts = set("postrotate prerotate firstaction lastaction preremove".split())
         Stanza = Forward()
         Spaces = Many(WSChar)
-        Bare = String(set(string.printable) - (set(string.whitespace) | set("#{}'\"")))
+        Bare = String(set(string.printable) - (set(string.whitespace) | set("=#{}'\"")))
         Num = Number & (WSChar | LineEnd)
         Comment = OneLineComment("#").map(lambda x: None)
         ScriptStart = WS >> PosMarker(Choice([Literal(s) for s in scripts])) << WS
@@ -169,9 +169,11 @@ class DocParser(object):
         Script = Script.map(lambda x: [x[0], [x[1]], None])
         BeginBlock = WS >> LeftCurly << WS
         EndBlock = WS >> RightCurly
+        EqualChars = set("=")
+        Equal = InSet(EqualChars)
         First = PosMarker((Bare | QuotedString)) << Spaces
         Attr = Spaces >> (Num | Bare | QuotedString) << Spaces
-        Rest = Many(Attr)
+        Rest = Opt(Equal) >> Many(Attr)
         Block = BeginBlock >> Many(Stanza).map(skip_none).map(self.to_entries) << EndBlock
         Stmt = WS >> (Script | (First + Rest + Opt(Block))) << WS
         Stanza <= WS >> (Stmt | Comment) << WS
@@ -255,4 +257,27 @@ class LogRotateConfPEG(ConfigParser):
         '/sbin/killall -HUP syslogd'
     """
     def parse_doc(self, content):
+        stack_list = []
+        glob_opts = ''
+        scripts = ('postrotate', 'prerotate', 'firstaction', 'lastaction', 'preremove')
+        for index, line in enumerate(content):
+            if line.lstrip(' \t\'"').startswith(('/', '~')) and not stack_list:
+                glob_opts += ' ' + line.strip()
+                content[index] = ''
+            if line.strip() in scripts:
+                stack_list.append('startscript')
+            if line.strip() == 'endscript' and stack_list[-1] == 'startscript':
+                stack_list.pop()
+            if stack_list and stack_list[-1] == 'startscript':
+                continue
+            if '{' in line.strip():
+                if not stack_list:
+                    content[index] = glob_opts.rstrip('{') + ' {'
+                    glob_opts = ''
+                stack_list.append('{')
+            if line.strip() == '}' and stack_list[-1] == '{':
+                stack_list.pop()
+        if stack_list:
+            raise ParseException("Invalid logrotate config file.")
+
         return parse_doc("\n".join(content), ctx=self)

--- a/insights/parsers/logrotate_conf.py
+++ b/insights/parsers/logrotate_conf.py
@@ -211,6 +211,12 @@ def parse_doc(content, ctx=None):
 @parser(Specs.logrotate_conf)
 class LogRotateConfPEG(ConfigParser):
     """
+    Class for parsing ``/etc/logrotate.conf`` and ``/etc/logrotate.d/*``
+    configuration files.
+
+    Note: It cannot handle the case without the target log file before
+    the braces for now.
+
     Sample logrotate configuration file::
 
         # sample file

--- a/insights/parsers/logrotate_conf.py
+++ b/insights/parsers/logrotate_conf.py
@@ -11,7 +11,7 @@ See: http://www.linuxmanpages.org/8/logrotate
 import string
 
 from insights.core import ConfigParser, LegacyItemAccess, Parser
-from insights.core.exceptions import ParseException
+from insights.core.exceptions import ParseException, SkipComponent
 from insights.core.plugins import parser
 from insights.parsers import get_active_lines
 from insights.parsr import (AnyChar, Choice, EOF, EOL, Forward, InSet, LeftCurly, LineEnd,
@@ -257,27 +257,31 @@ class LogRotateConfPEG(ConfigParser):
         '/sbin/killall -HUP syslogd'
     """
     def parse_doc(self, content):
+        """ configuration format pre-check for logrotate configuration file"""
         stack_list = []
         glob_opts = ''
         scripts = ('postrotate', 'prerotate', 'firstaction', 'lastaction', 'preremove')
         for index, line in enumerate(content):
+            line = line.strip()
             if line.lstrip(' \t\'"').startswith(('/', '~')) and not stack_list:
+                #  Converting the target file configuration format from set vertically to set with space.
                 glob_opts += ' ' + line.strip()
                 content[index] = ''
-            if line.strip() in scripts:
+            if line in scripts:
                 stack_list.append('startscript')
-            if line.strip() == 'endscript' and stack_list[-1] == 'startscript':
+            elif line == 'endscript' and stack_list[-1] == 'startscript':
                 stack_list.pop()
             if stack_list and stack_list[-1] == 'startscript':
                 continue
-            if '{' in line.strip():
+            if '{' in line:
                 if not stack_list:
                     content[index] = glob_opts.rstrip('{') + ' {'
                     glob_opts = ''
                 stack_list.append('{')
-            if line.strip() == '}' and stack_list[-1] == '{':
+            #  The '}' must be on a separate line.
+            elif line == '}' and stack_list[-1] == '{':
                 stack_list.pop()
         if stack_list:
-            raise ParseException("Invalid logrotate config file.")
+            raise SkipComponent("Invalid logrotate config file.")
 
         return parse_doc("\n".join(content), ctx=self)

--- a/insights/parsers/logrotate_conf.py
+++ b/insights/parsers/logrotate_conf.py
@@ -262,7 +262,7 @@ class LogRotateConfPEG(ConfigParser):
         glob_opts = ''
         scripts = ('postrotate', 'prerotate', 'firstaction', 'lastaction', 'preremove')
         for index, line in enumerate(content):
-            line = line.strip()
+            line = line.split("#")[0].strip()
             if line.lstrip(' \t\'"').startswith(('/', '~')) and not stack_list:
                 #  Converting the target file configuration format from set vertically to set with space.
                 glob_opts += ' ' + line.strip()

--- a/insights/tests/combiners/test_logrotate_conf_tree.py
+++ b/insights/tests/combiners/test_logrotate_conf_tree.py
@@ -84,6 +84,35 @@ LOGROTATE_MISSING_ENDSCRIPT = """
 }
 """.strip()
 
+CONF_NO_INCLUDE = """
+weekly
+rotate 4
+create
+dateext
+
+/var/log/wtmp {
+    missingok
+    monthly
+    create 0664 root utmp
+    minsize 1M
+    rotate 1
+    postrotate
+        do some stuff to wtmp
+    endscript
+}
+
+/var/log/btmp {
+    missingok
+    monthly
+    create 0600 root utmp
+    postrotate
+        do some stuff to btmp
+    endscript
+    rotate 1
+}
+
+""".strip()
+
 
 def test_logrotate_tree():
     p1 = logrotate_conf.LogRotateConfPEG(context_wrap(CONF, path="/etc/logrotate.conf"))
@@ -110,3 +139,14 @@ def test_junk_space():
 def test_logrotate_conf_combiner_missing_endscript():
     with pytest.raises(Exception):
         logrotate_conf.LogRotateConfPEG(context_wrap(LOGROTATE_MISSING_ENDSCRIPT, path='/etc/logrotate.conf')),
+
+
+def test_logrotate_conf_combiner_missing_include():
+    p1 = logrotate_conf.LogRotateConfPEG(context_wrap(CONF_NO_INCLUDE, path="/etc/logrotate.conf"))
+    p2 = logrotate_conf.LogRotateConfPEG(context_wrap(JUNK_SPACE, path="/etc/logrotate.d/test"))
+    conf = LogRotateConfTree([p1, p2])
+    assert 'rotate' in conf
+    assert len(conf["weekly"]) == 1
+    assert len(conf["/var/log/wtmp"]["missingok"]) == 1
+    assert conf["/var/log/wtmp"]["postrotate"][first].value == "do some stuff to wtmp"
+    assert '/var/log/spooler' not in conf

--- a/insights/tests/combiners/test_logrotate_conf_tree.py
+++ b/insights/tests/combiners/test_logrotate_conf_tree.py
@@ -86,8 +86,10 @@ LOGROTATE_MISSING_ENDSCRIPT = """
 
 
 def test_logrotate_tree():
-    p = logrotate_conf.LogRotateConfPEG(context_wrap(CONF, path="/etc/logrotate.conf"))
-    conf = LogRotateConfTree([p])
+    p1 = logrotate_conf.LogRotateConfPEG(context_wrap(CONF, path="/etc/logrotate.conf"))
+    p2 = logrotate_conf.LogRotateConfPEG(context_wrap(JUNK_SPACE, path="/etc/logrotate.d/test"))
+    conf = LogRotateConfTree([p1, p2])
+    assert 'rotate' in conf
     assert len(conf["weekly"]) == 1
     assert len(conf["/var/log/wtmp"]["missingok"]) == 1
     assert conf["/var/log/wtmp"]["postrotate"][first].value == "do some stuff to wtmp"
@@ -95,6 +97,8 @@ def test_logrotate_tree():
     assert len(conf["/var/log/btmp"]["rotate"]) == 1
     assert len(conf["/var/log/btmp"]["postrotate"]) == 1
     assert conf["/var/log/btmp"]["postrotate"][first].value == "do some stuff to btmp"
+
+    assert 'compress' in conf["/var/log/spooler"]
 
 
 def test_junk_space():

--- a/insights/tests/parsers/test_logrotate_conf.py
+++ b/insights/tests/parsers/test_logrotate_conf.py
@@ -1,5 +1,5 @@
 from insights.parsers import logrotate_conf
-from insights.parsers.logrotate_conf import LogrotateConf
+from insights.parsers.logrotate_conf import LogrotateConf, LogRotateConfPEG
 from insights.tests import context_wrap
 import doctest
 
@@ -65,7 +65,9 @@ LOGROTATE_MAN_PAGE_DOC = """
 # sample file
 compress
 
-/var/log/messages {
+/var/log/messages
+
+{
     rotate 5
     weekly
     postrotate
@@ -118,6 +120,20 @@ LOGROTATE_CONF_4 = """
         exit 0
   endscript
     nocompress
+} 
+
+/var/log/news/news1.crit
+/var/log/news/news2.crit
+
+/var/log/news/news3.crit {
+    monthly
+    rotate 2
+    olddir /var/log/news/old
+    missingok
+    postrotate
+                kill -HUP `cat /var/run/inn.pid`
+    endscript
+    nocompress
 }
 """.strip()
 
@@ -164,3 +180,26 @@ def test_logrotate_conf_4():
     assert 'mv -f $E /var/log/actlog/sysinfo/${E_backup}' in log_rt['/var/log/news/olds.crit']['prerotate']
     assert '} >>${ACTLOG_RLOG} 2>&1' in log_rt['/var/log/news/olds.crit']['prerotate']
     assert len(log_rt['/var/log/news/olds.crit']['prerotate']) == 12
+
+
+def test_logrotate_conf_peg_1():
+    log_rt = LogRotateConfPEG(context_wrap(LOGROTATE_MAN_PAGE_DOC, path='/etc/logrotate.d/abc'))
+    assert '/var/log/news/olds.crit' in log_rt
+    assert 'rotate' in log_rt['/var/log/httpd/error.log']
+    assert log_rt['/var/log/httpd/error.log']['rotate']
+    assert 'size' in log_rt['/var/log/httpd/access.log']
+    assert log_rt['/var/log/httpd/access.log']['size'].value == '100k'
+    assert log_rt['/var/log/httpd/error.log']['size'].value == '100k'
+    assert 'kill -HUP `cat /var/run/inn.pid`' in log_rt['/var/log/news/olds.crit']['postrotate'].value
+
+
+def test_logrotate_conf_peg_2():
+    log_rt = LogRotateConfPEG(context_wrap(LOGROTATE_CONF_4, path='/etc/logrotate.d/abc'))
+    assert '/var/log/news/olds.crit' in log_rt
+    assert 'mv -f $E /var/log/actlog/sysinfo/${E_backup}' in log_rt['/var/log/news/olds.crit']['prerotate'].value
+    assert '} >>${ACTLOG_RLOG} 2>&1' in log_rt['/var/log/news/olds.crit']['prerotate'].value
+    assert len(log_rt['/var/log/news/olds.crit']['prerotate']) == 1
+    assert '/var/log/news/news1.crit' in log_rt
+    assert log_rt['/var/log/news/news1.crit']['rotate'].value == 2
+    assert log_rt['/var/log/news/news2.crit']['rotate'].value == 2
+    assert log_rt['/var/log/news/news3.crit']['rotate'].value == 2

--- a/insights/tests/parsers/test_logrotate_conf.py
+++ b/insights/tests/parsers/test_logrotate_conf.py
@@ -1,7 +1,9 @@
+from insights.core.exceptions import SkipComponent
 from insights.parsers import logrotate_conf
 from insights.parsers.logrotate_conf import LogrotateConf, LogRotateConfPEG
 from insights.tests import context_wrap
 import doctest
+import pytest
 
 LOGROTATE_CONF_1 = """
 # see "man logrotate" for details
@@ -137,6 +139,78 @@ LOGROTATE_CONF_4 = """
 }
 """.strip()
 
+LOGROTATE_CONF_5 = """
+/var/log/news/olds.crit  {
+    monthly
+    rotate 2
+    olddir /var/log/news/old
+    missingok
+    prerotate
+        export LANG=C
+        ACTLOG_RLOG=/var/log/actlog/selfinfo/postrotate
+        {
+                E=/var/log/actlog.exports/eventlog.1
+                C=/var/log/actlog.exports/cpuload.1
+                if [ -e ${C}.gz -a -e $E ] ; then
+                        E_backup=eventlog.1-`date -r $E +%F.%H%M%S`
+                        echo "WARNING: Both ${C}.gz and $E exist ; move eventlog.1 to sysinfo/${E_backup}"
+                        mv -f $E /var/log/actlog/sysinfo/${E_backup}
+                fi
+        } >>${ACTLOG_RLOG} 2>&1
+        exit 0
+  endscript
+    nocompress
+} /var/log/news/news1.crit
+/var/log/news/news2.crit
+
+/var/log/news/news3.crit {
+    monthly
+    rotate 2
+    olddir /var/log/news/old
+    missingok
+    postrotate
+                kill -HUP `cat /var/run/inn.pid`
+    endscript
+    nocompress
+}
+""".strip()
+
+LOGROTATE_CONF_6 = """
+/var/log/news/olds.crit  {
+    monthly
+    rotate 2
+    olddir /var/log/news/old
+    missingok
+    prerotate
+        export LANG=C
+        ACTLOG_RLOG=/var/log/actlog/selfinfo/postrotate
+        {
+                E=/var/log/actlog.exports/eventlog.1
+                C=/var/log/actlog.exports/cpuload.1
+                if [ -e ${C}.gz -a -e $E ] ; then
+                        E_backup=eventlog.1-`date -r $E +%F.%H%M%S`
+                        echo "WARNING: Both ${C}.gz and $E exist ; move eventlog.1 to sysinfo/${E_backup}"
+                        mv -f $E /var/log/actlog/sysinfo/${E_backup}
+                fi
+        } >>${ACTLOG_RLOG} 2>&1
+        exit 0
+  endscript
+    nocompress
+} 
+/var/log/news/news1.crit
+/var/log/news/news2.crit
+
+/var/log/news/news3.crit {
+    monthly
+    rotate 2
+    olddir /var/log/news/old
+    missingok
+    postrotate
+                kill -HUP `cat /var/run/inn.pid`
+    endscript
+    nocompress}
+""".strip()
+
 
 def test_web_xml_doc_examples():
     env = {
@@ -203,3 +277,11 @@ def test_logrotate_conf_peg_2():
     assert log_rt['/var/log/news/news1.crit']['rotate'].value == 2
     assert log_rt['/var/log/news/news2.crit']['rotate'].value == 2
     assert log_rt['/var/log/news/news3.crit']['rotate'].value == 2
+
+
+def test_logrotate_conf_peg_3():
+    with pytest.raises(SkipComponent):
+        logrotate_conf.LogRotateConfPEG(context_wrap(LOGROTATE_CONF_5, path='/etc/logrotate.d/abc'))
+
+    with pytest.raises(SkipComponent):
+        logrotate_conf.LogRotateConfPEG(context_wrap(LOGROTATE_CONF_6, path='/etc/logrotate.d/abc'))

--- a/insights/tests/parsers/test_logrotate_conf.py
+++ b/insights/tests/parsers/test_logrotate_conf.py
@@ -196,7 +196,7 @@ LOGROTATE_CONF_6 = """
         exit 0
   endscript
     nocompress
-} 
+}
 /var/log/news/news1.crit
 /var/log/news/news2.crit
 

--- a/insights/tests/parsers/test_logrotate_conf.py
+++ b/insights/tests/parsers/test_logrotate_conf.py
@@ -120,7 +120,7 @@ LOGROTATE_CONF_4 = """
         exit 0
   endscript
     nocompress
-} 
+}
 
 /var/log/news/news1.crit
 /var/log/news/news2.crit


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
fix: #3883
