### PR TITLE
fix: spec mdadm_D to render arg /dev/md* properly

### DIFF
--- a/insights/parsers/mdadm.py
+++ b/insights/parsers/mdadm.py
@@ -217,8 +217,8 @@ class MDAdmDetail(CommandParser, list):
                 continue
 
             # Start line of a new device
-            if (line.startswith("/dev/md") and line.endswith(":")
-                    or line.startswith(self.MDADM_ERROR_MSG_PREFIX)):
+            if (line.startswith("/dev/md") and line.endswith(":") or
+                    line.startswith(self.MDADM_ERROR_MSG_PREFIX)):
 
                 # Handle the last recongnized device
                 if index > device_start_index:

--- a/insights/parsers/mdadm.py
+++ b/insights/parsers/mdadm.py
@@ -184,14 +184,23 @@ class MDAdmDetail(CommandParser, list):
         >>> mdadm_d[1].get("Version")
         '1.2'
     """
+
+    MDADM_ERROR_MSG_PREFIX = "mdadm: "
+
     def parse_content(self, content):
 
         if len(content) == 0:
             raise SkipComponent("Empty content of command output")
 
         self.unparsable_device_list = []
+        self.error_messages = []
 
         def _handle_device(device_start_index, table_start_index, index):
+
+            if content[device_start_index].startswith(self.MDADM_ERROR_MSG_PREFIX):
+                self.error_messages.append(content[device_start_index])
+                return
+
             try:
                 device_detail = MDAdmDetailDevice()
                 device_detail.parse_device(content, device_start_index, table_start_index, index)
@@ -207,12 +216,16 @@ class MDAdmDetail(CommandParser, list):
             if not line:
                 continue
 
-            if line.startswith("/dev/md") and line.endswith(":"):
+            # Start line of a new device
+            if (line.startswith("/dev/md") and line.endswith(":")
+                    or line.startswith(self.MDADM_ERROR_MSG_PREFIX)):
+
                 # Handle the last recongnized device
                 if index > device_start_index:
                     _handle_device(device_start_index, table_start_index, index)
 
                 device_start_index = index
+
             elif "Number   Major   Minor" in line:
                 table_start_index = index
 

--- a/insights/specs/datasources/mdadm.py
+++ b/insights/specs/datasources/mdadm.py
@@ -5,19 +5,19 @@ from insights.core.context import HostContext
 from insights.core.exceptions import SkipComponent
 from insights.core.plugins import datasource
 from insights.core.spec_factory import simple_command
+# from insights.parsers.mdstat import Mdstat
 from insights.specs import Specs
 
 
 class LocalSpecs(Specs):
     """ Local specs used only by raid_devices datasource. """
-    ls_dev_md = simple_command("ls /dev/md*")
+    ls_dev_md = simple_command("ls /dev/")
 
 
 @datasource(LocalSpecs.ls_dev_md, HostContext)
 def raid_devices(broker):
 
     content = broker[LocalSpecs.ls_dev_md].content
-    print(content)
     if content:
         if "No such file or directory" in content[0]:
             raise SkipComponent
@@ -25,10 +25,31 @@ def raid_devices(broker):
         devices = []
         for line in content:
             for dev in line.split():
-                if dev and dev.startswith("/dev/md"):
-                    devices.append(dev)
+                if dev and dev.startswith("md") and dev != "md":
+                    devices.append("/dev/" + dev)
 
         if devices:
-            return ' '.join(devices)
+            return devices
 
     raise SkipComponent
+
+
+# @datasource(Mdstat, HostContext)
+# def md_raid_arrays(broker):
+#     """
+#     Return the md RAID Array device names.
+
+#     Sample data returned::
+
+#         ["md1", "md2", "md3"]
+
+#     Returns:
+#         List[str]: Sorted list of md RAID Array device names.
+
+#     Raises:
+#         SkipComponent: Raised if no RAID Array name is available
+#     """
+#     md_raid_arrays = broker[Mdstat].mds.keys()
+#     if md_raid_arrays:
+#         return sorted(md_raid_arrays)
+#     raise SkipComponent

