### PR TITLE
fix: ParseException raising in parsers.scsi

### DIFF
--- a/insights/parsers/scsi.py
+++ b/insights/parsers/scsi.py
@@ -1,6 +1,6 @@
 from collections import deque
 from insights.core import Parser
-from insights.core.exceptions import ParseException
+from insights.core.exceptions import ParseException, SkipComponent
 from insights.core.plugins import parser
 from insights.specs import Specs
 
@@ -60,13 +60,15 @@ class SCSI(Parser):
     TYPE_KEYS_ALT = ['Type', 'ANSI  SCSI revision']
 
     def parse_content(self, content, header='Attached devices:'):
-        if not content or len(content) < 1:
-            raise ParseException("Empty content of file /proc/scsi/scsi", content)
+        if not content:
+            raise SkipComponent("Empty content of file /proc/scsi/scsi", content)
         devices = []
         if header:
             if content[0] != header:
                 msg = 'Expected Header: %s but got %s' % (header, content[0])
                 raise ParseException(msg)
+            if len(content) == 1:
+                raise ParseException("Content has only header but no other content: ", content)
             content = content[1:]
         lines = deque(filter(None, [line.strip() for line in content]))
         while lines:


### PR DESCRIPTION
 ### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

for RHINENG-9677 

Raise `SkipComponent` instead of `ParseException` for the empty content case. 

| count| component| request_id| exception|
|------|---------------------|--------------------------------|--------------------------------------------------|
| 53234| insights.specs.Specs.scsi|some-request-id| ParseException('Empty content of file /proc/scsi/scsi', [])|
| 53234| insights.parsers.scsi.SCSI|some-request-id| ParseException('Empty content of file /proc/scsi/scsi', [])|

