### PR TITLE
test: test_httpd_conf_files_main_miss failed when httpd.conf exists

### DIFF
--- a/insights/tests/datasources/test_httpd.py
+++ b/insights/tests/datasources/test_httpd.py
@@ -172,10 +172,11 @@ def test_httpd_conf_files_ssl_miss(m_open, m_glob, m_isdir, m_isfile):
     assert result == set(['/etc/httpd/conf/httpd.conf'])
 
 
+@patch("os.path.join", return_value='/etc/httpd/no_such_file')
 @patch("os.path.isfile", return_value=True)
 @patch("os.path.isdir", return_value=True)
 @patch("glob.glob", return_value=["/etc/httpd/conf.d/ssl.conf"])
-def test_httpd_conf_files_main_miss(m_glob, m_isdir, m_isfile):
+def test_httpd_conf_files_main_miss(m_glob, m_isdir, m_isfile, m_join):
     broker = {HostContext: None}
     with pytest.raises(SkipComponent):
         httpd_configuration_files(broker)


### PR DESCRIPTION
- this test tried to verify that the `httpd_conf` cannot be collected
  when the main httpd.conf doesn't exist.  However, when running test
  in a machine that have this httpd.conf in system already, it will fail.
- this PR mocks the `os.path.join` and hence simulates that the main
  httpd.conf doesn't exist and ignore the facts
- Jira: RHINENG-13664

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
