### PR TITLE
fix(yum_udpates): load dnf plugins

### DIFF
--- a/insights/specs/datasources/yum_updates.py
+++ b/insights/specs/datasources/yum_updates.py
@@ -57,6 +57,8 @@ class DnfManager:
         logging.disable(logging.WARNING)
         cli = dnf.cli.Cli(self.base)
         cli._read_conf_file()
+        self.base.init_plugins()
+        self.base.pre_configure_plugins()
         subst = self.base.conf.substitutions
         if subst.get("releasever"):
             self.releasever = subst["releasever"]
@@ -64,6 +66,7 @@ class DnfManager:
             self.basearch = subst["basearch"]
 
         self.base.read_all_repos()
+        self.base.configure_plugins()
 
         self.packages = hawkey.Query(hawkey.Sack())
         try:


### PR DESCRIPTION
we need to load dnf plugins to get package updates from dnf, especially on AWS systems where amazon-id plugin substitutes substrings in repo url - RHINENG-7888

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
yum_updates collection failed on AWS systems because it tried to download repo with invalid url (rhui.REGION.aws.ce.redhat.com). `REGION` string is replaced by `amazon-id` dnf plugin, so we need to load dnf plugins. `configure_plugins` must be called after `read_all_repos` since it modifies loeaded repos.
