### PR TITLE
feat(pgp): Use crypto.py during Egg and Collection verification

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+[extend]
+useDefault = true
+
+
+[allowlist]
+description = "Repository-specific configuration"
+
+paths = [
+    # Tests for `crypto.py` contain public and private GPG keypair. They were
+    # generated specifically for this usecase. The owner of the key is:
+    # insights-core (Signing key for unit testing) <insights-core@example.org>
+    "insights/tests/client/test_crypto.py",
+]

--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -3,15 +3,14 @@ import json
 import os
 import logging
 import tempfile
-import shlex
 import shutil
 import sys
 import atexit
-from subprocess import Popen, PIPE
 from requests import ConnectionError
 
 from .. import package_info
 from . import client
+from . import crypto
 from .constants import InsightsConstants as constants
 from .config import InsightsConfig
 from .auto_config import try_auto_configuration
@@ -268,7 +267,7 @@ class InsightsClient(object):
         else:
             logger.debug("Egg update disabled")
 
-    def verify(self, egg_path, gpg_key=constants.pub_gpg_path):
+    def verify(self, egg_path):
         """
             Verifies the GPG signature of the egg.  The signature is assumed to
             be in the same directory as the egg and named the same as the egg
@@ -283,46 +282,42 @@ class InsightsClient(object):
         if egg_path and not os.path.isfile(egg_path):
             the_message = "Provided egg path %s does not exist, cannot verify." % (egg_path)
             logger.debug(the_message)
-            return {'gpg': False,
-                    'stderr': the_message,
-                    'stdout': the_message,
-                    'rc': 1,
-                    'message': the_message}
-        if self.config.gpg and gpg_key and not os.path.isfile(gpg_key):
-            the_message = ("Running in GPG mode but cannot find "
-                            "file %s to verify against." % (gpg_key))
-            logger.debug(the_message)
-            return {'gpg': False,
-                    'stderr': the_message,
-                    'stdout': the_message,
-                    'rc': 1,
-                    'message': the_message}
+            return {
+                'gpg': False,
+                'stderr': the_message,
+                'stdout': the_message,
+                'rc': 1,
+                'message': the_message,
+            }
 
         # if we are running in no_gpg or not gpg mode then return true
         if not self.config.gpg:
-            return {'gpg': True,
-                    'stderr': None,
-                    'stdout': None,
-                    'rc': 0}
+            return {
+                'gpg': True,
+                'stderr': None,
+                'stdout': None,
+                'rc': 0,
+            }
 
         # if a valid egg path and gpg were received do the verification
-        if egg_path and gpg_key:
-            cmd_template = '/usr/bin/gpg --verify --keyring %s %s %s'
-            cmd = cmd_template % (gpg_key, egg_path + '.asc', egg_path)
-            logger.debug(cmd)
-            process = Popen(shlex.split(cmd), stdout=PIPE, stderr=PIPE)
-            stdout, stderr = process.communicate()
-            rc = process.returncode
-            logger.debug("GPG return code: %s" % rc)
-            return {'gpg': True if rc == 0 else False,
-                    'stderr': stderr,
-                    'stdout': stdout,
-                    'rc': rc}
-        else:
-            return {'gpg': False,
-                    'stderr': 'Must specify a valid core and gpg key.',
-                    'stdout': 'Must specify a valid core and gpg key.',
-                    'rc': 1}
+        if egg_path:
+            result = crypto.verify_gpg_signed_file(
+                file=egg_path, signature=egg_path + ".asc",
+                key=constants.pub_gpg_path,
+            )
+            return {
+                'gpg': result.ok,
+                'rc': result.return_code,
+                'stdout': result.stdout,
+                'stderr': result.stderr,
+            }
+
+        return {
+            'gpg': False,
+            'stderr': 'Must specify a valid core and gpg key.',
+            'stdout': 'Must specify a valid core and gpg key.',
+            'rc': 1,
+        }
 
     def install(self, new_egg, new_egg_gpg_sig):
         """

