### PR TITLE
Update malware-detection tests for different version of yara

### DIFF
--- a/insights/tests/datasources/malware_detection/test_malware_detection.py
+++ b/insights/tests/datasources/malware_detection/test_malware_detection.py
@@ -2234,6 +2234,9 @@ except CalledProcessError:
 
 if REAL_YARA:
     REAL_YARA_VERSION = str(call('%s --version' % REAL_YARA)).strip()
+    MAJOR_VERSION = REAL_YARA_VERSION.split('.')[:2]
+    # yara fast-scan option was fixed in 4.5.0 and produces different results than previous versions
+    FAST_SCAN_FIX = int(MAJOR_VERSION[0]) >= 4 and int(MAJOR_VERSION[1]) >= 5
 
     def find_test_item(item_name):
         for path, dirs, files in os.walk(os.getcwd()):
@@ -2625,17 +2628,17 @@ if REAL_YARA:
                 assert rule_match[0]['source'] == COMPILED_RULES_FILE
                 assert rule_match[0]['string_data'] == 'MalwareDetectionClient'
                 assert rule_match[0]['string_identifier'] == '$text1'
-                assert rule_match[0]['string_offset'] <= 544
+                assert rule_match[0]['string_offset'] == 568 if FAST_SCAN_FIX else 544
 
                 rule_match = mdc.host_scan['MiscellaneousStringsRule']
                 assert rule_match[0]['source'] == COMPILED_RULES_FILE
                 assert rule_match[0]['string_data'] == 'sent"'
                 assert rule_match[0]['string_identifier'] == '$string1'
-                assert rule_match[0]['string_offset'] == 601
+                assert rule_match[0]['string_offset'] == 625 if FAST_SCAN_FIX else 601
                 assert rule_match[1]['source'] == COMPILED_RULES_FILE
-                assert rule_match[1]['string_data'] == r'ata_sff\\x00bioset\\x00bond0\\x00cifsd\\x00'
+                assert rule_match[1]['string_data'] == r'ata_sff\x00bioset\x00bond0\x00cifsd\x00'
                 assert rule_match[1]['string_identifier'] == '$string2'
-                assert rule_match[1]['string_offset'] == 616
+                assert rule_match[1]['string_offset'] == 640 if FAST_SCAN_FIX else 616
                 assert mdc.scan_processes() is False
 
             @patch(GET_RULES_TARGET, return_value=COMPILED_RULES_FILE)
@@ -2991,7 +2994,7 @@ if REAL_YARA:
                        (REAL_YARA, CPUS, RULE_RULE_FILE) in caplog.text
                 mdc.scan_filesystem()
                 rule_match = mdc.host_scan['Rule']
-                assert len(rule_match) == 8
+                assert len(rule_match) == 10 if FAST_SCAN_FIX else 8
 
         @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
         class TestLineNumberMetadata:
@@ -3005,7 +3008,7 @@ if REAL_YARA:
 
                 # 8 matching strings for 'Rule' in 'another matching_entity' file
                 rule_match = mdc.host_scan['Rule']
-                assert len(rule_match) == 8
+                assert len(rule_match) == 10 if FAST_SCAN_FIX else 8
 
                 assert rule_match[0]['source'] == ANOTHER_MATCHING_ENTITY_FILE
                 assert rule_match[0]['string_data'] == "string match containing error scanning but it's ok because its not in a rule line"
@@ -3028,51 +3031,57 @@ if REAL_YARA:
                 assert metadata['line_number'] == 7
                 assert metadata['line'] == urlencode("This line contains = char")
 
-                assert rule_match[2]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[2]['string_data'] == "contains .+"
-                assert rule_match[2]['string_identifier'] == '$grep2'
-                assert rule_match[2]['string_offset'] == 153
-                metadata = rule_match[2]['metadata']
+                index = 3 if FAST_SCAN_FIX else 2
+                assert rule_match[index]['source'] == ANOTHER_MATCHING_ENTITY_FILE
+                assert rule_match[index]['string_data'] == "contains .+"
+                assert rule_match[index]['string_identifier'] == '$grep2'
+                assert rule_match[index]['string_offset'] == 153
+                metadata = rule_match[index]['metadata']
                 assert metadata['line_number'] == 9
                 assert metadata['line'] == urlencode("This line contains .+ chars")
 
