### PR TITLE
feat: extend Specs.ps_eo_cmd to deprecate Specs.ps_eo

### DIFF
--- a/insights/combiners/ps.py
+++ b/insights/combiners/ps.py
@@ -4,7 +4,6 @@ PS
 
 This combiner provides information about running processes based on the ``ps`` command.
 More specifically this consolidates data from
-:py:class:`insights.parsers.ps.PsEo`,
 :py:class:`insights.parsers.ps.PsAuxcww`,
 :py:class:`insights.parsers.ps.PsEoCmd`,
 :py:class:`insights.parsers.ps.PsEf`,
@@ -55,10 +54,10 @@ Examples:
 
 from insights.core.plugins import combiner
 from insights.parsers import keyword_search
-from insights.parsers.ps import PsAlxwww, PsAuxww, PsAux, PsAuxcww, PsEo, PsEf, PsEoCmd
+from insights.parsers.ps import PsAlxwww, PsAuxww, PsAux, PsAuxcww, PsEf, PsEoCmd
 
 
-@combiner([PsAlxwww, PsAuxww, PsAux, PsEf, PsAuxcww, PsEo, PsEoCmd])
+@combiner([PsAlxwww, PsAuxww, PsAux, PsEf, PsAuxcww, PsEoCmd])
 class Ps(object):
     """
     ``Ps`` combiner consolidates data from the parsers in ``insights.parsers.ps`` module.
@@ -100,12 +99,10 @@ class Ps(object):
         'WCHAN': None
     }
 
-    def __init__(self, ps_alxwww, ps_auxww, ps_aux, ps_ef, ps_auxcww, ps_eo, ps_eo_cmd):
+    def __init__(self, ps_alxwww, ps_auxww, ps_aux, ps_ef, ps_auxcww, ps_eo_cmd):
         self._pid_data = {}
 
         # order of parsers is important here
-        # if ps_eo:
-        #     self.__update_data(ps_eo)
         if ps_auxcww:
             self.__update_data(ps_auxcww)
         if ps_eo_cmd:

--- a/insights/combiners/ps.py
+++ b/insights/combiners/ps.py
@@ -47,7 +47,8 @@ Examples:
     ... 'F': '1',
     ... 'PRI': 20,
     ... 'NI': '0',
-    ... 'WCHAN': 'kthrea'
+    ... 'WCHAN': 'kthrea',
+    ... 'NLWP': '1'
     ... }
     True
 """
@@ -95,6 +96,7 @@ class Ps(object):
         'F': None,
         'PRI': None,
         'NI': None,
+        'NLWP': None,
         'WCHAN': None
     }
 
@@ -102,8 +104,8 @@ class Ps(object):
         self._pid_data = {}
 
         # order of parsers is important here
-        if ps_eo:
-            self.__update_data(ps_eo)
+        # if ps_eo:
+        #     self.__update_data(ps_eo)
         if ps_auxcww:
             self.__update_data(ps_auxcww)
         if ps_eo_cmd:
@@ -180,14 +182,14 @@ class Ps(object):
             ... {'PID': 9, 'USER': 'root', 'UID': 0, 'PPID': 2, '%CPU': 0.1, '%MEM': 0.0,
             ...  'VSZ': 0.0, 'RSS': 0.0, 'TTY': '?', 'STAT': 'S', 'START': '2019', 'TIME': '0:00',
             ...  'COMMAND': '[rcu_bh]', 'COMMAND_NAME': '[rcu_bh]', 'ARGS': '', 'F': '1', 'PRI': 20,
-            ...  'NI': '0', 'WCHAN': 'rcu_gp'}
+            ...  'NI': '0', 'WCHAN': 'rcu_gp', 'NLWP': '1'}
             ... ]
             True
             >>> ps_combiner.search(USER='root', COMMAND='[kthreadd]') == [
             ... {'PID': 2, 'USER': 'root', 'UID': 0, 'PPID': 0, '%CPU': 0.0, '%MEM': 0.0,
             ...  'VSZ': 0.0, 'RSS': 0.0, 'TTY': '?', 'STAT': 'S', 'START': '2019', 'TIME': '1:04',
             ...  'COMMAND': '[kthreadd]', 'COMMAND_NAME': '[kthreadd]', 'ARGS': '', 'F': '1', 'PRI': 20,
-            ...  'NI': '0', 'WCHAN': 'kthrea'}
+            ...  'NI': '0', 'WCHAN': 'kthrea', 'NLWP': '1'}
             ... ]
             True
         """

--- a/insights/parsers/ps.py
+++ b/insights/parsers/ps.py
@@ -10,6 +10,7 @@ from insights.core.filters import add_filter
 from insights.core.plugins import parser
 from insights.parsers import keyword_search, parse_delimited_table
 from insights.specs import Specs
+from insights.util import deprecated
 
 
 def are_present(tags, line):
@@ -393,6 +394,10 @@ class ContainerPsAux(ContainerParser, PsAuxww):
 @parser(Specs.ps_eo)
 class PsEo(Ps):
     """
+    .. warning::
+        This class is deprecated and will be removed from 3.6.0.
+        Please use the :class:`insights.parsers.ps.PsEoCmd` instead.
+
     Class to parse the command `ps -eo pid,ppid,comm,nlwp`
 
     Sample input data::
@@ -430,6 +435,10 @@ class PsEo(Ps):
     command_name = 'COMMAND'
     user_name = 'PID'
     max_splits = 3
+
+    def __init__(self, *args, **kwargs):
+        deprecated(PsEo, "Please use the :class:`insights.parsers.ps.PsEoCmd` instead.", "3.6.0")
+        super(PsEo, self).__init__(*args, **kwargs)
 
     def children(self, ppid):
         """list: Returns a list of dict for all rows with `ppid` as parent PID"""

