### PR TITLE
FIX: remove reference for a deprecated module

### DIFF
--- a/insights/formats/__init__.py
+++ b/insights/formats/__init__.py
@@ -97,7 +97,7 @@ class EvaluatorFormatterAdapter(FormatterAdapter):
 
     def __init__(self, args=None):
         if args:
-            hn = "insights.combiners.hostname, insights.parsers.branch_info"
+            hn = "insights.combiners.hostname, insights.parsers.client_metadata"
             args.plugins = ",".join([args.plugins, hn]) if args.plugins else hn
             self.missing = args.missing
             self.render_content = args.render_content


### PR DESCRIPTION
Module insights.parsers.branch_info was deprecated and removed in insights-core-3.4.0

- This is a fix for RHINENG-11214

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

`insights.parsers.branch_info.BranchInfo` was deprecated in favour of `insights.parsers.client_metadata.BranchInfo`.

In `insights-core-3.4.0`, the module `insights.parsers.branch_info` was completely removed while it is still referenced by `insights.formats.EvaluatorFormatterAdapter`
