### PR TITLE
chore: refine the format of default_manifest in collect.py

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -8,20 +8,26 @@ runs all datasources in ``insights.specs.Specs`` and
 ``insights.specs.Specs``.
 """
 from __future__ import print_function
+
 import argparse
 import logging
 import os
 import sys
 import tempfile
-import yaml
-
 from datetime import datetime
 
-from insights import apply_configs, apply_default_enabled, get_pool
-from insights.core import blacklist, dr, filters
+import yaml
+
+from insights import apply_configs
+from insights import apply_default_enabled
+from insights import get_pool
+from insights.core import blacklist
+from insights.core import dr
+from insights.core import filters
 from insights.core.serde import Hydration
 from insights.core.spec_cleaner import Cleaner
-from insights.util import fs, utc
+from insights.util import fs
+from insights.util import utc
 from insights.util.hostname import determine_hostname
 from insights.util.subproc import call
 
@@ -47,235 +53,194 @@ default_manifest = """
 version: 0
 
 client:
-    context:
-        class: insights.core.context.HostContext
-        args:
-            timeout: 10 # timeout in seconds for commands. Doesn't apply to files.
+  context:
+    class: insights.core.context.HostContext
+    args:
+      timeout: 10 # timeout in seconds for commands. Doesn't apply to files.
 
-    # commands and files to ignore
-    blacklist:
-        files: []
-        commands: []
-        patterns: []
-        keywords: []
+  # commands and files to ignore
+  blacklist:
+    files: []
+    commands: []
+    patterns: []
+    keywords: []
 
-    # Can be a list of dictionaries with name/enabled fields or a list of strings
-    # where the string is the name and enabled is assumed to be true. Matching is
-    # by prefix, and later entries override previous ones. Persistence for a
-    # component is disabled by default.
-    persist:
-        - name: insights.specs.Specs
-          enabled: true
+  # Can be a list of dictionaries with name/enabled fields or a list of strings
+  # where the string is the name and enabled is assumed to be true. Matching is
+  # by prefix, and later entries override previous ones. Persistence for a
+  # component is disabled by default.
+  persist:
+    - name: insights.specs.Specs
+      enabled: true
 
-    run_strategy:
-        name: serial
-        args:
-            max_workers: null
+  run_strategy:
+    name: serial
+    args:
+      max_workers: null
 
 plugins:
-    # disable everything by default
-    # defaults to false if not specified.
-    default_component_enabled: false
+  # disable everything by default
+  # defaults to false if not specified.
+  default_component_enabled: false
 
-    # packages and modules to load
-    packages:
-        - insights.specs.default
-        - insights.specs.datasources
+  # packages and modules to load
+  packages:
+    - insights.specs.default
+    - insights.specs.datasources
 
-    # configuration of loaded components. names are prefixes, so any component with
-    # a fully qualified name that starts with a key will get the associated
-    # configuration applied. Can specify timeout, which will apply to command
-    # datasources. Can specify metadata, which must be a dictionary and will be
-    # merged with the components' default metadata.
-    configs:
-        - name: insights.specs.datasources
-          enabled: true
+  # configuration of loaded components. names are prefixes, so any component with
+  # a fully qualified name that starts with a key will get the associated
+  # configuration applied. Can specify timeout, which will apply to command
+  # datasources. Can specify metadata, which must be a dictionary and will be
+  # merged with the components' default metadata.
+  configs:
+    - name: insights.specs.Specs
+      enabled: true
+    - name: insights.specs.default.DefaultSpecs
+      enabled: true
+    - name: insights.specs.datasources
+      enabled: true
+    # needed for specs that aren't given names before used in DefaultSpecs
+    - name: insights.core.spec_factory
+      enabled: true
 
-        - name: insights.specs.Specs
-          enabled: true
+    # needed by multiple datasource specs/components
+    - name: insights.parsers.hostname.Hostname
+      enabled: true
+    - name: insights.parsers.hostname.HostnameDefault
+      enabled: true
+    - name: insights.combiners.hostname.Hostname
+      enabled: true
+    - name: insights.parsers.uname.Uname
+      enabled: true
+    - name: insights.parsers.redhat_release.RedhatRelease
+      enabled: true
+    - name: insights.combiners.redhat_release.RedHatRelease
+      enabled: true
+    - name: insights.parsers.ps.PsAuxcww
+      enabled: true
+    - name: insights.parsers.ps.PsAuxww
+      enabled: true
+    - name: insights.combiners.ps.Ps
+      enabled: true
+    - name: insights.parsers.dmidecode.DMIDecode
+      enabled: true
+    - name: insights.parsers.installed_rpms.InstalledRpms
+      enabled: true
+    - name: insights.parsers.mount.ProcMounts
+      enabled: true
 
