### PR TITLE
fix: wrong spec file path of UdevRules66MD

### DIFF
--- a/insights/parsers/udev_rules.py
+++ b/insights/parsers/udev_rules.py
@@ -13,7 +13,7 @@ UdevRules40Redhat - files ``/etc/udev/rules.d/40-redhat.rules``, ``/run/udev/rul
 UdevRulesOracleASM - file ``/etc/udev/rules.d/*asm*.rules``
 -----------------------------------------------------------
 
-UdevRules66MD - files ``/etc/udev/rules.d/66-md-auto-re-add.rules``, ``/usr/lib/udev/rules.d/66-md-auto-re-add.rules``
+UdevRules66MD - files ``/etc/udev/rules.d/66-md-auto-readd.rules``, ``/usr/lib/udev/rules.d/66-md-auto-readd.rules``
 ----------------------------------------------------------------------------------------------------------------------
 """
 from insights import parser
@@ -112,7 +112,7 @@ class UdevRulesOracleASM(LogFileOutput):
 @parser(Specs.udev_66_md_rules)
 class UdevRules66MD(LogFileOutput):
     """
-    Read the content of ``66-md-auto-re-add.rules`` file.
+    Read the content of ``66-md-auto-readd.rules`` file.
 
     .. note::
 

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -657,7 +657,7 @@ class DefaultSpecs(Specs):
     tmpfilesd = glob_file(["/etc/tmpfiles.d/*.conf", "/usr/lib/tmpfiles.d/*.conf", "/run/tmpfiles.d/*.conf"])
     tomcat_vdc_fallback = simple_command("/usr/bin/find /usr/share -maxdepth 1 -name 'tomcat*' -exec /bin/grep -R -s 'VirtualDirContext' --include '*.xml' '{}' +")
     tuned_adm = simple_command("/usr/sbin/tuned-adm list")
-    udev_66_md_rules = first_file(["/etc/udev/rules.d/66-md-auto-re-add.rules", "/usr/lib/udev/rules.d/66-md-auto-re-add.rules"])
+    udev_66_md_rules = first_file(["/etc/udev/rules.d/66-md-auto-readd.rules", "/usr/lib/udev/rules.d/66-md-auto-readd.rules"])
     udev_fc_wwpn_id_rules = simple_file("/usr/lib/udev/rules.d/59-fc-wwpn-id.rules")
     uname = simple_command("/usr/bin/uname -a")
     up2date = simple_file("/etc/sysconfig/rhn/up2date")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This spec was added for a new Advisor rule. Here to correct the spec's file paths.