### PR TITLE
fix: ContainerMssqlApiAssessment ParseException

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -97,21 +97,6 @@ class Parser(object):
         raise NotImplementedError(msg)
 
 
-class ContainerParser(Parser):
-    """
-    A class specifically for container parser, with the "image" name, the
-    engine provider and the container ID on the basis of ``Parser``.
-    """
-    def __init__(self, context):
-        self.image = context.image
-        """str: The image of the container."""
-        self.engine = context.engine
-        """str: The engine provider of the container."""
-        self.container_id = context.container_id
-        """str: The ID of the container."""
-        super(ContainerParser, self).__init__(context)
-
-
 class StreamParser(Parser):
     """
     Parsers that don't have to store lines or look back in the data stream
@@ -629,6 +614,21 @@ class CommandParser(Parser):
             name = self.__class__.__name__
             raise ContentException(name + ": " + first)
         super(CommandParser, self).__init__(context)
+
+
+class ContainerParser(CommandParser):
+    """
+    A class specifically for container parser, with the "image" name, the
+    engine provider and the container ID on the basis of ``Parser``.
+    """
+    def __init__(self, context):
+        self.image = context.image
+        """str: The image of the container."""
+        self.engine = context.engine
+        """str: The engine provider of the container."""
+        self.container_id = context.container_id
+        """str: The ID of the container."""
+        super(ContainerParser, self).__init__(context)
 
 
 class XMLParser(LegacyItemAccess, Parser):

--- a/insights/parsers/cpu_online.py
+++ b/insights/parsers/cpu_online.py
@@ -7,13 +7,13 @@ This file shows the number of online cpu. The format of the content
 is string including comma.
 """
 
-from insights.core import CommandParser, ContainerParser
+from insights.core import ContainerParser
 from insights.core.plugins import parser
 from insights.specs import Specs
 
 
 @parser(Specs.container_cpu_online)
-class ContainerCpuOnline(ContainerParser, CommandParser):
+class ContainerCpuOnline(ContainerParser):
     """
     Class ``ContainerCpuOnline`` parses the content of the ``/sys/devices/system/cpu/online`` from containers.
 


### PR DESCRIPTION
 ### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

-----

Get this following exception from "Insights Times and Errors Report 2024-03-05" :

| count| component| request_id| exception|
| -------- | ------- | -------- | ------- |
|271483|insights.parsers.mssql_api_assessment.ContainerMssqlApiAssessment|some_request_id|ParseException("insights.parsers.mssql_api_assessment.ContainerMssqlApiAssessment couldn't parse json.")|

An example of the file content: 
```
cat: /var/opt/mssql/log/assessments/assessment-latest: No such file or directory
```

Fix this by special handling the `CommandParser.__bad_single_lines` like output in `ContainerParser`.
