### PR TITLE
fix: Run subshells with LC_ALL=C.UTF-8

### DIFF
--- a/insights/client/crypto.py
+++ b/insights/client/crypto.py
@@ -95,7 +95,7 @@ class GPGCommand(object):
             ["/usr/bin/gpg", "--version"],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             universal_newlines=True,
-            env={"GNUPGHOME": self._home},
+            env={"GNUPGHOME": self._home, "LC_ALL": "C.UTF-8"},
         )
         stdout, stderr = version_process.communicate()
         if version_process.returncode != 0:
@@ -141,7 +141,7 @@ class GPGCommand(object):
             ["/usr/bin/gpgconf", "--kill", "all"],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             universal_newlines=True,
-            env={"GNUPGHOME": self._home},
+            env={"GNUPGHOME": self._home, "LC_ALL": "C.UTF-8"},
         )
         _, stderr = shutdown_process.communicate()
         if shutdown_process.returncode != 0:
@@ -185,6 +185,7 @@ class GPGCommand(object):
         process = subprocess.Popen(
             self._raw_command,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            env={"LC_ALL": "C.UTF-8"},
         )
         stdout, stderr = process.communicate()
 

--- a/insights/tests/client/test_crypto.py
+++ b/insights/tests/client/test_crypto.py
@@ -102,6 +102,7 @@ def _initialize_gpg_environment(home):
     process = subprocess.Popen(
         ["/usr/bin/gpg", "--homedir", home, "--import", public_key],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env={"LC_ALL": "C.UTF-8"},
     )
     process.communicate()
     assert process.returncode == 0
@@ -113,6 +114,7 @@ def _initialize_gpg_environment(home):
     process = subprocess.Popen(
         ["/usr/bin/gpg", "--homedir", home, "--import", private_key],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env={"LC_ALL": "C.UTF-8"},
     )
     process.communicate()
     assert process.returncode == 0
@@ -124,6 +126,7 @@ def _initialize_gpg_environment(home):
     process = subprocess.Popen(
         ["/usr/bin/gpg", "--homedir", home, "--detach-sign", "--armor", file],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env={"LC_ALL": "C.UTF-8"},
     )
     process.communicate()
     assert process.returncode == 0


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: RHINENG-11802
* Card ID: CCT-653

Ensure we get Unicode data back when we run GPG in a subshell. This will ensure we are able to parse output of the command even if the host is configured to use non-UTF-8 character set.