--- a/insights/parsers/ps.py
+++ b/insights/parsers/ps.py
@@ -483,25 +483,25 @@ class PsAlxwww(Ps):
 @parser(Specs.ps_eo_cmd)
 class PsEoCmd(Ps):
     """
-    Class to parse the command `ps -eo pid,args` where the
+    Class to parse the command `ps -ewwo pid,ppid,nlwp,args` where the
     datasource `ps_eo_cmd` trims off all args leaving only the full
     path to the command.
 
-    Sample output from the ``ps -eo pid, args`` command::
+    Sample output from the ``ps -ewwo pid,ppid,nlwp,args`` command::
 
-        PID COMMAND
-          1 /usr/lib/systemd/systemd --switched-root --system --deserialize 31
-          2 [kthreadd]
-         11 /usr/bin/python3 /home/user1/pythonapp.py
-         12 [kworker/u16:0-kcryptd/253:0]
+        PID  PPID NLWP COMMAND
+          1     0    1 /usr/lib/systemd/systemd --switched-root --system --deserialize 31
+          2     0    1 [kthreadd]
+         11     2    1 /usr/bin/python3 /home/user1/python_app.py
+         12     2    1 [kworker/u16:0-kcryptd/253:0]
 
     Sample data after trimming by the datasource::
 
-        PID COMMAND
-          1 /usr/lib/systemd/systemd
-          2 [kthreadd]
-         11 /usr/bin/python3
-         12 [kworker/u16:0-kcryptd/253:0]
+        PID  PPID NLWP COMMAND
+          1     0    1 /usr/lib/systemd/systemd
+          2     0    1 [kthreadd]
+         11     2    1 /usr/bin/python3
+         12     2    1 [kworker/u16:0-kcryptd/253:0]
 
     Examples:
         >>> type(ps_eo_cmd)
@@ -509,10 +509,15 @@ class PsEoCmd(Ps):
         >>> ps_eo_cmd.running_pids() == ['1', '2', '11', '12']
         True
         >>> ps_eo_cmd.search(COMMAND__contains='python3') == [
-        ...     {'PID': '11', 'COMMAND': '/usr/bin/python3', 'COMMAND_NAME': 'python3', 'ARGS': ''}
+        ...     {'PID': '11', 'PPID': '2', 'NLWP': '1', 'COMMAND': '/usr/bin/python3',
+        ...      'COMMAND_NAME': 'python3', 'ARGS': ''}
         ... ]
         True
     """
     command_name = 'COMMAND'
     user_name = 'PID'
-    max_splits = 1
+    max_splits = 3
+
+    def children(self, ppid):
+        """list: Returns a list of dict for all rows with `ppid` as parent PID"""
+        return [row for row in self.data if row['PPID'] == ppid]

--- a/insights/tests/combiners/test_ps.py
+++ b/insights/tests/combiners/test_ps.py
@@ -4,16 +4,6 @@ from insights.parsers.ps import PsAlxwww, PsAuxww, PsAux, PsAuxcww, PsEf, PsEoCm
 from insights.tests import context_wrap
 import doctest
 
-PS_EO_LINES = """
-  PID  PPID COMMAND
-    1     0 systemd
-    2     0 kthreadd
-    3     2 ksoftirqd/0
-    8     2 migration/0
-    9     2 rcu_bh
-    10    2 rcu_sched
- """
-
 PS_EO_CMD_LINES = """
   PID  PPID NLWP COMMAND
     1     0    1 /usr/lib/systemd/systemd

--- a/insights/tests/combiners/test_ps.py
+++ b/insights/tests/combiners/test_ps.py
@@ -3,6 +3,7 @@ from insights.combiners.ps import Ps
 from insights.parsers.ps import PsAlxwww, PsAuxww, PsAux, PsAuxcww, PsEo, PsEf, PsEoCmd
 from insights.tests import context_wrap
 import doctest
+from pprint import pprint
 
 
 PS_EO_LINES = """
@@ -16,14 +17,14 @@ PS_EO_LINES = """
  """
 
 PS_EO_CMD_LINES = """
-  PID  COMMAND
-    1  /usr/lib/systemd/systemd
-    2  [kthreadd]
-    3  [ksoftirqd/0]
-    8  [migration/0]
-    9  [rcu_bh]
-   10  [rcu_sched]
-   13  /usr/bin/python3.6
+  PID  PPID NLWP COMMAND
+    1     0    1 /usr/lib/systemd/systemd
+    2     0    1 [kthreadd]
+    3     2    1 [ksoftirqd/0]
+    8     2    1 [migration/0]
+    9     2    1 [rcu_bh]
+   10     2    1 [rcu_sched]
+   13     2    1 /usr/bin/python3.6
  """
 
 PS_AUXCWW_LINES = """
@@ -86,23 +87,42 @@ root           -  0.0    -      -     - -        I<   09:56   0:00 -
 """
 
 
-def test_pseo_parser():
-    ps_eo = PsEo(context_wrap(PS_EO_LINES, strip=False))
-    ps = Ps(None, None, None, None, None, ps_eo, None)
-    assert len(ps.processes) == 6
-    proc = ps[1]
-    assert proc['USER'] is None
-    assert proc['TTY'] is None
-    assert proc['%CPU'] is None
-    assert proc['%MEM'] is None
-    assert proc['COMMAND'] == proc['COMMAND_NAME']
+# def test_pseo_parser():
+#     ps_eo = PsEo(context_wrap(PS_EO_LINES, strip=False))
+#     ps = Ps(None, None, None, None, None, ps_eo, None)
+#     assert len(ps.processes) == 6
+#     proc = ps[1]
+#     assert proc['USER'] is None
+#     assert proc['TTY'] is None
+#     assert proc['%CPU'] is None
+#     assert proc['%MEM'] is None
+#     assert proc['COMMAND'] == proc['COMMAND_NAME']
 
 
-def test_pseo_and_psauxcww_parsers():
-    ps_eo = PsEo(context_wrap(PS_EO_LINES, strip=False))
+# def test_pseo_and_psauxcww_parsers():
+#     ps_eo = PsEo(context_wrap(PS_EO_LINES, strip=False))
+#     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_LINES))
+#     ps = Ps(None, None, None, None, ps_auxcww, ps_eo, None)
+#     assert len(ps.processes) == 7
+#     proc9 = ps[9]
+#     assert proc9['USER'] == 'root'
+#     assert proc9['TTY'] == '?'
+#     assert proc9['%CPU'] == 0.1
+#     assert proc9['%MEM'] == 0.0
+#     assert proc9['COMMAND'] == proc9['COMMAND_NAME']
+#     proc10 = ps[10]
+#     assert proc10['USER'] is None
+#     assert proc10['TTY'] is None
+#     assert proc10['%CPU'] is None
+#     assert proc10['%MEM'] is None
+#     assert proc10['COMMAND'] == proc10['COMMAND_NAME']
+
+
+def test_pseocmd_and_psauxcww_parsers():
+    ps_eo_cmd = PsEoCmd(context_wrap(PS_EO_CMD_LINES, strip=False))
     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_LINES))
-    ps = Ps(None, None, None, None, ps_auxcww, ps_eo, None)
-    assert len(ps.processes) == 7
+    ps = Ps(None, None, None, None, ps_auxcww, None, ps_eo_cmd)
+    assert len(ps.processes) == 8
     proc9 = ps[9]
     assert proc9['USER'] == 'root'
     assert proc9['TTY'] == '?'