-        - name: insights.specs.default.DefaultSpecs
-          enabled: true
+    # needed for identifying RHEL major version
+    - name: insights.components.rhel_version.IsRhel6
+      enabled: true
+    - name: insights.components.rhel_version.IsRhel7
+      enabled: true
+    - name: insights.components.rhel_version.IsRhel8
+      enabled: true
+    - name: insights.components.rhel_version.IsRhel9
+      enabled: true
 
-        - name: insights.parsers.hostname
-          enabled: true
+    # needed for cloud specs
+    - name: insights.parsers.yum.YumRepoList
+      enabled: true
+    - name: insights.parsers.rhsm_conf.RHSMConf
+      enabled: true
+    - name: insights.combiners.cloud_provider.CloudProvider
+      enabled: true
+    - name: insights.components.cloud_provider.IsAWS
+      enabled: true
+    - name: insights.components.cloud_provider.IsAzure
+      enabled: true
+    - name: insights.components.cloud_provider.IsGCP
+      enabled: true
 
-        - name: insights.parsers.systemid
-          enabled: true
+    # needed for ceph specs
+    - name: insights.components.ceph.IsCephMonitor
+      enabled: true
 
-        - name: insights.combiners.hostname
-          enabled: true
+    # needed for pcp specs
+    - name: insights.parsers.systemd.unitfiles.UnitFiles
+      enabled: true
+    - name: insights.parsers.ros_config.RosConfig
+      enabled: true
 
-    # needed for the CloudProvider combiner
-        - name: insights.parsers.installed_rpms
-          enabled: true
-
-        - name: insights.parsers.dmidecode
-          enabled: true
-
-        - name: insights.parsers.yum
-          enabled: true
-
-        - name: insights.parsers.rhsm_conf
-          enabled: true
-
-        - name: insights.combiners.cloud_provider
-          enabled: true
-
-    # needed for the ausearch_insights_client
-        - name: insights.components.rhel_version.IsGtOrRhel86
-          enabled: true
-
-    # needed for the cloud related specs
-        - name: insights.components.cloud_provider.IsAWS
-          enabled: true
-
-        - name: insights.components.cloud_provider.IsAzure
-          enabled: true
-
-        - name: insights.components.cloud_provider.IsGCP
-          enabled: true
-
-    # needed for the ceph related specs
-        - name: insights.components.ceph.IsCephMonitor
-          enabled: true
-
-    # needed for the Services combiner
-        - name: insights.components.rhel_version.IsRhel6
-          enabled: true
-
-        - name: insights.parsers.chkconfig
-          enabled: true
-
-        - name: insights.parsers.systemd.unitfiles
-          enabled: true
-
-        - name: insights.combiners.services
-          enabled: true
-
-    # needed for the 'teamdctl_state_dump' spec
-        - name: insights.parsers.nmcli.NmcliConnShow
-          enabled: true
-
-    # needed for multiple Datasouce specs
-        - name: insights.parsers.ps.PsAuxcww
-          enabled: true
-
-        - name: insights.parsers.ps.PsAuxww
-          enabled: true
-
-        - name: insights.combiners.ps
-          enabled: true
-
-    # needed for httpd_on_nfs
-        - name: insights.parsers.mount.ProcMounts
-          enabled: true
+    # needed for 'teamdctl_config/state_dump' spec
+    - name: insights.parsers.nmcli.NmcliConnShow
+      enabled: true
 
     # needed for mssql_tls_cert_enddate
-        - name: insights.parsers.mssql_conf.MsSQLConf
-          enabled: true
+    - name: insights.parsers.mssql_conf.MsSQLConf
+      enabled: true
 
-    # need for rsyslog_tls_cert_file
-        - name: insights.parsers.rsyslog_conf.RsyslogConf
-          enabled: true
+    # needed for rsyslog_tls_cert_file
+    - name: insights.parsers.rsyslog_conf.RsyslogConf
+      enabled: true
+    - name: insights.combiners.rsyslog_confs.RsyslogAllConf
+      enabled: true
 
