### PR TITLE
fix: Remove pruning client code from rpm

### DIFF
--- a/MANIFEST.in.core
+++ b/MANIFEST.in.core
@@ -4,7 +4,6 @@ include insights/VERSION
 include insights/COMMIT
 include insights/RELEASE
 prune examples
-prune insights/client
 prune insights/combiners/tests
 prune insights/components/tests
 prune insights/parsers/tests


### PR DESCRIPTION
Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
A while back datasources were added that referenced client code, this broke the rpm usage because it pruned the client code in it's build. This weirdly caused some specs to work, and some to not which caused it to go un-noticed for a bit. This change removes the prune line that removed the client code in the build process. So the rpms will be slightly larger, but will allow specs to work properly again.