### PR TITLE
fix: nginx_ssl_certificate_files no longer depends on NginxConfTree

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -171,13 +171,6 @@ plugins:
         - name: insights.parsers.mount.ProcMounts
           enabled: true
 
-    # needed for nginx_ssl_cert_enddate
-        - name: insights.combiners.nginx_conf.NginxConfTree
-          enabled: true
-
-        - name: insights.parsers.nginx_conf.NginxConfPEG
-          enabled: true
-
     # needed for mssql_tls_cert_enddate
         - name: insights.parsers.mssql_conf.MsSQLConf
           enabled: true


### PR DESCRIPTION
  - The combiner and parser cannot handle special characters, so remove the dependency on it first
  - Jira: RHINENG-13447

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?
