### PR TITLE
fix: deprecated parser usage in combiner.rhsm_release

### DIFF
--- a/insights/combiners/rhsm_release.py
+++ b/insights/combiners/rhsm_release.py
@@ -4,19 +4,17 @@ Red Hat Subscription Manager Release
 
 Combiner provides the Red Hat Subscription Manager release information from
 the parsers :class:`insights.parsers.rhsm_releasever.RhsmReleaseVer`
-and :class:`insights.parsers.subscription_manager_release.SubscriptionManagerReleaseShow`
 and :class:`insights.parsers.rhui_release.RHUIReleaseVer`.
 """
 from insights.core.plugins import combiner
 from insights.parsers.rhsm_releasever import RhsmReleaseVer
-from insights.parsers.subscription_manager_release import SubscriptionManagerReleaseShow
 from insights.parsers.rhui_release import RHUIReleaseVer
 
 
-@combiner([RhsmReleaseVer, SubscriptionManagerReleaseShow, RHUIReleaseVer])
+@combiner([RhsmReleaseVer, RHUIReleaseVer])
 class RhsmRelease(object):
     """
-    Combiner for parsers RhsmReleaseVer and SubscriptionManagerReleaseShow and RHUIReleaseVer.
+    Combiner for parsers RhsmReleaseVer and RHUIReleaseVer.
 
     Examples:
         >>> type(rhsm_release)
@@ -28,7 +26,7 @@ class RhsmRelease(object):
         >>> rhsm_release.minor
         6
     """
-    def __init__(self, rhsm_release, sm_release, rhui_release):
+    def __init__(self, rhsm_release, rhui_release):
         self.set = None
         """ str: Release version string returned from the parsers """
 
@@ -37,15 +35,12 @@ class RhsmRelease(object):
 
         self.minor = None
         """ int: Minor version of the release """
+
         if rhsm_release is not None and rhsm_release.set:
             self.set = rhsm_release.set
             self.major = rhsm_release.major
             self.minor = rhsm_release.minor
 
-        elif sm_release is not None and sm_release.set:
-            self.set = sm_release.set
-            self.major = sm_release.major
-            self.minor = sm_release.minor
         elif rhui_release is not None and rhui_release.set:
             self.set = rhui_release.set
             self.major = rhui_release.major

--- a/insights/tests/combiners/test_rhsm_release.py
+++ b/insights/tests/combiners/test_rhsm_release.py
@@ -3,7 +3,6 @@ import doctest
 import insights.combiners.rhsm_release as rhsm_release_module
 from insights.combiners.rhsm_release import RhsmRelease
 from insights.parsers.rhsm_releasever import RhsmReleaseVer
-from insights.parsers.subscription_manager_release import SubscriptionManagerReleaseShow
 from insights.parsers.rhui_release import RHUIReleaseVer
 from insights.tests import context_wrap
 
@@ -15,73 +14,51 @@ RHSM_RELEASE_EMPTY = """
 {"releaseVer": null}
 """.strip()
 
-SUBSCRIPTION_MANAGER_RELEASE = """
-Release: 7.2
-""".strip()
-
-EMPTY_SUBSCRIPTION_MANAGER_RELEASE = """Release not set"""
-
 RHUI_RELEASE = """8.6"""
 
 RHUI_EMPTY_RELEASE = ""
 
-SM_PARSER = SubscriptionManagerReleaseShow(context_wrap(SUBSCRIPTION_MANAGER_RELEASE))
 RHSM_PARSER = RhsmReleaseVer(context_wrap(RHSM_RELEASE))
 RHSM_EMPTY_PARSER = RhsmReleaseVer(context_wrap(RHSM_RELEASE_EMPTY))
-SM_EMPTY_PARSER = SubscriptionManagerReleaseShow(context_wrap(EMPTY_SUBSCRIPTION_MANAGER_RELEASE))
 RHUI_PARSER = RHUIReleaseVer(context_wrap(RHUI_RELEASE))
 RHUI_EMPTY_PARSER = RHUIReleaseVer(context_wrap(RHUI_EMPTY_RELEASE))
 
 
 def test_with_rhsm():
-    rhsm_release = RhsmRelease(RHSM_PARSER, None, None)
+    rhsm_release = RhsmRelease(RHSM_PARSER, None)
     assert rhsm_release.set == '7.6'
     assert rhsm_release.major == 7
     assert rhsm_release.minor == 6
-
-
-def test_with_sub_mgr():
-    rhsm_release = RhsmRelease(None, SM_PARSER, None)
-    assert rhsm_release.set == '7.2'
-    assert rhsm_release.major == 7
-    assert rhsm_release.minor == 2
 
 
 def test_with_rhui_release():
-    rhsm_release = RhsmRelease(None, None, RHUI_PARSER)
+    rhsm_release = RhsmRelease(None, RHUI_PARSER)
     assert rhsm_release.set == '8.6'
     assert rhsm_release.major == 8
     assert rhsm_release.minor == 6
 
 
-def test_with_both():
-    rhsm_release = RhsmRelease(RHSM_PARSER, SM_PARSER, None)
+def test_with_all():
+    rhsm_release = RhsmRelease(RHSM_PARSER, RHUI_PARSER)
     assert rhsm_release.set == '7.6'
     assert rhsm_release.major == 7
     assert rhsm_release.minor == 6
 
 
-def test_with_three():
-    rhsm_release = RhsmRelease(RHSM_PARSER, SM_PARSER, RHUI_PARSER)
-    assert rhsm_release.set == '7.6'
-    assert rhsm_release.major == 7
-    assert rhsm_release.minor == 6
-
-
-def test_with_three_but_rhsm_is_empty():
-    rhsm_release = RhsmRelease(RHSM_EMPTY_PARSER, SM_EMPTY_PARSER, RHUI_PARSER)
+def test_with_all_but_rhsm_is_empty():
+    rhsm_release = RhsmRelease(RHSM_EMPTY_PARSER, RHUI_PARSER)
     assert rhsm_release.set == '8.6'
     assert rhsm_release.major == 8
     assert rhsm_release.minor == 6
 
 
-def test_all_empty():
-    rhsm_release = RhsmRelease(RHSM_EMPTY_PARSER, SM_EMPTY_PARSER, RHUI_EMPTY_PARSER)
+def test_with_all_but_all_are_empty():
+    rhsm_release = RhsmRelease(RHSM_EMPTY_PARSER, RHUI_EMPTY_PARSER)
     assert rhsm_release.set is None
     assert rhsm_release.major is None
     assert rhsm_release.minor is None
 
-    rhsm_release = RhsmRelease(RHSM_EMPTY_PARSER, SM_EMPTY_PARSER, None)
+    rhsm_release = RhsmRelease(RHSM_EMPTY_PARSER, None)
     assert rhsm_release.set is None
     assert rhsm_release.major is None
     assert rhsm_release.minor is None
@@ -89,7 +66,7 @@ def test_all_empty():
 
 def test_doc_examples():
     env = {
-        'rhsm_release': RhsmRelease(RHSM_PARSER, None, None),
+        'rhsm_release': RhsmRelease(RHSM_PARSER, None),
     }
     failed, total = doctest.testmod(rhsm_release_module, globs=env)
     assert failed == 0


### PR DESCRIPTION
  Parser SubscriptionManagerReleaseShow was deprecated,
  remove it from combiner.rhsm_release accordingly.

for RHINENG-7882 

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
