### PR TITLE
fix: Allow running setup.py from non-current directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
         name=name,
         version=package_info["VERSION"],
         description="Insights Core is a data collection and analysis framework",
-        long_description=open("README.rst").read(),
+        long_description=open(os.path.join(__here__, "README.rst")).read(),
         url="https://github.com/redhatinsights/insights-core",
         author="Red Hat, Inc.",
         author_email="insights@redhat.com",


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

When following the egg build steps from a directory that is not the root
of the repository, this step fails because the README is looked up by a
relative path.