### PR TITLE
fix: Fix problem parsing mnt opt quotes

### DIFF
--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -441,7 +441,7 @@ def _parse_mount_options(mount_options):
             comb_opt = ','.join(sp_opts[start_ndx:last_ndx + 1])
             opt_name, opt_value = comb_opt.split('=', 1)
             # Remove leading and trailing quotes
-            opts[opt_name] = opt_value[1:-1]
+            opts[opt_name] = opt_value.strip('"')
             in_quote = False
 
         # Else just a normal option or option=value

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -445,14 +445,11 @@ def _parse_mount_options(mount_options):
             in_quote = False
 
         # Else just a normal option or option=value
-        else:
+        elif not in_quote:
             if '=' in opt:
                 opt_name, opt_value = opt.split('=', 1)
-                # Check for quoted values and remove quotes if present
-                if not (opt_value.startswith('"') and opt_value.endswith('"')):
-                    opts[opt_name] = opt_value
-                else:
-                    opts[opt_name] = opt_value[1:-1]
+                # Remove quotes if present
+                opts[opt_name] = opt_value.strip('"')
             else:
                 opts[opt] = True
     return opts

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -428,24 +428,31 @@ def _parse_mount_options(mount_options):
     opts = dict()
     sp_opts = mount_options.split(',')
     start_ndx = 0
+    in_quote = False
     for i, opt in enumerate(sp_opts):
-        # Look for option="... start of quoted value
-        if '="' in opt:
+        # Look for option="... start of quoted value, and no end quote
+        if '="' in opt and not opt.endswith('"'):
             start_ndx = i
+            in_quote = True
 
         # Look for closing quote of option="..." and if found recombine value
-        elif '"' in opt:
+        elif in_quote and opt.endswith('"'):
             last_ndx = i
             comb_opt = ','.join(sp_opts[start_ndx:last_ndx + 1])
             opt_name, opt_value = comb_opt.split('=', 1)
             # Remove leading and trailing quotes
             opts[opt_name] = opt_value[1:-1]
+            in_quote = False
 
         # Else just a normal option or option=value
         else:
             if '=' in opt:
                 opt_name, opt_value = opt.split('=', 1)
-                opts[opt_name] = opt_value
+                # Check for quoted values and remove quotes if present
+                if not (opt_value.startswith('"') and opt_value.endswith('"')):
+                    opts[opt_name] = opt_value
+                else:
+                    opts[opt_name] = opt_value[1:-1]
             else:
                 opts[opt] = True
     return opts

--- a/insights/tests/parsers/test_mount.py
+++ b/insights/tests/parsers/test_mount.py
@@ -61,6 +61,7 @@ sunrpc /var/lib/nfs/rpc_pipefs rpc_pipefs rw,relatime 0 0
 PROC_MOUNT_QUOTES = """
 /dev/mapper/rootvg-rootlv / ext4 rw,relatime,barrier=1,data=ordered 0 0
 tmpfs /var/lib/containers/storage/overlay-containers/ff7e79fc09c/userdata/shm tmpfs rw,nosuid,nodev,noexec,relatime,context="system_u:object_r:container_file_t:s0:c184,c371",size=64000k 0 0
+tmpfs /var/lib/containers/storage/overlay-containers/aa7e79fc09c/userdata/shm tmpfs rw,nosuid,nodev,noexec,relatime,context="system_u:object_r:container_file_t:s0",size=64000k 0 0
 """
 
 PROCMOUNT_ERR_DATA = """
@@ -274,9 +275,11 @@ def test_proc_mount():
 def test_proc_mount_quotes():
     results = ProcMounts(context_wrap(PROC_MOUNT_QUOTES))
     assert results is not None
-    assert len(results) == 2
+    assert len(results) == 3
     device = results['/var/lib/containers/storage/overlay-containers/ff7e79fc09c/userdata/shm']
     assert device.mount_options.context == "system_u:object_r:container_file_t:s0:c184,c371"
+    device = results['/var/lib/containers/storage/overlay-containers/aa7e79fc09c/userdata/shm']
+    assert device.mount_options.context == "system_u:object_r:container_file_t:s0"
 
 
 def test_proc_mount_exception1():

--- a/insights/tests/parsers/test_mount.py
+++ b/insights/tests/parsers/test_mount.py
@@ -62,6 +62,7 @@ PROC_MOUNT_QUOTES = """
 /dev/mapper/rootvg-rootlv / ext4 rw,relatime,barrier=1,data=ordered 0 0
 tmpfs /var/lib/containers/storage/overlay-containers/ff7e79fc09c/userdata/shm tmpfs rw,nosuid,nodev,noexec,relatime,context="system_u:object_r:container_file_t:s0:c184,c371",size=64000k 0 0
 tmpfs /var/lib/containers/storage/overlay-containers/aa7e79fc09c/userdata/shm tmpfs rw,nosuid,nodev,noexec,relatime,context="system_u:object_r:container_file_t:s0",size=64000k 0 0
