### PR TITLE
fix: env INSIGHTS_FILTERS_ENABLED no longer works

### DIFF
--- a/insights/core/filters.py
+++ b/insights/core/filters.py
@@ -159,8 +159,13 @@ def get_filters(component):
             filters |= inner(d, filters)
         return filters
 
+    if not component:
+        # No filters for nothing
+        return set()
+
     if component not in _CACHE:
         _CACHE[component] = inner(component)
+
     return _CACHE[component]
 
 
@@ -170,7 +175,7 @@ def apply_filters(target, lines):
     integration tests. Filters are applied in an equivalent but more performant
     way at run time.
     """
-    filters = get_filters(target) if target else None
+    filters = get_filters(target)
     if filters:
         for l in lines:
             if any(f in l for f in filters):


### PR DESCRIPTION
- validate the filters of 'filterable' specs only when the variable is True
  when it's False, all content will be loaded (this is not changed in this PR)
- fix: #4103

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