@@ -242,6 +262,8 @@ def test_psalxwww_and_psauxww_and_psaux_and_psef_and_psauxcww_and_ps_eo_parsers(
     assert ps['PRI'] == 20
     assert ps['NI'] == '0'
     assert ps['WCHAN'] == 'ep_pol'
+    assert ps['NLWP'] is None
+
 
 
 def test_type_conversion():
@@ -286,7 +308,8 @@ def test_combiner_api():
                      'UID': None,
                      'USER': 'root',
                      'VSZ': 195712.0,
-                     'WCHAN': None}
+                     'WCHAN': None,
+                     'NLWP': None,}
     assert ps[1000] is None
     assert [proc for proc in ps]
 
@@ -357,5 +380,41 @@ def test_psalxwww_and_psauxww_and_psaux_and_psef_and_psauxcww_and_ps_eo_cmd_pars
     assert ps['PRI'] == 20
     assert ps['NI'] == '0'
     assert ps['WCHAN'] == 'ep_pol'
+    assert ps['NLWP'] == '1'
+
+    assert ps_combiner[13]['COMMAND'] == '/usr/bin/python3.6'
+
+
+def test_ps_all_parsers_combiner():
+    ps_alxwww = PsAlxwww(context_wrap(PS_ALXWWW_LINES))
+    ps_auxww = PsAuxww(context_wrap(PS_AUXWW_LINES))
+    ps_aux = PsAux(context_wrap(PS_AUX_LINES))
+    ps_ef = PsEf(context_wrap(PS_EF_LINES))
+    ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_LINES))
+    ps_eo = PsEo(context_wrap(PS_EO_LINES, strip=False))
+    ps_eo_cmd = PsEoCmd(context_wrap(PS_EO_CMD_LINES, strip=False))
+    ps_combiner = Ps(ps_alxwww, ps_auxww, ps_aux, ps_ef, ps_auxcww, ps_eo, ps_eo_cmd)
+    len(ps_combiner.processes) == 9
+    ps = ps_combiner[1]
+    pprint(ps)
+    assert ps['PID'] == 1
+    assert ps['USER'] == 'root'
+    assert ps['UID'] == 0
+    assert ps['PPID'] == 0
+    assert ps['%CPU'] == 0.1
+    assert ps['%MEM'] == 0.0
+    assert ps['VSZ'] == 195712.0
+    assert ps['RSS'] == 7756.0
+    assert ps['STAT'] == 'Ss'
+    assert ps['TTY'] == '?'
+    assert ps['START'] == '2019'
+    assert ps['TIME'] == '478:05'
+    assert ps['COMMAND'] == '/usr/lib/systemd/systemd --switched-root --system --deserialize 21'
+    assert ps['COMMAND_NAME'] == 'systemd'
+    assert ps['F'] == '4'
+    assert ps['PRI'] == 20
+    assert ps['NI'] == '0'
+    assert ps['WCHAN'] == 'ep_pol'
+    assert ps['NLWP'] == '1'
 
     assert ps_combiner[13]['COMMAND'] == '/usr/bin/python3.6'

--- a/insights/tests/combiners/test_ps.py
+++ b/insights/tests/combiners/test_ps.py
@@ -1,10 +1,8 @@
 from insights.combiners import ps
 from insights.combiners.ps import Ps
-from insights.parsers.ps import PsAlxwww, PsAuxww, PsAux, PsAuxcww, PsEo, PsEf, PsEoCmd
+from insights.parsers.ps import PsAlxwww, PsAuxww, PsAux, PsAuxcww, PsEf, PsEoCmd
 from insights.tests import context_wrap
 import doctest
-from pprint import pprint
-
 
 PS_EO_LINES = """
   PID  PPID COMMAND
@@ -87,41 +85,37 @@ root           -  0.0    -      -     - -        I<   09:56   0:00 -
 """
 
 
-# def test_pseo_parser():
-#     ps_eo = PsEo(context_wrap(PS_EO_LINES, strip=False))
-#     ps = Ps(None, None, None, None, None, ps_eo, None)
-#     assert len(ps.processes) == 6
-#     proc = ps[1]
-#     assert proc['USER'] is None
-#     assert proc['TTY'] is None
-#     assert proc['%CPU'] is None
-#     assert proc['%MEM'] is None
-#     assert proc['COMMAND'] == proc['COMMAND_NAME']
-
-
-# def test_pseo_and_psauxcww_parsers():
-#     ps_eo = PsEo(context_wrap(PS_EO_LINES, strip=False))
-#     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_LINES))
-#     ps = Ps(None, None, None, None, ps_auxcww, ps_eo, None)
-#     assert len(ps.processes) == 7
-#     proc9 = ps[9]
-#     assert proc9['USER'] == 'root'
-#     assert proc9['TTY'] == '?'
-#     assert proc9['%CPU'] == 0.1
-#     assert proc9['%MEM'] == 0.0
-#     assert proc9['COMMAND'] == proc9['COMMAND_NAME']
-#     proc10 = ps[10]
-#     assert proc10['USER'] is None
-#     assert proc10['TTY'] is None
-#     assert proc10['%CPU'] is None
-#     assert proc10['%MEM'] is None
-#     assert proc10['COMMAND'] == proc10['COMMAND_NAME']
-
-
-def test_pseocmd_and_psauxcww_parsers():
-    ps_eo_cmd = PsEoCmd(context_wrap(PS_EO_CMD_LINES, strip=False))
+def test_psauxcww_parser():
     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_LINES))
-    ps = Ps(None, None, None, None, ps_auxcww, None, ps_eo_cmd)
+    ps = Ps(None, None, None, None, ps_auxcww, None)
+    assert len(ps.processes) == 6
+    proc9 = ps[9]
+    assert proc9['USER'] == 'root'
+    assert proc9['TTY'] == '?'
+    assert proc9['%CPU'] == 0.1
+    assert proc9['%MEM'] == 0.0
+    assert proc9['COMMAND'] == proc9['COMMAND_NAME']
+
+
+def test_pseocmd_parser():
+    ps_eo_cmd = PsEoCmd(context_wrap(PS_EO_CMD_LINES, strip=False))
+    ps = Ps(None, None, None, None, None, ps_eo_cmd)
+    assert len(ps.processes) == 7
+    proc = ps[1]
+    assert proc['USER'] is None
+    assert proc['TTY'] is None
+    assert proc['%CPU'] is None
+    assert proc['%MEM'] is None
+    assert proc['COMMAND'] == '/usr/lib/systemd/systemd'
+    assert proc['COMMAND_NAME'] == 'systemd'
+    assert proc['PPID'] == 0
+    assert proc['NLWP'] == '1'
+
+
+def test_psauxcww_and_pseocmd_parsers():
+    ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_LINES))
+    ps_eo_cmd = PsEoCmd(context_wrap(PS_EO_CMD_LINES, strip=False))
+    ps = Ps(None, None, None, None, ps_auxcww, ps_eo_cmd)
     assert len(ps.processes) == 8
     proc9 = ps[9]
     assert proc9['USER'] == 'root'
