### PR TITLE
feat: collect specs in order based on given priority

### DIFF
--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -83,6 +83,7 @@ class datasource(PluginType):
     multi_output = False
     no_obfuscate = []
     no_redact = False
+    prio = 0
     raw = False
 
     def _handle_timeout(self, signum, frame):

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -486,17 +486,18 @@ class RegistryPoint(object):
     #
     # intentionally not a docstring so this doesn't show up in pydoc.
     def __init__(self, metadata=None, multi_output=False, raw=False,
-                 filterable=False, no_obfuscate=None, no_redact=False):
+                 filterable=False, no_obfuscate=None, no_redact=False, prio=0):
         self.metadata = metadata
         self.multi_output = multi_output
         self.no_obfuscate = [] if no_obfuscate is None else no_obfuscate
         self.no_redact = no_redact
+        self.prio = prio
         self.raw = raw
         self.filterable = filterable
         self.__name__ = self.__class__.__name__
         datasource([], metadata=metadata, multi_output=multi_output, raw=raw,
                    filterable=filterable, no_obfuscate=self.no_obfuscate,
-                   no_redact=no_redact)(self)
+                   no_redact=no_redact, prio=prio)(self)
 
     def __call__(self, broker):
         for c in reversed(dr.get_delegate(self).deps):
@@ -584,6 +585,7 @@ def _resolve_registry_points(cls, base, dct):
                 v.multi_output = delegate.multi_output = point.multi_output
                 v.no_obfuscate = delegate.no_obfuscate = point.no_obfuscate
                 v.no_redact = delegate.no_redact = point.no_redact
+                v.prio = delegate.prio = point.prio
 
                 # the RegistryPoint gets the implementation datasource as a
                 # dependency

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -4,8 +4,8 @@ from insights.core.spec_factory import SpecSet, RegistryPoint
 class Specs(SpecSet):
     # Client metadata specs/files
     ansible_host = RegistryPoint(no_obfuscate=['hostname', 'ip'])
-    blacklist_report = RegistryPoint()
-    blacklisted_specs = RegistryPoint(no_obfuscate=['hostname', 'ip'])
+    blacklist_report = RegistryPoint(prio=-1)
+    blacklisted_specs = RegistryPoint(no_obfuscate=['hostname', 'ip'], prio=-1)
     branch_info = RegistryPoint()  # https://issues.redhat.com/browse/RHIN-639
     display_name = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     egg_release = RegistryPoint()


### PR DESCRIPTION
- see RHINENG-6943 and RHINENG-6999
  the priority of specs can be set via the new "prio" option
  to the specs' RegistryPoint.  Integer is allowed, bigger
  value gets higher priority, and 0 is default and for no priority.
- and set the blacklist relevant specs to the lowest priority

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
