### PR TITLE
Remove double exception print

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -413,8 +413,7 @@ class InsightsConnection(object):
                 logger.info("Connectivity tests completed with some errors")
                 print("See %s for more details." % self.config.logging_file)
                 rc = 1
-        except requests.ConnectionError as exc:
-            print(exc)
+        except requests.ConnectionError:
             logger.error('Connectivity test failed! '
                          'Please check your network configuration')
             print('Additional information may be in %s' % self.config.logging_file)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

In case of a connection error, an exception description was printed on the standard output twice: once by the outer test_connection method and once by the inner _\_(legacy\_)test\_urls_ method. The legacy version tries multiple URLs and prints the exception description on each failure. Thus, removed the outer print that only duplicates the last caught exception.

Card IDs:

* [CCT-724](https://issues.redhat.com/browse/CCT-724)