--- a/insights/specs/datasources/mdadm.py
+++ b/insights/specs/datasources/mdadm.py
@@ -1,55 +1,23 @@
 """
 Custom datasources for mdadm information
 """
+import glob
+import os
+import stat
+
 from insights.core.context import HostContext
 from insights.core.exceptions import SkipComponent
 from insights.core.plugins import datasource
-from insights.core.spec_factory import simple_command
-# from insights.parsers.mdstat import Mdstat
-from insights.specs import Specs
 
 
-class LocalSpecs(Specs):
-    """ Local specs used only by raid_devices datasource. """
-    ls_dev_md = simple_command("ls /dev/")
-
-
-@datasource(LocalSpecs.ls_dev_md, HostContext)
+@datasource(HostContext)
 def raid_devices(broker):
-
-    content = broker[LocalSpecs.ls_dev_md].content
-    if content:
-        if "No such file or directory" in content[0]:
-            raise SkipComponent
-
-        devices = []
-        for line in content:
-            for dev in line.split():
-                if dev and dev.startswith("md") and dev != "md":
-                    devices.append("/dev/" + dev)
-
+    try:
+        extended = glob.glob("/dev/md*")
+        devices = [x for x in extended if stat.S_ISBLK(os.stat(x).st_mode)]
         if devices:
-            return devices
-
-    raise SkipComponent
-
-
-# @datasource(Mdstat, HostContext)
-# def md_raid_arrays(broker):
-#     """
-#     Return the md RAID Array device names.
-
-#     Sample data returned::
-
-#         ["md1", "md2", "md3"]
-
-#     Returns:
-#         List[str]: Sorted list of md RAID Array device names.
-
-#     Raises:
-#         SkipComponent: Raised if no RAID Array name is available
-#     """
-#     md_raid_arrays = broker[Mdstat].mds.keys()
-#     if md_raid_arrays:
-#         return sorted(md_raid_arrays)
-#     raise SkipComponent
+            return ' '.join(devices)
+        else:
+            raise SkipComponent("No /dev/md* raid devices found")
+    except Exception as e:
+        raise SkipComponent("Skipping raid_devices: {0}".format(str(e)))

--- a/insights/specs/datasources/mdadm.py
+++ b/insights/specs/datasources/mdadm.py
@@ -12,6 +12,7 @@ from insights.core.plugins import datasource
 
 @datasource(HostContext)
 def raid_devices(broker):
+    """ Glob extent "/dev/md*" to pass to ``mdadm_D`` Spec. """
     try:
         extended = glob.glob("/dev/md*")
         devices = [x for x in extended if stat.S_ISBLK(os.stat(x).st_mode)]

--- a/insights/specs/datasources/mdadm.py
+++ b/insights/specs/datasources/mdadm.py
@@ -1,0 +1,34 @@
+"""
+Custom datasources for mdadm information
+"""
+from insights.core.context import HostContext
+from insights.core.exceptions import SkipComponent
+from insights.core.plugins import datasource
+from insights.core.spec_factory import simple_command
+from insights.specs import Specs
+
+
+class LocalSpecs(Specs):
+    """ Local specs used only by raid_devices datasource. """
+    ls_dev_md = simple_command("ls /dev/md*")
+
+
+@datasource(LocalSpecs.ls_dev_md, HostContext)
+def raid_devices(broker):
+
+    content = broker[LocalSpecs.ls_dev_md].content
+    print(content)
+    if content:
+        if "No such file or directory" in content[0]:
+            raise SkipComponent
+
+        devices = []
+        for line in content:
+            for dev in line.split():
+                if dev and dev.startswith("/dev/md"):
+                    devices.append(dev)
+
+        if devices:
+            return ' '.join(devices)
+
+    raise SkipComponent

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -380,10 +380,7 @@ class DefaultSpecs(Specs):
     mariadb_log = simple_file("/var/log/mariadb/mariadb.log")
     max_uid = simple_command("/bin/awk -F':' '{ if($3 > max) max = $3 } END { print max }' /etc/passwd")
     md5chk_files = foreach_execute(md5chk.files, "/usr/bin/md5sum %s", keep_rc=True)
