### PR TITLE
Remove double exception print

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -349,7 +349,7 @@ class InsightsConnection(object):
                 else:
                     logger.info("Connection failed")
                     return False
-            except requests.ConnectionError as exc:
+            except REQUEST_FAILED_EXCEPTIONS as exc:
                 last_ex = exc
                 logger.error(
                     "Could not successfully connect to: %s", test_url + ext)
@@ -381,13 +381,11 @@ class InsightsConnection(object):
             else:
                 logger.info("Connection failed")
                 return False
-        except requests.ConnectionError as exc:
-            last_ex = exc
+        except REQUEST_FAILED_EXCEPTIONS as exc:
             logger.error(
                 "Could not successfully connect to: %s", url)
             print(exc)
-        if last_ex:
-            raise last_ex
+            raise exc
 
     def test_connection(self, rc=0):
         """
@@ -413,8 +411,7 @@ class InsightsConnection(object):
                 logger.info("Connectivity tests completed with some errors")
                 print("See %s for more details." % self.config.logging_file)
                 rc = 1
-        except requests.ConnectionError as exc:
-            print(exc)
+        except requests.ConnectionError:
             logger.error('Connectivity test failed! '
                          'Please check your network configuration')
             print('Additional information may be in %s' % self.config.logging_file)

--- a/insights/tests/client/connection/test_test_connection.py
+++ b/insights/tests/client/connection/test_test_connection.py
@@ -1,0 +1,1126 @@
+import pytest
+import requests
+from mock import mock
+
+from insights.client.config import InsightsConfig
+from insights.client.connection import InsightsConnection
+
+
+class UnexpectedException(Exception):
+    pass
+
+
+LOGGING_FILE = "logging-file.log"
+UPLOAD_URL = "https://www.example.com/insights"
+LEGACY_URL = "https://www.example.com"
+LEGACY_URL_SUFFIXES = ["/insights/", "", "/r", "/r/insights"]
+
+EXCEPTION_MESSAGE = "request exception"
+EXPECTED_EXCEPTIONS_TEST_CONNECTION = [
+    requests.exceptions.SSLError,
+    requests.exceptions.ConnectTimeout,
+]
+EXPECTED_EXCEPTIONS_TEST_URLS = EXPECTED_EXCEPTIONS_TEST_CONNECTION + [
+    requests.exceptions.ReadTimeout
+]
+UNEXPECTED_EXCEPTIONS_TEST_CONNECTION = [
+    UnexpectedException,
+    requests.exceptions.ReadTimeout,
+]
+parametrize_methods = pytest.mark.parametrize(
+    ["http_method", "request_function"],
+    [
+        ("GET", "insights.client.connection.InsightsConnection.get"),
+        ("POST", "insights.client.connection.InsightsConnection.post"),
+    ],
+)
+
+
+def parametrize_exceptions(exceptions):
+    return pytest.mark.parametrize(
+        ["exception"],
+        [(exception,) for exception in exceptions],
+    )
+
+
+@pytest.fixture
+@mock.patch("insights.client.connection.InsightsConnection._init_session")
+@mock.patch("insights.client.connection.InsightsConnection.get_proxies")
+def insights_connection(get_proxies, init_session):
+    config = InsightsConfig(
+        base_url="www.example.com",
+        logging_file=LOGGING_FILE,
+        upload_url=UPLOAD_URL,
+    )
+
+    connection = InsightsConnection(config)
+    connection.proxies = None
+
+    return connection
+
+
+@parametrize_methods
+@mock.patch("insights.client.connection.InsightsConnection._legacy_test_urls")
+def test_test_urls_legacy_test_urls_call(
+    legacy_test_urls, http_method, request_function, insights_connection
+):
+    """The non-legacy URL subtest hands over to its legacy counterpart if legacy_upload is enabled."""
+    insights_connection.config.legacy_upload = True
+
+    insights_connection._test_urls(UPLOAD_URL, http_method)
+
+    legacy_test_urls.assert_called_once_with(UPLOAD_URL, http_method)
+
+
+@parametrize_methods
+@mock.patch("insights.client.connection.InsightsConnection._legacy_test_urls")
+def test_test_urls_legacy_test_urls_result(
+    legacy_test_urls, http_method, request_function, insights_connection
+):
+    """The non-legacy URL subtest hands over to its legacy counterpart if legacy_upload is enabled."""
+    insights_connection.config.legacy_upload = True
+
+    result = insights_connection._test_urls(UPLOAD_URL, http_method)
+
+    assert result == legacy_test_urls.return_value
+
+
+@parametrize_methods
+@mock.patch("insights.client.connection.TemporaryFile")
+@mock.patch("insights.client.connection.InsightsConnection._legacy_test_urls")
+def test_test_urls_not_legacy_test_urls(
+    legacy_test_urls, temporary_file, http_method, request_function, insights_connection
+):
+    """The non-legacy URL subtest doesn't hand over to its legacy counterpart if legacy_upload is disabled."""
+    insights_connection.config.legacy_upload = False
+
+    with mock.patch(request_function):
+        insights_connection._test_urls(UPLOAD_URL, http_method)
+    legacy_test_urls.assert_not_called()
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_test_urls_get_no_catch(get, temporary_file, post, insights_connection):
+    """The non-legacy URL subtest issues one GET request in case of an unknown exception."""
+    get.side_effect = UnexpectedException
+    insights_connection.config.legacy_upload = False
+
+    try:
+        insights_connection._test_urls(UPLOAD_URL, "GET")
+    except UnexpectedException:
+        pass
+
+    get.assert_called_once_with(UPLOAD_URL)
+    post.assert_not_called()
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_test_urls_get_success(get, temporary_file, post, insights_connection):
+    """The non-legacy URL subtest issues one GET request if the API call succeeds."""
+    insights_connection.config.legacy_upload = False
+
+    insights_connection._test_urls(UPLOAD_URL, "GET")
+
+    get.assert_called_once_with(UPLOAD_URL)
+    post.assert_not_called()
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_test_urls_get_fail(get, temporary_file, post, insights_connection, exception):
+    """The non-legacy URL subtest issues one GET request if the API call fails."""
+    get.side_effect = exception
+    insights_connection.config.legacy_upload = False
+
+    try:
+        insights_connection._test_urls(UPLOAD_URL, "GET")
+    except exception:
+        pass
+
+    get.assert_called_once_with(UPLOAD_URL)
+    post.assert_not_called()
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_test_urls_post_no_catch(get, temporary_file, post, insights_connection):
+    """The non-legacy URL subtest issues one POST request in case of an unknown exception."""
+    post.side_effect = UnexpectedException
+    insights_connection.config.legacy_upload = False
+
+    try:
+        insights_connection._test_urls(UPLOAD_URL, "POST")
+    except UnexpectedException:
+        pass
+
+    post.assert_called_once_with(UPLOAD_URL, files=mock.ANY)
+    get.assert_not_called()
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_test_urls_post_success(get, temporary_file, post, insights_connection):
+    """The non-legacy URL subtest issues one POST request if the API call succeeds."""
+    insights_connection.config.legacy_upload = False
+
+    insights_connection._test_urls(UPLOAD_URL, "POST")
+    post.assert_called_once_with(UPLOAD_URL, files=mock.ANY)
+    get.assert_not_called()
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_test_urls_post_fail(get, temporary_file, post, exception, insights_connection):
+    """The non-legacy URL subtest issues one POST request if the API call fails."""
+    post.side_effect = exception
+    insights_connection.config.legacy_upload = False
+
+    try:
+        insights_connection._test_urls(UPLOAD_URL, "POST")
+    except exception:
+        pass
+
+    post.assert_called_once_with(UPLOAD_URL, files=mock.ANY)
+    get.assert_not_called()
+
+
+@parametrize_methods
+@mock.patch("insights.client.connection.TemporaryFile")
+def test_test_urls_no_catch(
+    temporary_file, http_method, request_function, insights_connection
+):
+    """The non-legacy URL subtest doesn't catch unknown exceptions."""
+    insights_connection.config.legacy_upload = False
+
+    raised = UnexpectedException()
+
+    with pytest.raises(UnexpectedException) as caught:
+        with mock.patch(request_function) as request_function_mock:
+            request_function_mock.side_effect = raised
+            insights_connection._test_urls(UPLOAD_URL, http_method)
+
+    assert caught.value is raised
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@parametrize_methods
+@mock.patch("insights.client.connection.TemporaryFile")
+def test_test_urls_raise(
+    temporary_file, http_method, request_function, exception, insights_connection
+):
+    """The non-legacy URL subtest re-raises the API call failure exception."""
+    insights_connection.config.legacy_upload = False
+
+    raised = exception()
+
+    with pytest.raises(exception) as caught:
+        with mock.patch(request_function) as request_function_mock:
+            request_function_mock.side_effect = raised
+            insights_connection._test_urls(UPLOAD_URL, http_method)
+
+    assert caught.value is raised
+
+
+@parametrize_methods
+@mock.patch("insights.client.connection.logger")
+def test_test_urls_error_log_no_catch(
+    logger, http_method, request_function, insights_connection
+):
+    """The non-legacy URL subtest doesn't log any errors in case of an unknown exception."""
+    insights_connection.config.legacy_upload = False
+
+    with mock.patch(request_function) as request_function_mock:
+        request_function_mock.side_effect = UnexpectedException
+        try:
+            insights_connection._test_urls(UPLOAD_URL, http_method)
+        except UnexpectedException:
+            pass
+
+    logger.error.assert_not_called()
+
+
+@parametrize_methods
+@mock.patch("insights.client.connection.logger")
+def test_test_urls_error_log_success(
+    logger, http_method, request_function, insights_connection
+):
+    """The non-legacy URL subtest doesn't log any errors if all API calls succeed."""
+    insights_connection.config.legacy_upload = False
+
+    with mock.patch(request_function):
+        insights_connection._test_urls(UPLOAD_URL, http_method)
+
+    logger.error.assert_not_called()
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@parametrize_methods
+@mock.patch("insights.client.connection.logger")
+def test_test_urls_error_log_fail(
+    logger, http_method, request_function, exception, insights_connection
+):
+    """The non-legacy URL subtest logs an ERROR if an API call fails."""
+    insights_connection.config.legacy_upload = False
+
+    try:
+        with mock.patch(request_function) as request_function_mock:
+            request_function_mock.side_effect = exception
+            insights_connection._test_urls(UPLOAD_URL, http_method)
+    except exception:
+        pass
+
+    logger.error.assert_called_once_with(
+        "Could not successfully connect to: %s", UPLOAD_URL
+    )
+
+
+@parametrize_methods
+def test_test_urls_print_no_catch(
+    http_method, request_function, insights_connection, capsys
+):
+    """The non-legacy URL subtest doesn't print anything in case of an unknown exception."""
+    insights_connection.config.legacy_upload = False
+
+    with mock.patch(request_function) as request_function_mock:
+        request_function_mock.side_effect = UnexpectedException
+        try:
+            insights_connection._test_urls(UPLOAD_URL, http_method)
+        except UnexpectedException:
+            pass
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert not err
+
+
+@parametrize_methods
+def test_test_urls_print_success(
+    http_method, request_function, insights_connection, capsys
+):
+    """The non-legacy URL subtest doesn't print anything if all API calls succeed."""
+    insights_connection.config.legacy_upload = False
+
+    with mock.patch(request_function):
+        insights_connection._test_urls(UPLOAD_URL, http_method)
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert not err
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@parametrize_methods
+def test_test_urls_print_fail(
+    http_method, request_function, exception, insights_connection, capsys
+):
+    """The non-legacy URL subtest prints the exception details if an API call fails."""
+    insights_connection.config.legacy_upload = False
+
+    with mock.patch(request_function) as request_function_mock:
+        request_function_mock.side_effect = exception(EXCEPTION_MESSAGE)
+        try:
+            insights_connection._test_urls(UPLOAD_URL, http_method)
+        except exception:
+            pass
+
+    out, err = capsys.readouterr()
+    assert out == "{0}\n".format(EXCEPTION_MESSAGE)
+    assert not err
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_legacy_urls_get_no_catch(get, post, insights_connection):
+    """The legacy URL subtest issues one GET request in case of an unknown exception."""
+    get.side_effect = UnexpectedException
+
+    try:
+        insights_connection._legacy_test_urls(UPLOAD_URL, "GET")
+    except UnexpectedException:
+        pass
+
+    get.assert_called_once_with(LEGACY_URL + LEGACY_URL_SUFFIXES[0])
+    post.assert_not_called()
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_legacy_urls_get_success(get, post, insights_connection):
+    """The non-legacy URL subtest issues one GET request if the API call succeeds."""
+    insights_connection._legacy_test_urls(UPLOAD_URL, "GET")
+
+    get.assert_called_once_with(LEGACY_URL + LEGACY_URL_SUFFIXES[0])
+    post.assert_not_called()
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_legacy_urls_get_one_fail(get, post, exception, insights_connection):
+    """The non-legacy URL subtest issues one GET request if one API call fails."""
+    get.side_effect = [exception, mock.Mock()]
+
+    insights_connection._legacy_test_urls(UPLOAD_URL, "GET")
+
+    assert get.mock_calls == [
+        mock.call(LEGACY_URL + LEGACY_URL_SUFFIXES[0]),
+        mock.call(LEGACY_URL + LEGACY_URL_SUFFIXES[1]),
+    ]
+    post.assert_not_called()
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_legacy_urls_get_all_fails(get, post, exception, insights_connection):
+    """The non-legacy URL subtest issues one GET request for every API call if the previous one fails."""
+    get.side_effect = [exception] * len(LEGACY_URL_SUFFIXES)
+
+    try:
+        insights_connection._legacy_test_urls(UPLOAD_URL, "GET")
+    except exception:
+        pass
+
+    assert get.mock_calls == [
+        mock.call(LEGACY_URL + suffix) for suffix in LEGACY_URL_SUFFIXES
+    ]
+    post.assert_not_called()
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_legacy_urls_post_no_catch(get, post, insights_connection):
+    """The legacy URL subtest issues one POST request in case of an unknown exception."""
+    post.side_effect = UnexpectedException
+
+    try:
+        insights_connection._legacy_test_urls(UPLOAD_URL, "POST")
+    except UnexpectedException:
+        pass
+
+    post.assert_called_once_with(LEGACY_URL + LEGACY_URL_SUFFIXES[0], data=mock.ANY)
+    get.assert_not_called()
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_legacy_urls_post_success(get, post, insights_connection):
+    """The non-legacy URL subtest issues one POST request if the API call succeeds."""
+    insights_connection._legacy_test_urls(UPLOAD_URL, "POST")
+
+    post.assert_called_once_with(LEGACY_URL + LEGACY_URL_SUFFIXES[0], data=mock.ANY)
+    get.assert_not_called()
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_legacy_urls_post_one_fail(get, post, exception, insights_connection):
+    """The non-legacy URL subtest issues one POST request if one API call fails."""
+    post.side_effect = [exception, mock.Mock(status_code=200)]
+
+    insights_connection._legacy_test_urls(UPLOAD_URL, "POST")
+
+    assert post.mock_calls == [
+        mock.call(LEGACY_URL + LEGACY_URL_SUFFIXES[0], data=mock.ANY),
+        mock.call(LEGACY_URL + LEGACY_URL_SUFFIXES[1], data=mock.ANY),
+    ]
+    get.assert_not_called()
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.InsightsConnection.get")
+def test_legacy_urls_post_all_fails(get, post, exception, insights_connection):
+    """The non-legacy URL subtest issues one POST request for every API call if the previous one fails."""
+    post.side_effect = [exception] * len(LEGACY_URL_SUFFIXES)
+
+    try:
+        insights_connection._legacy_test_urls(UPLOAD_URL, "POST")
+    except exception:
+        pass
+
+    assert post.mock_calls == [
+        mock.call(LEGACY_URL + suffix, data=mock.ANY) for suffix in LEGACY_URL_SUFFIXES
+    ]
+    get.assert_not_called()
+
+
+@parametrize_methods
+def test_legacy_urls_no_catch(http_method, request_function, insights_connection):
+    """The legacy URL subtest doesn't catch unknown exceptions."""
+    raised = UnexpectedException()
+
+    with pytest.raises(UnexpectedException) as caught:
+        with mock.patch(request_function) as request_function_mock:
+            request_function_mock.side_effect = raised
+            insights_connection._legacy_test_urls(UPLOAD_URL, http_method)
+
+    assert caught.value is raised
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@parametrize_methods
+def test_legacy_urls_raise(
+    http_method, request_function, exception, insights_connection
+):
+    """The legacy URL subtest re-raises the last API call failure exception."""
+    exceptions = [exception() for _ in LEGACY_URL_SUFFIXES]
+
+    with pytest.raises(exception) as caught:
+        with mock.patch(request_function) as request_function_mock:
+            request_function_mock.side_effect = exceptions
+            insights_connection._legacy_test_urls(UPLOAD_URL, http_method)
+
+    assert caught.value is exceptions[-1]
+
+
+@parametrize_methods
+@mock.patch("insights.client.connection.logger")
+def test_legacy_urls_error_log_no_catch(
+    logger, http_method, request_function, insights_connection
+):
+    """The legacy URL subtest doesn't log any errors in case of an unknown exception."""
+    with mock.patch(request_function) as request_function_mock:
+        request_function_mock.side_effect = UnexpectedException
+        try:
+            insights_connection._legacy_test_urls(UPLOAD_URL, http_method)
+        except UnexpectedException:
+            pass
+
+    logger.error.assert_not_called()
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@parametrize_methods
+@mock.patch("insights.client.connection.logger")
+def test_legacy_urls_error_log_success(
+    logger, http_method, request_function, exception, insights_connection
+):
+    """The legacy URL subtest doesn't log any errors if the API call succeeds."""
+    with mock.patch(request_function):
+        insights_connection._legacy_test_urls(UPLOAD_URL, http_method)
+
+    logger.error.assert_not_called()
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@parametrize_methods
+@mock.patch("insights.client.connection.logger")
+def test_legacy_urls_error_log_one_fail(
+    logger, http_method, request_function, exception, insights_connection
+):
+    """The legacy URL subtest logs one ERROR if one API call fails."""
+    try:
+        with mock.patch(request_function) as request_function_mock:
+            request_function_mock.side_effect = [exception(), mock.Mock()]
+            insights_connection._legacy_test_urls(UPLOAD_URL, http_method)
+    except exception:
+        pass
+
+    assert logger.error.mock_calls == [
+        mock.call(
+            "Could not successfully connect to: %s",
+            LEGACY_URL + LEGACY_URL_SUFFIXES[0],
+        )
+    ]
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@parametrize_methods
+@mock.patch("insights.client.connection.logger")
+def test_legacy_urls_error_log_all_fails(
+    logger, http_method, request_function, exception, insights_connection
+):
+    """The legacy URL subtest logs one ERROR for every failed API call."""
+    try:
+        with mock.patch(request_function) as request_function_mock:
+            request_function_mock.side_effect = [
+                exception() for _ in LEGACY_URL_SUFFIXES
+            ]
+            insights_connection._legacy_test_urls(UPLOAD_URL, http_method)
+    except exception:
+        pass
+
+    assert logger.error.mock_calls == [
+        mock.call("Could not successfully connect to: %s", LEGACY_URL + suffix)
+        for suffix in LEGACY_URL_SUFFIXES
+    ]
+
+
+@parametrize_methods
+def test_legacy_urls_exception_print_no_catch(
+    http_method, request_function, insights_connection, capsys
+):
+    """The legacy URL subtest doesn't print anything in case of an unknown exception."""
+    with mock.patch(request_function) as request_function_mock:
+        request_function_mock.side_effect = UnexpectedException
+        try:
+            insights_connection._legacy_test_urls(UPLOAD_URL, http_method)
+        except UnexpectedException:
+            pass
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert not err
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@parametrize_methods
+def test_legacy_urls_exception_print_success(
+    http_method, request_function, exception, insights_connection, capsys
+):
+    """The legacy URL subtest prints a message pointing to a log file if the API call succeeds."""
+    with mock.patch(request_function):
+        insights_connection._legacy_test_urls(UPLOAD_URL, http_method)
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert not err
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@parametrize_methods
+def test_legacy_urls_exception_print_one_fail(
+    http_method, request_function, exception, insights_connection, capsys
+):
+    """The legacy URL subtest prints the exception details if one API call fails."""
+    try:
+        with mock.patch(request_function) as request_function_mock:
+            request_function_mock.side_effect = [
+                exception(EXCEPTION_MESSAGE),
+                mock.Mock(),
+            ]
+            insights_connection._legacy_test_urls(UPLOAD_URL, http_method)
+    except exception:
+        pass
+
+    out, err = capsys.readouterr()
+    assert out == "{0}\n".format(EXCEPTION_MESSAGE)
+    assert not err
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_URLS)
+@parametrize_methods
+def test_legacy_urls_exception_print_all_fails(
+    http_method, request_function, exception, insights_connection, capsys
+):
+    """The legacy connection test prints the details for every exception if all API calls fail."""
+    exceptions = [
+        exception("{0} {1}".format(EXCEPTION_MESSAGE, suffix))
+        for suffix in LEGACY_URL_SUFFIXES
+    ]
+
+    try:
+        with mock.patch(request_function) as request_function_mock:
+            request_function_mock.side_effect = exceptions
+            insights_connection._legacy_test_urls(UPLOAD_URL, http_method)
+    except exception:
+        pass
+
+    out, err = capsys.readouterr()
+    assert out == "".join("{0}\n".format(exc) for exc in exceptions)
+    assert not err
+
+
+@parametrize_exceptions(UNEXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.InsightsConnection._test_urls")
+def test_test_connection_test_urls_no_catch(test_urls, exception, insights_connection):
+    """The connection test doesn't catch unknown exceptions."""
+    test_urls.side_effect = exception
+
+    try:
+        insights_connection.test_connection()
+    except exception:
+        pass
+
+    test_urls.assert_called_once()
+
+
+@mock.patch("insights.client.connection.InsightsConnection._test_urls")
+def test_test_connection_test_urls_success(test_urls, insights_connection):
+    """The connection test performs several API calls in case of no error."""
+    insights_connection.test_connection()
+    assert len(test_urls.mock_calls) > 1
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.InsightsConnection._test_urls")
+def test_test_connection_test_urls_fail(test_urls, exception, insights_connection):
+    """The connection test is stopped after the first API call failure."""
+    test_urls.side_effect = exception
+
+    insights_connection.test_connection()
+    test_urls.assert_called_once()
+
+
+@parametrize_exceptions(UNEXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.logger")
+@mock.patch("insights.client.connection.InsightsConnection._test_urls")
+def test_test_connection_error_log_no_catch(
+    test_urls, logger, exception, insights_connection
+):
+    """The connection test doesn't log any ERROR in case of an unknown exception."""
+    test_urls.side_effect = exception
+
+    try:
+        insights_connection.test_connection()
+    except exception:
+        pass
+
+    logger.error.assert_not_called()
+
+
+@mock.patch("insights.client.connection.logger")
+@mock.patch("insights.client.connection.InsightsConnection._test_urls")
+def test_test_connection_error_log_success(test_urls, logger, insights_connection):
+    """The connection test doesn't log any ERROR if all API calls succeed."""
+    insights_connection.test_connection()
+
+    logger.error.assert_not_called()
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.logger")
+@mock.patch("insights.client.connection.InsightsConnection._test_urls")
+def test_test_connection_error_log_fail(
+    test_urls, logger, exception, insights_connection
+):
+    """An error message is logged on the ERROR level."""
+    test_urls.side_effect = exception
+
+    insights_connection.test_connection()
+
+    logger.error.assert_called_once_with(
+        "Connectivity test failed! Please check your network configuration"
+    )
+
+
+@parametrize_exceptions(UNEXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.InsightsConnection._test_urls")
+def test_test_connection_print_no_catch(
+    test_urls, insights_connection, exception, capsys
+):
+    """The connection test doesn't print anything in case of an unknown exception."""
+    test_urls.side_effect = exception
+
+    try:
+        insights_connection.test_connection()
+    except exception:
+        pass
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert not err
+
+
+@mock.patch("insights.client.connection.InsightsConnection._test_urls")
+def test_test_connection_print_success(test_urls, insights_connection, capsys):
+    """The connection test prints a message pointing to a log file if all API calls succeed."""
+    insights_connection.test_connection()
+
+    out, err = capsys.readouterr()
+    assert out == "See {0} for more details.\n".format(
+        LOGGING_FILE,
+    )
+    assert not err
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.InsightsConnection._test_urls")
+def test_test_connection_print_fail(test_urls, exception, insights_connection, capsys):
+    """The connection test prints a message pointing to a log file if an API call fails."""
+    test_urls.side_effect = exception("request exception")
+
+    insights_connection.test_connection()
+    out, err = capsys.readouterr()
+    assert out == "Additional information may be in {0}\n".format(
+        LOGGING_FILE,
+    )
+    assert not err
+
+
+@parametrize_exceptions(UNEXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.InsightsConnection._test_urls")
+def test_test_connection_no_catch(test_urls, exception, insights_connection):
+    """The connection test doesn't catch and recreate an unknown exception."""
+    expected = exception()
+    test_urls.side_effect = expected
+
+    with pytest.raises(exception) as caught:
+        insights_connection.test_connection()
+
+    assert caught.value is expected
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+@mock.patch("insights.client.connection.logger")
+def test_test_connection_non_legacy_error_log_no_catch(
+    logger, temporary_file, post, insights_connection
+):
+    """The non-legacy connection test doesn't log any errors in case of an unknown exception."""
+    post.side_effect = UnexpectedException
+    insights_connection.config.legacy_upload = False
+
+    try:
+        insights_connection.test_connection()
+    except UnexpectedException:
+        pass
+
+    logger.error.assert_not_called()
+
+
+@mock.patch("insights.client.connection.InsightsConnection.get")
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+@mock.patch("insights.client.connection.logger")
+def test_test_connection_non_legacy_error_log_success(
+    logger, temporary_file, post, get, insights_connection
+):
+    """The non-legacy connection test doesn't log any errors if all API calls succeed."""
+    insights_connection.config.legacy_upload = False
+
+    insights_connection.test_connection()
+
+    logger.error.assert_not_called()
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+@mock.patch("insights.client.connection.logger")
+def test_test_connection_non_legacy_error_log_fail_connection(
+    logger, temporary_file, post, exception, insights_connection
+):
+    """The connection test logs an ERROR if an API call fails."""
+    post.side_effect = exception
+    insights_connection.config.legacy_upload = False
+
+    insights_connection.test_connection()
+
+    assert logger.error.mock_calls == [
+        mock.call("Could not successfully connect to: %s", UPLOAD_URL),
+        mock.call("Connectivity test failed! Please check your network configuration"),
+    ]
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+@mock.patch("insights.client.connection.logger")
+def test_test_connection_non_legacy_error_log_fail_read(
+    logger, temporary_file, post, insights_connection
+):
+    """The connection test logs an ERROR if an API call fails."""
+    post.side_effect = requests.exceptions.ReadTimeout
+    insights_connection.config.legacy_upload = False
+
+    try:
+        insights_connection.test_connection()
+    except requests.exceptions.ReadTimeout:
+        pass
+
+    assert logger.error.mock_calls == [
+        mock.call("Could not successfully connect to: %s", UPLOAD_URL)
+    ]
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+def test_test_connection_non_legacy_print_no_catch(
+    temporary_file, post, insights_connection, capsys
+):
+    """The non-legacy connection test doesn't print anything in case of an unknown exception."""
+    post.side_effect = UnexpectedException
+    insights_connection.config.legacy_upload = False
+
+    try:
+        insights_connection.test_connection()
+    except UnexpectedException:
+        pass
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert not err
+
+
+@mock.patch("insights.client.connection.InsightsConnection.get")
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+def test_test_connection_non_legacy_print_success(
+    temporary_file, post, get, insights_connection, capsys
+):
+    """The non-legacy connection test prints a message pointing to a log file if all API calls succeed."""
+    insights_connection.config.legacy_upload = False
+
+    insights_connection.test_connection()
+
+    out, err = capsys.readouterr()
+    assert out == "See {0} for more details.\n".format(LOGGING_FILE)
+    assert not err
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+def test_test_connection_non_legacy_print_fail_connection(
+    temporary_file, post, exception, insights_connection, capsys
+):
+    """The non-legacy connection test prints the exception details and a message pointing to a log file if an API call fails."""
+    post.side_effect = exception(EXCEPTION_MESSAGE)
+    insights_connection.config.legacy_upload = False
+
+    insights_connection.test_connection()
+
+    out, err = capsys.readouterr()
+    assert out == "{0}\nAdditional information may be in {1}\n".format(
+        EXCEPTION_MESSAGE, LOGGING_FILE
+    )
+    assert not err
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+def test_test_connection_non_legacy_print_fail_read(
+    temporary_file, post, insights_connection, capsys
+):
+    """The non-legacy connection test doesn't print anything in case of an unknown exception."""
+    post.side_effect = requests.exceptions.ReadTimeout(EXCEPTION_MESSAGE)
+    insights_connection.config.legacy_upload = False
+
+    try:
+        insights_connection.test_connection()
+    except requests.exceptions.ReadTimeout:
+        pass
+
+    out, err = capsys.readouterr()
+    assert out == "{0}\n".format(EXCEPTION_MESSAGE)
+    assert not err
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.logger")
+def test_test_connection_legacy_error_log_no_catch(logger, post, insights_connection):
+    """The legacy connection test doesn't log any errors in case of an unknown exception."""
+    post.side_effect = UnexpectedException
+    insights_connection.config.legacy_upload = True
+
+    try:
+        insights_connection.test_connection()
+    except UnexpectedException:
+        pass
+
+    logger.error.assert_not_called()
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.logger")
+def test_test_connection_legacy_error_log_success(
+    logger, post, exception, insights_connection
+):
+    """The legacy connection test doesn't log any errors if all API calls succeed."""
+    insights_connection.config.legacy_upload = True
+
+    insights_connection.test_connection()
+
+    logger.error.assert_not_called()
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.logger")
+def test_test_connection_legacy_error_log_one_fail_connection(
+    logger, post, exception, insights_connection
+):
+    """The connection test logs one ERROR if one API call fails."""
+    post.side_effect = [exception, mock.Mock()]
+    insights_connection.config.legacy_upload = True
+
+    insights_connection.test_connection()
+
+    assert logger.error.mock_calls == [
+        mock.call(
+            "Could not successfully connect to: %s",
+            LEGACY_URL + LEGACY_URL_SUFFIXES[0],
+        )
+    ]
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.logger")
+def test_test_connection_legacy_error_log_one_fail_read(
+    logger, post, insights_connection
+):
+    """The connection test logs one ERROR if one API call fails."""
+    post.side_effect = [requests.exceptions.ReadTimeout, mock.Mock()]
+    insights_connection.config.legacy_upload = True
+
+    insights_connection.test_connection()
+
+    assert logger.error.mock_calls == [
+        mock.call(
+            "Could not successfully connect to: %s",
+            LEGACY_URL + LEGACY_URL_SUFFIXES[0],
+        )
+    ]
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.logger")
+def test_test_connection_legacy_error_log_all_fails_connection(
+    logger, post, exception, insights_connection
+):
+    """The connection test logs one ERROR for every failed API call."""
+    post.side_effect = exception
+    insights_connection.config.legacy_upload = True
+
+    insights_connection.test_connection()
+
+    legacy_test_url_errors = [
+        ["Could not successfully connect to: %s", LEGACY_URL + suffix]
+        for suffix in LEGACY_URL_SUFFIXES
+    ]
+    test_connection_errors = [
+        ["Connectivity test failed! Please check your network configuration"]
+    ]
+    assert logger.error.mock_calls == [
+        mock.call(*args) for args in legacy_test_url_errors + test_connection_errors
+    ]
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.logger")
+def test_test_connection_legacy_error_log_all_fails_read(
+    logger, post, insights_connection
+):
+    """The connection test logs one ERROR for every failed API call."""
+    post.side_effect = requests.exceptions.ReadTimeout
+    insights_connection.config.legacy_upload = True
+
+    try:
+        insights_connection.test_connection()
+    except requests.exceptions.ReadTimeout:
+        pass
+
+    assert logger.error.mock_calls == [
+        mock.call("Could not successfully connect to: %s", LEGACY_URL + suffix)
+        for suffix in LEGACY_URL_SUFFIXES
+    ]
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+def test_test_connection_legacy_print_no_catch(
+    temporary_file, post, insights_connection, capsys
+):
+    """The legacy connection test doesn't print anything in case of an unknown exception."""
+    post.side_effect = UnexpectedException
+    insights_connection.config.legacy_upload = False
+
+    try:
+        insights_connection.test_connection()
+    except UnexpectedException:
+        pass
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert not err
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+@mock.patch("insights.client.connection.TemporaryFile")
+def test_test_connection_legacy_print_success(
+    temporary_file, post, insights_connection, capsys
+):
+    """The legacy connection test prints a message pointing to a log file if all API calls succeed."""
+    insights_connection.config.legacy_upload = False
+
+    insights_connection.test_connection()
+
+    out, err = capsys.readouterr()
+    assert out == "See {0} for more details.\n".format(LOGGING_FILE)
+    assert not err
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.InsightsConnection.post")
+def test_test_connection_legacy_print_one_fail_connection(
+    post, exception, insights_connection, capsys
+):
+    """The legacy connection test prints the exception details and a message pointing to a log file if one API call fails."""
+    post.side_effect = [exception(EXCEPTION_MESSAGE), mock.Mock()]
+    insights_connection.config.legacy_upload = True
+
+    insights_connection.test_connection()
+
+    out, err = capsys.readouterr()
+    assert out == "{0}\nSee {1} for more details.\n".format(
+        EXCEPTION_MESSAGE, LOGGING_FILE
+    )
+    assert not err
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+def test_test_connection_legacy_print_one_fail_read(post, insights_connection, capsys):
+    """The legacy connection test prints the exception details and a message pointing to a log file if one API call fails."""
+    post.side_effect = [requests.exceptions.ReadTimeout(EXCEPTION_MESSAGE), mock.Mock()]
+    insights_connection.config.legacy_upload = True
+
+    insights_connection.test_connection()
+
+    out, err = capsys.readouterr()
+    assert out == "{0}\nSee {1} for more details.\n".format(
+        EXCEPTION_MESSAGE, LOGGING_FILE
+    )
+    assert not err
+
+
+@parametrize_exceptions(EXPECTED_EXCEPTIONS_TEST_CONNECTION)
+@mock.patch("insights.client.connection.InsightsConnection.post")
+def test_test_connection_legacy_print_all_fails_connection(
+    post, exception, insights_connection, capsys
+):
+    """The legacy connection test prints the details for every exception and a message pointing to a log file if all API calls fail."""
+    post.side_effect = exception(EXCEPTION_MESSAGE)
+    insights_connection.config.legacy_upload = True
+
+    insights_connection.test_connection()
+
+    out, err = capsys.readouterr()
+
+    exception_messages = "{0}\n".format(EXCEPTION_MESSAGE) * len(LEGACY_URL_SUFFIXES)
+    test_connection_message = "Additional information may be in {0}\n".format(
+        LOGGING_FILE
+    )
+
+    assert out == exception_messages + test_connection_message
+    assert not err
+
+
+@mock.patch("insights.client.connection.InsightsConnection.post")
+def test_test_connection_legacy_print_all_fails_read(post, insights_connection, capsys):
+    """The legacy connection test prints the details for every exception and a message pointing to a log file if all API calls fail."""
+    post.side_effect = requests.exceptions.ReadTimeout(EXCEPTION_MESSAGE)
+    insights_connection.config.legacy_upload = True
+
+    try:
+        insights_connection.test_connection()
+    except requests.exceptions.ReadTimeout:
+        pass
+
+    out, err = capsys.readouterr()
+
+    assert out == "{0}\n".format(EXCEPTION_MESSAGE) * len(LEGACY_URL_SUFFIXES)
+    assert not err


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

In case of a connection error, an exception description was printed on the standard output twice: once by the outer test_connection method and once by the inner _\_(legacy\_)test\_urls_ method. The legacy version tries multiple URLs and prints the exception description on each failure. Thus, removed the outer print that only duplicates the last caught exception.

Card IDs:

* [CCT-724](https://issues.redhat.com/browse/CCT-724)
