### PR TITLE
fix: Serialize playbooks manually on Python 3.12+

### DIFF
--- a/insights/client/apps/ansible/playbook_verifier/__init__.py
+++ b/insights/client/apps/ansible/playbook_verifier/__init__.py
@@ -4,11 +4,13 @@ import hashlib
 import logging
 import os
 import pkgutil
+import sys
 import tempfile
 
 import six
 
 import insights.client.apps.ansible
+from insights.client.apps.ansible.playbook_verifier.serializer import PlaybookSerializer
 from insights.client.apps.ansible.playbook_verifier.contrib import gnupg
 from insights.client.apps.ansible.playbook_verifier.contrib.ruamel_yaml.ruamel import yaml
 from insights.client.apps.ansible.playbook_verifier.contrib.ruamel_yaml.ruamel.yaml.comments import CommentedMap, CommentedSeq
@@ -114,7 +116,9 @@ def serialize_playbook_snippet(snippet):
     """
     if six.PY2:
         return str(normalize_snippet(snippet)).encode("utf-8")
-    return str(snippet).encode("utf-8")
+    if sys.version_info < (3, 12):
+        return str(snippet).encode("utf-8")
+    return PlaybookSerializer.serialize(snippet).encode("utf-8")
 
 
 def hash_playbook_snippet(serialized_snippet):

--- a/insights/client/apps/ansible/playbook_verifier/serializer.py
+++ b/insights/client/apps/ansible/playbook_verifier/serializer.py
@@ -1,0 +1,70 @@
+from insights.client.apps.ansible.playbook_verifier.contrib.ruamel_yaml.ruamel.yaml.comments import (
+    CommentedMap,
+    CommentedSeq,
+)
+
+
+class PlaybookSerializer:
+    @classmethod
+    def serialize(cls, source):
+        """Serialize snippet into string.
+
+        :param source: Parsed playbook.
+        :type source: dict | yaml.comments.CommentedMap
+        :returns: Serialized playbook.
+        :rtype: str
+        """
+        return cls._dict(source)
+
+    @classmethod
+    def _dict(cls, source):
+        """
+        :type source: dict | yaml.comments.CommentedMap
+        :rtype: str
+        """
+        result_map = {}  # type: dict[str, str]
+
+        for key, value in source.items():
+            if isinstance(value, dict) or isinstance(value, CommentedMap):
+                result_map[key] = cls._dict(value)
+                continue
+            if isinstance(value, list) or isinstance(value, CommentedSeq):
+                result_map[key] = cls._list(value)
+                continue
+            if isinstance(value, int) or isinstance(value, float):
+                result_map[key] = str(value)
+                continue
+            result_map[key] = "'{value}'".format(value=value)
+
+        result = "ordereddict(["
+        result += ", ".join(
+            "('{key}', {value})".format(key=key, value=value)
+            for key, value in result_map.items()
+        )
+        result += "])"
+        return result
+
+    @classmethod
+    def _list(cls, source):
+        """
+        :type source: list | yaml.comments.CommentedSeq
+        :rtype: str
+        """
+        result_list = []  # type: list[str]
+
+        for value in source:
+            if isinstance(value, list) or isinstance(value, CommentedSeq):
+                result_list.append(cls._list(value))
+                continue
+            if isinstance(value, dict) or isinstance(value, CommentedMap):
+                result_list.append(cls._dict(value))
+                continue
+            if isinstance(value, int) or isinstance(value, float):
+                result_list.append(str(value))
+                continue
+            result_list.append("'{value}'".format(value=value))
+
+        result = "["
+        result += ", ".join(value for value in result_list)
+        result += "]"
+        return result


### PR DESCRIPTION
* Card ID: CCT-538

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The playbook verification relies signatures created from hashes of serialized snippets/playbooks. Python 3.12 changed the way it serializes OrderedDict objects into strings, making the verification fail, resulting in valid playbooks being rejected.

This patch mimics the old serialization logic in a tested and easy-to-debug way.