### PR TITLE
feat: include JSON format in malware detection results

### DIFF
--- a/insights/specs/datasources/malware_detection/__init__.py
+++ b/insights/specs/datasources/malware_detection/__init__.py
@@ -231,7 +231,7 @@ class MalwareDetectionClient:
                             MALWARE_APP_URL, MALWARE_CONFIG_FILE)
 
             # This is what is uploaded to the malware backend
-            return host_scan_mutation
+            return (host_scan_mutation, self.host_scan)
         else:
             logger.error("No scans performed, no results to upload.")
             exit(constants.sig_kill_bad)

--- a/insights/specs/datasources/malware_detection/malware_detection_ds.py
+++ b/insights/specs/datasources/malware_detection/malware_detection_ds.py
@@ -10,6 +10,7 @@ collected. To collect other specs within the collection of malware-detection,
 add them to the "persist" section in the "malware_detection_manifest"
 pre-defined in the :py:mod:`insights.specs.datasources.manifests`
 """
+import json
 import logging
 
 from insights.core.context import HostContext
@@ -40,7 +41,10 @@ def malware_detection(broker):
         mdc = MalwareDetectionClient(insights_config)
         scan_results = mdc.run()
         if scan_results:
-            return DatasourceProvider(content=scan_results, relative_path="malware-detection-results.json")
+            return [
+                DatasourceProvider(content=scan_results[0], relative_path="malware-detection-results.json"),
+                DatasourceProvider(content=json.dumps(scan_results[1]), relative_path="malware-detection-results-raw.json")
+            ]
         else:
             raise SkipComponent("No scan results were produced")
     except SkipComponent as msg:

--- a/insights/tests/datasources/malware_detection/test_malware_detection.py
+++ b/insights/tests/datasources/malware_detection/test_malware_detection.py
@@ -369,11 +369,23 @@ class TestsUtilizingFakeYara:
                                          "python insights_client/run.py --collector malware-detection"]
                 mutation = mdc.run()
             log_mock.info.assert_any_call("Found %d rule match%s.", 2, "es")
-            assert 'ruleName: "TEST_RedHatInsightsMalwareDetection"' in mutation
-            assert 'source: "%s"' % TEST_RULE_FILE in mutation
-            assert 'source: "%s"' % TEST_PID in mutation
-            assert re.search('metadata:.*line_number', mutation)
-            assert re.search('metadata:.*process_name', mutation)
+            # Test scan results in mutation format
+            assert 'ruleName: "TEST_RedHatInsightsMalwareDetection"' in mutation[0]
+            assert 'source: "%s"' % TEST_RULE_FILE in mutation[0]
+            assert 'source: "%s"' % TEST_PID in mutation[0]
+            assert re.search('metadata:.*line_number', mutation[0])
+            assert re.search('metadata:.*process_name', mutation[0])
+            # Test scan results in JSON format
+            rule = 'TEST_RedHatInsightsMalwareDetection'
+            assert len(mutation[1][rule]) == 2
+            assert mutation[1][rule][0]['source'] == TEST_RULE_FILE
+            assert mutation[1][rule][1]['source'] == TEST_PID
+            assert mutation[1][rule][0]['string_data'] == 'Malware Detection Client'
+            assert mutation[1][rule][1]['string_data'] == 'Malware Detection Client'
+            assert mutation[1][rule][0]['metadata']['source_type'] == 'file'
+            assert mutation[1][rule][0]['metadata']['line'] == '//%20Verifies%20the%20Red%20Hat%20Insights%20Malware%20Detection%20Client%20app%20is%20present%20on%20the%20system'
+            assert mutation[1][rule][1]['metadata']['source_type'] == 'process'
+            assert mutation[1][rule][1]['metadata']['process_name'] == 'python insights_client/run.py --collector malware-detection'
 
     @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
     @patch(BUILD_YARA_COMMAND_TARGET)


### PR DESCRIPTION
RHINENG-10594

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
In the Insights archive, malware scan results are passed as GraphQL mutation query only.
Incoming changes include additional file `malware-detection-results-raw.json`, which contains JSON representation of python dictionary that was used to compose mutation query.
New file will be consumed by the newest version of malware-detection app. Old file is still needed for backwards compatibility.