+tmpfs /var/lib/containers/storage/overlay-containers/bb7e79fc09c/userdata/shm tmpfs rw,nosuid,nodev,noexec,relatime,context="system_u:object_r:container_file_t:s0:c184,c371,c381,c391",size=64000k 0 0
 """
 
 PROCMOUNT_ERR_DATA = """
@@ -275,11 +276,13 @@ def test_proc_mount():
 def test_proc_mount_quotes():
     results = ProcMounts(context_wrap(PROC_MOUNT_QUOTES))
     assert results is not None
-    assert len(results) == 3
+    assert len(results) == 4
     device = results['/var/lib/containers/storage/overlay-containers/ff7e79fc09c/userdata/shm']
     assert device.mount_options.context == "system_u:object_r:container_file_t:s0:c184,c371"
     device = results['/var/lib/containers/storage/overlay-containers/aa7e79fc09c/userdata/shm']
     assert device.mount_options.context == "system_u:object_r:container_file_t:s0"
+    device = results['/var/lib/containers/storage/overlay-containers/bb7e79fc09c/userdata/shm']
+    assert device.mount_options.context == "system_u:object_r:container_file_t:s0:c184,c371,c381,c391"
 
 
 def test_proc_mount_exception1():

--- a/insights/tests/parsers/test_mount.py
+++ b/insights/tests/parsers/test_mount.py
@@ -58,12 +58,13 @@ sunrpc /var/lib/nfs/rpc_pipefs rpc_pipefs rw,relatime 0 0
 /etc/auto.misc /misc autofs rw,relatime,fd=7,pgrp=1936,timeout=300,minproto=5,maxproto=5,indirect 0 0
 """.strip()
 
-PROC_MOUNT_QUOTES = """
+PROC_MOUNT_QUOTES = '''
 /dev/mapper/rootvg-rootlv / ext4 rw,relatime,barrier=1,data=ordered 0 0
 tmpfs /var/lib/containers/storage/overlay-containers/ff7e79fc09c/userdata/shm tmpfs rw,nosuid,nodev,noexec,relatime,context="system_u:object_r:container_file_t:s0:c184,c371",size=64000k 0 0
 tmpfs /var/lib/containers/storage/overlay-containers/aa7e79fc09c/userdata/shm tmpfs rw,nosuid,nodev,noexec,relatime,context="system_u:object_r:container_file_t:s0",size=64000k 0 0
 tmpfs /var/lib/containers/storage/overlay-containers/bb7e79fc09c/userdata/shm tmpfs rw,nosuid,nodev,noexec,relatime,context="system_u:object_r:container_file_t:s0:c184,c371,c381,c391",size=64000k 0 0
-"""
+tmpfs /var/lib/containers/storage/overlay-containers/cc7e79fc09c/userdata/shm tmpfs rw,nosuid,nodev,noexec,relatime,context="system_u:object_r:container_file_t:s0:c184,c371,c381,c391" 0 0
+'''
 
 PROCMOUNT_ERR_DATA = """
 rootfs / rootfs rw 0 0
@@ -276,12 +277,19 @@ def test_proc_mount():
 def test_proc_mount_quotes():
     results = ProcMounts(context_wrap(PROC_MOUNT_QUOTES))
     assert results is not None
-    assert len(results) == 4
+    assert len(results) == 5
     device = results['/var/lib/containers/storage/overlay-containers/ff7e79fc09c/userdata/shm']
     assert device.mount_options.context == "system_u:object_r:container_file_t:s0:c184,c371"
     device = results['/var/lib/containers/storage/overlay-containers/aa7e79fc09c/userdata/shm']
     assert device.mount_options.context == "system_u:object_r:container_file_t:s0"
     device = results['/var/lib/containers/storage/overlay-containers/bb7e79fc09c/userdata/shm']
+    assert device.mount_options.context == "system_u:object_r:container_file_t:s0:c184,c371,c381,c391"
+    assert not hasattr(device.mount_options, "c391")
+    assert not hasattr(device.mount_options, "c381")
+    assert not hasattr(device.mount_options, "c371")
+    assert device.mount_options.relatime
+    assert device.mount_options.size == "64000k"
+    device = results['/var/lib/containers/storage/overlay-containers/cc7e79fc09c/userdata/shm']
     assert device.mount_options.context == "system_u:object_r:container_file_t:s0:c184,c371,c381,c391"
 
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
* Fixes the problem introduced in #3984 where there was no embedded comma in the quoted value then the option would not be saved.

