### PR TITLE
fix: avoid AttributeError raised by filterable check when run rules

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -150,7 +150,9 @@ class FileProvider(ContentProvider):
             log.warning("WARNING: Skipping file %s", "/" + self.relative_path)
             raise BlacklistedSpec()
 
-        if self.ds and self.ds.filterable and not get_filters(self.ds):
+        if (self.ds and
+                any(s.filterable for s in dr.get_registry_points(self.ds)) and
+                not get_filters(self.ds)):
             raise ContentException("Skipping %s due to no filters." % dr.get_name(self.ds))
 
         if not os.path.exists(self.path):
@@ -350,7 +352,9 @@ class CommandOutputProvider(ContentProvider):
             log.warning("WARNING: Skipping command %s", self.cmd)
             raise BlacklistedSpec()
 
-        if self.ds and self.ds.filterable and not get_filters(self.ds):
+        if (self.ds and
+                any(s.filterable for s in dr.get_registry_points(self.ds)) and
+                not get_filters(self.ds)):
             raise ContentException("Skipping %s due to no filters." % dr.get_name(self.ds))
 
         cmd = shlex.split(self.cmd)[0]


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
- Fix below issue:
For some specs defined with "first_of", the old check will raise the following exception:
```
 AttributeError: 'simple_file' object has no attribute 'filterable'
```
