### PR TITLE
fix(test): Catch errors caused by GPG

### DIFF
--- a/insights/tests/client/apps/test_playbook_verifier.py
+++ b/insights/tests/client/apps/test_playbook_verifier.py
@@ -76,7 +76,10 @@ class TestErrors:
                 assert key_error in str(error.value)
         finally:
             if os.path.exists(temp_dir):
-                shutil.rmtree(temp_dir)
+                try:
+                    shutil.rmtree(temp_dir)
+                except OSError:
+                    pass
 
     @patch('insights.client.apps.ansible.playbook_verifier.PUBLIC_KEY_PATH', None)
     def test_key_import_error(self):
@@ -100,7 +103,10 @@ class TestErrors:
                 assert key_error in str(error.value)
         finally:
             if os.path.exists(temp_dir):
-                shutil.rmtree(temp_dir)
+                try:
+                    shutil.rmtree(temp_dir)
+                except OSError:
+                    pass
 
     @patch('insights.client.apps.ansible.playbook_verifier.verify_playbook_snippet', return_value=([], []))
     @patch('insights.client.apps.ansible.playbook_verifier.get_playbook_snippet_revocation_list', return_value=[])
@@ -139,7 +145,10 @@ class TestErrors:
                 assert result == fake_playbook
         finally:
             if os.path.exists(temp_dir):
-                shutil.rmtree(temp_dir)
+                try:
+                    shutil.rmtree(temp_dir)
+                except OSError:
+                    pass
 
     # get_playbook_snippet_revocation_list can't load list
     @patch('insights.client.apps.ansible.playbook_verifier.contrib.ruamel_yaml.ruamel.yaml.YAML.load', side_effect=Exception())


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

There exists a race condition when removing files in a directory in which GPG has saved its runtime data.

When GPG detects the files are getting removed, it will kill its socket and start deleting the files. In that case, `rmtree` may try to delete a file that has already been deleted by GPG, causing `OSError`.
