### PR TITLE
chore: print warning when 'machine_id' is skipped for redaction

### DIFF
--- a/insights/client/collection_rules.py
+++ b/insights/client/collection_rules.py
@@ -393,7 +393,7 @@ class InsightsUploadConf(object):
     def get_rm_conf(self):
         '''
         Try to load the the "new" version of
-        remove.conf (file-redaction.yaml and file-redaction.yaml)
+        remove.conf (file-redaction.yaml and file-content-redaction.yaml)
         '''
         rm_conf = {}
         redact_conf = self.load_redaction_file(self.redaction_file)
@@ -409,6 +409,9 @@ class InsightsUploadConf(object):
             # remove Nones, empty strings, and empty lists
             self.rm_conf = dict((k, v) for k, v in rm_conf.items() if v)
 
+        if self.rm_conf and ('/etc/insights-client/machine-id' in self.rm_conf.get('files', []) or
+                'insights.specs.default.DefaultSpecs.machine_id' in self.rm_conf.get('components', [])):
+            logger.warning("WARNING: Spec machine_id will be skipped for redaction; as it would cause issues, please remove it from %s.", self.redaction_file)
         # return the RAW rm_conf
         return self.rm_conf
 

--- a/insights/tests/client/collection_rules/test_get_rm_conf.py
+++ b/insights/tests/client/collection_rules/test_get_rm_conf.py
@@ -357,6 +357,30 @@ def test_rm_conf_no_load_uploader_json_classic_collect(get_conf_file):
     get_conf_file.assert_not_called()
 
 
+@patch('insights.client.collection_rules.InsightsUploadConf.load_redaction_file', Mock(return_value={"files": "/etc/insights-client/machine-id"}))
+@patch('insights.client.collection_rules.InsightsUploadConf.get_conf_file')
+@patch("insights.client.collection_rules.logger.warning")
+def test_rm_conf_skipped_machine_id_file(warning, get_conf_file):
+    '''
+    Verify that '/etc/insights-client/machine-id' is set in file-redaction.yaml[files]
+    '''
+    upload_conf = insights_upload_conf()
+    upload_conf.get_rm_conf()
+    warning.assert_called_once_with("WARNING: Spec machine_id will be skipped for redaction; as it would cause issues, please remove it from %s.", "/etc/insights-client/file-redaction.yaml")
+
+
+@patch('insights.client.collection_rules.InsightsUploadConf.load_redaction_file', Mock(return_value={"components": "insights.specs.default.DefaultSpecs.machine_id"}))
+@patch('insights.client.collection_rules.InsightsUploadConf.get_conf_file')
+@patch("insights.client.collection_rules.logger.warning")
+def test_rm_conf_skipped_machine_id_component(warning, get_conf_file):
+    '''
+    Verify that 'insights.specs.default.DefaultSpecs.machine_id' is set in file-redaction.yaml[components]
+    '''
+    upload_conf = insights_upload_conf()
+    upload_conf.get_rm_conf()
+    warning.assert_called_once_with("WARNING: Spec machine_id will be skipped for redaction; as it would cause issues, please remove it from %s.", "/etc/insights-client/file-redaction.yaml")
+
+
 # @patch('insights.client.collection_rules.verify_permissions', return_value=True)
 # @patch_isfile(True)
 # def test_rm_conf_old_load_bad(isfile, verify):


### PR DESCRIPTION
- see RHINENG-9044

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
- A warning message should be printed to the console when the required `machine_id` is skipped for redaction by the customers.
