### PR TITLE
fix(test): spec cleaner tests are using 'is' for comparing strings

### DIFF
--- a/insights/tests/core/test_spec_cleaner_redact.py
+++ b/insights/tests/core/test_spec_cleaner_redact.py
@@ -275,7 +275,7 @@ def test_redact_exclude_patterns(line, expected):
     c = InsightsConfig()
     pp = Cleaner(c, {'patterns': ['myserver', 'mykey']})
     actual = pp._redact_line(line)
-    assert actual is expected
+    assert actual == expected
 
 
 @mark.parametrize(("line", "expected"), [
@@ -288,7 +288,7 @@ def test_redact_patterns_regex(line, expected):
     c = InsightsConfig()
     pp = Cleaner(c, {'patterns': {'regex': ['myserver', r'my(\w*)key']}})
     actual = pp._redact_line(line)
-    assert actual is expected
+    assert actual == expected
 
 
 @mark.parametrize(("line", "expected"), [
@@ -302,7 +302,7 @@ def test_redact_patterns_posix_regex(line, expected):
     c = InsightsConfig()
     pp = Cleaner(c, {'patterns': {'regex': ['myserver', r'my(\w*)key', 'test[[:digit:]]']}})
     actual = pp._redact_line(line)
-    assert actual is expected
+    assert actual == expected
 
 
 @mark.parametrize(("line", "expected"), [


### PR DESCRIPTION
This was causing the tests to fail locally.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

On Python 2.7, these tests were failing because the strings were being compared by their identity, instead of equivalence.