### PR TITLE
fix: 'filterable' specs were skipped incorrectly when running plugins

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -184,15 +184,18 @@ class FileProvider(ContentProvider):
         # 1. No Such File
         if not os.path.exists(self.path):
             raise ContentException("%s does not exist." % self.path)
-        # 2. No Filters for 'filterable=True' Specs
-        if (self.ds and filters.ENABLED and
-                any(s.filterable for s in dr.get_registry_points(self.ds)) and
-                not filters.get_filters(self.ds)):
-            raise NoFilterException("Skipping %s due to no filters." % dr.get_name(self.ds))
-        # 3. Customer Prohibits Collection
-        if not blacklist.allow_file("/" + self.relative_path):
-            log.warning("WARNING: Skipping file %s", "/" + self.relative_path)
-            raise BlacklistedSpec()
+        # 2. Check only when collecting
+        if isinstance(self.ctx, HostContext):
+            # 2.1 No Filters for 'filterable=True' Specs
+            if (self.ds and filters.ENABLED and
+                    isinstance(self.ctx, HostContext) and
+                    any(s.filterable for s in dr.get_registry_points(self.ds)) and
+                    not filters.get_filters(self.ds)):
+                raise NoFilterException("Skipping %s due to no filters." % dr.get_name(self.ds))
+            # 2.2 Customer Prohibits Collection
+            if not blacklist.allow_file("/" + self.relative_path):
+                log.warning("WARNING: Skipping file %s", "/" + self.relative_path)
+                raise BlacklistedSpec()
 
         resolved = os.path.realpath(self.path)
         if not resolved.startswith(os.path.realpath(self.root)):
@@ -358,15 +361,17 @@ class CommandOutputProvider(ContentProvider):
         cmd = shlex.split(self.cmd)[0]
         if not which(cmd, env=self._env):
             raise ContentException("Command not found: %s" % cmd)
-        # 2. No Filters for 'filterable=True' Specs
-        if (self.ds and filters.ENABLED and
-                any(s.filterable for s in dr.get_registry_points(self.ds)) and
-                not filters.get_filters(self.ds)):
-            raise NoFilterException("Skipping %s due to no filters." % dr.get_name(self.ds))
-        # 3. Customer Prohibits Collection
-        if not blacklist.allow_command(self.cmd):
-            log.warning("WARNING: Skipping command %s", self.cmd)
-            raise BlacklistedSpec()
+        # 2. Check only when collecting
+        if isinstance(self.ctx, HostContext):
+            # 2.1 No Filters for 'filterable=True' Specs
+            if (self.ds and filters.ENABLED and
+                    any(s.filterable for s in dr.get_registry_points(self.ds)) and
+                    not filters.get_filters(self.ds)):
+                raise NoFilterException("Skipping %s due to no filters." % dr.get_name(self.ds))
+            # 2.2 Customer Prohibits Collection
+            if not blacklist.allow_command(self.cmd):
+                log.warning("WARNING: Skipping command %s", self.cmd)
+                raise BlacklistedSpec()
 
     def create_args(self):
         command = [shlex.split(self.cmd)]

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -188,7 +188,6 @@ class FileProvider(ContentProvider):
         if isinstance(self.ctx, HostContext):
             # 2.1 No Filters for 'filterable=True' Specs
             if (self.ds and filters.ENABLED and
-                    isinstance(self.ctx, HostContext) and
                     any(s.filterable for s in dr.get_registry_points(self.ds)) and
                     not filters.get_filters(self.ds)):
                 raise NoFilterException("Skipping %s due to no filters." % dr.get_name(self.ds))


### PR DESCRIPTION
- 'filterable' is an option for collection but not running
   It should be acceptable to run plugins that depend on "filterable"
   spec but do not "add_filter" for the spec.
   And the results of running the plugin with or without "add_filter"
   should be the same.
- This change limits the validation of filter checking to data
   collection only. That is, the filters check only works when
   collecting a 'filterable' spec but not running it.
- tests are added as well

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
- see RHINENG-11728