@@ -139,7 +133,7 @@ def test_pseocmd_and_psauxcww_parsers():
 
 def test_psef_parser():
     ps_ef = PsEf(context_wrap(PS_EF_LINES))
-    ps = Ps(None, None, None, ps_ef, None, None, None)
+    ps = Ps(None, None, None, ps_ef, None, None)
     len(ps.processes) == 6
     proc = ps[1]
     assert proc.get('UID') is None
@@ -155,7 +149,7 @@ def test_psef_parser():
 def test_psauxcww_and_ps_ef_parsers():
     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_LINES))
     ps_ef = PsEf(context_wrap(PS_EF_LINES))
-    ps = Ps(None, None, None, ps_ef, ps_auxcww, None, None)
+    ps = Ps(None, None, None, ps_ef, ps_auxcww, None)
     assert len(ps.processes) == 7
     proc1 = ps[1]
     assert proc1['COMMAND'] == '/usr/lib/systemd/systemd --switched-root --system --deserialize 21'
@@ -176,7 +170,7 @@ def test_psalxwww_and_psauxww_and_psaux_parsers():
     ps_alxwww = PsAlxwww(context_wrap(PS_ALXWWW_LINES))
     ps_auxww = PsAuxww(context_wrap(PS_AUXWW_LINES))
     ps_aux = PsAux(context_wrap(PS_AUX_LINES))
-    ps = Ps(ps_alxwww, ps_auxww, ps_aux, None, None, None, None)
+    ps = Ps(ps_alxwww, ps_auxww, ps_aux, None, None, None)
     len(ps.processes) == 5
     ps = ps[1]
     assert ps['PID'] == 1
@@ -201,7 +195,7 @@ def test_psalxwww_and_psauxww_and_psaux_parsers():
 
 def test_psauxwwwm_parser():
     ps_auxwwwm = PsAuxww(context_wrap(PS_AUXWWWM_LINES))
-    ps = Ps(None, ps_auxwwwm, None, None, None, None, None)
+    ps = Ps(None, ps_auxwwwm, None, None, None, None)
 
     assert len(ps.processes) == 4
 
@@ -234,14 +228,14 @@ def test_psauxwwwm_parser():
     assert ps_4['COMMAND_NAME'] == '[rcu_par_gp]'
 
 
-def test_psalxwww_and_psauxww_and_psaux_and_psef_and_psauxcww_and_ps_eo_parsers():
+def test_psalxwww_and_psauxww_and_psaux_and_psef_and_psauxcww_and_pseocmd_parsers():
     ps_alxwww = PsAlxwww(context_wrap(PS_ALXWWW_LINES))
     ps_auxww = PsAuxww(context_wrap(PS_AUXWW_LINES))
     ps_aux = PsAux(context_wrap(PS_AUX_LINES))
     ps_ef = PsEf(context_wrap(PS_EF_LINES))
     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_LINES))
-    ps_eo = PsEo(context_wrap(PS_EO_LINES, strip=False))
-    ps = Ps(ps_alxwww, ps_auxww, ps_aux, ps_ef, ps_auxcww, ps_eo, None)
+    ps_eo_cmd = PsEoCmd(context_wrap(PS_EO_CMD_LINES, strip=False))
+    ps = Ps(ps_alxwww, ps_auxww, ps_aux, ps_ef, ps_auxcww, ps_eo_cmd)
     len(ps.processes) == 8
     ps = ps[1]
     assert ps['PID'] == 1
@@ -262,15 +256,14 @@ def test_psalxwww_and_psauxww_and_psaux_and_psef_and_psauxcww_and_ps_eo_parsers(
     assert ps['PRI'] == 20
     assert ps['NI'] == '0'
     assert ps['WCHAN'] == 'ep_pol'
-    assert ps['NLWP'] is None
-
+    assert ps['NLWP'] == '1'
 
 
 def test_type_conversion():
     ps_alxwww = PsAlxwww(context_wrap(PS_ALXWWW_LINES))
     ps_ef = PsEf(context_wrap(PS_EF_LINES))
     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_LINES))
-    ps = Ps(ps_alxwww, None, None, ps_ef, ps_auxcww, None, None)
+    ps = Ps(ps_alxwww, None, None, ps_ef, ps_auxcww, None)
     assert all(isinstance(p['PID'], int) for p in ps.processes)
     assert all(p['UID'] is None or isinstance(p['UID'], int) for p in ps.processes)
     assert all(p['PID'] is None or isinstance(p['PID'], int) for p in ps.processes)
@@ -283,7 +276,7 @@ def test_type_conversion():
 
 def test_combiner_api():
     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_LINES))
-    ps = Ps(None, None, None, None, ps_auxcww, None, None)
+    ps = Ps(None, None, None, None, ps_auxcww, None)
     assert ps.pids == [1, 2, 3, 8, 9, 11]
     assert len(ps.processes) == 6
     assert ps.processes[0]
@@ -309,7 +302,7 @@ def test_combiner_api():
                      'USER': 'root',
                      'VSZ': 195712.0,
                      'WCHAN': None,
-                     'NLWP': None,}
+                     'NLWP': None}
     assert ps[1000] is None
     assert [proc for proc in ps]
 
@@ -320,9 +313,8 @@ def test_docs():
     ps_aux = PsAux(context_wrap(PS_AUX_LINES))
     ps_ef = PsEf(context_wrap(PS_EF_LINES))
     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_LINES))
-    ps_eo = PsEo(context_wrap(PS_EO_LINES, strip=False))
     ps_eo_cmd = PsEoCmd(context_wrap(PS_EO_CMD_LINES, strip=False))
-    ps_combiner = Ps(ps_alxwww, ps_auxww, ps_aux, ps_ef, ps_auxcww, ps_eo, ps_eo_cmd)
+    ps_combiner = Ps(ps_alxwww, ps_auxww, ps_aux, ps_ef, ps_auxcww, ps_eo_cmd)
     env = {
         'ps_combiner': ps_combiner
     }
@@ -348,7 +340,7 @@ F   UID   PID  PPID PRI  NI    VSZ   RSS WCHAN  STAT TTY        TIME COMMAND
 
 def test_search_ps_alxwww_w_grep():
     p = PsAlxwww(context_wrap(PS_ALXWWW_W_GREP))
