### PR TITLE
chore: collect image builder's osbuild.facts

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -267,6 +267,7 @@ class Specs(SpecSet):
     ifcfg = RegistryPoint(multi_output=True)
     ifcfg_static_route = RegistryPoint(multi_output=True)
     imagemagick_policy = RegistryPoint(multi_output=True, filterable=True, no_obfuscate=['ip'])
+    image_builder_facts = RegistryPoint()
     init_ora = RegistryPoint()
     init_process_cgroup = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     initctl_lst = RegistryPoint(no_obfuscate=['hostname', 'ip'])

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -279,6 +279,7 @@ class DefaultSpecs(Specs):
     ifcfg = glob_file("/etc/sysconfig/network-scripts/ifcfg-*")
     ifcfg_static_route = glob_file("/etc/sysconfig/network-scripts/route-*")
     imagemagick_policy = glob_file(["/etc/ImageMagick/policy.xml", "/usr/lib*/ImageMagick-6.5.4/config/policy.xml"])
+    image_builder_facts = simple_file("/etc/rhsm/facts/osbuild.facts")
     init_process_cgroup = simple_file("/proc/1/cgroup")
     initctl_lst = simple_command("/sbin/initctl --system list")
     insights_client_conf = simple_file('/etc/insights-client/insights-client.conf')


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
RedHatInsights/insights-core#3848 added an image builder fact to the
    subscription_manage parser, but there are multiple facts present in
    osbuild.facts. Just expose all of them.
