### PR TITLE
Fix skipped assertions for itests

### DIFF
--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -71,6 +71,8 @@ DEFAULT_HOSTNAME = "hostname.example.com"
 
 MAKE_NONE_RESULT = make_none()
 
+_UNDEFINED = object()
+
 
 def _beautify_deep_compare_diff(result, expected):
     if not (isinstance(result, dict) and isinstance(expected, dict)):
@@ -153,7 +155,7 @@ COMPONENT_FILTERED_PARSERS = {
 
 
 def run_test(component, input_data,
-             expected=None, return_make_none=False, do_filter=True):
+             expected=_UNDEFINED, return_make_none=False, do_filter=True):
     """
     Arguments:
         component: The insights component need to test.
@@ -189,7 +191,7 @@ def run_test(component, input_data,
 
     broker = run_input_data(component, input_data)
     result = broker.get(component)
-    if expected:
+    if expected is not _UNDEFINED:
         deep_compare(result, expected)
     elif result == MAKE_NONE_RESULT and not return_make_none:
         # Convert make_none() result to None as default unless

--- a/insights/tests/test_integration_support.py
+++ b/insights/tests/test_integration_support.py
@@ -52,7 +52,7 @@ def test_run_test_parser_is_not_used():
     """
     input_data = InputData("fake_input")
     input_data.add(Specs.dmesg, "FAKE_CONTENT")
-    result = run_test(parser_is_not_used, input_data, None)
+    result = run_test(parser_is_not_used, input_data)
     # No Exception raised
     assert result
 
@@ -65,7 +65,7 @@ def test_run_test_parser_is_filtered():
     """
     input_data = InputData("fake_input")
     input_data.add(Specs.dmesg, "FAKE_CONTENT")
-    result = run_test(parser_is_filtered, input_data, None)
+    result = run_test(parser_is_filtered, input_data)
     # No Exception raised
     assert result
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Using `run_test` with `expected` parameter **DOES NOT** perform expected assertion if `expected` value evaluates to false. For example, if `expected` is an empty list or dict or str or a bool value of `False`. The result is that no assertion is performed meaning that when checking that an integration test for a `condition`, for example, returns `False` but it instead, in error, returns `True`, `run_test` does not perform the assertion giving the impression that the test passes even though it does not.

This change fixes this by using a default sentinel value for `expected` and always performing the assertion unless `expected` is the sentinel value.

This change required updating an existing integration test. Additionally, it is important to note that this change will result in existing integration tests to fail which have fallen victim to this bug as well as any calls to `run_test` that explicitly pass `expected=None` thinking that it should mean _do not perform any assertions_.
