### PR TITLE
fix: Set no_redact for sshd_test_mode

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -730,7 +730,7 @@ class Specs(SpecSet):
     sshd_config = RegistryPoint(filterable=True)
     sshd_config_d = RegistryPoint(multi_output=True, filterable=True)
     sshd_config_perms = RegistryPoint(no_obfuscate=['hostname', 'ip'])
-    sshd_test_mode = RegistryPoint(filterable=True)
+    sshd_test_mode = RegistryPoint(filterable=True, no_redact=True)
     sssd_config = RegistryPoint()
     sssd_conf_d = RegistryPoint(multi_output=True)
     sssd_logs = RegistryPoint(multi_output=True, filterable=True)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
- to fix issue: `permitemptypasswords no` is redacted to `permitemptypassword*********`
- sshd_test_mode is a filterable spec, the current filters does not contain the password information, and the available options of "sshd -T" also does not contain password information.