--- a/insights/client/crypto.py
+++ b/insights/client/crypto.py
@@ -1,0 +1,279 @@
+import errno
+import os.path
+import logging
+import shutil
+import tempfile
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+class GPGCommandResult(object):
+    """Output of a GPGCommand.
+
+    :param ok: Result of an operation.
+    :type ok: bool
+    :param return_code: Return code of an operation.
+    :type return_code: int
+    :param stdout: Standard output of the command.
+    :type stdout: str
+    :param stderr: Standard error of the command.
+    :type stderr: str
+    :param _command: An optional reference to the GPGCommand object that created the result.
+    :type _command: GPGCommand | None
+    """
+    def __init__(self, ok, return_code, stdout, stderr, command):
+        self.ok = ok
+        self.return_code = return_code
+        self.stdout = stdout
+        self.stderr = stderr
+        self._command = command
+
+    def __str__(self):
+        return (
+            "<{cls} ok={ok} return_code={code} stdout={out} stderr={err}>"
+        ).format(
+            cls=self.__class__.__name__,
+            ok=self.ok, code=self.return_code,
+            out=self.stdout, err=self.stderr,
+        )
+
+
+class GPGCommand(object):
+    """GPG command run in a temporary environment.
+
+    :param command: The command to be executed.
+    :type command: list[str]
+    :param key: Path to the GPG public key to check against.
+    :type key: str
+    :param _home: Path to the temporary GPG home directory.
+    :type _home: str | None
+    :param _raw_command: The last invoked command.
+    :type _raw_command: list[str] | None
+    """
+    TEMPORARY_GPG_HOME_PARENT_DIRECTORY = "/var/lib/insights/"
+
+    def __init__(self, command, key):
+        self.command = command
+        self.key = key
+        self._home = None
+        self._raw_command = None
+
+    def __str__(self):
+        return "<{cls} _home={home} _raw_command={raw}>".format(
+            cls=self.__class__.__name__,
+            home=self._home,
+            raw=self._raw_command
+        )
+
+    def _setup(self):
+        """Prepare GPG environment.
+
+        :returns: Result of the GPG key import.
+        :rtype: GPGCommandResult
+        """
+        # The /var/lib/insights/ directory is used instead of /tmp/ because
+        # GPG needs to have RW permissions in it, and existing SELinux rules only
+        # allow access here.
+        self._home = tempfile.mkdtemp(dir=type(self).TEMPORARY_GPG_HOME_PARENT_DIRECTORY)
+
+        logger.debug("setting up gpg temporary environment in '{home}'".format(home=self._home))
+        result = self._run(["--import", self.key])  # type: GPGCommandResult
+        if not result.ok:
+            logger.warning("failed to import key '{key}': {result}".format(
+                key=self.key, result=result
+            ))
+        return result
+
+    def _supports_cleanup_socket(self):
+        """Queries for the version of GPG binary.
+
+        :returns: `True` if the gnupg is known for supporting `--kill all`.
+        :rtype: bool
+        """
+        version_process = subprocess.Popen(
+            ["/usr/bin/gpg", "--version"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True,
+            env={"GNUPGHOME": self._home},
+        )
+        stdout, stderr = version_process.communicate()
+        if version_process.returncode != 0:
+            stderr = "\n".join("stderr: {line}".format(line=line) for line in stderr.split("\n") if len(line))
+            logger.debug("could not query for gpg version:\n{err}".format(err=stderr))
+            return False
+
+        for line in stdout.split("\n"):
+            if line.startswith("gpg (GnuPG) "):
+                version = line.split(" ")[-1]  # type: str
+                break
+        else:
+            stdout = "\n".join("stdout: {line}".format(line=line) for line in stdout.split("\n") if len(line))
+            logger.debug("could not query for gpg version: output not recognized:\n{out}".format(out=stdout))
+            return False
+
+        try:
+            version_info = tuple(int(v) for v in version.split("."))
+        except Exception as exc:
+            logger.debug("gpg version could not be parsed: '{version}: {exc}".format(version=version, exc=str(exc)))
+            return False
+        if len(version_info) < 3:
+            logger.debug("gpg version is not recognized: '{version}'".format(version=version))
+            return False
+
+        # `gpgconf --kill` was added in GnuPG 2.1.0-beta2 and `--kill all` exists since 2.1.18.
+        # - 2.1.0b1: commit 7c03c8cc65e68f1d77a5a5a497025191fe5df5e9 in GPG's repository.
+        # - 2.1.18: https://lists.gnupg.org/pipermail/gnupg-announce/2017q1/000401.html
+        #
+        # RHEL versions come with the following gpg versions:
+        # - 6.10: 2.0.14
+        # - 7.9:  2.0.22
+        # - 8.9:  2.2.20
+        # - 9.3:  2.3.3
+        # which means this code should return `True` for RHEL 8 and above.
+        return version_info >= (2, 1, 18)
+
+    def _cleanup_socket(self):
+        """Stop GPG socket in its home directory."""
+        # GPG writes a temporary socket file for the gpg-agent into the home
+        # directory. This is only supported since gnupg 2.1.18 (RHEL 8).
+        shutdown_process = subprocess.Popen(
+            ["/usr/bin/gpgconf", "--kill", "all"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True,
+            env={"GNUPGHOME": self._home},
+        )
+        _, stderr = shutdown_process.communicate()
+        if shutdown_process.returncode != 0:
+            stderr = "\n".join("stderr: {line}".format(line=line) for line in stderr.split("\n") if len(line))
+            logger.debug(
+                "could not kill the GPG agent, got return code {rc}: \n{err}".format(
+                    rc=shutdown_process.returncode, err=stderr
+                )
+            )
+
+    def _cleanup(self):
+        """Clean up GPG environment."""
+        if self._supports_cleanup_socket():
+            self._cleanup_socket()
+
+        # Older systems do not support `gpgconf --kill`.
+        # The socket may remove its socket file after `rmtree()` has determined
+        # it should be deleted, but before the actual deletion occurs.
+        # This would cause a FileNotFoundError/OSError.
+        for _ in range(5):
+            try:
+                shutil.rmtree(self._home)
+                break
+            except OSError as exc:
+                if exc.errno == errno.ENOENT:
+                    # The file has already been removed by the `gpg-agent`.
+                    continue
+                raise
+        else:
+            logger.debug(
+                "could not clean up temporary GPG directory '{path}'".format(path=self._home)
+            )
+
+    def _run(self, command):
+        """Run the actual command.
+
+        :returns: The result of the shell command.
+        :rtype: GPGCommandResult
+        """
+        self._raw_command = ["/usr/bin/gpg", "--homedir", self._home] + command
+        process = subprocess.Popen(
+            self._raw_command,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        stdout, stderr = process.communicate()
+
+        result = GPGCommandResult(
+            ok=process.returncode == 0,
+            return_code=process.returncode,
+            stdout=stdout.decode("utf-8"),
+            stderr=stderr.decode("utf-8"),
+            command=self,
+        )
+
+        if result.ok:
+            logger.debug("gpg command {command}: ok".format(command=command))
+        else:
+            logger.debug(
+                "gpg command {command} returned non-zero code: {result}".format(
+                    command=command, result=result,
+                )
+            )
+
+        return result
+
+    def evaluate(self):
+        """Run the command.
+
+        :returns: The result of the shell command.
+        :rtype: GPGCommandResult
+        """
+        try:
+            result = self._setup()
+            if not result.ok:
+                logger.debug("gpg setup failed")
+                return result
+
+            logger.debug("running gpg in the temporary environment")
+            return self._run(self.command)
+        finally:
+            self._cleanup()
+
+
+def verify_gpg_signed_file(file, signature, key):
+    """
+    Verify a file that was signed using GPG.
+
+    :param file: A path to the signed file.
+    :type file: str
+    :param signature: A path to the detached signature.
+    :type signature: str
+    :param key: Path to the public GPG key on the filesystem to check against.
+    :type key: str
+
+    :returns: Evaluated GPG command.
+    :rtype: GPGCommandResult
+    """
+    if not os.path.isfile(file):
+        logger.debug(
+            "cannot verify signature of '{file}', file does not exist".format(
+                file=file
+            )
+        )
+        return GPGCommandResult(
+            ok=False,
+            return_code=1,
+            stdout="",
+            stderr="file '{path}' does not exist".format(path=file),
+            command=None,
+        )
+
+    if not os.path.isfile(signature):
+        logger.debug((
+            "cannot verify signature of '{file}', "
+            "signature '{signature}' does not exist"
+        ).format(file=file, signature=signature))
+        return GPGCommandResult(
+            ok=False,
+            return_code=1,
+            stdout="",
+            stderr="file '{path}' does not exist".format(path=signature),
+            command=None,
+        )
+
+    gpg = GPGCommand(command=["--verify", signature, file], key=key)
+
+    logger.debug("starting gpg verification process for '{file}'".format(file=file))
+    result = gpg.evaluate()  # type: GPGCommandResult
+
+    if result.ok:
+        logger.debug("signature verification of '{file}' passed".format(file=file))
+    else:
+        logger.debug("signature verification of '{file}' failed".format(file=file))
+
+    return result

--- a/insights/tests/client/test_crypto.py
+++ b/insights/tests/client/test_crypto.py
@@ -1,0 +1,276 @@
+import os.path
+import shutil
+import subprocess
+import tempfile
+
+import mock
+import pytest
+
+from insights.client import crypto
+
+
+# GPG2 exports keys in a way gpg1.4 cannot read. Since gpg1.4 is present in the
+# Ubuntu image that is used in CI to test Python 2.6, we have to use the old
+# version, so it is recognised by all CI branches.
+#
+# $ gpg --gen-key            # gpg1.x
+# $ gpg --full-generate-key  # gpg2.x
+# $ gpg --list-secret-keys --keyid-format long
+# $ KEYID=xxx (line `sec`, after the `/` character)
+# $ gpg --armor --export $KEYID
+# $ gpg --armor --export-secret-keys $KEYID
+
+GPG_PUBLIC_KEY = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v1
+
+mQENBGUlPEcBCACXhinLd4KiyQ9CWXM+gpgo0HMuTdESTlVVDYRjm/ebazephXq7
+0hhAhXallAQJkaXFPuLETumwFYPx60agUDWsUie8gk3TLE+ejuTxoda0Yo6rehsD
+zds1ptHQLzar00SFUlfiJXnMaobXLeNjDSglkynQC4uQODouDa1jkSRfNbDJOJYd
+IBbPBIaJ3PlNrdVutPcx4yIZM1siqMZ9k0g2iYPWyp0ceuP0jpCTPc5TRRP5pLuz
+INRJzhfJ+oPtbFt8Y4s1xEZ0Kfy0sA8Awk3VJqzoCU3ILBU5cGquQDdNggxTRSPV
+X5Z4nW2zjN9lXAkwr29NL1rA1jjLt+c5upYZABEBAAG0SGluc2lnaHRzLWNvcmUg
+KFNpZ25pbmcga2V5IGZvciB1bml0IHRlc3RpbmcpIDxpbnNpZ2h0cy1jb3JlQGV4
+YW1wbGUub3JnPokBOAQTAQIAIgUCZSU8RwIbAwYLCQgHAwIGFQgCCQoLBBYCAwEC
+HgECF4AACgkQn+6Vu126uXAHdgf/Q8a7Jruhyn+EDLL94gAc6kXubvVArVe9Rdpo
+HwG7cj8wUa/7zd7FUcYJuz6bbebgmmlRwFf1CeodGURFpfwf1dkiKV5QqobeXhRp
+srrkeLlMR8bZVFSCvU+oOETpJfMo6feDI/tQrOcIpxrd/cEu2XSQ1JBM/+8NbQiU
+Ma1cWHOmQJ1OD7jWOllUq5hDs1vtUzPORUsYe1V1Dcx89gdlhfc1cc30yoLzDNqu
+0Abn34CAthUkr0sWplzltXOY+Za1kOmQVlaLQ0W3tq8BDi79bdHpTtD/g9QO++Nc
+r5xdP+tPNWAOUlyi7S6qscDLhMWv7o4eLq6UL9eUC/M2CWJSKg==
+=9pSV
+-----END PGP PUBLIC KEY BLOCK-----
+"""
+
+GPG_PRIVATE_KEY = """-----BEGIN PGP PRIVATE KEY BLOCK-----
+Version: GnuPG v1
+
+lQOYBGUlPEcBCACXhinLd4KiyQ9CWXM+gpgo0HMuTdESTlVVDYRjm/ebazephXq7
+0hhAhXallAQJkaXFPuLETumwFYPx60agUDWsUie8gk3TLE+ejuTxoda0Yo6rehsD
+zds1ptHQLzar00SFUlfiJXnMaobXLeNjDSglkynQC4uQODouDa1jkSRfNbDJOJYd
+IBbPBIaJ3PlNrdVutPcx4yIZM1siqMZ9k0g2iYPWyp0ceuP0jpCTPc5TRRP5pLuz
+INRJzhfJ+oPtbFt8Y4s1xEZ0Kfy0sA8Awk3VJqzoCU3ILBU5cGquQDdNggxTRSPV
+X5Z4nW2zjN9lXAkwr29NL1rA1jjLt+c5upYZABEBAAEAB/0QIdsaTA+PCEwFGuPv
+sFTF56eTsvpC8i8YnpdNSaI7nFcxR8JQ8+XcHLmMmG0znZuiG/dlwicUNb42CAAd
+ely0i4yqf88MYCfb8EfEyB/FVcbtz9LHfWfM1wV4nkY6VgRyE1nC/I1yq5bOmxae
+CZ0QHxJxEYGa6bmcBJ3Ev4O5VSKZRRByPI0HXmVB6GoqVtmwa7TFrlgLM5GPbgVe
+P76lNY2me8jEnHqzrPpuCB/N0VSCEUf45RV+TNjWL1lpF8JPzXS8oGoxcDoo+sIQ
+AdcfMFrRtf3DW8kJRZC8i4T9++/k3Sjak9GE8ocekCDJkFPRkKv3A4T8nvmMKbNx
+fugZBADAGD+u4Uhwlyzvr84wmwIPcozhQhTWot8dom6LCiZ47sfyG1qVhvxqDKtc
+ttPv+VfA0RyJb9PUKbOf71hA7lMm0qHyX6KTknYYl8u+s/ra8VSwdNyl2/DQDf2j
+OjnIMLM9IC6TMQ/mvpvRmXLc6m6HfL6ZBAbAL0EwOMUAUelnBQQAye626NZJTZ3E
+mQ9z6l6UEi3IZIw+uJfSg/HL4MgU4zRNsOqyJyizdmVzQm0h+1aHQu1SuFsllPXF
+DOKR/IlkjQJCbiU1wZASYYJuwmmVdG4HqZD0bjKU40fJgzBJhOfnhi079jnZzMsL
++NltcmAtUFKteWsPZe7Blic4QmIbtwUEAIick2Ai788yKGrAry5XBwHNcSIYKNr2
+FFWwjFQWAK82hG2tiKCtF8vg58KBvGR3KNUlCLqDeP85jK7+IuaExSlWKYxIKo70
+8Vfpqpyol/+V1yZ2duEcPSXtrMTg5Yl/7PITyGPnM4mFjvwg+cuYRDqYTT0kWbrl
+WxtODNwtZdIURTm0SGluc2lnaHRzLWNvcmUgKFNpZ25pbmcga2V5IGZvciB1bml0
+IHRlc3RpbmcpIDxpbnNpZ2h0cy1jb3JlQGV4YW1wbGUub3JnPokBOAQTAQIAIgUC
+ZSU8RwIbAwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AACgkQn+6Vu126uXAHdgf/
+Q8a7Jruhyn+EDLL94gAc6kXubvVArVe9RdpoHwG7cj8wUa/7zd7FUcYJuz6bbebg
+mmlRwFf1CeodGURFpfwf1dkiKV5QqobeXhRpsrrkeLlMR8bZVFSCvU+oOETpJfMo
+6feDI/tQrOcIpxrd/cEu2XSQ1JBM/+8NbQiUMa1cWHOmQJ1OD7jWOllUq5hDs1vt
+UzPORUsYe1V1Dcx89gdlhfc1cc30yoLzDNqu0Abn34CAthUkr0sWplzltXOY+Za1
+kOmQVlaLQ0W3tq8BDi79bdHpTtD/g9QO++Ncr5xdP+tPNWAOUlyi7S6qscDLhMWv
+7o4eLq6UL9eUC/M2CWJSKg==
+=ZQ6H
+-----END PGP PRIVATE KEY BLOCK-----
+"""
+
+GPG_FINGERPRINT = "E884 7216 86A8 1EE3 EBF4  5771 9FEE 95BB 5DBA B970"
+GPG_OWNER = (
+    "insights-core (Signing key for unit testing) "
+    "<insights-core@example.org>"
+)
+
+
+def _initialize_gpg_environment(home):
+    """Save GPG keys and sign a file with them.
+
+    The home directory is populated with the following files:
+    - key.public.gpg
+    - key.private.gpg
+    - file.txt
+    - file.txt.asc
+    """
+    # Save the public key into temporary file
+    public_key = home + "/key.public.gpg"
+    with open(public_key, "w") as f:
+        f.write(GPG_PUBLIC_KEY)
+    # It is strictly not necessary to import both public and private keys,
+    #  the private key should be enough.
+    #  However, the Python 2.6 CI image requires that.
+    process = subprocess.Popen(
+        ["/usr/bin/gpg", "--homedir", home, "--import", public_key],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    process.communicate()
+    assert process.returncode == 0
+
+    # Save the private key into temporary file and import it
+    private_key = home + "/key.private.gpg"
+    with open(private_key, "w") as f:
+        f.write(GPG_PRIVATE_KEY)
+    process = subprocess.Popen(
+        ["/usr/bin/gpg", "--homedir", home, "--import", private_key],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    process.communicate()
+    assert process.returncode == 0
+
+    # Create a file and sign it
+    file = home + "/file.txt"
+    with open(file, "w") as f:
+        f.write("a signed message")
+    process = subprocess.Popen(
+        ["/usr/bin/gpg", "--homedir", home, "--detach-sign", "--armor", file],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    process.communicate()
+    assert process.returncode == 0
+
+    # Ensure the signature has been created
+    assert os.path.exists(home + "/file.txt.asc")
+
+
+@mock.patch("insights.client.crypto.GPGCommand.TEMPORARY_GPG_HOME_PARENT_DIRECTORY", "/tmp/")
+def test_valid_signature():
+    """A detached file signature can be verified."""
+    home = tempfile.mkdtemp()
+    _initialize_gpg_environment(home)
+
+    # Run the test
+    result = crypto.verify_gpg_signed_file(
+        file=home + "/file.txt",
+        signature=home + "/file.txt.asc",
+        key=home + "/key.public.gpg",
+    )
+    shutil.rmtree(home)
+
+    # Verify results
+    assert True is result.ok
+    assert "" == result.stdout
+    assert (
+        'gpg: Good signature from "{owner}"'.format(owner=GPG_OWNER)
+    ) in result.stderr
+    assert (
+        'Primary key fingerprint: {fp}'.format(fp=GPG_FINGERPRINT)
+    ) in result.stderr
+    assert 0 == result.return_code
+
+    assert not os.path.isfile(result._command._home)
+
+
+@pytest.mark.parametrize("file", ("/file.txt", "/file.txt.asc"))
+def test_no_file(file):
+    """Missing file or its signature is caught and returned as command result."""
+    home = tempfile.mkdtemp()
+    _initialize_gpg_environment(home)
+
+    os.remove(home + file)
+
+    result = crypto.verify_gpg_signed_file(
+        file=home + "/file.txt",
+        signature=home + "/file.txt.asc",
+        key=home + "/key.public.gpg",
+    )
+
+    assert result.ok is False
+    assert result.return_code > 0
+    assert "file '{path}' does not exist".format(path=home + file) == result.stderr
+
+
+@mock.patch("insights.client.crypto.GPGCommand.TEMPORARY_GPG_HOME_PARENT_DIRECTORY", "/tmp/")
+def test_invalid_public_key():
+    """Invalid key is rejected."""
+    home = tempfile.mkdtemp()
+    _initialize_gpg_environment(home)
+
+    with open(home + "/key.public.gpg", "w") as f:
+        f.write("instead of the key, this file contains garbage")
+
+    result = crypto.verify_gpg_signed_file(
+        file=home + "/file.txt",
+        signature=home + "/file.txt.asc",
+        key=home + "/key.public.gpg",
+    )
+
+    assert result.ok is False
+    assert result.return_code > 0
+
+
+@mock.patch("insights.client.crypto.GPGCommand.TEMPORARY_GPG_HOME_PARENT_DIRECTORY", "/tmp/")
+def test_invalid_signature():
+    """A bad detached file signature can be detected."""
+    home = tempfile.mkdtemp()
+    _initialize_gpg_environment(home)
+
+    # Change the contents of the file, making the signature incorrect
+    with open(home + "/file.txt", "w") as f:
+        f.write("an unsigned message")
+
+    # Run the test
+    result = crypto.verify_gpg_signed_file(
+        file=home + "/file.txt",
+        signature=home + "/file.txt.asc",
+        key=home + "/key.public.gpg",
+    )
+    shutil.rmtree(home)
+
+    # Verify results
+    assert not result.ok
+    assert "" == result.stdout
+    assert (
+        'gpg: BAD signature from "{owner}"'.format(owner=GPG_OWNER)
+    ) in result.stderr
+    assert (
+        'Primary key fingerprint: {fp}'.format(fp=GPG_FINGERPRINT)
+    ) not in result.stderr
+    assert 1 == result.return_code
+
+    assert not os.path.isfile(result._command._home)
+
+
+GPG_VERSION_CENTOS7 = """gpg (GnuPG) 2.0.22
+libgcrypt 1.5.3
+Copyright (C) 2013 Free Software Foundation, Inc.
+...
+"""
+GPG_VERSION_CENTOS8 = """gpg (GnuPG) 2.2.20
+libgcrypt 1.8.5
+Copyright (C) 2020 Free Software Foundation, Inc.
+...
+"""
+GPG_VERSION_CENTOS9 = """gpg (GnuPG) 2.3.3
+libgcrypt 1.10.0-unknown
+Copyright (C) 2021 Free Software Foundation, Inc.
+...
+"""
+
+
+@pytest.mark.parametrize("output,supports", [
+    (GPG_VERSION_CENTOS7, False),
+    (GPG_VERSION_CENTOS8, True),
+    (GPG_VERSION_CENTOS9, True),
+    ("garbage output", False),
+    ("gpg (GnuPG) 2.8", False),
+    ("gpg (GnuPG) 2.8.1a9", False),
+])
+@mock.patch("insights.client.crypto.GPGCommand.TEMPORARY_GPG_HOME_PARENT_DIRECTORY", "/tmp/")
+def test_gpg_socket_cleanup_support(output, supports):
+    home = tempfile.mkdtemp()
+
+    command = crypto.GPGCommand(command=[], key="")
+    command._home = home
+
+    class MockPopen:
+        def __init__(self, stdout):
+            self.stdout = stdout
+            self.returncode = 0
+
+        def communicate(self, *args, **kwargs):
+            return self.stdout, ""
+
+    with mock.patch("insights.client.crypto.subprocess.Popen", return_value=MockPopen(stdout=output)):
+        result = command._supports_cleanup_socket()
+
+    assert result == supports


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: CCT-131
* Card ID: CCT-405
* Card ID: RHEL-2480
* Card ID: RHEL-2482

This patch adds a self-contained and isolated GPG verification
environment. It runs GPG in an isolated environment where only selected
PGP keys are allowed to check the file signature matches its file.

GPG creates a directory `$HOME/.gnupg/` every time it performs some
operation. When run under root, but not manually (e.g. via
subscription-manager Cockpit plugin), it tries to create and write to
this directory, which pollutes user directories and/or causes SELinux
denials.

This patch utilizes the `--homedir` argument GPG supports in order to
move the GPG home directory to a temporary directory for the time of the
transaction. After the GPG action is performed, the directory is cleaned
up.

---

This PR is an improvement over previously reverted https://github.com/RedHatInsights/insights-core/pull/3930