### PR TITLE
fix: Make utilities.write_to_disk use current time by default

### DIFF
--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -89,12 +89,15 @@ def delete_cache_files():
         os.remove(f)
 
 
-def write_to_disk(filename, delete=False, content=get_time()):
+def write_to_disk(filename, delete=False, content=None):
     """
     Write filename out to disk
     """
     if not os.path.exists(os.path.dirname(filename)):
         return
+    if content is None:
+        content = get_time()
+
     if delete:
         if os.path.lexists(filename):
             logger.debug("Removing '%s'" % filename)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The bug in the signature makes this function write down the time the egg was loaded, not the current time when this function is actually being called.