### PR TITLE
fix: Skip empty spec only when collecting

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -95,7 +95,7 @@ class ContentProvider(object):
                     obf_funcs=self.cleaner.get_obfuscate_functions(self.relative_path, no_obf),
                     no_redact=no_red)
                 if len(self._content) == 0:
-                    log.debug("Skipping %s due to empty after cleaning", "/" + self.relative_path)
+                    log.debug("Skipping %s due to empty after cleaning", self.path)
                     raise ContentException("Empty after cleaning: %s" % self.path)
             else:
                 log.debug("Skipping cleaning %s", "/" + self.relative_path)
@@ -117,7 +117,10 @@ class ContentProvider(object):
                 raise
 
         if len(self._content) == 0:
-            raise ContentException("Empty (after filtering): %s" % self.path)
+            log.debug("File is empty (after filtering): %s", self.path)
+            if isinstance(self.ctx, HostContext):
+                # Do not collect empty spec
+                raise ContentException("Empty (after filtering): %s" % self.path)
 
         return self._content
 


### PR DESCRIPTION
- When running plugins, print a debug information only for 
 empty spec, but not raise Exception
- As before, the empty spec will be collected, but the
  reason will be recorded as an ContentException in its
  meta_data JSON
- JIRA: RHINENG-11843
- And change to show the full real path instead of relative path
  in the debug message
- Fix the relevant test of compliance ds
- fix #4180

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

