### PR TITLE
fix: add dependencies to manifest for ausearch_insights_client

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -122,6 +122,10 @@ plugins:
         - name: insights.combiners.cloud_provider
           enabled: true
 
+    # needed for the ausearch_insights_client
+        - name: insights.components.rhel_version.IsGtOrRhel86
+          enabled: true
+
     # needed for the cloud related specs
         - name: insights.components.cloud_provider.IsAWS
           enabled: true
@@ -137,6 +141,9 @@ plugins:
           enabled: true
 
     # needed for the Services combiner
+        - name: insights.components.rhel_version.IsRhel6
+          enabled: true
+
         - name: insights.parsers.chkconfig
           enabled: true
 

--- a/insights/components/rhel_version.py
+++ b/insights/components/rhel_version.py
@@ -39,7 +39,7 @@ class IsRhel(object):
 
 class IsGtRhel(object):
     """
-    This component uses ``RedhatRelease`` combiner to determine the RHEL
+    This component uses ``RedHatRelease`` combiner to determine the RHEL
     version. It then checks if the major version matches the version argument,
     if it doesn't it raises ``SkipComponent``.
 

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -109,7 +109,7 @@ class DefaultSpecs(Specs):
     auditctl_status = simple_command("/sbin/auditctl -s")
     auditd_conf = simple_file("/etc/audit/auditd.conf")
     audispd_conf = simple_file("/etc/audisp/audispd.conf")
-    ausearch_insights_client = simple_command("ausearch -i -m avc,user_avc,selinux_err,user_selinux_err -ts recent -su insights_client", deps=[IsGtOrRhel86])
+    ausearch_insights_client = simple_command("/usr/sbin/ausearch -i -m avc,user_avc,selinux_err,user_selinux_err -ts recent -su insights_client", deps=[IsGtOrRhel86], keep_rc=True)
     aws_instance_id_doc = command_with_args('/usr/bin/curl -s -H "X-aws-ec2-metadata-token: %s" http://169.254.169.254/latest/dynamic/instance-identity/document --connect-timeout 5', aws.aws_imdsv2_token, deps=[aws.aws_imdsv2_token])
     aws_instance_id_pkcs7 = command_with_args('/usr/bin/curl -s -H "X-aws-ec2-metadata-token: %s" http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 --connect-timeout 5', aws.aws_imdsv2_token, deps=[aws.aws_imdsv2_token])
     aws_public_hostnames = command_with_args('/usr/bin/curl -s -H "X-aws-ec2-metadata-token: %s" http://169.254.169.254/latest/meta-data/public-hostname --connect-timeout 5', aws.aws_imdsv2_token, deps=[aws.aws_imdsv2_token])


### PR DESCRIPTION
- In the first implementation of the spec, its collection
  is failed due to its `deps` was not loaded before executing
- change to use full path of ausearch in command line
- keep the commend result even it's failed
- fix a typo in the IsGtRhel component
- Add the missed IsRhel6 for chkconfig spec

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
- see above
