### PR TITLE
fixes: Update the spec "rhui_set_release"

### DIFF
--- a/insights/parsers/rhui_release.py
+++ b/insights/parsers/rhui_release.py
@@ -1,9 +1,9 @@
 """
-RHUI release commands
-=====================
+RHUI release commands or files
+==============================
 
-RHUISetRelease - command ``rhui_set_release``
----------------------------------------------
+RHUISetRelease - file ``/etc/yum/vars/releasever``
+--------------------------------------------------
 
 """
 import os
@@ -17,9 +17,10 @@ from insights.specs import Specs
 @parser(Specs.rhui_set_release)
 class RHUISetRelease(CommandParser):
     """
-    Class for parsing the output of `rhui_set_release` command.
+    Class for parsing the file `/etc/yum/vars/releasever`.
     It will output the rhel minor release when a minor release is set,
-    or emtpy when it isn't set.
+    or emtpy when it isn't set. It does not exist when no minor release
+    is set on some images.
 
     Typical output of the command is::
 

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -516,7 +516,10 @@ class DefaultSpecs(Specs):
     resolv_conf = simple_file("/etc/resolv.conf")
     rhsm_conf = simple_file("/etc/rhsm/rhsm.conf")
     rhsm_releasever = simple_file('/var/lib/rhsm/cache/releasever.json')
-    rhui_set_release = simple_command("/usr/bin/rhui-set-release")
+    rhui_set_release = first_of([
+        simple_file('/etc/yum/vars/releasever'),
+        simple_file('/etc/dnf/vars/releasever'),
+    ])
     rndc_status = simple_command("/usr/sbin/rndc status")
     ros_config = simple_file("/var/lib/pcp/config/pmlogger/config.ros")
     rpm_V_packages = simple_command("/bin/rpm -V coreutils procps procps-ng shadow-utils passwd sudo chrony findutils glibc systemd", keep_rc=True, signum=signal.SIGTERM)

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -205,7 +205,6 @@ class InsightsArchiveSpecs(Specs):
     readlink_e_shift_cert_server = simple_file("insights_commands/readlink_-e_.etc.origin.node.certificates.kubelet-server-current.pem")
     repquota_agnpuv = simple_file("insights_commands/repquota_-agnpuv")
     rhsm_katello_default_ca_cert = simple_file("insights_commands/openssl_x509_-in_.etc.rhsm.ca.katello-default-ca.pem_-noout_-issuer")
-    rhui_set_release = simple_file("insights_commands/rhui-set-release")
     rndc_status = simple_file("insights_commands/rndc_status")
     rpm_ostree_status = simple_file("insights_commands/rpm-ostree_status_--json")
     rpm_V_packages = first_file([


### PR DESCRIPTION
* The command "/usr/bin/rhui-set-release" does not exist on all clouds. Replace it with "/etc/yum/vars/releasever" or "/etc/dnf/vars/releasever"

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

