### PR TITLE
fix: canonical facts was not obfuscated when '--checkin'

### DIFF
--- a/insights/tests/client/test_connection_clean_facts.py
+++ b/insights/tests/client/test_connection_clean_facts.py
@@ -1,0 +1,71 @@
+try:
+    from unittest.mock import patch
+except Exception:
+    from mock import patch
+
+from copy import deepcopy
+
+from insights.client.connection import InsightsConnection
+from insights.util.hostname import determine_hostname
+
+from insights.client.config import InsightsConfig
+
+
+class MockSession(object):
+    def __init__(self):
+        self.status_code = None
+        self.text = None
+        self.content = '{"display_name": "test"}'
+        self.headers = dict()
+
+
+def mock_init_session(obj):
+    return MockSession()
+
+
+CFACTS = {
+    'hostname': determine_hostname(),
+    'ip': ['10.0.0.1', '192.168.0.1'],
+}
+
+
+@patch('insights.client.connection.InsightsConnection._init_session', mock_init_session)
+@patch('insights.client.connection.InsightsConnection.post', return_value=MockSession())
+@patch('insights.client.connection.InsightsUploadConf.get_rm_conf', return_value={})
+def test_connection_clean_facts_no_clean_all(rm_conf, post):
+    # No cleaning per client configuration
+    config = InsightsConfig(obfuscate=False)
+    conn = InsightsConnection(config)
+    tmp = deepcopy(CFACTS)
+    ret = conn._clean_facts(tmp)
+    # Nothing changed
+    assert ret == CFACTS
+
+
+@patch('insights.client.connection.InsightsConnection._init_session', mock_init_session)
+@patch('insights.client.connection.InsightsConnection.post', return_value=MockSession())
+@patch('insights.client.connection.InsightsUploadConf.get_rm_conf', return_value={})
+def test_connection_clean_facts_clean_ip_only(rm_conf, post):
+    # No hostname cleaning per client configuration
+    config = InsightsConfig(obfuscate=True, obfuscate_hostname=False)
+    conn = InsightsConnection(config)
+    tmp = deepcopy(CFACTS)
+    ret = conn._clean_facts(tmp)
+    # Hostname is not changed
+    assert ret['hostname'] == CFACTS['hostname']
+    # IPs are changed
+    assert ret['ip'] != CFACTS['ip']
+
+
+@patch('insights.client.connection.InsightsConnection._init_session', mock_init_session)
+@patch('insights.client.connection.InsightsConnection.post', return_value=MockSession())
+@patch('insights.client.connection.InsightsUploadConf.get_rm_conf', return_value={})
+def test_connection_clean_facts_clean_all(rm_conf, post):
+    config = InsightsConfig(obfuscate=True, obfuscate_hostname=True)
+    conn = InsightsConnection(config)
+    tmp = deepcopy(CFACTS)
+    ret = conn._clean_facts(tmp)
+    # Hostname is changed
+    assert ret['hostname'] != CFACTS['hostname']
+    # IPs are changed
+    assert ret['ip'] != CFACTS['ip']

--- a/insights/tests/client/test_platform.py
+++ b/insights/tests/client/test_platform.py
@@ -85,11 +85,12 @@ def test_upload_urls():
     assert c.upload_url == 'BUNCHANONSENSE'
 
 
+@patch('insights.client.connection.InsightsUploadConf.get_rm_conf', return_value={})
 @patch("insights.client.connection.InsightsConnection._legacy_upload_archive")
 @patch("insights.client.connection.get_canonical_facts", return_value={'test': 'facts'})
 @patch('insights.client.connection.InsightsConnection.post')
 @patch("insights.client.connection.open", new_callable=mock_open)
-def test_payload_upload(op, post, c, _legacy_upload_archive):
+def test_payload_upload(op, post, c, _legacy_upload_archive, rm_conf):
     '''
     Ensure a payload upload occurs with the right URL and params
     '''

--- a/insights/tests/client/test_upload_archive_cfacts.py
+++ b/insights/tests/client/test_upload_archive_cfacts.py
@@ -10,7 +10,6 @@ except Exception:
 
 from insights.client.connection import InsightsConnection
 from insights.util.hostname import determine_hostname
-
 from insights.client.config import InsightsConfig
 
 


### PR DESCRIPTION
- When obfuscate=True/obfuacate_hostname=True is specified,
  the canonical facts should also be obfuscated even when 'checkin'
- See RHINENG-9595

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
- RHINENG-9595