-        - name: insights.combiners.rsyslog_confs.RsyslogAllConf
-          enabled: true
-
-    # needed to collect the sap_hdb_version spec that uses the Sap combiner
-        - name: insights.parsers.saphostctrl
-          enabled: true
-
-        - name: insights.combiners.sap
-          enabled: true
+    # needed for sap specs
+    - name: insights.parsers.saphostctrl.SAPHostCtrlInstances
+      enabled: true
+    - name: insights.combiners.sap.Sap
+      enabled: true
 
     # needed for fw_devices and fw_security specs
-        - name: insights.parsers.dmidecode.DMIDecode
-          enabled: true
+    - name: insights.parsers.virt_what.VirtWhat
+      enabled: true
+    - name: insights.combiners.virt_what.VirtWhat
+      enabled: true
+    - name: insights.components.virtualization.IsBareMetal
+      enabled: true
 
-        - name: insights.parsers.virt_what.VirtWhat
-          enabled: true
+    # needed for 'modinfo_filtered_modules' spec
+    - name: insights.parsers.lsmod.LsMod
+      enabled: true
 
-        - name: insights.combiners.virt_what.VirtWhat
-          enabled: true
+    # needed for satellite server specs
+    - name: insights.combiners.satellite_version.SatelliteVersion
+      enabled: true
+    - name: insights.combiners.satellite_version.CapsuleVersion
+      enabled: true
+    - name: insights.components.satellite.IsSatellite
+      enabled: true
+    - name: insights.components.satellite.IsSatellite614AndLater
+      enabled: true
+    - name: insights.components.satellite.IsSatelliteLessThan614
+      enabled: true
+    - name: insights.components.satellite.IsSatellite611
+      enabled: true
+    - name: insights.components.satellite.IsCapsule
+      enabled: true
 
-        - name: insights.components.virtualization.IsBareMetal
-          enabled: true
+    # needed for container specs
+    - name: insights.parsers.podman_list.PodmanListContainers
+      enabled: true
+    - name: insights.parsers.docker_list.DockerListContainers
+      enabled: true
 
-    # needed for the 'pre-check' of the 'ss' spec and the 'modinfo_filtered_modules' spec
-        - name: insights.parsers.lsmod.LsMod
-          enabled: true
+    # needed for 'luks_data_sources' spec
+    - name: insights.parsers.blkid.BlockIDInfo
+      enabled: true
+    - name: insights.components.cryptsetup.HasCryptsetupWithTokens
+      enabled: true
+    - name: insights.components.cryptsetup.HasCryptsetupWithoutTokens
+      enabled: true
 
-    # needed for the 'pre-check' of the 'is_satellite_server' spec
-        - name: insights.combiners.satellite_version.SatelliteVersion
-          enabled: true
-        - name: insights.components.satellite.IsSatellite
-          enabled: true
-        - name: insights.components.satellite.IsSatellite614AndLater
-          enabled: true
-        - name: insights.components.satellite.IsSatelliteLessThan614
-          enabled: true
+    # needed for 'iris' specs
+    - name: insights.parsers.iris.IrisList
+      enabled: true
+    - name: insights.parsers.iris.IrisCpf
+      enabled: true
 
-    # needed for the 'pre-check' of the 'is_satellite_capsule' spec
-        - name: insights.combiners.satellite_version.CapsuleVersion
-          enabled: true
-        - name: insights.components.satellite.IsCapsule
-          enabled: true
+    # needed for ausearch_insights_client
+    - name: insights.components.rhel_version.IsGtOrRhel86
+      enabled: true
 
