### PR TITLE
fix: do not obfuscate in runtime but in archive only

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -128,9 +128,10 @@ class ContentProvider(object):
     def write(self, dst):
         fs.ensure_path(os.path.dirname(dst))
         # Clean Spec Content when writing it down to disk before uploading
+        content = "\n".join(self._clean_content())
+        content = content.encode("utf-8") if six.PY3 else content
         with open(dst, "wb") as f:
-            content = "\n".join(self._clean_content())
-            f.write(content.encode('utf-8') if six.PY3 else content)
+            f.write(content)
 
         self.loaded = False
 

--- a/insights/tests/test_specs_content_redaction_empty.py
+++ b/insights/tests/test_specs_content_redaction_empty.py
@@ -1,0 +1,137 @@
+import json
+import os
+from collections import defaultdict
+
+from mock.mock import patch
+
+from insights import collect
+from insights.client.archive import InsightsArchive
+from insights.client.config import InsightsConfig
+from insights.core import dr
+from insights.core.spec_factory import encoding
+from insights.core.spec_factory import RegistryPoint
+from insights.core.spec_factory import safe_open
+from insights.core.spec_factory import simple_file
+from insights.core.spec_factory import SpecSet
+
+tmp_file_path = "/tmp/empty_insights_unittest_with_pattern"
+
+specs_manifest = """
+---
+version: 0
+
+client:
+    context:
+        class: insights.core.context.HostContext
+        args:
+            timeout: 5
+
+    # commands and files to ignore
+    blacklist:
+        files: []
+        commands: []
+        patterns: []
+        keywords: []
+
+    persist:
+        - name: insights.tests.test_specs_content_redaction_empty.Specs
+          enabled: true
+
+    run_strategy:
+        name: serial
+        args:
+            max_workers: null
+
+plugins:
+    default_component_enabled: false
+
+    packages:
+        - insights.tests.test_specs_content_redaction_empty
+
+    configs:
+        - name: insights.tests.test_specs_content_redaction_empty.Specs
+          enabled: true
+        - name: insights.tests.test_specs_content_redaction_empty.Stuff
+          enabled: true
+""".strip()
+
+
+class Specs(SpecSet):
+    file_no_redact = RegistryPoint(no_redact=True)
+    file_w_redact = RegistryPoint(no_redact=False)
+
+
+class Stuff(Specs):
+    file_no_redact = simple_file(tmp_file_path, save_as=tmp_file_path + '_1')
+    file_w_redact = simple_file(tmp_file_path)
+
+
+#
+# TEST
+#
+
+
+def setup_function(func):
+    with safe_open(tmp_file_path, "w+", encoding=encoding, errors="surrogateescape") as f:
+        f.write('\n'.join(["KEEEY {0}".format(i) for i in range(3)]))
+
+
+def teardown_function(func):
+    os.remove(tmp_file_path)
+    # Reset Test ENV
+    dr.COMPONENTS = defaultdict(lambda: defaultdict(set))
+    dr.TYPE_OBSERVERS = defaultdict(set)
+    dr.ENABLED = defaultdict(lambda: True)
+
+
+@patch('insights.core.spec_cleaner.Cleaner.generate_report')
+def test_specs_ds_with_hn_collect(mock_fun):
+    # Preparation
+    manifest = collect.load_manifest(specs_manifest)
+    for pkg in manifest.get("plugins", {}).get("packages", []):
+        dr.load_components(pkg, exclude=None)
+    # For verifying convenience, test obfuscate=False only
+    conf = InsightsConfig(manifest=manifest)
+    arch = InsightsArchive(conf)
+    arch.create_archive_dir()
+    rm_conf = {'patterns': {'regex': ['KEEEY']}, 'keywords': ['TeST']}
+    output_path, errors = collect.collect(
+            tmp_path=arch.tmp_dir,
+            archive_name=arch.archive_name,
+            rm_conf=rm_conf,
+            client_config=conf)
+    meta_data_root = os.path.join(output_path, 'meta_data')
+    data_root = os.path.join(output_path, 'data')
+
+    assert not errors
+    spec_count = 0
+    line_count = 0
+    for spec in Specs.__dict__:
+        if not spec.startswith(('__', 'context_handlers', 'registry')):
+            file_name = "insights.tests.test_specs_content_redaction_empty.Specs.{0}.json".format(spec)
+            meta_data = os.path.join(meta_data_root, file_name)
+            with open(meta_data, 'r') as fp:
+                mdata = json.load(fp)
+                results = mdata.get('results')
+                if 'file_no_redact' in spec:
+                    spec_count += 1
+                    assert not mdata.get('errors')
+                    assert results
+                    if not isinstance(results, list):
+                        results = [results]
+                    for result in results:
+                        rel = result['object']['relative_path']
+                        with open(os.path.join(data_root, rel), 'r') as fp:
+                            for line in fp:
+                                line_count += 1
+                                assert "KEEEY" in line
+                else:
+                    spec_count += 1
+                    # file_w_redact is not collected as it's reacted to empty
+                    assert mdata.get('errors')
+                    assert not results
+
+    assert spec_count == 2  # Number of Specs
+    assert line_count == 3  # Number of Lines in "file_no_redact"
+
+    arch.delete_archive_dir()

