### PR TITLE
fix: Properly serialize playbook strings containing quote marks

### DIFF
--- a/insights/client/apps/ansible/playbook_verifier/serializer.py
+++ b/insights/client/apps/ansible/playbook_verifier/serializer.py
@@ -6,65 +6,49 @@ from insights.client.apps.ansible.playbook_verifier.contrib.ruamel_yaml.ruamel.y
 
 class PlaybookSerializer:
     @classmethod
-    def serialize(cls, source):
-        """Serialize snippet into string.
+    def serialize(cls, value):
+        """Serialize a playbook into a string.
 
-        :param source: Parsed playbook.
-        :type source: dict | yaml.comments.CommentedMap
         :returns: Serialized playbook.
         :rtype: str
         """
-        return cls._dict(source)
+        return cls._obj(value)
 
     @classmethod
-    def _dict(cls, source):
+    def _obj(cls, value):
         """
-        :type source: dict | yaml.comments.CommentedMap
+        :type value: any
         :rtype: str
         """
-        result_map = {}  # type: dict[str, str]
+        if isinstance(value, dict) or isinstance(value, CommentedMap):
+            return cls._dict(value)
+        if isinstance(value, list) or isinstance(value, CommentedSeq):
+            return cls._list(value)
+        if isinstance(value, int) or isinstance(value, float):
+            return str(value)
+        return "'" + str(value) + "'"
 
-        for key, value in source.items():
-            if isinstance(value, dict) or isinstance(value, CommentedMap):
-                result_map[key] = cls._dict(value)
-                continue
-            if isinstance(value, list) or isinstance(value, CommentedSeq):
-                result_map[key] = cls._list(value)
-                continue
-            if isinstance(value, int) or isinstance(value, float):
-                result_map[key] = str(value)
-                continue
-            result_map[key] = "'{value}'".format(value=value)
-
+    @classmethod
+    def _dict(cls, value):
+        """
+        :type value: dict | yaml.comments.CommentedMap
+        :rtype: str
+        """
         result = "ordereddict(["
         result += ", ".join(
-            "('{key}', {value})".format(key=key, value=value)
-            for key, value in result_map.items()
+            "('{key}', {value})".format(key=k, value=cls._obj(v))
+            for k, v in value.items()
         )
         result += "])"
         return result
 
     @classmethod
-    def _list(cls, source):
+    def _list(cls, value):
         """
