### PR TITLE
chore: use the uploader.json in '/testing' for unit test

### DIFF
--- a/insights/tests/test_uploader_json.py
+++ b/insights/tests/test_uploader_json.py
@@ -9,7 +9,7 @@ def get_uploader_json():
     Download latest uploader.json to use for unit tests
     '''
     try:
-        url = "https://api.access.redhat.com/r/insights/v1/static/uploader.v2.json"
+        url = "https://cloud.redhat.com/api/v1/static/testing/uploader.v2.json"
         uploader_json = requests.get(url).json()
         return uploader_json
     except Exception:


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
- The consistent check of the symbolic_name can be applied on the uploader.json in the canary deployment "/testing" instead of production "/release"

