### PR TITLE
test: fix the py26 flake8 error in ssl_certificate test

### DIFF
--- a/insights/tests/datasources/test_ssl_certificate.py
+++ b/insights/tests/datasources/test_ssl_certificate.py
@@ -320,14 +320,14 @@ queue.type = "LinkedList"
 def test_httpd_certificate(m_open, m_exist):
     m_open.side_effect = [m_open.return_value, mock_open(read_data=HTTPD_SSL_CONF).return_value]
     broker = {
-        httpd.httpd_configuration_files: {'/etc/httpd/conf/httpd.conf', '/etc/httpd/conf.d/ssl.conf'}
+        httpd.httpd_configuration_files: ['/etc/httpd/conf/httpd.conf', '/etc/httpd/conf.d/ssl.conf']
     }
     result = httpd_ssl_certificate_files(broker)
     assert result == ['/etc/pki/katello/certs/gént-katello-apache.crt']
 
     m_open.side_effect = [m_open.return_value, mock_open(read_data=HTTPD_SSL_CONF_2).return_value]
     broker = {
-        httpd.httpd_configuration_files: {'/etc/httpd/conf/httpd.conf', '/etc/httpd/conf.d/ssl.conf'}
+        httpd.httpd_configuration_files: ['/etc/httpd/conf/httpd.conf', '/etc/httpd/conf.d/ssl.conf']
     }
     result = httpd_ssl_certificate_files(broker)
     # "/etc/pki/katello/certs/katello-apache_e.crt" not in the result
@@ -361,14 +361,14 @@ def test_nginx_certificate():
 def test_httpd_ssl_cert_exception(m_open, m_exists):
     m_open.side_effect = [m_open.return_value, mock_open(read_data=HTTPD_CONF_WITHOUT_SSL).return_value]
     broker1 = {
-        httpd.httpd_configuration_files: {'/etc/httpd/conf/httpd.conf', '/etc/httpd/conf.d/no_ssl.conf'}
+        httpd.httpd_configuration_files: ['/etc/httpd/conf/httpd.conf', '/etc/httpd/conf.d/no_ssl.conf']
     }
     with pytest.raises(SkipComponent):
         httpd_ssl_certificate_files(broker1)
 
     m_open.side_effect = [m_open.return_value, mock_open(read_data=HTTPD_SSL_CONF_NO_VALUE).return_value]
     broker2 = {
-        httpd.httpd_configuration_files: {'/etc/httpd/conf/httpd.conf', '/etc/httpd/conf.d/no_ssl.conf'}
+        httpd.httpd_configuration_files: ['/etc/httpd/conf/httpd.conf', '/etc/httpd/conf.d/no_ssl.conf']
     }
     with pytest.raises(SkipComponent):
         httpd_ssl_certificate_files(broker2)
@@ -408,7 +408,7 @@ def test_mssql_tls_no_cert_exception():
 def test_httpd_certificate_info_in_nss(m_open, m_exists):
     m_open.side_effect = [m_open.return_value, mock_open(read_data=HTTPD_WITH_NSS).return_value]
     broker = {
-        httpd.httpd_configuration_files: {'/etc/httpd/conf/httpd.conf', '/etc/httpd/conf.d/nss.conf'}
+        httpd.httpd_configuration_files: ['/etc/httpd/conf/httpd.conf', '/etc/httpd/conf.d/nss.conf']
     }
     result = httpd_certificate_info_in_nss(broker)
     assert result == [('/etc/httpd/aliasa', 'testcertaê'), ('/etc/httpd/aliasb', 'testcertb')]
@@ -419,7 +419,7 @@ def test_httpd_certificate_info_in_nss(m_open, m_exists):
 def test_httpd_certificate_info_in_nss_exception(m_open, m_exists):
     m_open.side_effect = [m_open.return_value, mock_open(read_data=HTTPD_WITH_NSS_OFF).return_value]
     broker = {
-        httpd.httpd_configuration_files: {'/etc/httpd/conf/httpd.conf', '/etc/httpd/conf.d/nss.conf'}
+        httpd.httpd_configuration_files: ['/etc/httpd/conf/httpd.conf', '/etc/httpd/conf.d/nss.conf']
     }
     with pytest.raises(SkipComponent):
         httpd_certificate_info_in_nss(broker)


### PR DESCRIPTION
- it's introduced by #4220

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