-                assert rule_match[3]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[3]['string_data'] == 'contains "'
-                assert rule_match[3]['string_identifier'] == '$grep3'
-                assert rule_match[3]['string_offset'] == 213
-                metadata = rule_match[3]['metadata']
+                index = 5 if FAST_SCAN_FIX else 3
+                assert rule_match[index]['source'] == ANOTHER_MATCHING_ENTITY_FILE
+                assert rule_match[index]['string_data'] == 'contains "'
+                assert rule_match[index]['string_identifier'] == '$grep3'
+                assert rule_match[index]['string_offset'] == 213
+                metadata = rule_match[index]['metadata']
                 assert metadata['line_number'] == 11
                 assert metadata['line'] == urlencode('This line contains "" chars')
 
-                assert rule_match[4]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[4]['string_data'] == "contains '"
-                assert rule_match[4]['string_identifier'] == '$grep4'
-                assert rule_match[4]['string_offset'] == 241
-                metadata = rule_match[4]['metadata']
+                index = 6 if FAST_SCAN_FIX else 4
+                assert rule_match[index]['source'] == ANOTHER_MATCHING_ENTITY_FILE
+                assert rule_match[index]['string_data'] == "contains '"
+                assert rule_match[index]['string_identifier'] == '$grep4'
+                assert rule_match[index]['string_offset'] == 241
+                metadata = rule_match[index]['metadata']
                 assert metadata['line_number'] == 12
                 assert metadata['line'] == urlencode("This line contains '' chars")
 
-                assert rule_match[5]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[5]['string_data'] == 'contains ()[]'
-                assert rule_match[5]['string_identifier'] == '$grep5'
-                assert rule_match[5]['string_offset'] == 269
-                metadata = rule_match[5]['metadata']
+                index = 7 if FAST_SCAN_FIX else 5
+                assert rule_match[index]['source'] == ANOTHER_MATCHING_ENTITY_FILE
+                assert rule_match[index]['string_data'] == 'contains ()[]'
+                assert rule_match[index]['string_identifier'] == '$grep5'
+                assert rule_match[index]['string_offset'] == 269
+                metadata = rule_match[index]['metadata']
                 assert metadata['line_number'] == 13
                 assert metadata['line'] == urlencode("This line contains ()[] chars")
 
-                assert rule_match[6]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[6]['string_data'] == 'contains {'
-                assert rule_match[6]['string_identifier'] == '$grep6'
-                assert rule_match[6]['string_offset'] == 299
-                metadata = rule_match[6]['metadata']
+                index = 8 if FAST_SCAN_FIX else 6
+                assert rule_match[index]['source'] == ANOTHER_MATCHING_ENTITY_FILE
+                assert rule_match[index]['string_data'] == 'contains {'
+                assert rule_match[index]['string_identifier'] == '$grep6'
+                assert rule_match[index]['string_offset'] == 299
+                metadata = rule_match[index]['metadata']
                 assert metadata['line_number'] == 14
                 assert metadata['line'] == urlencode("This line contains {} chars")
 
-                assert rule_match[7]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[7]['string_data'] == 'contains ^$'
-                assert rule_match[7]['string_identifier'] == '$grep7'
-                assert rule_match[7]['string_offset'] == 327
-                metadata = rule_match[7]['metadata']
+                index = 9 if FAST_SCAN_FIX else 7
+                assert rule_match[index]['source'] == ANOTHER_MATCHING_ENTITY_FILE
+                assert rule_match[index]['string_data'] == 'contains ^$'
+                assert rule_match[index]['string_identifier'] == '$grep7'
+                assert rule_match[index]['string_offset'] == 327
+                metadata = rule_match[index]['metadata']
                 assert metadata['line_number'] == 15
                 assert metadata['line'] == urlencode("This line contains ^$ chars")
 
@@ -3085,24 +3094,24 @@ if REAL_YARA:
                 mdc.scan_filesystem()
 
                 rule_match = mdc.host_scan['MetadataTestRule']
-                assert len(rule_match) == 9
+                assert len(rule_match) == 10 if FAST_SCAN_FIX else 9  # 12 matches but limited to 10 with string_match_limit
 
                 assert rule_match[0]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[0]['string_data'] == r'echo -e "[-] Ping \\033[31m${host_name}\\033[0m bad"'
