### PR TITLE
feat: Reuse subscription-manager identity for machine-id

### DIFF
--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -96,6 +96,7 @@ def write_to_disk(filename, delete=False, content=get_time()):
         return
     if delete:
         if os.path.lexists(filename):
+            logger.debug("Removing '%s'" % filename)
             try:
                 os.remove(filename)
             except OSError as err:
@@ -105,6 +106,7 @@ def write_to_disk(filename, delete=False, content=get_time()):
                 if err.errno != errno.ENOENT:
                     raise err
     else:
+        logger.debug("Writing '%s'" % filename)
         with open(filename, 'wb') as f:
             f.write(content.encode('utf-8'))
 

--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -26,6 +26,7 @@ except ImportError:
 from .. import package_info
 from .constants import InsightsConstants as constants
 from .collection_rules import InsightsUploadConf, load_yaml
+from insights.client import cert_auth
 
 from insights.core.context import Context
 from insights.parsers.os_release import OsRelease
@@ -111,30 +112,62 @@ def write_to_disk(filename, delete=False, content=get_time()):
             f.write(content.encode('utf-8'))
 
 
-def generate_machine_id(new=False,
-                        destination_file=constants.machine_id_file):
+def _get_rhsm_identity():
+    """Get the subscription-manager identity certificate UUID.
+
+    :returns: The subscription-manager UUID, or None if not found.
+    :rtype: str | None
     """
-    Generate a machine-id if /etc/insights-client/machine-id does not exist
+    if cert_auth.RHSM_CONFIG is None:
+        return None
+
+    try:
+        cert = cert_auth.rhsmCertificate.read()  # type: cert_auth.rhsmCertificate
+        subscription_manager_uuid = cert.getConsumerId()  # type: str
+    except Exception:
+        return None
+
+    logger.debug("Found subscription-manager UUID in '%s/%s'.", cert.PATH, cert.CERT)
+    return subscription_manager_uuid
+
+
+def generate_machine_id(new=False, destination_file=constants.machine_id_file):
+    """Generate a machine-id if /etc/insights-client/machine-id does not exist.
+
+    :param new: Force generate a new ID.
+    :type new: bool
+    :param destination_file: Path to the file the ID should be written to.
+    :type destination_file: str
+
+    :returns: The machine ID
+    :rtype: str
     """
-    machine_id = None
-    machine_id_file = None
-    logging_name = 'machine-id'
+    machine_id = None  # type: str | None
 
     if os.path.isfile(destination_file) and not new:
-        logger.debug('Found %s', destination_file)
-        with open(destination_file, 'r') as machine_id_file:
-            machine_id = machine_id_file.read()
-    else:
-        logger.debug('Could not find %s file, creating', logging_name)
+        with open(destination_file, "r") as f:
+            machine_id = f.read()
+        logger.debug("Using existing machine-id: '%s'." % machine_id)
+
+    if not machine_id:
+        machine_id = _get_rhsm_identity()
+        if machine_id:
+            logger.debug("Using subscription-manager identity as machine-id: '%s'." % machine_id)
+            write_to_disk(destination_file, content=machine_id)
+
+    if not machine_id:
         machine_id = str(uuid.uuid4())
-        logger.debug("Creating %s", destination_file)
+        logger.debug("Creating fresh machine-id: '%s'." % machine_id)
         write_to_disk(destination_file, content=machine_id)
     try:
+        # Old versions (redhat-access-insights) could save the UUID without hyphens,
+        # and that could mess up Inventory via e.g. `insights-client --check-results`.
+        # See RHBZ#1998560 for more details.
         return str(uuid.UUID(str(machine_id).strip(), version=4))
-    except ValueError as e:
-        logger.error("Invalid machine ID: %s", machine_id)
-        logger.error("Error details: %s", str(e))
-        logger.error("Remove %s and a new one will be generated.\nRerun the client with --register", destination_file)
+    except ValueError as exc:
+        logger.error("Invalid machine ID: '%s'." % machine_id)
+        logger.error("Error details: %s", str(exc))
+        logger.error("Please delete the file '%s' and rerun the client with '--register'." % destination_file)
         sys.exit(constants.sig_kill_bad)
 
 

--- a/insights/tests/client/test_utilities.py
+++ b/insights/tests/client/test_utilities.py
@@ -5,6 +5,7 @@ import tarfile
 import tempfile
 import uuid
 import insights.client.utilities as util
+import insights.client.cert_auth
 from insights.client.constants import InsightsConstants as constants
 import re
 import mock
@@ -76,12 +77,12 @@ def test_write_to_disk_with_broken_path():
     os.remove(filename)
 
 
-def test_get_machine_id():
-    """
-    Test get machine_id with generate_machine_id method, if the machine-id file exists
-    """
-    machine_id_regex = re.match('\w{8}-\w{4}-\w{4}-\w{4}-\w{12}',
-                                util.generate_machine_id(destination_file='/tmp/testmachineid'))
+@patch("insights.client.utilities._get_rhsm_identity", lambda: None)
+def test_generate_machine_id_with_no_subman():
+    machine_id_regex = re.match(
+        '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}',
+        util.generate_machine_id(destination_file='/tmp/testmachineid')
+    )
     assert machine_id_regex.group(0) is not None
     with open('/tmp/testmachineid', 'r') as _file:
         machine_id = _file.read()
@@ -89,7 +90,32 @@ def test_get_machine_id():
     os.remove('/tmp/testmachineid')
 
 
-def test_get_machineid_with_non_hyphen_id():
+@pytest.mark.skipif(insights.client.cert_auth.RHSM_CONFIG is None, reason="RHSM config is not available")
+@patch("insights.client.utilities.os.path.isfile", lambda _: True)
+@patch("insights.client.cert_auth.rhsmCertificate")
+@patch("insights.client.utilities.cert_auth.RHSM_CONFIG")
+def test__get_rhsm_identity(mock_config, mock_rhsm_cert):
+    mock_config.return_value = "non-None-value"
+
+    cert = mock.MagicMock()
+    cert.CERT = "cert.pem"
+    cert.getConsumerId.return_value = machine_id
+    mock_rhsm_cert.read.return_value = cert
+
+    assert machine_id == util._get_rhsm_identity()
+
+
+@patch("insights.client.utilities._get_rhsm_identity", lambda: machine_id)
+def test_generate_machine_id_with_subman():
+    """Use sub-man's identity certificate for generating new machine-id."""
+    machine_id_file = "/tmp/test-machine-id"
+    read_uuid = util.generate_machine_id(destination_file=machine_id_file)
+    os.remove(machine_id_file)
+
+    assert machine_id == read_uuid
+
+
+def test_generate_machine_id_with_non_hyphen_id():
     content = '86f6f5fad8284730b708a2e44ba5c14a'
     filename = '/tmp/testmachineid'
     util.write_to_disk(filename, content=content)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: CCT-161

insights-client sometimes incorrectly regenerates identity while it shouldn't. Because the machine-id file is created preemptively, instead of at registration time (and deleted if the registration fails or Inventory returns error status signaling the system has been deleted in there), this is the easiest way to ensure the UUID will stay semi-stable.

subscription-manager already provides a stable way to identify a system. To ensure external tooling doesn't get confused, we should try to keep them consistent.
