### PR TITLE
fix: subscription-manager identity should be obfuscated with hostname

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -712,7 +712,7 @@ class Specs(SpecSet):
     sssd_logs = RegistryPoint(multi_output=True, filterable=True)
     sys_block_queue_stable_writes = RegistryPoint(multi_output=True)
     subscription_manager_facts = RegistryPoint(filterable=True)
-    subscription_manager_id = RegistryPoint(no_obfuscate=['hostname', 'ip'], no_redact=True)
+    subscription_manager_id = RegistryPoint(no_obfuscate=['ip'], no_redact=True)
     subscription_manager_installed_product_ids = RegistryPoint(filterable=True, no_obfuscate=['hostname', 'ip'])
     subscription_manager_list_consumed = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     subscription_manager_list_installed = RegistryPoint(no_obfuscate=['hostname', 'ip'])


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
The output of the `subscription-manage identity` looks:
```
# sudo subscription-manager identity
system identity: 9b53c93a-88ea-4168-9edf-b58e6c2ba66d
name: insights-xyz.redhat.com
org name: EXD
org ID: EXD
environment name: Library
```

The hostname should be obfuscated accordingly.
