### PR TITLE
fix: debug print of egg versions doesn't handle corrupted eggs

### DIFF
--- a/insights/client/utilities.py
+++ b/insights/client/utilities.py
@@ -304,8 +304,13 @@ def print_egg_versions():
             logger.debug('Could not start python.')
             return
         stdout, stderr = proc.communicate()
-        version = stdout.decode('utf-8', 'ignore').strip()
-        logger.debug('%s: %s', egg, version)
+        exit_code = proc.wait()
+
+        if exit_code == 0:
+            version = stdout.decode('utf-8', 'ignore').strip()
+            logger.debug('%s: %s', egg, version)
+        else:
+            logger.debug('%s: Could not read egg version.', egg)
 
 
 def read_pidfile():


### PR DESCRIPTION
New if-else statement is added to check if exit code of previous Popen call is == 0 . Statement is added to insights.client.utilities.print_egg_version method.

CARD ID: CCT-406

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

Originally, when unimportable egg was encountered, Insights client logged part of the traceback to the DEBUG log. I added a functionality which checks exit code of corresponding subprocess calling import and egg and if the code is not == 0, then it results to message ""path/to/egg: Corrupted egg." I was not able to capture exception from subprocess, so I choose this approach by using exit status. There is space for discussion whether there could happen another scenarios other than unimportable corrupted egg. Non-existing egg is already handled in code before.