### PR TITLE
feat: collect LEAPP_* and CONVERT2RHEL_ env vars in migration-results

### DIFF
--- a/insights/tests/datasources/test_leapp.py
+++ b/insights/tests/datasources/test_leapp.py
@@ -31,7 +31,7 @@ LEAPP_REPORT_NG_1 = json.loads("""
 
 LEAPP_REPORT_NG_2 = MIGRATION_RESULTS_NG_2 = json.loads("{}")
 
-MIGRATION_RESULTS_OK = json.loads("""
+MIGRATION_RESULTS_OK_1 = json.loads("""
 {
    "activities": [
      {
@@ -133,17 +133,54 @@ MIGRATION_RESULTS_OK = json.loads("""
   ]
 }""".strip())
 
-MIGRATION_RESULTS_RET = """
+MIGRATION_RESULTS_OK_2 = json.loads("""
+{
+  "activities": [
+    {
+      "executed": "/usr/bin/convert2rhel analyze -y",
+      "run_id": "null",
+      "packages": [
+        {
+          "nevra": "0:convert2rhel-1.6.1-1.el7.noarch",
+          "signature": "RSA/SHA256, Wed Dec 13 19:27:28 2023, Key ID 199e2f91fd431d51"
+        }
+      ],
+      "target_os": "null",
+      "success": true,
+      "activity_ended": "2024-03-01T07:44:15.814899Z",
+      "version": "1",
+      "env": {},
+      "activity": "analysis",
+      "source_os": {
+        "version": "7.9",
+        "id": "Core",
+        "name": "CentOS Linux"
+      },
+      "activity_started": "2024-03-01T07:37:39.278478Z"
+    }
+  ]
+}""".strip())
+
+MIGRATION_RESULTS_RET_1 = """
 [
   {
     "activity": "preupgrade",
     "activity_ended": "2023-08-22T08:56:26.971009Z",
     "activity_started": "2023-08-22T08:55:47.798008Z",
     "env": {
-      "LEAPP_CURRENT_PHASE": "FactsCollection",
-      "LEAPP_EXPERIMENTAL": "0",
-      "LEAPP_NO_RHSM": "0",
-      "LEAPP_UNSUPPORTED": "0"
+         "LEAPP_COMMON_FILES": ":/etc/leapp/repos.d/system_upgrade/common/files:/etc/leapp/repos.d/system_upgrade/el8toel9/files",
+         "LEAPP_COMMON_TOOLS": ":/etc/leapp/repos.d/system_upgrade/common/tools:/etc/leapp/repos.d/system_upgrade/el8toel9/tools",
+         "LEAPP_CURRENT_PHASE": "FactsCollection",
+         "LEAPP_DEBUG": "0",
+         "LEAPP_EXECUTION_ID": "1edff870-626d-41ba-854c-8f9dc8f20dc3",
+         "LEAPP_EXPERIMENTAL": "0",
+         "LEAPP_HOSTNAME": "kvm-04-guest17.lab.eng.rdu2.redhat.com",
+         "LEAPP_IPU_IN_PROGRESS": "8to9",
+         "LEAPP_NO_RHSM": "0",
+         "LEAPP_UNSUPPORTED": "0",
+         "LEAPP_UPGRADE_PATH_FLAVOUR": "default",
+         "LEAPP_UPGRADE_PATH_TARGET_RELEASE": "9.0",
+         "LEAPP_VERBOSE": "0"
     },
     "run_id": "1edff870-626d-41ba-854c-8f9dc8f20dc3",
     "source_os": "Red Hat Enterprise Linux 8.6",
@@ -156,10 +193,19 @@ MIGRATION_RESULTS_RET = """
     "activity_ended": "2023-08-22T09:21:40.483395Z",
     "activity_started": "2023-08-22T09:13:50.876865Z",
     "env": {
-      "LEAPP_CURRENT_PHASE": "InterimPreparation",
-      "LEAPP_EXPERIMENTAL": "0",
-      "LEAPP_NO_RHSM": "0",
-      "LEAPP_UNSUPPORTED": "0"
+         "LEAPP_COMMON_FILES": ":/etc/leapp/repos.d/system_upgrade/common/files:/etc/leapp/repos.d/system_upgrade/el8toel9/files",
+         "LEAPP_COMMON_TOOLS": ":/etc/leapp/repos.d/system_upgrade/common/tools:/etc/leapp/repos.d/system_upgrade/el8toel9/tools",
+         "LEAPP_CURRENT_PHASE": "InterimPreparation",
+         "LEAPP_DEBUG": "0",
+         "LEAPP_EXECUTION_ID": "b3baa3f4-de86-4c4b-a7f3-bbe271207efd",
+         "LEAPP_EXPERIMENTAL": "0",
+         "LEAPP_HOSTNAME": "kvm-04-guest17.lab.eng.rdu2.redhat.com",
+         "LEAPP_IPU_IN_PROGRESS": "8to9",
+         "LEAPP_NO_RHSM": "0",
+         "LEAPP_UNSUPPORTED": "0",
+         "LEAPP_UPGRADE_PATH_FLAVOUR": "default",
+         "LEAPP_UPGRADE_PATH_TARGET_RELEASE": "9.0",
+         "LEAPP_VERBOSE": "0"
     },
     "run_id": "b3baa3f4-de86-4c4b-a7f3-bbe271207efd",
     "source_os": "Red Hat Enterprise Linux 8.6",
