### PR TITLE
fix: use ubi8 instead of centos7 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN microdnf update -y && microdnf -y install which procps-ng git libffi-devel file xz bzip2 tar zip python3.11 python3.11-pip && microdnf clean all
-RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --no-cache-dir --upgrade pip
 COPY . /src
-RUN pip install /src
+RUN python3 -m pip install --no-cache-dir /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM centos:7
-RUN yum install -y python-devel file zip gcc libffi-devel && yum clean all
-RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && python get-pip.py && rm get-pip.py
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+RUN microdnf update -y && microdnf -y install which procps-ng git libffi-devel file xz bzip2 tar zip python3.11 python3.11-pip && microdnf clean all
+RUN python3 -m pip install --upgrade pip
 COPY . /src
 RUN pip install /src


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
* To fix below error when build image by Dockerfile

> Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
14: curl#6 - “Could not resolve host: [mirrorlist.centos.org](http://mirrorlist.centos.org/); Unknown error”

