### PR TITLE
feat: Remove --force-reregister command

### DIFF
--- a/insights/client/config.py
+++ b/insights/client/config.py
@@ -338,16 +338,6 @@ DEFAULT_OPTS = {
         # non-CLI
         'default': os.path.join(constants.default_conf_dir, 'file-content-redaction.yaml')
     },
-    'reregister': {
-        'default': False,
-        'opt': ['--force-reregister'],
-        'help': ('This flag is deprecated and it will be removed in a future release.'
-                 'Forcefully reregister this machine to Red Hat.'
-                 'Please use `insights-client --unregister && insights-client --register `instead'),
-        'action': 'store_true',
-        'group': 'debug',
-        'dest': 'reregister'
-    },
     'retries': {
         'default': 1,
         'opt': ['--retry'],
@@ -704,11 +694,6 @@ class InsightsConfig(object):
         if self.analyze_container:
             raise ValueError(
                 '--analyze-container is no longer supported.')
-        if self.reregister:
-            raise ValueError(
-                "`force-reregistration` has been deprecated. Please use `insights-client "
-                "--unregister && insights-client --register` instead",
-            )
         if self.use_atomic:
             raise ValueError(
                 '--use-atomic is no longer supported.')

--- a/insights/tests/client/test_config.py
+++ b/insights/tests/client/test_config.py
@@ -318,15 +318,3 @@ def test_command_line_parse_twice():
     assert c.status
     c._load_command_line()
     assert c.status
-
-
-@patch('insights.client.config.sys.argv', [sys.argv[0], "--force-reregister"])
-def test_deprecated_reregister():
-    """
-    Verify that --force-reregistration is deprecated
-    """
-    insights_config = InsightsConfig()
-    with pytest.raises(ValueError) as error:
-        insights_config.load_all()
-
-    assert "deprecated" in str(error.value)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID [CCT-404](https://issues.redhat.com/browse/CCT-404)

The command has been removed from the CLI and from the documentation. It only used to raise a deprecation error message, that being its only presence in the actual logic. There was only a single test verifying the deprecation message.