-    # needed for the 'pre-check' of the 'satellite_provision_param_settings' spec
-        - name: insights.components.satellite.IsSatellite611
-          enabled: true
-
-    # needed for the 'pre-check' of the 'corosync_cmapctl_cmd_list' spec
-        - name: insights.combiners.redhat_release.RedHatRelease
-          enabled: true
-        - name: insights.parsers.uname.Uname
-          enabled: true
-        - name: insights.parsers.redhat_release.RedhatRelease
-          enabled: true
-        - name: insights.components.rhel_version.IsRhel7
-          enabled: true
-        - name: insights.components.rhel_version.IsRhel8
-          enabled: true
-        - name: insights.components.rhel_version.IsRhel9
-          enabled: true
-
-    # needed for the 'pmlog_summary' spec
-        - name: insights.parsers.ros_config.RosConfig
-          enabled: true
-
-    # needed for the 'container' specs
-        - name: insights.parsers.podman_list.PodmanListContainers
-          enabled: true
-
-        - name: insights.parsers.docker_list.DockerListContainers
-          enabled: true
-
-    # needed because some specs aren't given names before they're used in DefaultSpecs
-        - name: insights.core.spec_factory
-          enabled: true
-
-    # needed by the 'luks_data_sources' spec
-        - name: insights.parsers.blkid.BlockIDInfo
-          enabled: true
-
-        - name: insights.components.cryptsetup
-          enabled: true
-
-    # needed by the 'iris_cpf' spec
-        - name: insights.parsers.iris.IrisList
-          enabled: true
-
-    # needed by the 'iris_messages_log' spec
-        - name: insights.parsers.iris.IrisCpf
-          enabled: true
-
-    # needed by the 'sealert' spec
-        - name: insights.parsers.selinux_config.SelinuxConfig
-          enabled: true
-
-        - name: insights.components.selinux.SELinuxEnabled
-          enabled: true
+    # needed for sealert spec
+    - name: insights.parsers.selinux_config.SelinuxConfig
+      enabled: true
+    - name: insights.components.selinux.SELinuxEnabled
+      enabled: true
 """.strip()
 
 EXCEPTIONS_TO_REPORT = set([

--- a/insights/specs/datasources/pcp.py
+++ b/insights/specs/datasources/pcp.py
@@ -7,12 +7,14 @@ import logging
 import os
 
 from insights.combiners.ps import Ps
-from insights.combiners.services import Services
 from insights.core.context import HostContext
-from insights.core.exceptions import SkipComponent, ContentException
+from insights.core.exceptions import ContentException
+from insights.core.exceptions import SkipComponent
 from insights.core.plugins import datasource
-from insights.parsers.hostname import Hostname, HostnameDefault
+from insights.parsers.hostname import Hostname
+from insights.parsers.hostname import HostnameDefault
 from insights.parsers.ros_config import RosConfig
+from insights.parsers.systemd.unitfiles import UnitFiles
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +32,7 @@ pcp_metrics = [
 ]
 
 
-@datasource(Services, HostContext)
+@datasource(UnitFiles, HostContext)
 def pcp_enabled(broker):
     """
     Returns:
@@ -39,7 +41,7 @@ def pcp_enabled(broker):
     Raises:
         SkipComponent: When pmproxy service is not enabled
     """
-    if not broker[Services].is_on("pmproxy"):
+    if not broker[UnitFiles].is_on("pmproxy.service"):
         raise SkipComponent("pmproxy not enabled")
     return True
 

--- a/insights/tests/datasources/test_pcp.py
+++ b/insights/tests/datasources/test_pcp.py
@@ -5,7 +5,6 @@ from mock.mock import patch
 
 from insights.client.config import InsightsConfig
 from insights.combiners.ps import Ps
-from insights.combiners.services import Services
 from insights.core import dr
 from insights.core.exceptions import SkipComponent, ContentException
 from insights.parsers.hostname import HostnameDefault, Hostname
@@ -95,18 +94,14 @@ PCP_RAW_FILES = [
 
 
 def test_pcp_enabled():
-    unitfiles = UnitFiles(context_wrap(LIST_UNIT_FILES))
-    services = Services(None, unitfiles)
     broker = dr.Broker()
-    broker[Services] = services
+    broker[UnitFiles] = UnitFiles(context_wrap(LIST_UNIT_FILES))
 
     result = pcp_enabled(broker)
     assert result is True
 
-    unitfiles = UnitFiles(context_wrap(LIST_UNIT_FILES_no_pmproxy))
-    services = Services(None, unitfiles)
     broker = dr.Broker()
-    broker[Services] = services
+    broker[UnitFiles] = UnitFiles(context_wrap(LIST_UNIT_FILES_no_pmproxy))
 
     with pytest.raises(SkipComponent):
         pcp_enabled(broker)


### PR DESCRIPTION
- reorder and regroup the 'configs' that should be loaded in collection
- use the full path to the Class for each 'configs'
- tapstop=2 for the inline YAML
- replace Services combiner in datasources with UnitFiles Parser
- and reorder python imports with pre-commit

Signed-off-by: Xiangce Liu <xiangceliu@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
