### PR TITLE
fix: Prevent test teardown issues of fast_fetch

### DIFF
--- a/insights/tests/client/init/test_fetch.py
+++ b/insights/tests/client/init/test_fetch.py
@@ -47,6 +47,7 @@ def test_request_forced(insights_client):
 @patch('insights.client.InsightsClient._fetch', Mock())
 @patch('insights.client.os.path', Mock())
 @patch('insights.client.tempfile', Mock())
+@patch('insights.client.InsightsClient.delete_tmpdir', Mock())
 @patch('insights.client.InsightsClient.get_egg_url', return_value='/testvalue')
 @patch('insights.client.write_data_to_file')
 def test_egg_release_written(write_data_to_file, get_egg_url, insights_client):
@@ -60,6 +61,7 @@ def test_egg_release_written(write_data_to_file, get_egg_url, insights_client):
 @patch('insights.client.InsightsClient._fetch')
 @patch('insights.client.os.path', Mock())
 @patch('insights.client.tempfile', Mock())
+@patch('insights.client.InsightsClient.delete_tmpdir', Mock())
 @patch('insights.client.InsightsClient.get_egg_url', return_value='/testvalue')
 @patch('insights.client.write_data_to_file')
 def test_egg_release_error(write_data_to_file, get_egg_url, _fetch, insights_client):


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Two tests were mocking result of tempfile to prevent files from being written to filesystem during a test. A few years ago, a cleanup method was added to the tested code, to ensure the temporary directory the egg was downloaded to is cleaned up. Since then, these tests have been emitting warnings that Mock cannot be `lstat`ed.

This patch fixes it.