### PR TITLE
Add subscription_manager_status spec file path for sos_archive

### DIFF
--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -301,6 +301,7 @@ class SosSpecs(Specs):
         'sos_commands/subscription_manager/subscription-manager_list_--consumed',
         'sos_commands/general/subscription-manager_list_--consumed']
     )
+    subscription_manager_status = simple_file("sos_commands/subscription_manager/subscription-manager_status")
     subscription_manager_list_installed = first_file([
         'sos_commands/yum/subscription-manager_list_--installed',
         'sos_commands/subscription_manager/subscription-manager_list_--installed',


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

The **SubscriptionManagerStatus** parser is well-implemented for handling sosreport file content. 
Initially, the file path for the insights-archive was specified only in `/insights/specs/insights_archive.py`.
 To extend support for sos archives, the corresponding file path  added to `/insights/specs/sos_archive.py`.

