### PR TITLE
fix: datasource pass unicode to foreach_execute in py26

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -940,7 +940,7 @@ class command_with_args(object):
                  deps=None, split=True, keep_rc=False, timeout=None,
                  inherit_env=None, override_env=None, signum=None, **kwargs):
         deps = deps if deps is not None else []
-        self.cmd = cmd
+        self.cmd = cmd if six.PY3 else str(cmd)
         self.provider = provider
         self.save_as = save_as.strip("/") if save_as else None  # strip as a relative file path
         self.context = context


### PR DESCRIPTION
- when collecting in py26 env, if the foreach_execute specs depends
  on datasource, the provider will be in unicode type and cause validate()
  failed
- this change converted the unicode to string by force for all 'cmd' passed to
  CommandOutputProvider

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

- In the integration test under py26, the `foreach_execute` depends on
  datasources cannot be collected as expected due to the following error:
```
  File "/root/insights-core/insights.zip/insights/core/spec_factory.py", line 365, in validate
    if not which(cmd, env=self._env):
  File "/root/insights-core/insights.zip/insights/util/__init__.py", line 60, in which
    if os.access(cmd, os.X_OK) and os.path.isfile(cmd):
TypeError: access() argument 1 must be encoded string without NULL bytes, not str
```
