### PR TITLE
fix: support commands/files in file-redaction.yaml per manual

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -300,7 +300,13 @@ def apply_blacklist(cfg):
         log.warning('WARNING: Skipping component: %s' % component)
 
     def _check_and_skip_component(name):
-        if '/' in name or ' ' in name:
+        def _isidentifier(name):
+            if hasattr(str, 'isidentifier'):
+                return name.isidentifier()
+            else:
+                return not any(it in name for it in ('/', ' ', '.', '-'))
+
+        if not _isidentifier(name):
             # not symbolic name
             return False
         # like a symbolic name
@@ -312,13 +318,13 @@ def apply_blacklist(cfg):
         # not symbolic name
         return False
 
-    for b in cfg.get("files", []):
-        if not _check_and_skip_component(b):
-            blacklist.add_file('^' + b + '$')
+    for fil in cfg.get("files", []):
+        if not _check_and_skip_component(fil):
+            blacklist.add_file(fil)
 
-    for b in cfg.get("commands", []):
-        if not _check_and_skip_component(b):
-            blacklist.add_command('^' + b + '$')
+    for cmd in cfg.get("commands", []):
+        if not _check_and_skip_component(cmd):
+            blacklist.add_command(cmd)
 
     for component in cfg.get('components', []):
         if not dr.get_component_by_name(component):
@@ -328,13 +334,9 @@ def apply_blacklist(cfg):
 
     if cfg.get('patterns'):
         log.warning("WARNING: Excluding patterns defined in blacklist configuration")
-        for b in cfg.get("patterns"):
-            blacklist.add_pattern(b)
 
     if cfg.get('keywords'):
         log.warning("WARNING: Replacing keywords defined in blacklist configuration")
-        for b in cfg.get("keywords"):
-            blacklist.add_keyword(b)
 
 
 def create_context(ctx):

--- a/insights/core/blacklist.py
+++ b/insights/core/blacklist.py
@@ -1,6 +1,3 @@
-import re
-
-
 BLACKLISTED_SPECS = []
 _FILE_FILTERS = set()
 _COMMAND_FILTERS = set()
@@ -9,11 +6,11 @@ _KEYWORD_FILTERS = set()
 
 
 def add_file(f):
-    _FILE_FILTERS.add(re.compile(f))
+    _FILE_FILTERS.add(f)
 
 
 def add_command(f):
-    _COMMAND_FILTERS.add(re.compile(f))
+    _COMMAND_FILTERS.add(f)
 
 
 def add_pattern(f):
@@ -25,11 +22,13 @@ def add_keyword(f):
 
 
 def allow_file(c):
-    return not any(f.match(c) for f in _FILE_FILTERS)
+    cl = len(c)
+    return not any(c.startswith(f) and (cl == len(f) or c[len(f)] == ' ') for f in _FILE_FILTERS)
 
 
 def allow_command(c):
-    return not any(f.match(c) for f in _COMMAND_FILTERS)
+    cl = len(c)
+    return not any(c.startswith(f) and (cl == len(f) or c[len(f)] == ' ') for f in _COMMAND_FILTERS)
 
 
 def get_disallowed_patterns():

--- a/insights/tests/test_collect_apply_blacklist.py
+++ b/insights/tests/test_collect_apply_blacklist.py
@@ -19,9 +19,9 @@ def test_apply_blacklist_valid(_log):
                 "/bin/df -alP -x autofs",
                 "/bin/ps aux",
                 # foreach_execute
-                "/bin/du -s -k ().*",
+                "/bin/du -s -k",
                 # command_with_args
-                "/usr/bin/getent group ().*",
+                "/usr/bin/getent group",
                 # spec name
                 "installed_rpms",  # will be converted to component
             ],
@@ -31,10 +31,8 @@ def test_apply_blacklist_valid(_log):
                 "/var/log/messages",
                 # first_file
                 "/proc/meminfo",
-                # foreach_collect
-                "/proc/().*/limits",
                 # glob_file
-                "/boot/config-().*",
+                "/boot/config-",
                 # spec name
                 "container_installed_rpms",  # will be converted to component
             ],
@@ -59,14 +57,20 @@ def test_apply_blacklist_valid(_log):
     # files
     check_files = rm_conf['files'][:-1]
     for fil in check_files:
-        fil = fil.replace('().*', 'abcd')
         assert blacklist.allow_file(fil) is False
+        _file = fil + ' abc'
+        assert blacklist.allow_file(_file) is False
+        _file = fil + 'abc'
+        assert blacklist.allow_file(_file) is True
 
     # commonds
     check_commands = rm_conf['commands'][:-1]
     for cmd in check_commands:
-        cmd = cmd.replace('().*', 'abcd')
         assert blacklist.allow_command(cmd) is False
+        _cmd = cmd + ' abc'
+        assert blacklist.allow_command(_cmd) is False
+        _cmd = cmd + 'abc'
+        assert blacklist.allow_command(_cmd) is True
 
 
 @patch('insights.collect.log.warning')


### PR DESCRIPTION
- see RHINENG-8898
- and do not support regex for commands/files anymore

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
- Per the manual, in file redaction, the "commands" and "files" do not support regex match, this feature is also removed from this change.
