### PR TITLE
fix: lvm_system_devices contains hostname and should be obfuscated

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -414,7 +414,7 @@ class Specs(SpecSet):
     lvdisplay = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     lvm_conf = RegistryPoint(filterable=True, no_obfuscate=['hostname', 'ip'])
     lvm_fullreport = RegistryPoint()
-    lvm_system_devices = RegistryPoint(no_obfuscate=['hostname', 'ip'])
+    lvm_system_devices = RegistryPoint(no_obfuscate=['ip'])
     lvmconfig = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     lvs_headings = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     lvs_noheadings = RegistryPoint(no_obfuscate=['hostname', 'ip'])


### PR DESCRIPTION
- the content of lvm_system_devices contains `hostname` and should be obfuscated
  it was set as `no_obfuscste=['hostname', 'ip']` by mistake.
  This PR removed the 'hostname' from the `no_obfuscate` list.
- see RHINENG-10744

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
