### PR TITLE
feat: add warning message when BASIC auth is used

### DIFF
--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -57,6 +57,11 @@ def get_phases():
 
 @phase
 def pre_update(client, config):
+
+    # Check if BASIC auth is used to print a WARNING message
+    if config.authmethod == 'BASIC':
+        logger.warning('WARN: BASIC authentication method is being deprecated. Please consider using CERT authentication method.')
+
     if config.version:
         logger.info(constants.version)
         sys.exit(constants.sig_kill_ok)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

This commit adds a warning message to let user know BASIC auth is being deprecated:
- New message added to log. When the egg is running its first phase. This will log the message and also print it in the command output.

These messages appear when BASIC auth is configured.

Resolves: CCT-137