-    #mdadm_D = command_with_args("/usr/sbin/mdadm -D %s", mdadm.raid_devices)    # command broken due to /dev/mdxyz
-    #mdadm_D = simple_command("/usr/sbin/mdadm -D /dev/md1 /dev/md56 /dev/xyz")  # command broken due to /dev/mdxyz
-    #mdadm_D = simple_command("/usr/sbin/mdadm -D /dev/md1 /dev/md56")           # command be collected successfully
-    mdadm_D = foreach_execute(mdadm.raid_devices, "/usr/sbin/mdadm -D %s")       # seperate command to not affect each other
+    mdadm_D = command_with_args("/usr/sbin/mdadm -D %s", mdadm.raid_devices, keep_rc=True)
     mdstat = simple_file("/proc/mdstat")
     meminfo = first_file(["/proc/meminfo", "/meminfo"])
     messages = simple_file("/var/log/messages")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -31,7 +31,7 @@ from insights.specs.datasources import (
     aws, awx_manage, client_metadata, cloud_init, corosync as corosync_ds,
     dir_list, eap_reports, ethernet, httpd, intersystems, ipcs, kernel,
     kernel_module_list, leapp, lpstat, ls, luks_devices, machine_ids,
-    malware_detection, md5chk, mount as mount_ds, package_provides,
+    malware_detection, md5chk, mdadm, mount as mount_ds, package_provides,
     ps as ps_datasource, rpm_pkgs, sap, satellite_missed_queues,
     ssl_certificate, sys_fs_cgroup_memory, sys_fs_cgroup_memory_tasks_number,
     user_group, yum_updates)
@@ -380,7 +380,7 @@ class DefaultSpecs(Specs):
     mariadb_log = simple_file("/var/log/mariadb/mariadb.log")
     max_uid = simple_command("/bin/awk -F':' '{ if($3 > max) max = $3 } END { print max }' /etc/passwd")
     md5chk_files = foreach_execute(md5chk.files, "/usr/bin/md5sum %s", keep_rc=True)
-    mdadm_D = simple_command("/usr/sbin/mdadm -D /dev/md*")
+    mdadm_D = command_with_args("/usr/sbin/mdadm -D %s", mdadm.raid_devices)
     mdstat = simple_file("/proc/mdstat")
     meminfo = first_file(["/proc/meminfo", "/meminfo"])
     messages = simple_file("/var/log/messages")

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -380,7 +380,10 @@ class DefaultSpecs(Specs):
     mariadb_log = simple_file("/var/log/mariadb/mariadb.log")
     max_uid = simple_command("/bin/awk -F':' '{ if($3 > max) max = $3 } END { print max }' /etc/passwd")
     md5chk_files = foreach_execute(md5chk.files, "/usr/bin/md5sum %s", keep_rc=True)
-    mdadm_D = command_with_args("/usr/sbin/mdadm -D %s", mdadm.raid_devices)
+    #mdadm_D = command_with_args("/usr/sbin/mdadm -D %s", mdadm.raid_devices)    # command broken due to /dev/mdxyz
+    #mdadm_D = simple_command("/usr/sbin/mdadm -D /dev/md1 /dev/md56 /dev/xyz")  # command broken due to /dev/mdxyz
+    #mdadm_D = simple_command("/usr/sbin/mdadm -D /dev/md1 /dev/md56")           # command be collected successfully
+    mdadm_D = foreach_execute(mdadm.raid_devices, "/usr/sbin/mdadm -D %s")       # seperate command to not affect each other
     mdstat = simple_file("/proc/mdstat")
     meminfo = first_file(["/proc/meminfo", "/meminfo"])
     messages = simple_file("/var/log/messages")

--- a/insights/tests/datasources/test_mdadm.py
+++ b/insights/tests/datasources/test_mdadm.py
@@ -1,44 +1,53 @@
 import pytest
