### PR TITLE
fix: no context and datasource when running against insights-archive

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -490,7 +490,7 @@ def collect(client_config=None, rm_conf=None, tmp_path=None, archive_name=None,
 
     pool_args = run_strategy.get("args", {})
     with get_pool(parallel, "insights-collector-pool", pool_args) as pool:
-        h = Hydration(output_path, pool=pool)
+        h = Hydration(output_path, ctx, pool=pool)
         broker.add_observer(h.make_persister(to_persist))
         dr.run_all(broker=broker, pool=pool)
 

--- a/insights/combiners/hostname.py
+++ b/insights/combiners/hostname.py
@@ -60,5 +60,5 @@ def serialize(obj, root=None):
 
 
 @deserializer(Hostname)
-def deserialize(_type, data, root=None):
+def deserialize(_type, data, root=None, ctx=None, ds=None):
     return Hostname(**data)

--- a/insights/combiners/redhat_release.py
+++ b/insights/combiners/redhat_release.py
@@ -30,7 +30,7 @@ def serialize(obj, root=None):
 
 
 @deserializer(Release)
-def deserialize(_type, obj, root=None):
+def deserialize(_type, obj, root=None, ctx=None, ds=None):
     return Release(**obj)
 
 
@@ -102,7 +102,7 @@ def serialize_RedHatRelease(obj, root=None):
 
 
 @deserializer(RedHatRelease)
-def deserialize_RedHatRelease(_type, obj, root=None):
+def deserialize_RedHatRelease(_type, obj, root=None, ctx=None, ds=None):
     foo = _type.__new__(_type)
     foo.major = obj.get("major")
     foo.minor = obj.get("minor")

--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -115,7 +115,7 @@ def default_parser_serializer(obj):
 
 
 @deserializer(Parser)
-def default_parser_deserializer(_type, data):
+def default_parser_deserializer(_type, data, root=None, ctx=None, ds=None):
     obj = _type.__new__(_type)
     obj.file_path = None
     obj.file_name = None

--- a/insights/core/hydration.py
+++ b/insights/core/hydration.py
@@ -69,6 +69,6 @@ def initialize_broker(path, context=None, broker=None):
 
     broker[ctx.__class__] = ctx
     if isinstance(ctx, SerializedArchiveContext):
-        h = Hydration(ctx.root)
+        h = Hydration(root=ctx.root, ctx=ctx)
         broker = h.hydrate(broker=broker)
     return ctx, broker

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -323,8 +323,7 @@ class TextFileProvider(FileProvider):
 
 
 class SerializedOutputProvider(TextFileProvider):
-    def create_args(self):
-        pass
+    pass
 
 
 class SerializedRawOutputProvider(RawFileProvider):
@@ -1359,10 +1358,10 @@ def serialize_command_output(obj, root):
 
 
 @deserializer(CommandOutputProvider)
-def deserialize_command_output(_type, data, root):
+def deserialize_command_output(_type, data, root, ctx, ds):
     rel = data["relative_path"]
 
-    res = SerializedOutputProvider(rel, root=root)
+    res = SerializedOutputProvider(rel, root=root, ctx=ctx, ds=ds)
 
     res.rc = data["rc"]
     res.cmd = data["cmd"]
@@ -1387,9 +1386,9 @@ def serialize_text_file_provider(obj, root):
 
 
 @deserializer(TextFileProvider)
-def deserialize_text_provider(_type, data, root):
+def deserialize_text_provider(_type, data, root, ctx, ds):
     rel = data["relative_path"]
-    res = SerializedOutputProvider(rel, root=root)
+    res = SerializedOutputProvider(rel, root=root, ctx=ctx, ds=ds)
     res.rc = data["rc"]
     return res
 
@@ -1411,9 +1410,9 @@ def serialize_raw_file_provider(obj, root):
 
 
 @deserializer(RawFileProvider)
-def deserialize_raw_file_provider(_type, data, root):
+def deserialize_raw_file_provider(_type, data, root, ctx, ds):
     rel = data["relative_path"]
-    res = SerializedRawOutputProvider(rel, root=root)
+    res = SerializedRawOutputProvider(rel, root=root, ctx=ctx, ds=ds)
     res.rc = data["rc"]
     return res
 
@@ -1431,8 +1430,8 @@ def serialize_datasource_provider(obj, root):
 
 
 @deserializer(DatasourceProvider)
-def deserialize_datasource_provider(_type, data, root):
-    res = SerializedOutputProvider(data["relative_path"], root=root)
+def deserialize_datasource_provider(_type, data, root, ctx, ds):
+    res = SerializedOutputProvider(data["relative_path"], root=root, ctx=ctx, ds=ds)
     return res
 
 
@@ -1451,10 +1450,10 @@ def serialize_metadata_provider(obj, root):
 
 
 @deserializer(MetadataProvider)
-def deserialize_metadata_provider(_type, data, root):
+def deserialize_metadata_provider(_type, data, root, ctx, ds):
     # Built-in metadata files are put in the root instead of '/data'
     root = os.path.dirname(root) if os.path.basename(root) == 'data' else root
-    res = SerializedOutputProvider(data["relative_path"], root=root)
+    res = SerializedOutputProvider(data["relative_path"], root=root, ctx=ctx, ds=ds)
     return res
 
 
@@ -1478,9 +1477,9 @@ def serialize_container_file_output(obj, root):
 
 
 @deserializer(ContainerFileProvider)
-def deserialize_container_file(_type, data, root):
+def deserialize_container_file(_type, data, root, ctx, ds):
     rel = data["relative_path"]
-    res = SerializedOutputProvider(rel, root=root)
+    res = SerializedOutputProvider(rel, root=root, ctx=ctx, ds=ds)
     res.rc = data["rc"]
     res.image = data["image"]
     res.engine = data["engine"]
@@ -1510,9 +1509,9 @@ def serialize_container_command(obj, root):
 
 
 @deserializer(ContainerCommandProvider)
-def deserialize_container_command(_type, data, root):
+def deserialize_container_command(_type, data, root, ctx, ds):
     rel = data["relative_path"]
-    res = SerializedOutputProvider(rel, root=root)
+    res = SerializedOutputProvider(rel, root=root, ctx=ctx, ds=ds)
     res.rc = data["rc"]
     res.cmd = data["cmd"]
     res.args = data["args"]

--- a/insights/shell.py
+++ b/insights/shell.py
@@ -62,7 +62,7 @@ def _create_new_broker(path=None):
         broker[ctx.__class__] = ctx
 
         if isinstance(ctx, SerializedArchiveContext):
-            h = Hydration(ctx.root)
+            h = Hydration(ctx.root, ctx)
             broker = h.hydrate(broker=broker)
 
         dr.run(datasources, broker=broker)

--- a/insights/tests/test_serde.py
+++ b/insights/tests/test_serde.py
@@ -45,7 +45,7 @@ def serialize_doo(obj, root=None):
 
 
 @deserializer(Foo)
-def deserialize_foo(_type, data, root=None):
+def deserialize_foo(_type, data, root=None, ctx=None, ds=None):
     foo = _type.__new__(_type)
     foo.a = data.get("a")
     foo.b = data.get("b")
@@ -238,7 +238,7 @@ def test_round_trip():
         broker.exec_times[thing] = 0.5
         h.dehydrate(thing, broker)
         fn = ".".join([dr.get_name(thing), h.ser_name])
-        assert os.path.exists(os.path.join(h.meta_data, fn))
+        assert os.path.exists(os.path.join(h.meta_root, fn))
 
         broker = h.hydrate()
         assert thing in broker
@@ -263,7 +263,7 @@ def test_dehydrate():
         h = Hydration(tmp_path)
         h.dehydrate(spec_the_data, broker)
         fn = ".".join([dr.get_name(spec_the_data), h.ser_name])
-        meta_data_json = os.path.join(h.meta_data, fn)
+        meta_data_json = os.path.join(h.meta_root, fn)
         assert os.path.exists(meta_data_json)
         with open(meta_data_json, 'r') as fp:
             ret = json.load(fp)


### PR DESCRIPTION
- Pass the context and datasource to the Provider to fix the issue of: 
  When running rules against insights-archive collected by core-collection
  the context and datasource is not generated accordingly, it results in
  different behavior than sos-archive, e.g. cannot get the filters of specs

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
fix: #4081