-    ps = Ps(p, None, None, None, None, None, None)
+    ps = Ps(p, None, None, None, None, None)
     assert len(ps.search(COMMAND_NAME__contains='dbus')) == 1
 
 
@@ -359,7 +351,7 @@ def test_psalxwww_and_psauxww_and_psaux_and_psef_and_psauxcww_and_ps_eo_cmd_pars
     ps_ef = PsEf(context_wrap(PS_EF_LINES))
     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_LINES))
     ps_eo_cmd = PsEoCmd(context_wrap(PS_EO_CMD_LINES, strip=False))
-    ps_combiner = Ps(ps_alxwww, ps_auxww, ps_aux, ps_ef, ps_auxcww, None, ps_eo_cmd)
+    ps_combiner = Ps(ps_alxwww, ps_auxww, ps_aux, ps_ef, ps_auxcww, ps_eo_cmd)
     len(ps_combiner.processes) == 9
     ps = ps_combiner[1]
     assert ps['PID'] == 1
@@ -391,12 +383,10 @@ def test_ps_all_parsers_combiner():
     ps_aux = PsAux(context_wrap(PS_AUX_LINES))
     ps_ef = PsEf(context_wrap(PS_EF_LINES))
     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_LINES))
-    ps_eo = PsEo(context_wrap(PS_EO_LINES, strip=False))
     ps_eo_cmd = PsEoCmd(context_wrap(PS_EO_CMD_LINES, strip=False))
-    ps_combiner = Ps(ps_alxwww, ps_auxww, ps_aux, ps_ef, ps_auxcww, ps_eo, ps_eo_cmd)
+    ps_combiner = Ps(ps_alxwww, ps_auxww, ps_aux, ps_ef, ps_auxcww, ps_eo_cmd)
     len(ps_combiner.processes) == 9
     ps = ps_combiner[1]
-    pprint(ps)
     assert ps['PID'] == 1
     assert ps['USER'] == 'root'
     assert ps['UID'] == 0

--- a/insights/tests/components/test_ceph.py
+++ b/insights/tests/components/test_ceph.py
@@ -25,11 +25,11 @@ vdsm     27323 98.0 11.3  9120    987 ?        Ss   10.01   1:31 vdsm
 
 def test_is_ceph_monitor():
     ps_auxcww = PsAuxcww(context_wrap(PsAuxcww_CEPH))
-    ps = Ps(None, None, None, None, ps_auxcww, None, None)
+    ps = Ps(None, None, None, None, ps_auxcww, None)
     result = IsCephMonitor(ps)
     assert isinstance(result, IsCephMonitor)
 
     ps_auxcww = PsAuxcww(context_wrap(PsAuxcww_NO_CEPH))
-    ps = Ps(None, None, None, None, ps_auxcww, None, None)
+    ps = Ps(None, None, None, None, ps_auxcww, None)
     with pytest.raises(SkipComponent):
         IsCephMonitor(ps)

--- a/insights/tests/core/test_dr.py
+++ b/insights/tests/core/test_dr.py
@@ -82,7 +82,7 @@ def test_get_registry_points_multiple_specs():
         assert spec in specs
 
     specs = dr.get_registry_points(Ps)
-    assert len(specs) == 7
+    assert len(specs) == 6
     for spec in [Specs.ps_aux, Specs.ps_auxww, Specs.ps_auxcww, Specs.ps_ef,
-                 Specs.ps_auxcww, Specs.ps_eo, Specs.ps_eo_cmd]:
+                 Specs.ps_auxcww, Specs.ps_eo_cmd]:
         assert spec in specs

--- a/insights/tests/datasources/test_get_running_commands.py
+++ b/insights/tests/datasources/test_get_running_commands.py
@@ -6,40 +6,40 @@ from insights.specs.datasources import get_running_commands
 from insights.tests import context_wrap
 
 PS_EO_CMD = """
-   PID COMMAND
-     1 /usr/lib/systemd/systemd --switched-root --system --deserialize 22
-     2 [kthreadd]
-   988 /usr/sbin/httpd -DFOREGROUND
-  1036 /usr/sbin/httpd -DFOREGROUND
-  1037 /usr/sbin/httpd -DFOREGROUND
-  1038 /usr/sbin/httpd -DFOREGROUND
-  1039 /usr/sbin/httpd -DFOREGROUND
-  1040 /usr/local/sbin/httpd -DFOREGROUND
- 28218 /usr/bin/java TestSleepMethod1
- 28219 java TestSleepMethod1
- 28240 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.292.b10-1.el7_9.x86_64/jre/bin/java TestSleepMethod2
-333083 /home/user3/apps/pycharm-2021.1.1/jbr/bin/java -classpath /home/user3/apps/pycharm-2021.1.1/lib/bootstrap.jar:/home/user3/apps/pycharm-2021.1.1/lib/util.jar:/home/user3/apps/pycharm-2021.1.1/lib/jdom.jar:/home/user3/apps/pycharm-2021.1.1/lib/log4j.jar:/home/user3/apps/pycharm-2021.1.1/lib/jna.jar -Xms128m -Xmx2048m -XX:ReservedCodeCacheSize=512m -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=50 -XX:CICompilerCount=2 -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow -ea -Dsun.io.useCanonCaches=false -Djdk.http.auth.tunneling.disabledSchemes="" -Djdk.attach.allowAttachSelf=true -Djdk.module.illegalAccess.silent=true -Dkotlinx.coroutines.debug=off -Dsun.tools.attach.tmp.only=true -XX:ErrorFile=/home/user3/java_error_in_pycharm_%p.log -XX:HeapDumpPath=/home/user3/java_error_in_pycharm_.hprof -Didea.vendor.name=JetBrains -Didea.paths.selector=PyCharm2021.1 -Djb.vmOptionsFile=/home/user3/.config/JetBrains/PyCharm2021.1/pycharm64.vmoptions -Didea.platform.prefix=Python com.intellij.idea.Main
+   PID  PPID NLWP COMMAND
+     1     0    1 /usr/lib/systemd/systemd --switched-root --system --deserialize 22
+     2     0    1 [kthreadd]
+   988     2    1 /usr/sbin/httpd -DFOREGROUND
+  1036     2    1 /usr/sbin/httpd -DFOREGROUND
+  1037     2    1 /usr/sbin/httpd -DFOREGROUND
+  1038     2    1 /usr/sbin/httpd -DFOREGROUND
+  1039     2    1 /usr/sbin/httpd -DFOREGROUND
+  1040     2    1 /usr/local/sbin/httpd -DFOREGROUND
+ 28218     2    1 /usr/bin/java TestSleepMethod1
+ 28219     2    1 java TestSleepMethod1
+ 28240     2    1 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.292.b10-1.el7_9.x86_64/jre/bin/java TestSleepMethod2
+333083     2    1 /home/user3/apps/pycharm-2021.1.1/jbr/bin/java -classpath /home/user3/apps/pycharm-2021.1.1/lib/bootstrap.jar:/home/user3/apps/pycharm-2021.1.1/lib/util.jar:/home/user3/apps/pycharm-2021.1.1/lib/jdom.jar:/home/user3/apps/pycharm-2021.1.1/lib/log4j.jar:/home/user3/apps/pycharm-2021.1.1/lib/jna.jar -Xms128m -Xmx2048m -XX:ReservedCodeCacheSize=512m -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=50 -XX:CICompilerCount=2 -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow -ea -Dsun.io.useCanonCaches=false -Djdk.http.auth.tunneling.disabledSchemes="" -Djdk.attach.allowAttachSelf=true -Djdk.module.illegalAccess.silent=true -Dkotlinx.coroutines.debug=off -Dsun.tools.attach.tmp.only=true -XX:ErrorFile=/home/user3/java_error_in_pycharm_%p.log -XX:HeapDumpPath=/home/user3/java_error_in_pycharm_.hprof -Didea.vendor.name=JetBrains -Didea.paths.selector=PyCharm2021.1 -Djb.vmOptionsFile=/home/user3/.config/JetBrains/PyCharm2021.1/pycharm64.vmoptions -Didea.platform.prefix=Python com.intellij.idea.Main
 """
 
 PS_EO_CMD_MISSING = """
-PID COMMAND
-  1 /usr/lib/systemd/systemd --switched-root --system --deserialize 22
-  2 [kthreadd]
+PID  PPID NLWP COMMAND
+  1     0    1 /usr/lib/systemd/systemd --switched-root --system --deserialize 22
+  2     0    1 [kthreadd]
 """
 
 PS_EO_CMD_EXCEPTION = """
-  PID COMMAND
-    1 /usr/lib/systemd/systemd --switched-root --system --deserialize 22
-    2 [kthreadd]
-28218 /usr/bin/java TestSleepMethod1
-28219 /exception/java
+  PID  PPID NLWP COMMAND
+    1     0    1 /usr/lib/systemd/systemd --switched-root --system --deserialize 22
+    2     0    1 [kthreadd]
+28218     2    1 /usr/bin/java TestSleepMethod1
+28219     2    1 /exception/java
 """
 
 PS_EO_CMD_ONE = """
-   PID COMMAND
-     1 /usr/lib/systemd/systemd --switched-root --system --deserialize 22
-     2 [kthreadd]
-   988 /usr/sbin/httpd -DFOREGROUND
+   PID  PPID NLWP COMMAND
+     1     0    1 /usr/lib/systemd/systemd --switched-root --system --deserialize 22
+     2     0    1 [kthreadd]
+   988     2    1 /usr/sbin/httpd -DFOREGROUND
 """
 
 
