### PR TITLE
fix: password regex skip lines end with 'password'

### DIFF
--- a/insights/core/spec_cleaner.py
+++ b/insights/core/spec_cleaner.py
@@ -29,7 +29,7 @@ from insights.util.posix_regex import replace_posix
 logger = logging.getLogger(__name__)
 
 DEFAULT_PASSWORD_REGEXS = [
-    r"(password[a-zA-Z0-9_]*)(\s*\:\s*\"*\s*|\s*\"*\s*=\s*\"\s*|\s*=+\s*|\s*--md5+\s*|\s*)([a-zA-Z0-9_!@#$%^&*()+=/-]*)",
+    r"(password[a-zA-Z0-9_]*)(\s*\:\s*\"*\s*|\s*\"*\s*=\s*\"\s*|\s*=+\s*|\s*--md5+\s*|\s*)([a-zA-Z0-9_!@#$%^&*()+=/-]+)",
     r"(password[a-zA-Z0-9_]*)(\s*\*+\s+)(.+)",
 ]
 """The regex for password removal, which is read from the "/etc/insights-client/.exp.sed"."""
@@ -338,13 +338,11 @@ class Cleaner(object):
             # patterns found, remove it
             return None
         # 2. password removal
-        # TODO - refine the workaround
-        if not line.strip().endswith(".withoutpassword"):  # workaround special lines
-            for regex in DEFAULT_PASSWORD_REGEXS:
-                tmp_line = line
-                line = re.sub(regex, r"\1\2********", tmp_line)
-                if line != tmp_line:
-                    break
+        for regex in DEFAULT_PASSWORD_REGEXS:
+            tmp_line = line
+            line = re.sub(regex, r"\1\2********", tmp_line)
+            if line != tmp_line:
+                break
         # 3. keyword replacement redaction
         return self._sub_keywords(line)
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
- refine the workaround of #4074
- fix RHINENG-9901 as well