--- a/insights/tests/test_specs_content_redaction_empty.py
+++ b/insights/tests/test_specs_content_redaction_empty.py
@@ -127,9 +127,10 @@ def test_specs_ds_with_hn_collect(mock_fun):
                                 assert "KEEEY" in line
                 else:
                     spec_count += 1
-                    # file_w_redact is not collected as it's reacted to empty
+                    # file_w_redact is not collected as it's redacted to empty
                     assert mdata.get('errors')
                     assert not results
+                    assert not os.path.exists(os.path.join(data_root, tmp_file_path.lstrip('/')))
 
     assert spec_count == 2  # Number of Specs
     assert line_count == 3  # Number of Lines in "file_no_redact"

--- a/insights/tests/test_specs_runtime_ds_obfuscation.py
+++ b/insights/tests/test_specs_runtime_ds_obfuscation.py
@@ -152,11 +152,11 @@ def test_specs_ds_with_hn_collect(mock_fun, obfuscate):
                     results = [results]
                 count += 1
                 for result in results:
-                    if not result:
-                        continue
                     rel = result['object']['relative_path']
-                    assert rel.endswith(collected_file)
+                    # save_as is used
                     assert result['object']['save_as'] is True
+                    assert orig_hostname not in rel
+                    assert rel.endswith(collected_file)
                     with open(os.path.join(data_root, rel), 'r') as fp:
                         new_content = ''.join(fp.readlines())
                         if obfuscate:

