### PR TITLE
feat: collect selinux issues of collection via ausearch

### DIFF
--- a/insights/components/rhel_version.py
+++ b/insights/components/rhel_version.py
@@ -1,15 +1,18 @@
 """
-IsRhel6, IsRhel7, IsRhel8, and IsRhel9
-======================================
+IsRhel - components to check RHEL version
+=========================================
 
-An ``IsRhel*`` component is valid if the
-:py:class:`insights.combiners.redhat_release.RedHatRelease` combiner indicates
-the major RHEL version represented by the component. Otherwise, it raises a
-:py:class:`insights.core.exceptions.SkipComponent` to prevent dependent components from
-executing.
+``IsRhel#``,  ``IsGtRhel#``, ``IsGtOrRhel#`` component are included in this
+module.
 
-In particular, an ``IsRhel*`` component can be added as a dependency of a
-parser to limit it to a given version.
+The component is valid if the RHEL version got from the
+:py:class:`insights.combiners.redhat_release.RedHatRelease` of the current
+host satisfies the requirements.  Otherwise, it raises a
+:py:class:`insights.core.exceptions.SkipComponent` to prevent dependent
+components from triggering.
+
+In particular, the component can be added as a dependency of another
+components, e.g. Specs or Parsers parser to limit it to a given version.
 """
 from insights.combiners.redhat_release import RedHatRelease
 from insights.core.exceptions import SkipComponent
@@ -28,24 +31,51 @@ class IsRhel(object):
     Raises:
         SkipComponent: When RHEL major version does not match version.
     """
-    def __init__(self, rhel, version=None):
-        if rhel.major != version:
-            raise SkipComponent("Not RHEL{vers}".format(vers=version))
+    def __init__(self, rhel, major=None):
+        if rhel.major != major:
+            raise SkipComponent("Not RHEL {0}".format(major))
+        self.minor = rhel.minor
+
+
+class IsGtRhel(object):
+    """
+    This component uses ``RedhatRelease`` combiner to determine the RHEL
+    version. It then checks if the major version matches the version argument,
+    if it doesn't it raises ``SkipComponent``.
+
+    When `equal` is set to True, it checks "greater than or equal".  Otherwise,
+    it only checks "greater than".
+
+    Attributes:
+        major (int): The major version of RHEL.
+        minor (int): The minor version of RHEL.
+
+    Raises:
+        SkipComponent: When RHEL version does not match the specified version.
+    """
+    def __init__(self, rhel, major, minor, equal=False):
+        if rhel.major < major:
+            raise SkipComponent("Not RHEL newer than {0}.{1}".format(major, minor))
+        if equal:
+            if rhel.major == major and rhel.minor < minor:
+                raise SkipComponent("Not RHEL newer than or equal {0}.{1}".format(major, minor))
+        else:
+            if rhel.major == major and rhel.minor <= minor:
+                raise SkipComponent("Not RHEL newer than {0}.{1}".format(major, minor))
+        self.major = rhel.major
         self.minor = rhel.minor
 
 
 @component(RedHatRelease)
 class IsRhel6(IsRhel):
     """
-    This component uses ``RedHatRelease`` combiner
-    to determine RHEL version. It checks if RHEL6, if not
-    RHEL6 it raises ``SkipComponent``.
+    This component checks if it's RHEL 6.
 
     Attributes:
         minor (int): The minor version of RHEL 6.
 
     Raises:
-        SkipComponent: When RHEL version is not RHEL6.
+        SkipComponent: When RHEL version is not RHEL 6.
     """
     def __init__(self, rhel):
         super(IsRhel6, self).__init__(rhel, 6)
@@ -54,15 +84,13 @@ class IsRhel6(IsRhel):
 @component(RedHatRelease)
 class IsRhel7(IsRhel):
     """
-    This component uses ``RedHatRelease`` combiner
-    to determine RHEL version. It checks if RHEL7, if not
-    RHEL7 it raises ``SkipComponent``.
+    This component checks if it's RHEL 7.
 
     Attributes:
         minor (int): The minor version of RHEL 7.
 
     Raises:
