### PR TITLE
feat: replace deprecated datetime.utcnow() usage

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -21,7 +21,7 @@ from insights import apply_configs, apply_default_enabled, get_pool
 from insights.core import blacklist, dr, filters
 from insights.core.serde import Hydration
 from insights.core.spec_cleaner import Cleaner
-from insights.util import fs
+from insights.util import fs, utc
 from insights.util.hostname import determine_hostname
 from insights.util.subproc import call
 
@@ -419,7 +419,7 @@ def generate_archive_name():
     Creates the archive directory to store the component output.
     """
     hostname = determine_hostname()
-    suffix = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    suffix = datetime.now(utc).strftime("%Y%m%d%H%M%S")
     return "insights-%s-%s" % (hostname, suffix)
 
 

--- a/insights/tests/test_collect.py
+++ b/insights/tests/test_collect.py
@@ -7,6 +7,7 @@ from mock.mock import Mock
 from insights.collect import (
         load_manifest,
         default_manifest,
+        generate_archive_name,
         _parse_broker_exceptions)
 from insights.core.dr import Broker
 from insights.core.exceptions import ContentException
@@ -62,3 +63,8 @@ def test_load_manifest():
     ret = load_manifest(tmpfile.name)
     assert ret == data
     os.remove(tmpfile.name)
+
+
+def test_generate_archive_name():
+    archive_name = generate_archive_name()
+    assert archive_name.startswith("insights-")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

 - datetime.utcnow() was deprecated since Python 3.12