@@ -60,7 +60,7 @@ class FakeContext(object):
 
 def test_get_running_commands_present():
     pseo = PsEoCmd(context_wrap(PS_EO_CMD))
-    ps = Ps(None, None, None, None, None, None, pseo)
+    ps = Ps(None, None, None, None, None, pseo)
     assert ps is not None
     ctx = FakeContext()
 
@@ -86,7 +86,7 @@ def test_get_running_commands_present():
 
 def test_get_running_commands_missing():
     pseo = PsEoCmd(context_wrap(PS_EO_CMD_MISSING))
-    ps = Ps(None, None, None, None, None, None, pseo)
+    ps = Ps(None, None, None, None, None, pseo)
     assert ps is not None
     ctx = FakeContext()
 
@@ -96,7 +96,7 @@ def test_get_running_commands_missing():
 
 def test_get_running_commands_cmd_exception():
     pseo = PsEoCmd(context_wrap(PS_EO_CMD_EXCEPTION))
-    ps = Ps(None, pseo, None, None, None, None, pseo)
+    ps = Ps(None, pseo, None, None, None, pseo)
     assert ps is not None
     ctx = FakeContext()
 
@@ -106,7 +106,7 @@ def test_get_running_commands_cmd_exception():
 
 def test_get_running_commands_exception():
     pseo = PsEoCmd(context_wrap(PS_EO_CMD_MISSING))
-    ps = Ps(None, None, None, None, None, None, pseo)
+    ps = Ps(None, None, None, None, None, pseo)
     assert ps is not None
     ctx = FakeContext()
 
@@ -119,7 +119,7 @@ def test_get_running_commands_exception():
 
 def test_get_running_commands_one():
     pseo = PsEoCmd(context_wrap(PS_EO_CMD_ONE))
-    ps = Ps(None, None, None, None, None, None, pseo)
+    ps = Ps(None, None, None, None, None, pseo)
     assert ps is not None
     ctx = FakeContext()
 

