### PR TITLE
Update __init__.py to fix JSONParser's list parsing implementation

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -782,7 +782,7 @@ class JSONParser(Parser, LegacyItemAccess):
     def parse_content(self, content):
         try:
             if isinstance(content, list):
-                self.data = json.loads('\n'.join(content))
+                self.data = json.loads("[" + ','.join(content) +  "]")
             else:
                 self.data = json.loads(content)
         except:


### PR DESCRIPTION
The current list implementation of the json parser doesn't seem to work with josnl data; this should fix the issue.

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

When implementing a custom Parse based on the JSONParser that parses jsonl files (or jsonl data) this parser is unable to read the data due to the following error. 

`json.decoder.JSONDecodeError: Extra data: line 2 column 1 (char ####)`

This is caused because content (is a list), but we are not properly handing the conversion of said list into a proper large json array (or object); so that it can be properly loaded.  This correct that behavior. 
