### PR TITLE
chore: Disable legacy upload

### DIFF
--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -445,7 +445,7 @@ DEFAULT_OPTS = {
     'legacy_upload': {
         # True: upload to insights classic API
         # False: upload to insights platform API
-        'default': True
+        'default': False
     },
     'payload': {
         'default': None,
@@ -663,6 +663,11 @@ class InsightsConfig(object):
                         'ERROR: {0}.\nCould not read configuration file, '
                         'using defaults\n'.format(e))
                 return
+
+        if d.get("legacy_upload", False):
+            logger.debug("'legacy_upload' is set in the configuration file, but is no longer supported. Ignoring.")
+            del d["legacy_upload"]
+
         self._update_dict(d)
 
     def load_all(self):
@@ -762,6 +767,10 @@ class InsightsConfig(object):
         if self.app and not self.manifest:
             raise ValueError("Unable to find app: %s\nList of available apps: %s"
                              % (self.app, ', '.join(sorted(manifests.keys()))))
+
+        if self.legacy_upload:
+            logger.debug("Legacy upload is no longer supported. Using current APIs.")
+            self.legacy_upload = False
 
     def _imply_options(self):
         '''

--- a/insights/tests/client/test_ansiblehost.py
+++ b/insights/tests/client/test_ansiblehost.py
@@ -63,17 +63,3 @@ def test_ansible_host_no_reg_forces_legacy_false():
     conf._cli_opts = ["ansible_host"]
     conf._imply_options()
     assert not conf.legacy_upload
-
-
-def test_ansible_host_reg_legacy_no_change():
-    '''
-    When specifying --register, using --ansible-host on the CLI does not affect legacy_upload
-    '''
-    conf = InsightsConfig(register=True, ansible_host="test", legacy_upload=True)
-    conf._cli_opts = ["ansible_host"]
-    conf._imply_options()
-    assert conf.legacy_upload
-    conf = InsightsConfig(register=True, ansible_host="test", legacy_upload=False)
-    conf._cli_opts = ["ansible_host"]
-    conf._imply_options()
-    assert not conf.legacy_upload

--- a/insights/tests/client/test_platform.py
+++ b/insights/tests/client/test_platform.py
@@ -69,11 +69,6 @@ def test_upload_urls():
     '''
     Ensure upload urls are defined correctly
     '''
-    # legacy default
-    conf = InsightsConfig()
-    c = InsightsConnection(conf)
-    assert c.upload_url == c.base_url + '/uploads'
-
     # plaform implied
     conf = InsightsConfig(legacy_upload=False)
     c = InsightsConnection(conf)
@@ -108,33 +103,3 @@ def test_payload_upload(op, post, c, _legacy_upload_archive, rm_conf):
             })},
         headers={})
     _legacy_upload_archive.assert_not_called()
-
-
-@patch('insights.contrib.magic.open', MockMagic)
-@patch('insights.client.connection.generate_machine_id', mock_machine_id)
-@patch("insights.client.connection.get_canonical_facts", return_value={'test': 'facts'})
-@patch('insights.client.connection.InsightsConnection.post')
-@patch("insights.client.connection.open", new_callable=mock_open)
-def test_legacy_upload(op, post, c):
-    '''
-    Ensure an Insights collected tar upload to legacy occurs with the right URL and params
-    '''
-    conf = InsightsConfig()
-    c = InsightsConnection(conf)
-    c.upload_archive('testp', 'testct', None)
-    post.assert_called_with(
-        c.base_url + '/uploads/XXXXXXXX',
-        files={
-            'file': ('testp', ANY, 'application/gzip')},  # ANY = return call from mocked open(), acts as filepointer here
-        headers={'x-rh-collection-time': 'None'})
-
-
-@patch("insights.client.connection.InsightsConnection._legacy_upload_archive")
-def test_legacy_upload_func(_legacy_upload_archive):
-    '''
-    Ensure the _legacy_upload_archive path is used
-    '''
-    conf = InsightsConfig()
-    c = InsightsConnection(conf)
-    c.upload_archive('testp', 'testct', None)
-    _legacy_upload_archive.assert_called_with('testp', None)

--- a/insights/tests/client/test_upload_archive_cfacts.py
+++ b/insights/tests/client/test_upload_archive_cfacts.py
@@ -25,16 +25,6 @@ def mock_init_session(obj):
     return MockSession()
 
 
-@patch("insights.client.connection.InsightsConnection._legacy_upload_archive", return_value=None)
-@patch("insights.client.connection.logger")
-def test_cfacts_no_cleaning_1(logger, legacy_upload):
-    # 1. No need to cleaning as legacy_upload=True
-    config = InsightsConfig(legacy_upload=True, obfuscate=True, obfuscate_hostname=True)
-    conn = InsightsConnection(config)
-    conn.upload_archive('data_collected', 'content_type')
-    logger.debug.assert_not_called()
-
-
 @patch('insights.client.connection.InsightsConnection._init_session', mock_init_session)
 @patch('insights.client.connection.InsightsConnection.post', return_value=MockSession())
 @patch(builtin_open, new_callable=mock_open, read_data='')


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: CCT-252
* Card ID: RHENING-7569

This patch disables the legacy APIs. The code and configuration option will be removed later; this is the first step to get rid of the duplication and differences.

Only the absolutely necessary changes were made to tests; without these removals the suite wouldn't pass.