+                assert rule_match[0]['string_data'] == r'echo -e "[-] Ping \033[31m${host_name}\033[0m bad"'
                 assert rule_match[0]['string_identifier'] == '$s1'
                 assert rule_match[0]['string_offset'] == 392
                 metadata = rule_match[0]['metadata']
                 assert metadata['source_type'] == 'file'
                 assert metadata['file_type'] == 'UTF-8 Unicode text'
                 assert metadata['mime_type'] == 'text/plain; charset=utf-8'
-                assert metadata['md5sum'] == '6ea8306ed20cede50ea10964dddc8d47'
+                assert metadata['md5sum'] == '227429b142ad425733fe155386d4a405'
                 assert metadata['line_number'] == 9
-                assert metadata['line'] == urlencode(r'Testing $s1 = "echo -e "[-] Ping \\033[31m${host_name}\\033[0m bad" ascii fullword')
+                assert metadata['line'] == urlencode(r'Testing $s1 = "echo -e "[-] Ping \033[31m${host_name}\033[0m bad"" ascii fullword')
 
                 assert rule_match[1]['source'] == RULE_METADATA_TEST_FILE
                 assert rule_match[1]['string_data'] == '"${user_name}"@"${host_name}" -p "${port}'
                 assert rule_match[1]['string_identifier'] == '$s2'
-                assert rule_match[1]['string_offset'] == 477
+                assert rule_match[1]['string_offset'] == 478
                 metadata = rule_match[1]['metadata']
                 assert metadata['line_number'] == 10
                 assert metadata['line'] == urlencode('Testing $s2 = ""${user_name}"@"${host_name}" -p "${port}" ascii fullword')
@@ -3110,7 +3119,7 @@ if REAL_YARA:
                 assert rule_match[2]['source'] == RULE_METADATA_TEST_FILE
                 assert rule_match[2]['string_data'] == """'$password' &" <<< GMANcode27'"""
                 assert rule_match[2]['string_identifier'] == '$s3'
-                assert rule_match[2]['string_offset'] == 554
+                assert rule_match[2]['string_offset'] == 555
                 metadata = rule_match[2]['metadata']
                 assert metadata['line_number'] == 11
                 assert metadata['line'] == urlencode("""Testing $s3 = "'$password' &" <<< GMANcode27'" ascii fullword""")
@@ -3123,45 +3132,51 @@ if REAL_YARA:
                 assert metadata['line_number'] == 4
                 assert metadata['line'] == urlencode('Testing $s4 = "for ssh_creds in ${allThreads[@]}; do" ascii fullword')
 
-                assert rule_match[4]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[4]['string_data'] == '"text=$MSG" "$MSG_URL$id&"'
-                assert rule_match[4]['string_identifier'] == '$s5'
-                assert rule_match[4]['string_offset'] == 620
-                metadata = rule_match[4]['metadata']
+                index = 5 if FAST_SCAN_FIX else 4
+                assert rule_match[index]['source'] == RULE_METADATA_TEST_FILE
+                assert rule_match[index]['string_data'] == '"text=$MSG" "$MSG_URL$id&"'
+                assert rule_match[index]['string_identifier'] == '$s5'
+                assert rule_match[index]['string_offset'] == 621
+                metadata = rule_match[index]['metadata']
                 assert metadata['line_number'] == 12
                 assert metadata['line'] == urlencode('Testing $s5 = ""text=$MSG" "$MSG_URL$id&"" ascii fullword')
 
                 # Cannot match line_numbers for this rule due to non-ascii chars
-                assert rule_match[5]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[5]['string_data'] == r"--exclude=\\*.\\xE2\\x98\\xA2 -l"
-                assert rule_match[5]['string_identifier'] == '$s6'
-                assert rule_match[5]['string_offset'] == 682
-                metadata = rule_match[5]['metadata']
+                index = 6 if FAST_SCAN_FIX else 5
+                assert rule_match[index]['source'] == RULE_METADATA_TEST_FILE
+                assert rule_match[index]['string_data'] == r"--exclude=\*.\xE2\x98\xA2 -l"
+                assert rule_match[index]['string_identifier'] == '$s6'
+                assert rule_match[index]['string_offset'] == 683
+                metadata = rule_match[index]['metadata']
                 assert all([key not in ['line_number', 'line'] for key in metadata.keys()])
 
