### PR TITLE
fix: 'NoneType' AttributeError in insights-info

### DIFF
--- a/insights/tools/query.py
+++ b/insights/tools/query.py
@@ -174,7 +174,7 @@ def matches(d, path):
 
     if isinstance(d, sf.foreach_execute):
         # Get the command name from the simple_command string
-        search_tgt = d.cmd.strip('/').split()[0].split('/')[-1]
+        search_tgt = d.cmd.strip('/').split()[0].split('/')[-1] if d.cmd else ''
         return search_tgt.startswith(path)
 
     if isinstance(d, sf.foreach_collect):


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

fix this below error of `insights-info` run: 
```
$ insights-info insights.specs.Specs.hosts  
Traceback (most recent call last):
  File "/Users/joy/Work/insights-core/venv/bin/insights-info", line 33, in <module>
    sys.exit(load_entry_point('insights-core', 'console_scripts', 'insights-info')())
  File "/Users/joy/Work/insights-core/insights/tools/query.py", line 412, in main
    ds = get_matching_datasources(args.paths)
  File "/Users/joy/Work/insights-core/insights/tools/query.py", line 193, in get_matching_datasources
    if matches(d, path):
  File "/Users/joy/Work/insights-core/insights/tools/query.py", line 177, in matches
    search_tgt = d.cmd.strip('/').split()[0].split('/')[-1]
AttributeError: 'NoneType' object has no attribute 'strip'
```