### PR TITLE
fix: get bios_uuid (system_uuid) from dmidecode correctly

### DIFF
--- a/insights/parsers/dmidecode.py
+++ b/insights/parsers/dmidecode.py
@@ -122,7 +122,7 @@ class DMIDecode(CommandParser, LegacyItemAccess):
     @defaults()
     def system_uuid(self):
         """(str): Convenience method to get system UUID"""
-        sys_uuid = self["system_information"][0]['UUID']
+        sys_uuid = self["system_information"][0]['uuid']
         return str(uuid.UUID(sys_uuid))
 
     @property

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -42,6 +42,7 @@ class Specs(SpecSet):
     azure_load_balancer = RegistryPoint()
     basic_auth_insights_client = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     bdi_read_ahead_kb = RegistryPoint(multi_output=True, no_obfuscate=['hostname', 'ip'])
+    bios_uuid = RegistryPoint()
     blkid = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     bond = RegistryPoint(multi_output=True)
     bond_dynamic_lb = RegistryPoint(multi_output=True, no_obfuscate=['hostname', 'ip'])

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -42,7 +42,6 @@ class Specs(SpecSet):
     azure_load_balancer = RegistryPoint()
     basic_auth_insights_client = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     bdi_read_ahead_kb = RegistryPoint(multi_output=True, no_obfuscate=['hostname', 'ip'])
-    bios_uuid = RegistryPoint()
     blkid = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     bond = RegistryPoint(multi_output=True)
     bond_dynamic_lb = RegistryPoint(multi_output=True, no_obfuscate=['hostname', 'ip'])

--- a/insights/tests/parsers/test_dmidecode.py
+++ b/insights/tests/parsers/test_dmidecode.py
@@ -424,6 +424,7 @@ def test_get_dmidecode():
 
     # Test property accessors
     assert ret.system_info == ret['system_information'][0]
+    assert ret.system_uuid == '34373936-3439-4D32-3233-333630303036'.lower()
     assert ret.bios == ret['bios_information'][0]
     assert ret.bios_vendor == 'HP'
     assert ret.bios_date == date(2013, 3, 1)
@@ -438,6 +439,7 @@ def test_get_dmidecode_fail():
     ret = DMIDecode(context)
 
     assert ret.is_present is False
+    assert ret.system_uuid is None
 
 
 # def test_virt_what_1():
@@ -509,6 +511,7 @@ def test_get_dmidecode_dmi():
     assert ret.get("system_information")[0].get("serial_number") == "3H6CMK2537"
     assert ret.get("system_information")[0].get("uuid") == "58585858-5858-3348-3643-4D4B32353337"
     assert ret.get("system_information")[0].get("wake-up_type") == "Power Switch"
+    assert ret.system_uuid == '58585858-5858-3348-3643-4D4B32353337'.lower()
 
 
 def test_dmidecode_oddities():


### PR DESCRIPTION
- fix the typo of the key of UUID to "uuid"
- and remove it from Specs


### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
