### PR TITLE
feat: Improve debugging experience

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -26,7 +26,7 @@ from .support import registration_check
 from .constants import InsightsConstants as constants
 
 NETWORK = constants.custom_network_log_level
-LOG_FORMAT = ("%(asctime)s %(levelname)8s %(name)s %(message)s")
+LOG_FORMAT = ("%(asctime)s %(levelname)8s %(name)s:%(lineno)s %(message)s")
 logger = logging.getLogger(__name__)
 
 

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -7,6 +7,7 @@ import os
 import sys
 import runpy
 
+import insights
 from insights.client import InsightsClient
 from insights.client.config import InsightsConfig
 from insights.client.constants import InsightsConstants as constants
@@ -27,8 +28,10 @@ def phase(func):
         except (ValueError, OSError) as e:
             sys.stderr.write('ERROR: ' + str(e) + '\n')
             sys.exit(constants.sig_kill_bad)
-        if config.debug:
-            logger.info("Core path: %s", os.path.dirname(__file__))
+
+        logger.debug("Core path: %s", os.path.dirname(insights.__path__[0]))
+        logger.debug("Core version: %s", client.version())
+
         try:
             func(client, config)
         except Exception:


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

[CCT-372](https://issues.redhat.com/browse/CCT-372)

This pull request fixes a repeating issue that it’s hard to determine the core (egg) version from customer logs.

To improve client-side debugging, made the core log its version along its path whenever verbose mode is enabled. It is no longer necessary to pass --debug, which was the sole use case of this undocumented flag. Like this, the core version can be found in any log file captured from a customer’s machine.

The core path is now less confusing. It points to core package top directory, not to a module containing the log call. The logic is the same as in the Client.

To find the exact place where logged events occur, a line number is now part of every log message.

Steps to verify:

1. Run the Client with the `--verbose` CLI switch, or the `INSIGHTS_VERBOSE=True` environment variable, but without the `--debug` switch and the `INSIGHTS_DEBUG`.
2. See the Core version being logged at the initialization of every phase.
3. See the improved Core path pointing to the package root, not to `/insights/client/phase/v1`.


