### PR TITLE
fix: Update value format of CupsBrowsedConf

### DIFF
--- a/insights/parsers/cups_confs.py
+++ b/insights/parsers/cups_confs.py
@@ -96,6 +96,7 @@ class CupsdConf(ConfigParser):
 class CupsBrowsedConf(Parser, dict):
     """
     Class for parsing the file ``/etc/cups/cups-browsed.conf``
+
     .. note::
 
         The admin can add multiple directives into the configuration file, and restart service without issue.

--- a/insights/parsers/cups_confs.py
+++ b/insights/parsers/cups_confs.py
@@ -105,7 +105,7 @@ class CupsBrowsedConf(Parser, dict):
     Examples:
         >>> type(cups_browsed_conf)
         <class 'insights.parsers.cups_confs.CupsBrowsedConf'>
-        >>> 'dnssd' in cups_browsed_conf['BrowseRemoteProtocols']
+        >>> 'dnssd cups' in cups_browsed_conf['BrowseRemoteProtocols']
         True
         >>> 'cups.example.com' in cups_browsed_conf['BrowseAllow']
         True
@@ -117,13 +117,9 @@ class CupsBrowsedConf(Parser, dict):
         for line in get_active_lines(content):
             k, v = [i.strip() for i in line.split(None, 1)]
             if k not in self:
-                self[k] = v if len(v.split()) == 1 else v.split()
+                self[k] = [v]
             else:
-                _v = self[k]
-                _v = [_v] if not isinstance(_v, list) else _v
-                if v not in _v:
-                    _v.append(v)
-                    self[k] = _v
+                self[k].append(v)
 
 
 @parser(Specs.cups_files_conf)

--- a/insights/parsers/cups_confs.py
+++ b/insights/parsers/cups_confs.py
@@ -96,6 +96,12 @@ class CupsdConf(ConfigParser):
 class CupsBrowsedConf(Parser, dict):
     """
     Class for parsing the file ``/etc/cups/cups-browsed.conf``
+    .. note::
+
+        The admin can add multiple directives into the configuration file, and restart service without issue.
+        However, item like BrowseRemoteProtocols only works for the last one, and the item like BrowseAllow works
+        for all directives. So the values of each directives will get stored to a list with the original order,
+        and duplicated values will be kept without de-duplication.
 
     Sample file content::
 

--- a/insights/tests/parsers/test_cups_confs.py
+++ b/insights/tests/parsers/test_cups_confs.py
@@ -132,6 +132,7 @@ CUPS_BROWSED_CONF = """
 # Can use DNSSD and/or CUPS and/or LDAP, or 'none' for neither.
 
 BrowseRemoteProtocols dnssd cups
+BrowseRemoteProtocols none
 BrowseAllow 192.168.0.1
 BrowseAllow 192.168.0.255
 BrowseAllow cups.example.com
@@ -176,8 +177,8 @@ def test_cups_browsed_files_conf():
     result = CupsBrowsedConf(context_wrap(CUPS_BROWSED_CONF))
     assert len(result) == 2
     assert 'BrowseRemoteProtocols' in result
-    assert result['BrowseRemoteProtocols'] == ['dnssd', 'cups']
-    assert sorted(result['BrowseAllow']) == sorted(['192.168.0.1', '192.168.0.255', 'cups.example.com'])
+    assert result['BrowseRemoteProtocols'] == ['dnssd cups', 'none']
+    assert result['BrowseAllow'] == ['192.168.0.1', '192.168.0.255', 'cups.example.com', '192.168.0.255']
 
 
 def test_cups_browsed_conf_empty():


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
Update the value format of this parser to adjust the Advisor rule.
- Per the manual and tests of cups_browsed.conf, 
  different directives will be handled differently. E.g, 
  for `BrowseAllow`, all its configured values will be kept, 
  but for `BrowseRemoteProtocols`, only its last one will work.