-
-from mock.mock import Mock
+from mock.mock import Mock, patch
 
 from insights.core.exceptions import SkipComponent
-from insights.specs.datasources.mdadm import LocalSpecs, raid_devices
+from insights.specs.datasources.mdadm import raid_devices
+
+MOCK_OS_STAT_ST_MODE = {
+    "b": 25008,
+    "d": 16877,
+    "-": 33188,
+}
+
+GLOB_DEV_MD_1 = "/dev/md1 /dev/md2 /dev/md3".split()
+GLOB_DEV_MD_2 = "/dev/md".split()
+GLOB_DEV_MD_3 = "/dev/mdxyz".split()
+GLOB_DEV_MD_4 = "".split()
+
+mock_os_stat_return_1 = Mock(st_mode=MOCK_OS_STAT_ST_MODE["b"])
+mock_os_stat_return_2 = Mock(st_mode=MOCK_OS_STAT_ST_MODE["d"])
+mock_os_stat_return_3 = Mock(st_mode=MOCK_OS_STAT_ST_MODE["-"])
 
 
-LS_DEV_MD_1 = """
-/dev/md1  /dev/md2  /dev/md3
-""".strip()
-
-LS_DEV_MD_2 = """
-/dev/md1   /dev/md14  /dev/md20  /dev/md27  /dev/md33  /dev/md4   /dev/md46  /dev/md52  /dev/md59  /dev/md8
-/dev/md0   /dev/md15  /dev/md21  /dev/md28  /dev/md34  /dev/md40  /dev/md47  /dev/md53  /dev/md6   /dev/md9
-""".strip()
-
-LS_DEV_MD_3 = """
-ls: cannot access '/dev/md*': No such file or directory
-""".strip()
-
-
-def test_raid_devices():
-    ls_dev_md_command = Mock()
-    ls_dev_md_command.content = LS_DEV_MD_1.splitlines()
-    broker = {LocalSpecs.ls_dev_md: ls_dev_md_command}
-    result = raid_devices(broker)
+@patch("os.stat", return_value=mock_os_stat_return_1)
+@patch("glob.glob", return_value=GLOB_DEV_MD_1)
+def test_raid_devices(m_glob, m_stst):
+    result = raid_devices({})
     assert result is not None
     assert isinstance(result, str)
     assert result == "/dev/md1 /dev/md2 /dev/md3"
 
 
-def test_raid_devices_bad():
-    ls_dev_md_command = Mock()
-    ls_dev_md_command.content = LS_DEV_MD_3.splitlines()
-    broker = {LocalSpecs.ls_dev_md: ls_dev_md_command}
-    with pytest.raises(SkipComponent):
-        raid_devices(broker)
+@patch("os.stat", return_value=mock_os_stat_return_2)
+@patch("glob.glob", return_value=GLOB_DEV_MD_2)
+def test_raid_devices_bad_2(m_glob, m_stst):
+    with pytest.raises(SkipComponent) as e:
+        raid_devices({})
+    assert "Skipping raid_devices: No /dev/md* raid devices found" in str(e)
 
-    ls_dev_md_command = Mock()
-    ls_dev_md_command.content = ""
-    broker = {LocalSpecs.ls_dev_md: ls_dev_md_command}
-    with pytest.raises(SkipComponent):
-        raid_devices(broker)
+
+@patch("os.stat", return_value=mock_os_stat_return_3)
+@patch("glob.glob", return_value=GLOB_DEV_MD_3)
+def test_raid_devices_bad_3(m_glob, m_stst):
+    with pytest.raises(SkipComponent) as e:
+        raid_devices({})
+    assert "Skipping raid_devices: No /dev/md* raid devices found" in str(e)
+
+
+@patch("os.stat", return_value=mock_os_stat_return_1)
+@patch("glob.glob", return_value=GLOB_DEV_MD_4)
+def test_raid_devices_bad_4(m_glob, m_stst):
+    with pytest.raises(SkipComponent) as e:
+        raid_devices({})
+    assert "Skipping raid_devices: No /dev/md* raid devices found" in str(e)