-        SkipComponent: When RHEL version is not RHEL7.
+        SkipComponent: When RHEL version is not RHEL 7.
     """
     def __init__(self, rhel):
         super(IsRhel7, self).__init__(rhel, 7)
@@ -71,15 +99,13 @@ class IsRhel7(IsRhel):
 @component(RedHatRelease)
 class IsRhel8(IsRhel):
     """
-    This component uses ``RedhatRelease`` combiner
-    to determine RHEL version. It checks if RHEL8, if not
-    RHEL8 it raises ``SkipComponent``.
+    This component checks if it's RHEL 8.
 
     Attributes:
         minor (int): The minor version of RHEL 8.
 
     Raises:
-        SkipComponent: When RHEL version is not RHEL8.
+        SkipComponent: When RHEL version is not RHEL 8.
     """
     def __init__(self, rhel):
         super(IsRhel8, self).__init__(rhel, 8)
@@ -88,15 +114,45 @@ class IsRhel8(IsRhel):
 @component(RedHatRelease)
 class IsRhel9(IsRhel):
     """
-    This component uses ``RedhatRelease`` combiner
-    to determine RHEL version. It checks if RHEL9, if not
-    RHEL9 it raises ``SkipComponent``.
+    This component checks if it's RHEL 9.
 
     Attributes:
         minor (int): The minor version of RHEL 9.
 
     Raises:
-        SkipComponent: When RHEL version is not RHEL9.
+        SkipComponent: When RHEL version is not RHEL 9.
     """
     def __init__(self, rhel):
         super(IsRhel9, self).__init__(rhel, 9)
+
+
+@component(RedHatRelease)
+class IsGtOrRhel86(IsGtRhel):
+    """
+    This component checks if the RHEL version is 8.6 or grater than 8.6.
+
+    Attributes:
+        major (int): The major version of RHEL.
+        minor (int): The minor version of RHEL.
+
+    Raises:
+        SkipComponent: When RHEL version is not 8.6 and less than 8.6
+    """
+    def __init__(self, rhel):
+        super(IsGtOrRhel86, self).__init__(rhel, 8, 6, equal=True)
+
+
+@component(RedHatRelease)
+class IsGtRhel86(IsGtRhel):
+    """
+    This component checks if the RHEL version is grater than 8.6.
+
+    Attributes:
+        major (int): The major version of RHEL.
+        minor (int): The minor version of RHEL.
+
+    Raises:
+        SkipComponent: When RHEL version is 8.6 or less than 8.6
+    """
+    def __init__(self, rhel):
+        super(IsGtRhel86, self).__init__(rhel, 8, 6, equal=False)

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -25,6 +25,7 @@ class Specs(SpecSet):
     auditctl_status = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     auditd_conf = RegistryPoint()
     audispd_conf = RegistryPoint()
+    ausearch_insights_client = RegistryPoint(prio=-1)  # The last spec to collect
     authselect_current = RegistryPoint()
     autofs_conf = RegistryPoint()
     avc_cache_threshold = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -16,7 +16,7 @@ import signal
 # - keep line length less than 80 characters
 from insights.components.ceph import IsCephMonitor
 from insights.components.cloud_provider import IsAzure, IsGCP
-from insights.components.rhel_version import IsRhel6
+from insights.components.rhel_version import IsRhel6, IsGtOrRhel86
 from insights.components.satellite import (
     IsSatellite, IsSatellite611,
     IsSatellite614AndLater, IsSatelliteLessThan614)
@@ -109,6 +109,7 @@ class DefaultSpecs(Specs):
     auditctl_status = simple_command("/sbin/auditctl -s")
     auditd_conf = simple_file("/etc/audit/auditd.conf")
     audispd_conf = simple_file("/etc/audisp/audispd.conf")
+    ausearch_insights_client = simple_command("ausearch -i -m avc,user_avc,selinux_err,user_selinux_err -ts recent -su insights_client", deps=[IsGtOrRhel86])
     aws_instance_id_doc = command_with_args('/usr/bin/curl -s -H "X-aws-ec2-metadata-token: %s" http://169.254.169.254/latest/dynamic/instance-identity/document --connect-timeout 5', aws.aws_imdsv2_token, deps=[aws.aws_imdsv2_token])
     aws_instance_id_pkcs7 = command_with_args('/usr/bin/curl -s -H "X-aws-ec2-metadata-token: %s" http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 --connect-timeout 5', aws.aws_imdsv2_token, deps=[aws.aws_imdsv2_token])
     aws_public_hostnames = command_with_args('/usr/bin/curl -s -H "X-aws-ec2-metadata-token: %s" http://169.254.169.254/latest/meta-data/public-hostname --connect-timeout 5', aws.aws_imdsv2_token, deps=[aws.aws_imdsv2_token])

--- a/insights/tests/components/test_rhel_version.py
+++ b/insights/tests/components/test_rhel_version.py
@@ -1,7 +1,9 @@
 import pytest
 
 from insights.combiners.redhat_release import RedHatRelease as RR
-from insights.components.rhel_version import IsRhel6, IsRhel7, IsRhel8, IsRhel9
+from insights.components.rhel_version import (
+    IsRhel6, IsRhel7, IsRhel8, IsRhel9,
+    IsGtRhel86, IsGtOrRhel86)
 from insights.core.exceptions import SkipComponent
 from insights.parsers.redhat_release import RedhatRelease
 from insights.parsers.uname import Uname
@@ -10,110 +12,141 @@ from insights.tests import context_wrap
 
 UNAME = "Linux localhost.localdomain 3.10.0-327.rt56.204.el7.x86_64 #1 SMP PREEMPT RT Thu Oct 29 21:54:23 EDT 2015 x86_64 x86_64 x86_64 GNU/Linux"
 
-REDHAT_RELEASE1 = """
+REDHAT_RELEASE_67 = """
 Red Hat Enterprise Linux Server release 6.7 (Santiago)
 """.strip()
 
