### PR TITLE
fix: do not encode(utf-8) when writing content in py2 env

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -126,7 +126,8 @@ class ContentProvider(object):
         # Clean Spec Content when writing it down to disk and before uploading
         self._clean_content()
         with open(dst, "wb") as f:
-            f.write("\n".join(self.content).encode('utf-8'))
+            content = "\n".join(self.content)
+            f.write(content.encode('utf-8') if six.PY3 else content)
 
         self.loaded = False
 


### PR DESCRIPTION
- For Python 2, ascii encoding is used by default, so when 
  writing content to a file, encode('utf-8') should not be used
- This issue caused the compliance data cannot be collected in RHEL 7, 
  see RHINENG-11682
- No tests added for this change

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

