### PR TITLE
Draft: feat: collect all cmdline files for each qemu-kvm processes

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -82,6 +82,7 @@ class DefaultSpecs(Specs):
     # Dependent specs that aren't in the registry
     block_devices_by_uuid = listdir("/dev/disk/by-uuid/", context=HostContext)
     httpd_pid = simple_command("/usr/bin/pgrep -o httpd")
+    qemu_kvm_pid = simple_command("/usr/bin/pgrep qemu-kvm")
     openshift_router_pid = simple_command("/usr/bin/pgrep -n openshift-route")
     ovs_vsctl_list_br = simple_command("/usr/bin/ovs-vsctl list-br")
 
@@ -515,6 +516,7 @@ class DefaultSpecs(Specs):
     puppet_ca_cert_expire_date = simple_command("/usr/bin/openssl x509 -in /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem -enddate -noout")
     pvs_noheadings = simple_command("/sbin/pvs --nameprefixes --noheadings --separator='|' -a -o pv_all,vg_name --config=\"global{locking_type=0}\"")
     rhsm_katello_default_ca_cert = simple_command("/usr/bin/openssl x509 -in /etc/rhsm/ca/katello-default-ca.pem -noout -issuer")
+    qemu_kvm_cmdline = foreach_collect(qemu_kvm_pid, "/proc/%s/cmdline")
     qemu_xml = glob_file(r"/etc/libvirt/qemu/*.xml")
     ql2xmaxlun = simple_file("/sys/module/qla2xxx/parameters/ql2xmaxlun")
     ql2xmqsupport = simple_file("/sys/module/qla2xxx/parameters/ql2xmqsupport")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
To collect the cmdline files for each qemu-kvm processes.
The example data is as below:
~~~
/usr/libexec/qemu-kvm-namejiajun-vm-1_jiajun-db2-test-S-machinepc-i440fx-rhel7.0.0,accel=kvm,usb=off,dump-guest-core=off-cpuIvyBridge,+ds,+acpi,+ss,+ht,+tm,+pbe,+dtes64,+monitor,+ds_cpl,+vmx,+smx,+est,+tm2,+xtpr,+pdcm,+pcid,+dca,+osxsave,+arat,+xsaveopt,+pdpe1gb-m24000-realtimemlock=off-smp8,sockets=8,cores=1,threads=1-uuidaa742374-099c-4db4-bbc9-a7768bbb2a3e-no-user-config-nodefaults-chardevsocket,id=charmonitor,path=/var/lib/libvirt/qemu/domain-1294-jiajun-vm-1_jiajun-d/monitor.sock,server,nowait-monchardev=charmonitor,id=monitor,mode=control-rtcbase=utc-no-shutdown-bootstrict=on-devicepiix3-usb-uhci,id=usb,bus=pci.0,addr=0x1.0x2-drivefile=/var/lib/libvirt/images/jiajun-vm-1_jiajun-db2-test.img,format=qcow2,if=none,id=drive-ua-box-volume-0-devicevirtio-blk-pci,scsi=off,bus=pci.0,addr=0x3,drive=drive-ua-box-volume-0,id=ua-box-volume-0,bootindex=1-netdevtap,fd=47,id=hostua-net-0,vhost=on,vhostfd=51-devicevirtio-net-pci,netdev=hostua-net-0,id=ua-net-0,mac=52:54:00:fc:b1:cb,bus=pci.0,addr=0x5-chardevpty,id=charserial0-deviceisa-serial,chardev=charserial0,id=serial0-vnc127.0.0.1:5-ken-us-vgacirrus-devicevirt
~~~