-                assert rule_match[6]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[6]['string_data'] == r"--include=\\*.{txt,sh,exe}"
-                assert rule_match[6]['string_identifier'] == '$s7'
-                assert rule_match[6]['string_offset'] == 731
-                metadata = rule_match[6]['metadata']
+                index = 7 if FAST_SCAN_FIX else 6
+                assert rule_match[index]['source'] == RULE_METADATA_TEST_FILE
+                assert rule_match[index]['string_data'] == r"--include=\*.{txt,sh,exe}"
+                assert rule_match[index]['string_identifier'] == '$s7'
+                assert rule_match[index]['string_offset'] == 732
+                metadata = rule_match[index]['metadata']
                 assert metadata['line_number'] == 14
                 assert metadata['line'] == urlencode(r'Testing $s7 = "--include=\*.{txt,sh,exe}" ascii fullword')
 
-                assert rule_match[7]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[7]['string_data'] == "allThreads=($1)"
-                assert rule_match[7]['string_identifier'] == '$s8'
-                assert rule_match[7]['string_offset'] == 192
-                metadata = rule_match[7]['metadata']
+                index = 8 if FAST_SCAN_FIX else 7
+                assert rule_match[index]['source'] == RULE_METADATA_TEST_FILE
+                assert rule_match[index]['string_data'] == "allThreads=($1)"
+                assert rule_match[index]['string_identifier'] == '$s8'
+                assert rule_match[index]['string_offset'] == 192
+                metadata = rule_match[index]['metadata']
                 assert metadata['line_number'] == 5
                 assert metadata['line'] == urlencode('Testing $s8 = "allThreads=($1)" ascii fullword')
 
-                assert rule_match[8]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[8]['string_data'] == "$(host): encrypt files. Done."
-                assert rule_match[8]['string_identifier'] == '$s9'
-                assert rule_match[8]['string_offset'] == 243
-                metadata = rule_match[8]['metadata']
-                assert metadata['line_number'] == 6
-                assert metadata['line'] == urlencode('Testing $s9 = "$(host): encrypt files. Done." ascii fullword')
+                # This match won't appear when using FAST_SCAN_FIX because string_match_limit is 10
+                if not FAST_SCAN_FIX:
+                    assert rule_match[8]['source'] == RULE_METADATA_TEST_FILE
+                    assert rule_match[8]['string_data'] == "$(host): encrypt files. Done."
+                    assert rule_match[8]['string_identifier'] == '$s9'
+                    assert rule_match[8]['string_offset'] == 243
+                    metadata = rule_match[8]['metadata']
+                    assert metadata['line_number'] == 6
+                    assert metadata['line'] == urlencode('Testing $s9 = "$(host): encrypt files. Done." ascii fullword')
 
         @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
         # Rule used is irrelevant for these tests because we aren't actually scanning, just parsing canned yara output
@@ -3634,24 +3649,23 @@ if REAL_YARA:
                 assert all([x in scan_dict['/usr']['include']
                             for x in ['/usr/local/bin', '/usr/local/share']])
 
-                # Test including /usr/local/lib and excluding an item from it
-                # Confirm that only items from /usr/local/lib are included and NOT from any other directory
-                usr_local_lib = sorted(filter(lambda x: not os.path.islink(x),
-                                              map(lambda x: '/usr/local/lib/' + x, os.listdir('/usr/local/lib'))))
-                assert len(usr_local_lib) > 2
-                excluded_item1 = usr_local_lib[0]
-                excluded_item2 = usr_local_lib[1]
-                mdc.scan_fsobjects = ['/usr/local/lib']
-                mdc.filesystem_scan_exclude_list = [excluded_item1, excluded_item2]
-                scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
-                                                          exclude_items=mdc.filesystem_scan_exclude_list)
-                assert list(scan_dict.keys()) == ['/usr']
-                assert sorted(scan_dict['/usr']['exclude']['items']) == [excluded_item1, excluded_item2]
-                # Ensure only /usr/local/lib items are included (except the first 2 in the directory)
-                assert all([x not in scan_dict['/usr']['include']
-                            for x in ['/usr', '/usr/local', '/usr/local/lib', '/usr/local/libexec',
-                                      excluded_item1, excluded_item2]])
-                assert all([x in scan_dict['/usr']['include'] for x in usr_local_lib[2:]])
+                # Test including /usr/local/share and excluding an item from it (usually there are 3 directories in it)
+                # Confirm that only items from /usr/local/share are included and NOT from any other directory
+                usr_local_share = sorted(filter(lambda x: not os.path.islink(x),
+                                              map(lambda x: '/usr/local/share/' + x, os.listdir('/usr/local/share'))))
+                if len(usr_local_share) > 2:
+                    excluded_item1, excluded_item2 = usr_local_share[:2]
+                    mdc.scan_fsobjects = ['/usr/local/share']
+                    mdc.filesystem_scan_exclude_list = [excluded_item1, excluded_item2]
+                    scan_dict = process_include_exclude_items(include_items=mdc.scan_fsobjects,
+                                                              exclude_items=mdc.filesystem_scan_exclude_list)
+                    assert list(scan_dict.keys()) == ['/usr']
+                    assert sorted(scan_dict['/usr']['exclude']['items']) == [excluded_item1, excluded_item2]
+                    # Ensure only /usr/local/share items are included (except the first 2 in the directory)
+                    assert all([x not in scan_dict['/usr']['include']
+                                for x in ['/usr', '/usr/local', '/usr/local/lib', '/usr/local/libexec',
+                                          '/usr/local/share', excluded_item1, excluded_item2]])
+                    assert all([x in scan_dict['/usr']['include'] for x in usr_local_share[2:]])
 
             @patch(GET_RULES_TARGET, return_value=RULE_RULE_FILE)
             @patch(DISABLED_RULES_TARGET)
