### PR TITLE
fix(compliance): RHINENG-1935 handle non-list responses from inventory

### DIFF
--- a/insights/client/apps/compliance/__init__.py
+++ b/insights/client/apps/compliance/__init__.py
@@ -285,7 +285,7 @@ class ComplianceClient:
 
     def _get_inventory_id(self):
         systems = self.conn._fetch_system_by_machine_id()
-        if len(systems) == 1 and 'id' in systems[0]:
+        if type(systems) is list and len(systems) == 1 and 'id' in systems[0]:
             return systems[0].get('id')
         else:
             logger.error('Failed to find system in Inventory')


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The `_fetch_system_by_machine_id` might return `False` or `None` responses that weren't handled in our codebase properly. In this fix I am adding a type check on the list of returned systems to make sure that the `len()` method doesn't fail.