### PR TITLE
feat(client): write .last-upload.results also after non-legacy uploads

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -413,6 +413,9 @@ def upload(config, pconn, tar_file, content_type, collection_duration=None):
             continue
 
         if upload.status_code in (200, 202):
+            # Write to last upload file
+            write_to_disk(constants.last_upload_results_file, upload.text)
+            os.chmod(constants.last_upload_results_file, 0o644)
             write_to_disk(constants.lastupload_file)
             os.chmod(constants.lastupload_file, 0o644)
             msg_name = determine_hostname(config.display_name)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

While that file is deprecated and it is good that it is not written after non-legacy uploads, in practice it is actually used by tooling that uses insights-client.

To avoid breaking functionalities in other software when switching to non-legacy, write /etc/insights-client/.last-upload.results also after non-legacy uploads. While those softwares are fixed to not rely on that file, at least this is one small step ahead in switching the default away to non-legacy without regressions elsewhere.

Implements CCT-710