--- a/insights/tests/test_specs_runtime_ds_obfuscation.py
+++ b/insights/tests/test_specs_runtime_ds_obfuscation.py
@@ -1,0 +1,171 @@
+import json
+import os
+from collections import defaultdict
+
+import pytest
+from mock.mock import patch
+
+from insights import collect
+from insights.client.archive import InsightsArchive
+from insights.client.config import InsightsConfig
+from insights.core import dr
+from insights.core.context import HostContext
+from insights.core.plugins import datasource
+from insights.core.spec_factory import command_with_args
+from insights.core.spec_factory import RegistryPoint
+from insights.core.spec_factory import SpecSet
+from insights.parsers.hostname import Hostname
+from insights.util.hostname import determine_hostname
+
+orig_hostname = determine_hostname().split('.')[0]
+base_path = "/tmp/empty_insights_unittest_"
+# file path include the original hostname which is not obfuscated
+tmp_file_path = "{0}{1}".format(base_path, orig_hostname)
+collected_file = "localhost_empty"
+
+specs_manifest = """
+---
+version: 0
+
+client:
+    context:
+        class: insights.core.context.HostContext
+        args:
+            timeout: 5
+
+    # commands and files to ignore
+    blacklist:
+        files: []
+        commands: []
+        patterns: []
+        keywords: []
+
+    persist:
+        # add Specs.hostname here, as only 'persist' items will be collected
+        - name: insights.specs.Specs.hostname
+          enabled: true
+
+        - name: insights.tests.test_specs_runtime_ds_obfuscation.Specs
+          enabled: true
+
+    run_strategy:
+        name: serial
+        args:
+            max_workers: null
+
+plugins:
+    default_component_enabled: false
+
+    packages:
+        - insights.tests.test_specs_runtime_ds_obfuscation
+
+    configs:
+        - name: insights.core.spec_factory
+          enabled: true
+        - name: insights.specs.Specs.hostname
+          enabled: true
+        - name: insights.specs.default.DefaultSpecs.hostname
+          enabled: true
+        - name: insights.parsers.hostname.Hostname
+          enabled: true
+        - name: insights.tests.test_specs_runtime_ds_obfuscation.Specs
+          enabled: true
+        - name: insights.tests.test_specs_runtime_ds_obfuscation.Stuff
+          enabled: true
+""".strip()
+
+
+class Specs(SpecSet):
+    # datasource spec
+    # - no need to filter
+    # - must be obfuscated
+    # - must be redacted
+    ds_read_hostname = RegistryPoint(filterable=False, no_obfuscate=[], no_redact=False)
+
+
+class Stuff(Specs):
+
+    @datasource(Hostname, HostContext)
+    def path_with_hostname(broker):
+        hn = broker.get(Hostname).hostname
+        # the hostname must be not obfuscated
+        return '{0}{1}'.format(base_path, hn)
+
+    ds_read_hostname = command_with_args(
+            'ls -l  %s',
+            path_with_hostname,
+            save_as='localhost_empty'
+    )
+
+
+#
+# TEST
+#
+
+
+def setup_function(func):
+    open(tmp_file_path, 'w+').close()
+
+
+def teardown_function(func):
+    os.remove(tmp_file_path)
+    # Reset Test ENV
+    dr.COMPONENTS = defaultdict(lambda: defaultdict(set))
+    dr.TYPE_OBSERVERS = defaultdict(set)
+    dr.ENABLED = defaultdict(lambda: True)
+
+
+@pytest.mark.parametrize("obfuscate", [True, False])
+@patch('insights.core.spec_cleaner.Cleaner.generate_report')
+def test_specs_ds_with_hn_collect(mock_fun, obfuscate):
+    # Preparation
+    manifest = collect.load_manifest(specs_manifest)
+    for pkg in manifest.get("plugins", {}).get("packages", []):
+        dr.load_components(pkg, exclude=None)
+    # For verifying convenience, test obfuscate=False only
+    conf = InsightsConfig(
+            obfuscate=obfuscate, obfuscate_hostname=obfuscate,
+            manifest=manifest)
+    arch = InsightsArchive(conf)
+    arch.create_archive_dir()
+    output_path, errors = collect.collect(
+            tmp_path=arch.tmp_dir,
+            archive_name=arch.archive_name,
+            client_config=conf)
+    meta_data_root = os.path.join(output_path, 'meta_data')
+    data_root = os.path.join(output_path, 'data')
+
+    assert not errors
+    count = 0
+    for spec in Specs.__dict__:
+        if not spec.startswith(('__', 'context_handlers', 'registry')):
+            file_name = "insights.tests.test_specs_runtime_ds_obfuscation.Specs.{0}.json".format(spec)
+            meta_data = os.path.join(meta_data_root, file_name)
+            with open(meta_data, 'r') as fp:
+                mdata = json.load(fp)
+                assert not mdata.get('errors')
+
+                results = mdata.get('results')
+                assert results
+
+                if not isinstance(results, list):
+                    results = [results]
+                count += 1
+                for result in results:
+                    if not result:
+                        continue
+                    rel = result['object']['relative_path']
+                    assert rel.endswith(collected_file)
+                    assert result['object']['save_as'] is True
+                    with open(os.path.join(data_root, rel), 'r') as fp:
+                        new_content = ''.join(fp.readlines())
+                        if obfuscate:
+                            # hostname is obfuscated
+                            assert orig_hostname not in new_content
+                        else:
+                            # hostname is not obfuscated
+                            assert orig_hostname in new_content
+
+    assert count == 1  # Number of Specs
+
+    arch.delete_archive_dir()


### PR DESCRIPTION
- For 'persist' specs, they might be used during collection,
  to avoid failure collection of dependencies, they shouldn't
  be obfuscated in runtime.  But they should be obfuscated when
  writing to archive. See the tests
- Jira: RHINENG-13591

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