-REDHAT_RELEASE2 = """
+REDHAT_RELEASE_72 = """
 Red Hat Enterprise Linux Server release 7.2 (Maipo)
 """.strip()
 
-REDHAT_RELEASE3 = """
+REDHAT_RELEASE_75_014 = """
 Red Hat Enterprise Linux release 7.5-0.14
 """.strip()
 
-REDHAT_RELEASE4 = """
+REDHAT_RELEASE_80 = """
 Red Hat Enterprise Linux release 8.0 (Ootpa)
 """.strip()
 
-REDHAT_RELEASE5 = """
+REDHAT_RELEASE_86 = """
+Red Hat Enterprise Linux release 8.6 (Ootpa)
+""".strip()
+
+REDHAT_RELEASE_90 = """
 Red Hat Enterprise Linux release 9.0 (Plow)
 """.strip()
 
 
 # RHEL6 Tests
 def test_is_rhel6():
-    rr = RedhatRelease(context_wrap(REDHAT_RELEASE1))
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_67))
     rel = RR(None, rr)
     result = IsRhel6(rel)
     assert isinstance(result, IsRhel6)
 
-
-def test_not_rhel6():
-    rr = RedhatRelease(context_wrap(REDHAT_RELEASE2))
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_72))
     rel = RR(None, rr)
     with pytest.raises(SkipComponent) as e:
         IsRhel6(rel)
-    assert "Not RHEL6" in str(e)
+    assert "Not RHEL 6" in str(e)
 
 
 # RHEL7 Server Tests
-def test_is_rhel7s():
-    rr = RedhatRelease(context_wrap(REDHAT_RELEASE2))
+def test_is_rhel7():
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_72))
     rel = RR(None, rr)
     result = IsRhel7(rel)
     assert isinstance(result, IsRhel7)
 
-
-def test_not_rhel7s():
-    rr = RedhatRelease(context_wrap(REDHAT_RELEASE1))
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_67))
     rel = RR(None, rr)
     with pytest.raises(SkipComponent) as e:
         IsRhel7(rel)