--- a/insights/tests/datasources/test_mdadm.py
+++ b/insights/tests/datasources/test_mdadm.py
@@ -1,0 +1,44 @@
+import pytest
+
+from mock.mock import Mock
+
+from insights.core.exceptions import SkipComponent
+from insights.specs.datasources.mdadm import LocalSpecs, raid_devices
+
+
+LS_DEV_MD_1 = """
+/dev/md1  /dev/md2  /dev/md3
+""".strip()
+
+LS_DEV_MD_2 = """
+/dev/md1   /dev/md14  /dev/md20  /dev/md27  /dev/md33  /dev/md4   /dev/md46  /dev/md52  /dev/md59  /dev/md8
+/dev/md0   /dev/md15  /dev/md21  /dev/md28  /dev/md34  /dev/md40  /dev/md47  /dev/md53  /dev/md6   /dev/md9
+""".strip()
+
+LS_DEV_MD_3 = """
+ls: cannot access '/dev/md*': No such file or directory
+""".strip()
+
+
+def test_raid_devices():
+    ls_dev_md_command = Mock()
+    ls_dev_md_command.content = LS_DEV_MD_1.splitlines()
+    broker = {LocalSpecs.ls_dev_md: ls_dev_md_command}
+    result = raid_devices(broker)
+    assert result is not None
+    assert isinstance(result, str)
+    assert result == "/dev/md1 /dev/md2 /dev/md3"
+
+
+def test_raid_devices_bad():
+    ls_dev_md_command = Mock()
+    ls_dev_md_command.content = LS_DEV_MD_3.splitlines()
+    broker = {LocalSpecs.ls_dev_md: ls_dev_md_command}
+    with pytest.raises(SkipComponent):
+        raid_devices(broker)
+
+    ls_dev_md_command = Mock()
+    ls_dev_md_command.content = ""
+    broker = {LocalSpecs.ls_dev_md: ls_dev_md_command}
+    with pytest.raises(SkipComponent):
+        raid_devices(broker)

--- a/insights/tests/parsers/test_mdadm.py
+++ b/insights/tests/parsers/test_mdadm.py
@@ -165,7 +165,8 @@ Consistency Policy : bitmap
 """.strip()
 
 MDADM_D_CONTENT_MULTI_DEVICES = """
-/dev/md/d1p2:
+mdadm: cannot open /dev/md0: No such file or directory
+/dev/md21:
            Version : 1.2
      Creation Time : Thu Jun 17 09:03:18 2021
         Raid Level : raid1
@@ -192,7 +193,9 @@ Consistency Policy : bitmap
     Number   Major   Minor   RaidDevice State
        0      94       33        0      active sync   /dev/dasdi1
        1      94       53        1      active sync   /dev/dasdn1
-/dev/md21p3:
+mdadm: cannot open /dev/md2: No such file or directory
+some continue message of last line
+/dev/md22:
            Version : 1.2
      Creation Time : Sun Jun 27 19:14:00 2021
         Raid Level : raid1
@@ -218,6 +221,7 @@ Consistency Policy : resync
     Number   Major   Minor   RaidDevice State
        0      94       29        0      active sync   /dev/dasdh1
        1      94       37        1      active sync   /dev/dasdj1
+mdadm: cannot open /dev/md3: No such file or directory
 """.strip()
 
 
@@ -273,18 +277,20 @@ def test_mdadm_d():
     assert len(mds) == 2
     assert len(mds.unparsable_device_list) == 0
     md = mds[0]
-    assert md.device_name == '/dev/md/d1p2'
+    assert md.device_name == '/dev/md21'
     assert len(md) == 21
     assert md['State'] == 'clean'
     assert md['Consistency Policy'] == 'bitmap'
     assert md.is_internal_bitmap is True
     assert len(md.device_table) == 2
     md = mds[1]
-    assert md.device_name == '/dev/md21p3'
+    assert md.device_name == '/dev/md22'
     assert md['State'] == 'clean'
     assert md['Consistency Policy'] == 'resync'
     assert md.is_internal_bitmap is False
     assert len(md.device_table) == 2
+    assert len(mds.error_messages) == 3
+    assert mds.error_messages[-1] == "mdadm: cannot open /dev/md3: No such file or directory"
 
 
 MDADM_D_CONTENT_EMPTY_TABLE = """


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Resolve https://github.com/RedHatInsights/insights-core/issues/4010 

