### PR TITLE
doc(conf): remove definiation of html_theme_path

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,8 +113,6 @@ exclude_patterns = ['_build', '**.ipynb_checkpoints']
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-import sphinx_rtd_theme
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme


### PR DESCRIPTION
- as per the latest sphinx-rtd-theme, the definiation can be removed

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

To fix the following error when building doc:
```
Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/sphinx/config.py", line 529, in eval_config_file
    exec(code, namespace)  # NoQA: S102
  File "/home/runner/work/insights-core/insights-core/docs/conf.py", line 117, in <module>
    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/sphinx_rtd_theme/__init__.py", line 24, in get_html_theme_path
    logger.warning(
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/sphinx/util/logging.py", line 184, in warning
    return super().warning(
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/logging/__init__.py", line 1812, in warning
    self.log(WARNING, msg, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/sphinx/util/logging.py", line 131, in log
    super().log(level, msg, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/logging/__init__.py", line 1844, in log
    self.logger.log(level, msg, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/logging/__init__.py", line 1512, in log
    self._log(level, msg, args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/logging/__init__.py", line 1589, in _log
    self.handle(record)
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/logging/__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/logging/__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/logging/__init__.py", line 948, in handle
    rv = self.filter(record)
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/logging/__init__.py", line 806, in filter
    result = f.filter(record)
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/sphinx/util/logging.py", line 473, in filter
    raise exc
sphinx.errors.SphinxWarning: Calling get_html_theme_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.
```