-        :type source: list | yaml.comments.CommentedSeq
+        :type value: list | yaml.comments.CommentedSeq
         :rtype: str
         """
-        result_list = []  # type: list[str]
-
-        for value in source:
-            if isinstance(value, list) or isinstance(value, CommentedSeq):
-                result_list.append(cls._list(value))
-                continue
-            if isinstance(value, dict) or isinstance(value, CommentedMap):
-                result_list.append(cls._dict(value))
-                continue
-            if isinstance(value, int) or isinstance(value, float):
-                result_list.append(str(value))
-                continue
-            result_list.append("'{value}'".format(value=value))
-
         result = "["
-        result += ", ".join(value for value in result_list)
+        result += ", ".join(cls._obj(v) for v in value)
         result += "]"
         return result

--- a/insights/client/apps/ansible/playbook_verifier/serializer.py
+++ b/insights/client/apps/ansible/playbook_verifier/serializer.py
@@ -1,7 +1,12 @@
+import logging
+
+import six
 from insights.client.apps.ansible.playbook_verifier.contrib.ruamel_yaml.ruamel.yaml.comments import (
     CommentedMap,
     CommentedSeq,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class PlaybookSerializer:
@@ -26,7 +31,33 @@ class PlaybookSerializer:
             return cls._list(value)
         if isinstance(value, int) or isinstance(value, float):
             return str(value)
+        if isinstance(value, six.string_types):
+            return cls._str(value)
+
+        logger.debug("Value type not recognized, it may misbehave: {value} ({typ})".format(
+            value=value, typ=type(value).__name__)
+        )
         return "'" + str(value) + "'"
+
+    @classmethod
+    def _str(cls, value):
+        """
+        :type value: str
+        :rtype: str
+        """
+        # no quote      'no quote'
+        # single'quote  "single'quote"
+        # double"quote  'double"quote'
+        # both"'quotes  'both"\'quotes'
+
+        quote = "'"
+        if "'" in value:
+            if '"' not in value:
+                quote = '"'
+            else:
+                value = value.replace("'", "\\'")
+
+        return quote + value + quote
 
     @classmethod
     def _dict(cls, value):

--- a/insights/tests/client/apps/test_playbook_verifier.py
+++ b/insights/tests/client/apps/test_playbook_verifier.py
@@ -360,6 +360,19 @@ class TestPlaybookSerializer:
         result = playbook_verifier.PlaybookSerializer.serialize(source)
         assert result == expected
 
+    @pytest.mark.parametrize(
+        "source,expected",
+        [
+            ("no quote", "'no quote'"),
+            ("single'quote", '''"single'quote"'''),
+            ("double\"quote", """'double"quote'"""),
+            ("both\"'quotes", r"""'both"\'quotes'""")
+        ]
+    )
+    def test_strings(self, source, expected):
+        result = playbook_verifier.PlaybookSerializer.serialize(source)
+        assert result == expected
+
 
 @SKIP_BELOW_27
 class TestSerializePlaybookSnippet:

--- a/insights/tests/client/apps/test_playbook_verifier.py
+++ b/insights/tests/client/apps/test_playbook_verifier.py
@@ -1,6 +1,7 @@
 # -*- coding: UTF-8 -*-
 # flake8: noqa: E402
 import os
+import collections
 import pkgutil
 import sys
 
@@ -319,41 +320,44 @@ class TestExcludeDynamicElements:
         assert excinfo.value.message == expected
 
 
+@SKIP_BELOW_27
 class TestPlaybookSerializer:
+
     def test_list(self):
         source = ["value1", "value2"]
-        result = playbook_verifier.PlaybookSerializer._list(source)
+        result = playbook_verifier.PlaybookSerializer.serialize(source)
         expected = "['value1', 'value2']"
         assert result == expected
 
-    def test_dict_single(self):
+    def test_dict_single_key(self):
         source = {"key": "value"}
-        result = playbook_verifier.PlaybookSerializer._dict(source)
+        result = playbook_verifier.PlaybookSerializer.serialize(source)
         expected = "ordereddict([('key', 'value')])"
         assert result == expected
 
-    def test_dict_list(self):
+    def test_dict_value_list(self):
         source = {"key": ["value1", "value2"]}
-        result = playbook_verifier.PlaybookSerializer._dict(source)
+        result = playbook_verifier.PlaybookSerializer.serialize(source)
         expected = "ordereddict([('key', ['value1', 'value2'])])"
         assert result == expected
 
-    def test_dict_mixed(self):
-        source = {"key": "key", "value": ["value1", "value2"]}
-        result = playbook_verifier.PlaybookSerializer._dict(source)
+    # Python 2.7 dictionaries do not keep insertion order, we have to use OrderedDicts.
+
+    def test_dict_mixed_value_types(self):
+        source = collections.OrderedDict([("key", "key"), ("value", ["value1", "value2"])])
+        result = playbook_verifier.PlaybookSerializer.serialize(source)
         expected = "ordereddict([('key', 'key'), ('value', ['value1', 'value2'])])"
         assert result == expected
 
-    def test_dict_multiple(self):
-        source = {"key": "key", "value": "value"}
-        result = playbook_verifier.PlaybookSerializer._dict(source)
+    def test_dict_multiple_keys(self):
+        source = collections.OrderedDict([("key", "key"), ("value", "value")])
+        result = playbook_verifier.PlaybookSerializer.serialize(source)
         expected = "ordereddict([('key', 'key'), ('value', 'value')])"
         assert result == expected
 
-    def test_numbers(self):
-        source = {"integer": 37, "float": 17.93233901}
-        result = playbook_verifier.PlaybookSerializer._dict(source)
-        expected = "ordereddict([('integer', 37), ('float', 17.93233901)])"
+    @pytest.mark.parametrize("source,expected", [(37, "37"), (17.93233901, "17.93233901")])
+    def test_numbers(self, source, expected):
+        result = playbook_verifier.PlaybookSerializer.serialize(source)
         assert result == expected
 
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: CCT-647
* Card ID: RHINENG-11692

The string serialization should reflect what Python does.