~Local test with `insights-collect`,~ 
~~~
Create MD Array /dev/md1 /dev/md56, and touch a file /dev/mdxyz as a fake one:
    #mdadm_D = command_with_args("/usr/sbin/mdadm -D %s", mdadm.raid_devices)      # command broken due to /dev/mdxyz
    #mdadm_D = simple_command("/usr/sbin/mdadm -D /dev/md1 /dev/md56 /dev/mdxyz")  # command broken due to /dev/mdxyz
    #mdadm_D = simple_command("/usr/sbin/mdadm -D /dev/md1 /dev/md56")             # command be collected successfully
    mdadm_D = foreach_execute(mdadm.raid_devices, "/usr/sbin/mdadm -D %s")         # seperate command to not affect each other
~~~
~The collected `meta_data/insights.specs.Specs.mdadm_D.json` with `foreach_execute`:~
~~~
[root@xiaoxwan-test321-rhel91 insights-xiaoxwan-test321-rhel91.default-20240205131844]# cat meta_data/insights.specs.Specs.mdadm_D.json 
{"name": "insights.specs.Specs.mdadm_D", "exec_time": 0.0007004737854003906, "errors": ["Traceback (most recent call last):\n  File \"/root/Work/insights-core/insights/core/serde.py\", line 102, in call_serializer\n    return func(value), None\n  File \"/root/Work/insights-core/insights/core/serde.py\", line 87, in serialize\n    \"object\": to_dict(obj, root=root),\n  File \"/root/Work/insights-core/insights/core/spec_factory.py\", line 1252, in serialize_command_output\n    rc = obj.write(dst)\n  File \"/root/Work/insights-core/insights/core/spec_factory.py\", line 432, in write\n    return p.write(dst, keep_rc=self.keep_rc)\n  File \"/root/Work/insights-core/insights/util/subproc.py\", line 121, in write\n    six.reraise(be.__class__, be, sys.exc_info()[2])\n  File \"/root/Work/insights-core/venv39/lib64/python3.9/site-packages/six.py\", line 719, in reraise\n    raise value\n  File \"/root/Work/insights-core/insights/util/subproc.py\", line 117, in write\n    raise CalledProcessError(rc, self.cmds[0], \"\")\ninsights.core.exceptions.CalledProcessError: (1, ['timeout', '-s', '9', '10', '/usr/sbin/mdadm', '-D', '/dev/mdxyz'], '')\n"], "results": [{"type": "insights.core.spec_factory.CommandOutputProvider", "object": {"rc": null, "cmd": "/usr/sbin/mdadm -D /dev/md1", "args": "/dev/md1", "relative_path": "insights_commands/mdadm_-D_.dev.md1"}}, {"type": "insights.core.spec_factory.CommandOutputProvider", "object": {"rc": null, "cmd": "/usr/sbin/mdadm -D /dev/md3", "args": "/dev/md3", "relative_path": "insights_commands/mdadm_-D_.dev.md3"}}, {"type": "insights.core.spec_factory.CommandOutputProvider", "object": {"rc": null, "cmd": "/usr/sbin/mdadm -D /dev/md56", "args": "/dev/md56", "relative_path": "insights_commands/mdadm_-D_.dev.md56"}}], "ser_time": 0.08197736740112305}
~~~

#### Finally - Use `command_with_args` with `keep_rc` : 
```
mdadm_D = command_with_args("/usr/sbin/mdadm -D %s", mdadm.raid_devices, keep_rc=True)
``` 