@@ -3678,7 +3692,7 @@ if REAL_YARA:
                 mdc.scan_filesystem()
                 assert mdc.matches == 2  # There were only 2 files the matched the rule
                 rule_match = mdc.host_scan['Rule']
-                assert len(rule_match) == 11  # There were 11 strings matched in the 2 files
+                assert len(rule_match) == 13 if FAST_SCAN_FIX else 11  # There were 11 or 13 strings matched in the 2 files
                 # Asserting the names of the 2 files that were matched
                 sources = set([rm['source'] for rm in rule_match])
                 assert len(sources) == 2
@@ -3710,7 +3724,7 @@ if REAL_YARA:
                 mdc.scan_filesystem()
                 assert mdc.matches == 1  # There was 1 file modified since last_scan
                 rule_match = mdc.host_scan['Rule']
-                assert len(rule_match) == 8  # There were 8 strings matched in the 2 files
+                assert len(rule_match) == 10 if FAST_SCAN_FIX else 8  # There were 8 or 10 strings matched in the 2 files
                 assert rule_match[0]['source'] == scan_me_file
 
                 # Touch another of the matching files, keeping the same last_scan time.
@@ -3722,14 +3736,13 @@ if REAL_YARA:
                 mdc.scan_filesystem()
                 assert mdc.matches == 2  # There were 2 files modified since last_scan the matched the rule
                 rule_match = mdc.host_scan['Rule']
-                assert len(rule_match) == 11  # There were 11 strings matched in the 2 files
+                assert len(rule_match) == 13 if FAST_SCAN_FIX else 11  # There were 11 or 13 strings matched in the 2 files
                 # Asserting the names of the 2 files that were matched
                 sources = set([rm['source'] for rm in rule_match])
                 assert len(sources) == 2
                 assert scan_me_file in sources
                 assert scan_me_too_file in sources
 
-        @patch(NAMEDTMPFILE_TARGET)
         @patch.object(InsightsConnection, 'get', return_value=Mock(status_code=200, content=b"Rule Content"))
         @patch.object(InsightsConnection, 'get_proxies')
         @patch.object(InsightsConnection, '_init_session', return_value=Mock())
@@ -3738,7 +3751,7 @@ if REAL_YARA:
         class TestGetRules:
 
             @patch.dict(os.environ)
-            def test_get_regular_rules_location_urls(self, disabled, init_session, get_proxies, get, tmpfile, caplog):
+            def test_get_regular_rules_location_urls(self, disabled, init_session, get_proxies, get, caplog):
                 # Test the standard rules_location urls, depending on whether test rule or cert auth is set
                 # With test scan true, expect to download test-rule.yar
                 test_rule_url = "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
@@ -3771,7 +3784,7 @@ if REAL_YARA:
                 get.assert_called_with(signatures_url, log_response_text=False, verify=True, stream=True)
                 assert signatures_url in caplog.text
 