@@ -169,6 +215,27 @@ MIGRATION_RESULTS_RET = """
   }
 ]
 """.strip()
+
+MIGRATION_RESULTS_RET_2 = """
+[
+  {
+      "activity": "analysis",
+      "activity_ended": "2024-03-01T07:44:15.814899Z",
+      "activity_started": "2024-03-01T07:37:39.278478Z",
+      "env": {},
+      "run_id": "null",
+      "source_os": {
+          "version": "7.9",
+          "id": "Core",
+          "name": "CentOS Linux"
+      },
+      "success": true,
+      "target_os": "null",
+      "version": "1"
+  }
+]
+""".strip()
+
 
 MIGRATION_RESULTS_NG_1 = json.loads("""
 { "activities":[
@@ -215,13 +282,24 @@ def test_leapp_report_no_file(isfile):
         leapp_report({})
 
 
-@patch("json.load", return_value=MIGRATION_RESULTS_OK)
+@patch("json.load", return_value=MIGRATION_RESULTS_OK_1)
 @patch("os.path.isfile", return_value=True)
 @patch(builtin_open)
 def test_leapp_migration_results_ok(m_open, m_isfile, m_load):
     result = migration_results({})
     result_json = json.loads(''.join(result.content).strip())
-    expected_json = json.loads(''.join(MIGRATION_RESULTS_RET).strip())
+    expected_json = json.loads(''.join(MIGRATION_RESULTS_RET_1).strip())
+    for ret in result_json:
+        assert ret in expected_json
+
+
+@patch("json.load", return_value=MIGRATION_RESULTS_OK_2)
+@patch("os.path.isfile", return_value=True)
+@patch(builtin_open)
+def test_c2r_migration_results_ok(m_open, m_isfile, m_load):
+    result = migration_results({})
+    result_json = json.loads(''.join(result.content).strip())
+    expected_json = json.loads(''.join(MIGRATION_RESULTS_RET_2).strip())
     for ret in result_json:
         assert ret in expected_json
 

--- a/insights/tests/parsers/test_leapp.py
+++ b/insights/tests/parsers/test_leapp.py
@@ -4,7 +4,7 @@ from insights.parsers import leapp
 from insights.parsers.leapp import LeappReport, LeappMigrationResults
 from insights.tests import context_wrap
 from insights.tests.datasources.test_leapp import LEAPP_REPORT_RESULT
-from insights.tests.datasources.test_leapp import MIGRATION_RESULTS_RET
+from insights.tests.datasources.test_leapp import MIGRATION_RESULTS_RET_1, MIGRATION_RESULTS_RET_2
 
 
 def test_leapp_report():
@@ -23,7 +23,7 @@ def test_leapp_report():
 
 
 def test_leapp_migration_results():
-    ret = LeappMigrationResults(context_wrap(MIGRATION_RESULTS_RET, path='insights_commands/leapp_migration_results'))
+    ret = LeappMigrationResults(context_wrap(MIGRATION_RESULTS_RET_1, path='insights_commands/leapp_migration_results'))
     assert len(ret) == 2
     assert ret[0]['activity_ended'] == "2023-08-22T08:56:26.971009Z"
     assert ret[0]['run_id'] == "1edff870-626d-41ba-854c-8f9dc8f20dc3"
@@ -31,10 +31,19 @@ def test_leapp_migration_results():
     assert ret[1]['env']['LEAPP_CURRENT_PHASE'] == "InterimPreparation"
 
 
+def test_c2r_migration_results():
+    ret = LeappMigrationResults(context_wrap(MIGRATION_RESULTS_RET_2, path='insights_commands/leapp_migration_results'))
+    assert len(ret) == 1
+    assert ret[0]['activity_ended'] == "2024-03-01T07:44:15.814899Z"
+    assert ret[0]['run_id'] == "null"
+    assert ret[0]['target_os'] == "null"
+    assert len(ret[0]['env']) == 0
+
+
 def test_doc_examples():
     env = {
         'leapp_report': LeappReport(context_wrap(LEAPP_REPORT_RESULT)),
-        'leapp_migration_results': LeappMigrationResults(context_wrap(MIGRATION_RESULTS_RET)),
+        'leapp_migration_results': LeappMigrationResults(context_wrap(MIGRATION_RESULTS_RET_1)),
     }
     failed, total = doctest.testmod(leapp, globs=env)
     assert failed == 0


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

- Resolves: RHINENG-6807
- parser for `/etc/migration-results` now collects all `LEAPP_*` and `CONVERT2RHEL_*` env variables, this will allow us to obtain knowledge of environments from where convert2rhel and leapp were executed and get very valuable statistics. 
- [x] Add test for convert2rhel related record in migration-results