--- a/insights/tests/datasources/test_package_provides.py
+++ b/insights/tests/datasources/test_package_provides.py
@@ -93,19 +93,19 @@ def test_get_package_err():
 
 
 PS_EO_CMD = """
-   PID COMMAND
-     1 /usr/lib/systemd/systemd --switched-root --system --deserialize 22
-     2 [kthreadd]
-   988 /usr/sbin/httpd -DFOREGROUND
-  1036 /usr/sbin/httpd -DFOREGROUND
-  1037 /usr/sbin/httpd -DFOREGROUND
-  1038 /usr/sbin/httpd -DFOREGROUND
-  1039 /usr/sbin/httpd -DFOREGROUND
-  1040 /usr/local/sbin/httpd -DFOREGROUND
- 28218 /usr/bin/java TestSleepMethod1
- 28219 java TestSleepMethod1
- 28240 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.292.b10-1.el7_9.x86_64/jre/bin/java TestSleepMethod2
-333083 /home/user3/apps/pycharm-2021.1.1/jbr/bin/java -classpath /home/user3/apps/pycharm-2021.1.1/lib/bootstrap.jar:/home/user3/apps/pycharm-2021.1.1/lib/util.jar:/home/user3/apps/pycharm-2021.1.1/lib/jdom.jar:/home/user3/apps/pycharm-2021.1.1/lib/log4j.jar:/home/user3/apps/pycharm-2021.1.1/lib/jna.jar -Xms128m -Xmx2048m -XX:ReservedCodeCacheSize=512m -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=50 -XX:CICompilerCount=2 -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow -ea -Dsun.io.useCanonCaches=false -Djdk.http.auth.tunneling.disabledSchemes="" -Djdk.attach.allowAttachSelf=true -Djdk.module.illegalAccess.silent=true -Dkotlinx.coroutines.debug=off -Dsun.tools.attach.tmp.only=true -XX:ErrorFile=/home/user3/java_error_in_pycharm_%p.log -XX:HeapDumpPath=/home/user3/java_error_in_pycharm_.hprof -Didea.vendor.name=JetBrains -Didea.paths.selector=PyCharm2021.1 -Djb.vmOptionsFile=/home/user3/.config/JetBrains/PyCharm2021.1/pycharm64.vmoptions -Didea.platform.prefix=Python com.intellij.idea.Main
+   PID  PPID NLWP COMMAND
+     1     0    1 /usr/lib/systemd/systemd --switched-root --system --deserialize 22
+     2     0    1 [kthreadd]
+   988     2    1 /usr/sbin/httpd -DFOREGROUND
+  1036     2    1 /usr/sbin/httpd -DFOREGROUND
+  1037     2    1 /usr/sbin/httpd -DFOREGROUND
+  1038     2    1 /usr/sbin/httpd -DFOREGROUND
+  1039     2    1 /usr/sbin/httpd -DFOREGROUND
+  1040     2    1 /usr/local/sbin/httpd -DFOREGROUND
+ 28218     2    1 /usr/bin/java TestSleepMethod1
+ 28219     2    1 java TestSleepMethod1
+ 28240     2    1 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.292.b10-1.el7_9.x86_64/jre/bin/java TestSleepMethod2
+333083     2    1 /home/user3/apps/pycharm-2021.1.1/jbr/bin/java -classpath /home/user3/apps/pycharm-2021.1.1/lib/bootstrap.jar:/home/user3/apps/pycharm-2021.1.1/lib/util.jar:/home/user3/apps/pycharm-2021.1.1/lib/jdom.jar:/home/user3/apps/pycharm-2021.1.1/lib/log4j.jar:/home/user3/apps/pycharm-2021.1.1/lib/jna.jar -Xms128m -Xmx2048m -XX:ReservedCodeCacheSize=512m -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=50 -XX:CICompilerCount=2 -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow -ea -Dsun.io.useCanonCaches=false -Djdk.http.auth.tunneling.disabledSchemes="" -Djdk.attach.allowAttachSelf=true -Djdk.module.illegalAccess.silent=true -Dkotlinx.coroutines.debug=off -Dsun.tools.attach.tmp.only=true -XX:ErrorFile=/home/user3/java_error_in_pycharm_%p.log -XX:HeapDumpPath=/home/user3/java_error_in_pycharm_.hprof -Didea.vendor.name=JetBrains -Didea.paths.selector=PyCharm2021.1 -Djb.vmOptionsFile=/home/user3/.config/JetBrains/PyCharm2021.1/pycharm64.vmoptions -Didea.platform.prefix=Python com.intellij.idea.Main
 """
 
 EXPECTED = DatasourceProvider(
@@ -120,7 +120,7 @@ EXPECTED = DatasourceProvider(
 
 def test_cmd_and_pkg():
     pseo = PsEoCmd(context_wrap(PS_EO_CMD))
-    ps = Ps(None, None, None, None, None, None, pseo)
+    ps = Ps(None, None, None, None, None, pseo)
     broker = dr.Broker()
     broker[HostContext] = FakeContext()
     broker[Ps] = ps
@@ -132,7 +132,7 @@ def test_cmd_and_pkg():
 
 def test_cmd_and_pkg_no_filters():
     pseo = PsEoCmd(context_wrap(PS_EO_CMD))
-    ps = Ps(None, None, None, None, None, None, pseo)
+    ps = Ps(None, None, None, None, None, pseo)
     broker = dr.Broker()
     broker[HostContext] = FakeContext()
     broker[Ps] = ps
@@ -143,7 +143,7 @@ def test_cmd_and_pkg_no_filters():
 
 def test_cmd_and_pkg_not_found():
     pseo = PsEoCmd(context_wrap(PS_EO_CMD))
-    ps = Ps(None, None, None, None, None, None, pseo)
+    ps = Ps(None, None, None, None, None, pseo)
     broker = dr.Broker()
     broker[HostContext] = FakeContext()
     broker[Ps] = ps

--- a/insights/tests/datasources/test_pcp.py
+++ b/insights/tests/datasources/test_pcp.py
@@ -113,7 +113,7 @@ def test_pmlog_summary_args(isfile, exists):
     # Case 1: OK
     ros = RosConfig(context_wrap(ROS_CONFIG))
     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW))
-    ps = Ps(None, None, None, None, ps_auxcww, None, None)
+    ps = Ps(None, None, None, None, ps_auxcww, None)
 
     broker = dr.Broker()
     broker[Ps] = ps
@@ -140,7 +140,7 @@ def test_pmlog_summary_args(isfile, exists):
     # Case 3 No pmloger proc in ps
     ros = RosConfig(context_wrap(ROS_CONFIG))
     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW_NG))
-    ps = Ps(None, None, None, None, ps_auxcww, None, None)
+    ps = Ps(None, None, None, None, ps_auxcww, None)
     broker = dr.Broker()
     broker[Ps] = ps
     broker[RosConfig] = ros
@@ -153,7 +153,7 @@ def test_pmlog_summary_args(isfile, exists):
 def test_pmlog_summary_args_no_pmloger_file(isfile):
     ros = RosConfig(context_wrap(ROS_CONFIG))
     ps_auxcww = PsAuxcww(context_wrap(PS_AUXCWW))
-    ps = Ps(None, None, None, None, ps_auxcww, None, None)
+    ps = Ps(None, None, None, None, ps_auxcww, None)
 
     broker = dr.Broker()
     broker[Ps] = ps

