### PR TITLE
Fix: Enhance datasource httpd include upcase

### DIFF
--- a/insights/specs/datasources/httpd.py
+++ b/insights/specs/datasources/httpd.py
@@ -78,7 +78,7 @@ def _get_all_include_conf(root, glob_path):
                             section_number = section_number - 1
                         elif line.startswith("<"):
                             section_number = section_number + 1
-                        elif section_number == 0 and (line.lower().startswith("include ") or line.lower().startswith("includeoptional ")):
+                        elif section_number == 0 and line.lower().startswith(("include ", "includeoptional ")):
                             _includes = line.split()[-1].strip('"\'')
                             _paths.update(_get_all_include_conf(root, _includes))
             if os.path.isdir(conf):
@@ -105,9 +105,9 @@ def get_httpd_configuration_files(httpd_root):
                     section_number = section_number - 1
                 elif line.startswith("<"):
                     section_number = section_number + 1
-                elif line.startswith("ServerRoot "):
+                elif line.lower().startswith("serverroot "):
                     server_root = line.strip().split()[-1].strip().strip('"\'')
-                elif section_number == 0 and (line.lower().startswith("include ") or line.lower().startswith("includeoptional ")):
+                elif section_number == 0 and line.lower().startswith(("include ", "includeoptional ")):
                     includes = line.split()[-1].strip('"\'')
                     # For multiple "Include" directives, all of them will be included
                     all_paths.update(_get_all_include_conf(server_root, includes))

--- a/insights/specs/datasources/httpd.py
+++ b/insights/specs/datasources/httpd.py
@@ -78,7 +78,7 @@ def _get_all_include_conf(root, glob_path):
                             section_number = section_number - 1
                         elif line.startswith("<"):
                             section_number = section_number + 1
-                        if section_number == 0 and (line.lower().startswith("include ") or line.lower().startswith("includeoptional ")):
+                        elif section_number == 0 and (line.lower().startswith("include ") or line.lower().startswith("includeoptional ")):
                             _includes = line.split()[-1].strip('"\'')
                             _paths.update(_get_all_include_conf(root, _includes))
             if os.path.isdir(conf):
@@ -105,7 +105,7 @@ def get_httpd_configuration_files(httpd_root):
                     section_number = section_number - 1
                 elif line.startswith("<"):
                     section_number = section_number + 1
-                if line.startswith("ServerRoot "):
+                elif line.startswith("ServerRoot "):
                     server_root = line.strip().split()[-1].strip().strip('"\'')
                 elif section_number == 0 and (line.lower().startswith("include ") or line.lower().startswith("includeoptional ")):
                     includes = line.split()[-1].strip('"\'')

--- a/insights/specs/datasources/httpd.py
+++ b/insights/specs/datasources/httpd.py
@@ -78,7 +78,7 @@ def _get_all_include_conf(root, glob_path):
                             section_number = section_number - 1
                         elif line.startswith("<"):
                             section_number = section_number + 1
-                        if section_number == 0 and (line.startswith("Include ") or line.startswith("IncludeOptional ")):
+                        if section_number == 0 and (line.lower().startswith("include ") or line.lower().startswith("includeoptional ")):
                             _includes = line.split()[-1].strip('"\'')
                             _paths.update(_get_all_include_conf(root, _includes))
             if os.path.isdir(conf):
@@ -107,7 +107,7 @@ def get_httpd_configuration_files(httpd_root):
                     section_number = section_number + 1
                 if line.startswith("ServerRoot "):
                     server_root = line.strip().split()[-1].strip().strip('"\'')
-                elif section_number == 0 and (line.startswith("Include ") or line.startswith("IncludeOptional ")):
+                elif section_number == 0 and (line.lower().startswith("include ") or line.lower().startswith("includeoptional ")):
                     includes = line.split()[-1].strip('"\'')
                     # For multiple "Include" directives, all of them will be included
                     all_paths.update(_get_all_include_conf(server_root, includes))


### PR DESCRIPTION
Signed-off-by: jiazhang <jiazhang@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
lower cases of "Include"/"IncludeOptional" can also work. Current code ignores the case like "include <file path>". This PR can fix this issue
