### PR TITLE
bug: Fix nginx conf parser for empty quoted params

### DIFF
--- a/insights/parsers/nginx_conf.py
+++ b/insights/parsers/nginx_conf.py
@@ -142,7 +142,7 @@ class NginxConfPEG(ConfigParser):
         EndBlock = WS >> RightCurly << WS
         Bare = String(set(string.printable) - (set(string.whitespace) | set("#;{}'\"")))
         Name = WS >> PosMarker(String(name_chars) | EmptyQuotedString(name_chars)) << WS
-        Attr = WS >> (Num | Bare | QuotedString) << WS
+        Attr = WS >> (Num | Bare | QuotedString | EmptyQuotedString(name_chars)) << WS
         Attrs = Many(Attr)
         Block = BeginBlock >> Many(Stmt).map(skip_none) << EndBlock
         Stanza = (Lift(to_entry) * Name * Attrs * (Block | SemiColon)) | Comment

--- a/insights/tests/parsers/test_nginx_conf.py
+++ b/insights/tests/parsers/test_nginx_conf.py
@@ -99,6 +99,20 @@ http {
 }
 """.strip()
 
+NGINX_EMPTY_QUOTE = """
+server{
+        listen 443 ssl;
+        ssl_certificate /etc/nginx/certificate/nginx-certificate.crt;
+        ssl_certificate_key /etc/nginx/certificate/nginx.key;
+        location / { try_files $uri @api; }
+        location @api {
+            include fastcgi_params;
+            fastcgi_param PATH_INFO $fastcgi_script_name;
+            fastcgi_param SCRIPT_NAME "";
+            fastcgi_pass localhost:5000;
+        }
+}""".strip()
+
 
 def test_nginxconfpeg():
     nginxconf = nginx_conf.NginxConfPEG(context_wrap(NGINXCONF))
@@ -152,6 +166,11 @@ def test_nginxconfpeg_container():
     assert nginxconf.engine == 'podman'
     assert nginxconf.image == 'quay.io/rhel8'
     assert nginxconf.container_id == 'xxxx'
+
+
+def test_nginxconf_empty_quote():
+    nginxconf = nginx_conf.NginxConfPEG(context_wrap(NGINX_EMPTY_QUOTE))
+    assert nginxconf['server'][0]['location'][-1]['fastcgi_param'][-1].value == 'SCRIPT_NAME '
 
 
 def test_doc():


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
* Fix issue #4086 by including empty quoted string as a valid param
* Added test for config