### PR TITLE
Catch Timeout on test connection

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -413,7 +413,7 @@ class InsightsConnection(object):
                 logger.info("Connectivity tests completed with some errors")
                 print("See %s for more details." % self.config.logging_file)
                 rc = 1
-        except requests.ConnectionError:
+        except REQUEST_FAILED_EXCEPTIONS:
             logger.error('Connectivity test failed! '
                          'Please check your network configuration')
             print('Additional information may be in %s' % self.config.logging_file)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The `--test-connection` command only used to catch `ConnectionError`, including `ConnectionTimeout`, but not other timeouts such as `ReadTimeoutError`. Re-used the existing `REQUEST_FAILED_EXCEPTIONS` list to process all timeouts in the same way.

There is an integration test pull request https://github.com/RedHatInsights/insights-client/pull/244 for this fix.

Card IDs:
* [CCT-506](https://issues.redhat.com/browse/CCT-506)