### PR TITLE
feat: update specs for parser crictl_logs 

### DIFF
--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -53,7 +53,7 @@ class SosSpecs(Specs):
     cpe = simple_file("/etc/system-release-cpe")
     cpu_smt_control = simple_file("sys/devices/system/cpu/smt/control")
     cpupower_frequency_info = simple_file("sos_commands/processor/cpupower_frequency-info")
-    crictl_logs = glob_file("sos_commands/crio/containers/crictl_logs_-t*")
+    crictl_logs = glob_file(["sos_commands/crio/containers/crictl_logs_-t*", "sos_commands/crio/containers/logs/crictl_logs_-t*"])
     crio_conf = glob_file([r"etc/crio/crio.conf", r"etc/crio/crio.conf.d/*"])
     cups_files_conf = simple_file("/etc/cups/cups-files.conf")
     cups_ppd = glob_file("etc/cups/ppd/*")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

As the subdir/path of `crictl_logs` has changes in sos-report archive from `sos_commands/crio/containers/crictl_logs_-t_` to `sos_commands/crio/containers/logs/crictl_logs_-t_*`, This enhancement is to add the new path in existing specs of log path so that both the old and new path will be compatible and can be supported by insights-core. we may consider to deprecated the old path in a long term.
