### PR TITLE
refactor: avoid passing duplicated mainfest to insights.collect()

### DIFF
--- a/insights/client/core_collector.py
+++ b/insights/client/core_collector.py
@@ -30,21 +30,14 @@ class CoreCollector(DataCollector):
         self.archive.create_archive_dir()
 
         logger.debug('Beginning to run core collection ...')
-        manifest = collect.default_manifest
-        if hasattr(self.config, 'manifest') and self.config.manifest:
-            if self.config.app is None:
-                with open(self.config.manifest, 'r') as f:
-                    manifest = f.read()
-            else:
-                manifest = self.config.manifest
 
         collect.collect(
-            manifest=manifest,
             tmp_path=self.archive.tmp_dir,
             archive_name=self.archive.archive_name,
             rm_conf=rm_conf or {},
             client_config=self.config,
         )
+
         logger.debug('Core collection finished.')
 
         # collect metadata

--- a/insights/collect.py
+++ b/insights/collect.py
@@ -281,7 +281,11 @@ def load_manifest(data):
     """ Helper for loading a manifest yaml doc. """
     if isinstance(data, dict):
         return data
-    doc = yaml.safe_load(data)
+    if os.path.isfile(data):
+        with open(data, 'r') as f:
+            doc = yaml.safe_load(f)
+    else:
+        doc = yaml.safe_load(data)
     if not isinstance(doc, dict):
         raise Exception("Manifest didn't result in dict.")
     return doc
@@ -411,7 +415,7 @@ def collect(client_config=None, rm_conf=None, tmp_path=None, archive_name=None,
 
     Args:
         client_config (InsightsConfig): Configurations read from insights-client
-            configuration, including "mainfest".
+            configuration, including "manifest".
         rm_conf (dict): Client-provided python dict containing keys
             "commands", "files", and "keywords", to be injected
             into the manifest blacklist.

--- a/insights/collect.py
+++ b/insights/collect.py
@@ -403,15 +403,18 @@ def generate_archive_name():
     return "insights-%s-%s" % (hostname, suffix)
 
 
-def collect(manifest=default_manifest, tmp_path=None, archive_name=None,
-            compress=False, rm_conf=None, client_config=None):
+def collect(client_config=None, rm_conf=None, tmp_path=None, archive_name=None,
+            compress=False):
     """
     This is the collection entry point. It accepts a manifest, a temporary
     directory in which to store output, and a boolean for optional compression.
 
     Args:
-        manifest (str or dict): json document or dictionary containing the
-            collection manifest. See default_manifest for an example.
+        client_config (InsightsConfig): Configurations read from insights-client
+            configuration, including "mainfest".
+        rm_conf (dict): Client-provided python dict containing keys
+            "commands", "files", and "keywords", to be injected
+            into the manifest blacklist.
         tmp_path (str): The temporary directory that is used to create a
             working directory for storing the final tar.gz if one is generated.
         archive_name (str): The directory that is used to generate the output
@@ -419,10 +422,6 @@ def collect(manifest=default_manifest, tmp_path=None, archive_name=None,
         compress (boolean): True to create a tar.gz and remove the original
             workspace containing output. False to leave the workspace without
             creating a tar.gz
-        rm_conf (dict): Client-provided python dict containing keys
-            "commands", "files", and "keywords", to be injected
-            into the manifest blacklist.
-        client_config (InsightsConfig): Configurations read by the client tool.
 
     Returns:
         (str, dict): The full path to the created tar.gz or workspace.
@@ -430,8 +429,12 @@ def collect(manifest=default_manifest, tmp_path=None, archive_name=None,
         core collection, this dictionary has the following structure:
         ``{ exception_type: [ (exception_obj, component), (exception_obj, component) ]}``.
     """
-
+    # Get the manifest from client configuration
+    manifest = default_manifest
+    if hasattr(client_config, 'manifest') and client_config.manifest:
+        manifest = client_config.manifest
     manifest = load_manifest(manifest)
+
     client = manifest.get("client", {})
     plugins = manifest.get("plugins", {})
 

--- a/insights/tests/test_collect.py
+++ b/insights/tests/test_collect.py
@@ -1,6 +1,13 @@
+import os
+import tempfile
+import yaml
+
 from mock.mock import Mock
 
-from insights.collect import _parse_broker_exceptions
+from insights.collect import (
+        load_manifest,
+        default_manifest,
+        _parse_broker_exceptions)
 from insights.core.dr import Broker
 from insights.core.exceptions import ContentException
 
@@ -37,3 +44,21 @@ def test_parse_broker_exceptions_oserror_contentexception():
     assert ContentException not in errors.keys()
     assert len(errors[OSError]) == 1
     assert all(type(ex) is OSError for ex, comp in errors[OSError])
+
+
+def test_load_manifest():
+    # dict
+    data = yaml.safe_load(default_manifest)
+    ret = load_manifest(data)
+    assert ret == data
+    # string
+    ret = load_manifest(default_manifest)
+    assert ret == data
+    # file
+    tmpfile = tempfile.NamedTemporaryFile(prefix='tmp_', suffix='_manifest_rhin', delete=False)
+    tmpfile.close()
+    with open(tmpfile.name, 'w') as fd:
+        fd.write(default_manifest)
+    ret = load_manifest(tmpfile.name)
+    assert ret == data
+    os.remove(tmpfile.name)

--- a/insights/tests/test_specs_save_as.py
+++ b/insights/tests/test_specs_save_as.py
@@ -171,11 +171,12 @@ def test_specs_save_as_collect(obfuscate):
     for pkg in manifest.get("plugins", {}).get("packages", []):
         dr.load_components(pkg, exclude=None)
 
-    conf = InsightsConfig(obfuscate=obfuscate, obfuscate_hostname=obfuscate)
+    conf = InsightsConfig(
+            obfuscate=obfuscate, obfuscate_hostname=obfuscate,
+            manifest=specs_save_as_manifest)
     arch = InsightsArchive(conf)
     arch.create_archive_dir()
     output_path, errors = collect.collect(
-            manifest=specs_save_as_manifest,
             tmp_path=arch.tmp_dir,
             archive_name=arch.archive_name,
             client_config=conf)


### PR DESCRIPTION
- the "client_config" (InsightsConfig) already contains the
  manifest read from the client tool, this change removes it
  from the argument list of insights.collect() and simplify
  the code

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

