### PR TITLE
fix: resolve missing 'insights-client/lib' error in playbook verification tests

### DIFF
--- a/insights/tests/client/apps/test_playbook_verifier.py
+++ b/insights/tests/client/apps/test_playbook_verifier.py
@@ -1,16 +1,20 @@
 # -*- coding: UTF-8 -*-
 import sys
 import pytest
+import tempfile
+import shutil
 from mock.mock import patch
 from pytest import raises
 
 # don't even bother on 2.6
 if sys.version_info >= (2, 7):
+    from insights.client.constants import InsightsConstants as constants
     from insights.client.apps.ansible.playbook_verifier import verify, PlaybookVerificationError, getRevocationList, normalizeSnippet, loadPlaybookYaml  # noqa
 
 
 @pytest.mark.skipif(sys.version_info < (2, 7), reason='Playbook verifier must be run on python 2.7 or above')
-def test_vars_not_found_error():
+@patch("insights.client.apps.ansible.playbook_verifier.getRevocationList", return_value=[])
+def test_vars_not_found_error(mock_method):
     vars_error = 'VERIFICATION FAILED: Vars field not found'
     fake_playbook = [{'name': "test playbook"}]
 
@@ -20,7 +24,8 @@ def test_vars_not_found_error():
 
 
 @pytest.mark.skipif(sys.version_info < (2, 7), reason='Playbook verifier must be run on python 2.7 or above')
-def test_empty_vars_error():
+@patch("insights.client.apps.ansible.playbook_verifier.getRevocationList", return_value=[])
+def test_empty_vars_error(mock_method):
     sig_error = 'VERIFICATION FAILED: Empty vars field'
     fake_playbook = [{'name': "test playbook", 'vars': None}]
 
@@ -30,7 +35,8 @@ def test_empty_vars_error():
 
 
 @pytest.mark.skipif(sys.version_info < (2, 7), reason='Playbook verifier must be run on python 2.7 or above')
-def test_signature_not_found_error():
+@patch("insights.client.apps.ansible.playbook_verifier.getRevocationList", return_value=[])
+def test_signature_not_found_error(mock_method):
     sig_error = 'VERIFICATION FAILED: Signature not found'
     fake_playbook = [{'name': "test playbook", 'vars': {}}]
 
@@ -51,9 +57,17 @@ def test_key_not_imported():
         }
     }]
 
-    with raises(PlaybookVerificationError) as error:
-        verify(fake_playbook, skipVerify=False)
-    assert key_error in str(error.value)
+    # Create a temporary directory as the mocked insights_core_lib_dir
+    # in insights constants instead of directly manipulating
+    # the system insights lib directory.
+    temp_dir = tempfile.mkdtemp(dir="/tmp/", prefix="insights_")
+    try:
+        with patch.object(constants, "insights_core_lib_dir", temp_dir):
+            with raises(PlaybookVerificationError) as error:
+                verify(fake_playbook, skipVerify=False)
+            assert key_error in str(error.value)
+    finally:
+        shutil.rmtree(temp_dir)
 
 
 @pytest.mark.skipif(sys.version_info < (2, 7), reason='Playbook verifier must be run on python 2.7 or above')
@@ -68,9 +82,17 @@ def test_key_import_error():
         }
     }]
 
-    with raises(PlaybookVerificationError) as error:
-        verify(fake_playbook, skipVerify=False)
-    assert key_error in str(error.value)
+    # Create a temporary directory as the mocked insights_core_lib_dir
+    # in insights constants instead of directly manipulating
+    # the system insights lib directory.
+    temp_dir = tempfile.mkdtemp(dir="/tmp/", prefix="insights_")
+    try:
+        with patch.object(constants, "insights_core_lib_dir", temp_dir):
+            with raises(PlaybookVerificationError) as error:
+                verify(fake_playbook, skipVerify=False)
+            assert key_error in str(error.value)
+    finally:
+        shutil.rmtree(temp_dir)
 
 
 @pytest.mark.skipif(sys.version_info < (2, 7), reason='Playbook verifier must be run on python 2.7 or above')
@@ -103,8 +125,16 @@ def test_playbook_verification_success(mock_method):
         }
     }]
 
-    result = verify(fake_playbook, skipVerify=False)
-    assert result == fake_playbook
+    # Create a temporary directory as the mocked insights_core_lib_dir
+    # in insights constants instead of directly manipulating
+    # the system insights lib directory.
+    temp_dir = tempfile.mkdtemp(dir="/tmp/", prefix="insights_")
+    try:
+        with patch.object(constants, "insights_core_lib_dir", temp_dir):
+            result = verify(fake_playbook, skipVerify=False)
+            assert result == fake_playbook
+    finally:
+        shutil.rmtree(temp_dir)
 
 
 # getRevocationList can't load list


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This fix creates improvements to existing ansible playbook verification tests by
creating temp directories in tests that need a gpnughome directory.
This fix attempts to resolve the playbook verification errors by making
changes to only the test cases, without modifying the core playbook verifier app.

**Changes Made:**
- The 'vars' verification tests (`test_vars_not_found_error`, `test_empty_vars_error`, `test_signature_not_found_error`)  are updated to mock the `getRevocationList` method since it's not needed for the purpose of these tests. 
The purpose of these tests are to verify specific values of `vars` in the playbook snippets.
- The other tests that use code related to public keys use temp
directories and mock the `insights_core_lib_dir`.