-            def test_get_irregular_rules_location_urls(self, disabled, init_session, get_proxies, get, tmpfile, create_test_files_real_yara, caplog):
+            def test_get_irregular_rules_location_urls(self, disabled, init_session, get_proxies, get, create_test_files_real_yara, caplog):
                 # Non-standard rules URLs
                 # Without https:// at the start and not signatures.yar
                 logger.setLevel('DEBUG')
@@ -3794,7 +3807,7 @@ if REAL_YARA:
                                        log_response_text=False, verify=True, stream=True)
                 assert "https://cert.console.redhat.com/rules.yar" in caplog.text
 
-            def test_get_rules_location_files(self, disabled, init_session, get_proxies, get, tmpfile, create_test_files_real_yara, caplog):
+            def test_get_rules_location_files(self, disabled, init_session, get_proxies, get, create_test_files_real_yara, caplog):
                 # Test using files for rules_location, esp irregular file names
                 # Re-writing the rule to be test-rule.yar doesn't apply to local files
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
@@ -3978,14 +3991,14 @@ rule Rule
         description = "Strings to trigger matches in the test/*matching_entity files"
 
     strings:
-        $match0 = "string match in the file \\"matching_entity\\""
+        $match0 = "string match in the file \"matching_entity\""
         $match1 = "another string match in matching_entity"
-        $match2 = "string with different types of quotes 'here' and \\"here\\""
+        $match2 = "string with different types of quotes 'here' and \"here\""
         $match3 = "string match containing error scanning but it's ok because its not in a rule line"
 
         $grep1 = "contains ="
         $grep2 = "contains .+"
-        $grep3 = "contains \\""
+        $grep3 = "contains \""
         $grep4 = "contains '"
         $grep5 = "contains ()[]"
         $grep6 = "contains {"
@@ -4004,7 +4017,7 @@ RULE_METADATA_TEST_FILE_CONTENTS = r"""rule MetadataTestRule
     Testing $s9 = "$(host): encrypt files. Done." ascii fullword
 
     // These rule strings with some modifications match the rule strings below ...
-    Testing $s1 = "echo -e \"[-] Ping \\033[31m${host_name}\\033[0m bad" ascii fullword
+    Testing $s1 = "echo -e "[-] Ping \033[31m${host_name}\033[0m bad"" ascii fullword
     Testing $s2 = ""${user_name}"@"${host_name}" -p "${port}" ascii fullword
     Testing $s3 = "'$password' &" <<< GMANcode27'" ascii fullword
     Testing $s5 = ""text=$MSG" "$MSG_URL$id&"" ascii fullword
@@ -4013,13 +4026,13 @@ RULE_METADATA_TEST_FILE_CONTENTS = r"""rule MetadataTestRule
 */
 {
     strings:
-        $s1 = "echo -e \\"[-] Ping \\\\033[31m${host_name}\\\\033[0m bad\\"" ascii fullword
-        $s2 = "\\"${user_name}\\"@\\"${host_name}\\" -p \\"${port}" ascii fullword
-        $s3 = "'$password' &\\" <<< GMANcode27'" ascii fullword
+        $s1 = "echo -e \"[-] Ping \\033[31m${host_name}\\033[0m bad\"" ascii fullword
+        $s2 = "\"${user_name}\"@\"${host_name}\" -p \"${port}" ascii fullword
+        $s3 = "'$password' &\" <<< GMANcode27'" ascii fullword
         $s4 = "for ssh_creds in ${allThreads[@]}; do" ascii fullword
-        $s5 = "\\"text=$MSG\\" \\"$MSG_URL$id&\\"" ascii fullword
-        $s6 = "--exclude=\\\\*.☢ -l" fullword
-        $s7 = "--include=\\\\*.{txt,sh,exe}" ascii fullword
+        $s5 = "\"text=$MSG\" \"$MSG_URL$id&\"" ascii fullword
+        $s6 = "--exclude=\\*.☢ -l" fullword
+        $s7 = "--include=\\*.{txt,sh,exe}" ascii fullword
         $s8 = "allThreads=($1)" ascii fullword
         $s9 = "$(host): encrypt files. Done." ascii fullword
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Versions of yara 4.5.x and later change/fix the fast-scan option and produce different results than earlier versions.  This PR updates the malware-detection tests so they work with both versions before and after version 4.5.x.

This PR doesn't affect the functionality of malware-detection in any way.  It just modifies some of the unittests.  And even then, the modified unittests only run if yara is actually installed on system running the tests.
