### PR TITLE
feat: enhance falconctl_aid exception parsing

### DIFF
--- a/insights/parsers/falconctl.py
+++ b/insights/parsers/falconctl.py
@@ -43,9 +43,9 @@ class FalconctlBackend(CommandParser):
         if not content:
             raise SkipComponent("Empty.")
         self.backend = ""
-        if "=" in content[0]:
+        if len(content) == 1 and "=" in content[0]:
             self.backend = content[0].split(".")[0].split("=")[-1].strip()
-        elif " is not set." in content[0]:
+        elif len(content) == 1 and " is not set." in content[0]:
             self.backend = "not set"
 
         if not self.backend:

--- a/insights/parsers/falconctl.py
+++ b/insights/parsers/falconctl.py
@@ -45,8 +45,11 @@ class FalconctlBackend(CommandParser):
         self.backend = ""
         if "=" in content[0]:
             self.backend = content[0].split(".")[0].split("=")[-1].strip()
-        else:
+        elif " is not set." in content[0]:
             self.backend = "not set"
+
+        if not self.backend:
+            raise ParseException("Invalid content: {0}".format(content))
 
 
 @parser(Specs.falconctl_rfm)
@@ -100,6 +103,8 @@ class FalconctlAid(CommandParser):
         self.aid = None
         if len(content) == 1 and "=" in content[0]:
             self.aid = content[0].split(".")[0].split("=")[-1].strip('" ')
+        elif len(content) == 1 and " is not set." in content[0]:
+            self.aid = "not set"
 
         if not self.aid:
             raise ParseException("Invalid content: {0}".format(content))

--- a/insights/tests/parsers/test_falconctl.py
+++ b/insights/tests/parsers/test_falconctl.py
@@ -14,6 +14,10 @@ BACKEND_2 = """
 backend=auto.
 """.strip()
 
+BACKEND_INVALID_1 = """
+backend?auto.
+""".strip()
+
 RFM_1 = """
 rfm-state=false.
 """.strip()
@@ -27,6 +31,10 @@ RFM_EMPTY = ""
 
 AID_VALID = """
 aid="44e3b7d20b434a2bb2815d9808fa3a8b".
+""".strip()
+
+AID_VALID_UNSET = """
+aid is not set.
 """.strip()
 
 AID_INVALID_1 = """
@@ -66,6 +74,10 @@ def test_backend_empty():
         FalconctlBackend(context_wrap(BACKEND_EMPTY))
     assert 'SkipComponent' in str(e)
 
+    with pytest.raises(ParseException) as e:
+        FalconctlBackend(context_wrap(BACKEND_INVALID_1))
+    assert 'Invalid content:' in str(e)
+
 
 def test_rfm_empty():
     with pytest.raises(SkipComponent) as e:
@@ -76,6 +88,9 @@ def test_rfm_empty():
 def test_falconctl_aid():
     aid = FalconctlAid(context_wrap(AID_VALID))
     assert aid.aid == "44e3b7d20b434a2bb2815d9808fa3a8b"
+
+    aid = FalconctlAid(context_wrap(AID_VALID_UNSET))
+    assert aid.aid == "not set"
 
 
 def test_falconctl_aid_invalid():


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Had seen some `ParseException: "Invalid content: ['aid is not set.']"` .  enhance to special handle this `"not set"` case as `falconctl_backend`.