-    assert "Not RHEL7" in str(e)
+    assert "Not RHEL 7" in str(e)
 
-
-# RHEL7 Tests
-def test_uname_is_rhel7():
     uname = Uname(context_wrap(UNAME))
-    rr = RedhatRelease(context_wrap(REDHAT_RELEASE3))
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_75_014))
     rel = RR(uname, rr)
     result = IsRhel7(rel)
     assert isinstance(result, IsRhel7)
 
-
-def test_is_rhel7():
-    rr = RedhatRelease(context_wrap(REDHAT_RELEASE3))
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_75_014))
     rel = RR(None, rr)
     result = IsRhel7(rel)
     assert isinstance(result, IsRhel7)
 
-
-def test_not_rhel7():
-    rr = RedhatRelease(context_wrap(REDHAT_RELEASE1))
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_67))
     rel = RR(None, rr)
     with pytest.raises(SkipComponent) as e:
         IsRhel7(rel)
-    assert "Not RHEL7" in str(e)
+    assert "Not RHEL 7" in str(e)
 
 
 # RHEL8 Tests
 def test_is_rhel8():
-    rr = RedhatRelease(context_wrap(REDHAT_RELEASE4))
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_80))
     rel = RR(None, rr)
     result = IsRhel8(rel)
     assert isinstance(result, IsRhel8)
 
-
-def test_not_rhel8():
-    rr = RedhatRelease(context_wrap(REDHAT_RELEASE2))
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_72))
     rel = RR(None, rr)
     with pytest.raises(SkipComponent) as e:
         IsRhel8(rel)
-    assert "Not RHEL8" in str(e)
+    assert "Not RHEL 8" in str(e)
 
 
 # RHEL9 Tests
 def test_is_rhel9():
-    rr = RedhatRelease(context_wrap(REDHAT_RELEASE5))
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_90))
     rel = RR(None, rr)
     result = IsRhel9(rel)
     assert isinstance(result, IsRhel9)
 
-
-def test_not_rhel9():
-    rr = RedhatRelease(context_wrap(REDHAT_RELEASE2))
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_80))
     rel = RR(None, rr)
     with pytest.raises(SkipComponent) as e:
         IsRhel9(rel)
-    assert "Not RHEL9" in str(e)
+    assert "Not RHEL 9" in str(e)
+
+
+# Great Than or Equal
+def test_gt_or_eq_rhel86():
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_80))
+    rel = RR(None, rr)
+    with pytest.raises(SkipComponent) as e:
+        IsGtOrRhel86(rel)
+    assert "Not RHEL newer than or equal 8.6" in str(e)
+
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_86))
+    rel = RR(None, rr)
+    ret = IsGtOrRhel86(rel)
+    assert ret.major == 8
+    assert ret.minor == 6
+
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_90))
+    rel = RR(None, rr)
+    ret = IsGtOrRhel86(rel)
+    assert ret.major == 9
+    assert ret.minor == 0
+
+
+# Great Than
+def test_gt_rhel86():
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_80))
+    rel = RR(None, rr)
+    with pytest.raises(SkipComponent) as e:
+        IsGtRhel86(rel)
+    assert "Not RHEL newer than 8.6" in str(e)
+
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_86))
+    rel = RR(None, rr)
+    with pytest.raises(SkipComponent) as e:
+        IsGtRhel86(rel)
+    assert "Not RHEL newer than 8.6" in str(e)
+
+    rr = RedhatRelease(context_wrap(REDHAT_RELEASE_90))
+    rel = RR(None, rr)
+    ret = IsGtRhel86(rel)
+    assert ret.major == 9
+    assert ret.minor == 0


### PR DESCRIPTION
- this ausearch command will be executed at the end of collection
  it can have the same 'prio' with the blacklisted_specs
  as the latter is a datasource but not a command
- it will be executed only on RHEL 8.6 or later,
  so new component IsGtOrRhel86 is also added in this commit
- no parser is required for this spec for now

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