--- a/insights/tests/datasources/test_ps.py
+++ b/insights/tests/datasources/test_ps.py
@@ -10,45 +10,45 @@ from insights.core.spec_factory import DatasourceProvider
 from insights.specs.datasources.ps import ps_eo_cmd, LocalSpecs, jboss_runtime_versions
 
 PS_DATA = """
-PID COMMAND
-  1 /usr/lib/systemd/systemd --switched-root --system --deserialize 31
-  2 [kthreadd]
-  3 [rcu_gp]
-  4 [rcu_par_gp]
-  6 [kworker/0:0H-events_highpri]
-  9 [mm_percpu_wq]
- 10 [rcu_tasks_kthre]
- 11 /usr/bin/python3 /home/user1/python_app.py
- 12 [kworker/u16:0-kcryptd/253:0]
+PID  PPID NLWP COMMAND
+  1     0    1 /usr/lib/systemd/systemd --switched-root --system --deserialize 31
+  2     0    1 [kthreadd]
+  3     2    1 [rcu_gp]
+  4     2    1 [rcu_par_gp]
+  6     2    1 [kworker/0:0H-events_highpri]
+  9     2    1 [mm_percpu_wq]
+ 10     2    1 [rcu_tasks_kthre]
+ 11     2    1 /usr/bin/python3 /home/user1/python_app.py
+ 12     2    1 [kworker/u16:0-kcryptd/253:0]
 """
 
 PS_EXPECTED = """
-PID COMMAND
-1 /usr/lib/systemd/systemd
-2 [kthreadd]
-3 [rcu_gp]
-4 [rcu_par_gp]
-6 [kworker/0:0H-events_highpri]
-9 [mm_percpu_wq]
-10 [rcu_tasks_kthre]
-11 /usr/bin/python3
-12 [kworker/u16:0-kcryptd/253:0]
+PID PPID NLWP COMMAND
+1 0 1 /usr/lib/systemd/systemd
+2 0 1 [kthreadd]
+3 2 1 [rcu_gp]
+4 2 1 [rcu_par_gp]
+6 2 1 [kworker/0:0H-events_highpri]
+9 2 1 [mm_percpu_wq]
+10 2 1 [rcu_tasks_kthre]
+11 2 1 /usr/bin/python3
+12 2 1 [kworker/u16:0-kcryptd/253:0]
 """
 
 PS_BAD = "Command not found"
 
 PS_EMPTY = """
-PID COMMAND
+PID PPID NLWP COMMAND
 """
 jboss_home_1 = tempfile.mkdtemp(prefix='insights_test')
 jboss_home_2 = tempfile.mkdtemp(prefix='insights_test')
 PS_JBOSS_VERSION = """
-    PID COMMAND
-    1 /usr/lib/systemd/systemd --switched-root --system --deserialize 17
-    2 [kthreadd]
-    3 [rcu_gp]
-    8686 java -D[Standalone] -server -verbose:gc -Xloggc:/opt/jboss-datagrid-7.3.0-server/standalone/log/gc.log -XX:+PrintGCDetails -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -XX:-TraceClassUnloading -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/opt/jboss-datagrid-7.3.0-server/standalone/log/server.log -Dlogging.configuration=file:/opt/jboss-datagrid-7.3.0-server/standalone/configuration/logging.properties -jar /opt/jboss-datagrid-7.3.0-server/jboss-modules.jar -mp /opt/jboss-datagrid-7.3.0-server/modules org.jboss.as.standalone -Djboss.home.dir={0} -Djboss.server.base.dir=/opt/jboss-datagrid-7.3.0-server/standalone
-    8880 /usr/lib/jvm/java-1.8.0-oracle/bin/java -D[Process Controller] -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/home/jboss/jboss-eap-7.1/domain/log/process-controller.log -Dlogging.configuration=file:/home/jboss/jboss-eap-7.1/domain/configuration/logging.properties -jar /home/jboss/jboss-eap-7.1/jboss-modules.jar -mp /home/jboss/jboss-eap-7.1/modules org.jboss.as.process-controller -jboss-home {1} -jvm /usr/lib/jvm/java-1.8.0-oracle/bin/java -mp /home/jboss/jboss-eap-7.1/modules -- -Dorg.jboss.boot.log.file=/home/jboss/jboss-eap-7.1/domain/log/host-controller.log -Dlogging.configuration=file:/home/jboss/jboss-eap-7.1/domain/configuration/logging.properties -server
+  PID  PPID NLWP COMMAND
+    1     0    1 /usr/lib/systemd/systemd --switched-root --system --deserialize 31
+    2     0    1 [kthreadd]
+    3     2    1 [rcu_gp]
+ 8686   525    1 java -D[Standalone] -server -verbose:gc -Xloggc:/opt/jboss-datagrid-7.3.0-server/standalone/log/gc.log -XX:+PrintGCDetails -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -XX:-TraceClassUnloading -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/opt/jboss-datagrid-7.3.0-server/standalone/log/server.log -Dlogging.configuration=file:/opt/jboss-datagrid-7.3.0-server/standalone/configuration/logging.properties -jar /opt/jboss-datagrid-7.3.0-server/jboss-modules.jar -mp /opt/jboss-datagrid-7.3.0-server/modules org.jboss.as.standalone -Djboss.home.dir={0} -Djboss.server.base.dir=/opt/jboss-datagrid-7.3.0-server/standalone
+ 8880   525    1 /usr/lib/jvm/java-1.8.0-oracle/bin/java -D[Process Controller] -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/home/jboss/jboss-eap-7.1/domain/log/process-controller.log -Dlogging.configuration=file:/home/jboss/jboss-eap-7.1/domain/configuration/logging.properties -jar /home/jboss/jboss-eap-7.1/jboss-modules.jar -mp /home/jboss/jboss-eap-7.1/modules org.jboss.as.process-controller -jboss-home {1} -jvm /usr/lib/jvm/java-1.8.0-oracle/bin/java -mp /home/jboss/jboss-eap-7.1/modules -- -Dorg.jboss.boot.log.file=/home/jboss/jboss-eap-7.1/domain/log/host-controller.log -Dlogging.configuration=file:/home/jboss/jboss-eap-7.1/domain/configuration/logging.properties -server
 """.format(jboss_home_1, jboss_home_2)
 
 RELATIVE_PATH = 'insights_commands/ps_eo_cmd'

--- a/insights/tests/parsers/test_ps.py
+++ b/insights/tests/parsers/test_ps.py
@@ -424,6 +424,7 @@ PS_EO_WITH_NLWP = """
 """
 
 
+
 def test_ps_eo():
     p = ps.PsEo(context_wrap(PS_EO_WITHOUT_NLWP, strip=False))
     assert p is not None

--- a/insights/tests/parsers/test_ps.py
+++ b/insights/tests/parsers/test_ps.py
@@ -424,7 +424,6 @@ PS_EO_WITH_NLWP = """
 """
 
 
-
 def test_ps_eo():
     p = ps.PsEo(context_wrap(PS_EO_WITHOUT_NLWP, strip=False))
     assert p is not None


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

RHINENG-9075 

(Changes based on our last discussion about "Deprecate Specs.ps_eo".)

 -   Move the data collection of ps columns(ppid and nlwp)
      from Specs.ps_eo to datasource Specs.ps_eo_cmd. And
      popular the data to Ps combiner.
      This is for the future deprecation of Specs.ps_eo to
      resolve https://github.com/RedHatInsights/insights-core/issues/4054
 
 - Remove PsEo parser from Ps combiner
 - Deprecate PsEo parser