### PR TITLE
fixes: Fix a bug about spec "modinfo_filtered_modules"

### DIFF
--- a/insights/specs/datasources/kernel_module_list.py
+++ b/insights/specs/datasources/kernel_module_list.py
@@ -23,6 +23,6 @@ def kernel_module_filters(broker):
             if module_list:
                 loaded_modules.extend(module_list)
         if loaded_modules:
-            return ' '.join(loaded_modules)
+            return str(' '.join(loaded_modules))
         raise SkipComponent
     raise SkipComponent


### PR DESCRIPTION
* The class "command_with_args" requires the arg to be str or tuple. But the return value of the "kernel_module_filters" datasource is unicode with python2. As a result, an exception is raised.
* Fixes https://github.com/RedHatInsights/insights-core/issues/3980

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?
