### PR TITLE
Simplify re-raise for non-legacy

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -382,12 +382,10 @@ class InsightsConnection(object):
                 logger.info("Connection failed")
                 return False
         except REQUEST_FAILED_EXCEPTIONS as exc:
-            last_ex = exc
             logger.error(
                 "Could not successfully connect to: %s", url)
             print(exc)
-        if last_ex:
-            raise last_ex
+            raise
 
     def test_connection(self, rc=0):
         """


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

To avoid confusion for developers, removed the unnecessary conditional for exception re-raise.

* It is unnecessary to set last_ex on non-legacy, because there is no fallback to other URLs. Only one URL is tried and if it fails, there is only a single exception.
* The `if last_ex` condition can never be false, because if an exception is not raised, the function hits a return clause earlier. It only gets to the conditional if an exception has been caught.

A simple `raise` is enough. Without an argument, the last caught exception is re-raised by default. It’s thus equivalent to `raise exc`.

Card IDs:

* [CCT-867](https://issues.redhat.com/browse/CCT-867)
