### PR TITLE
fix: hostname is not obfuscated when using display_name

### DIFF
--- a/insights/core/spec_cleaner.py
+++ b/insights/core/spec_cleaner.py
@@ -86,7 +86,7 @@ class Cleaner(object):
         self._keywords2db(keywords)
 
         # Obfuscation
-        fqdn = fqdn if fqdn else determine_hostname(config.display_name)
+        fqdn = fqdn if fqdn else determine_hostname()
         name_list = fqdn.split('.')
         self.hostname = name_list[0]
         self.fqdn = fqdn

--- a/insights/tests/core/test_spec_cleaner_redact.py
+++ b/insights/tests/core/test_spec_cleaner_redact.py
@@ -315,20 +315,3 @@ def test_redact_password(line, expected):
     pp = Cleaner(c, {'patterns': {'regex': ['myserver', r'my(\w*)key']}})
     actual = pp._redact_line(line)
     assert actual == expected
-
-
-def test_cleaner_fqdn():
-    fqdn = 'test.abc.com'
-    c = InsightsConfig(obfuscate=True, obfuscate_hostname=True, display_name=fqdn)
-    pp = Cleaner(c, {}, fqdn)
-    assert pp.fqdn == fqdn
-    assert len(pp.obfuscated_fqdn.split('.')[0]) == 12
-
-    fqdn1 = 'test.def.com'
-    pp = Cleaner(c, {}, fqdn1)
-    assert pp.fqdn == fqdn1
-    assert len(pp.obfuscated_fqdn.split('.')[0]) == 12
-
-    pp = Cleaner(c, {}, '')
-    assert pp.fqdn == fqdn  # get hostname from config.display_name
-    assert len(pp.obfuscated_fqdn.split('.')[0]) == 12


### PR DESCRIPTION
- when 'display_name' was specified,  the hostname was set to
   display_name in spec cleaner by mistake,  resulting in the actual
   hostname being missed to be obfuscated.
- see RHINENG-8200

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
