### PR TITLE
fix: only non-filter exception can terminate the first_file spec

### DIFF
--- a/insights/core/exceptions.py
+++ b/insights/core/exceptions.py
@@ -80,6 +80,11 @@ class ContentException(SkipComponent):
     pass
 
 
+class NoFilterException(ContentException):
+    """ Raised whenever no filters added to a `filterable` :class:`datasource`."""
+    pass
+
+
 class InvalidContentType(InvalidArchive):
     def __init__(self, content_type):
         self.msg = 'Invalid content type: "%s"' % content_type


### PR DESCRIPTION
- see RHINENG-9993
- the "non-filter" exception can terminate a first_file spec,
  as the "filter" is based on the RegistryPoint, but not the sub-items
- the "non-existing" path exception should not terminate the first_file spec,
  as all paths in the list should be checked one by one

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
- See RHINENG-9993
