### PR TITLE
test: refine the tests used add_filter()

### DIFF
--- a/insights/tests/core/test_filters.py
+++ b/insights/tests/core/test_filters.py
@@ -55,29 +55,7 @@ def setup_function(func):
 
 def teardown_function(func):
     filters._CACHE = {}
-    if func is test_get_filter:
-        del filters.FILTERS[Specs.ps_aux]
-
-    if func is test_get_filter_registry_point:
-        del filters.FILTERS[Specs.ps_aux]
-        del filters.FILTERS[DefaultSpecs.ps_aux]
-
-    if func is test_filter_dumps_loads:
-        del filters.FILTERS[Specs.ps_aux]
-
-    if func in [
-        test_add_filter_to_MySpecsHasFilters,
-        test_add_filter_to_LocalSpecsHasFilters,
-    ]:
-        del filters.FILTERS[MySpecs.has_filters]
-        del filters.FILTERS[LocalSpecs.has_filters]
-
-    if func is test_add_filter_to_PsAux:
-        del filters.FILTERS[Specs.ps_aux]
-        del filters.FILTERS[DefaultSpecs.ps_aux]
-
-    if func is test_add_filter_to_parser_patterns_list:
-        del filters.FILTERS[Specs.ps_aux]
+    filters.FILTERS = defaultdict(set)
 
 
 @pytest.mark.skipif(sys.version_info < (2, 7), reason='Playbook verifier code uses oyaml library which is incompatable with this test')
@@ -85,7 +63,6 @@ def test_filter_dumps_loads():
     r = filters.dumps()
     assert r is not None
 
-    filters.FILTERS = defaultdict(set)
     filters.loads(r)
 
     assert Specs.ps_aux in filters.FILTERS

--- a/insights/tests/datasources/container/test_containers_inspect.py
+++ b/insights/tests/datasources/container/test_containers_inspect.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 
+from collections import defaultdict
 from mock.mock import Mock
 
 from insights.core import dr, filters
@@ -916,15 +917,15 @@ EXPECTED_RESULT_NG = [{'Id': '28fb57be8bb2', 'engine': 'podman'}]
 
 
 def setup_function(func):
-    if Specs.container_inspect_keys in filters._CACHE:
-        del filters._CACHE[Specs.container_inspect_keys]
-    if Specs.container_inspect_keys in filters.FILTERS:
-        del filters.FILTERS[Specs.container_inspect_keys]
-
     if func is test_containers_inspect_datasource or func is test_containers_inspect_datasource_NG_output_1 or func is test_containers_inspect_datasource_NG_output_2:
         filters.add_filter(Specs.container_inspect_keys, ["HostConfig|Privileged", "NoSuchKey|Privileged", "Config|Cmd", "Id", "Image"])
     if func is test_containers_inspect_datasource_no_filter:
         filters.add_filter(Specs.container_inspect_keys, [])
+
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_running_rhel_containers_id():

--- a/insights/tests/datasources/test_awx_manage.py
+++ b/insights/tests/datasources/test_awx_manage.py
@@ -1,7 +1,7 @@
-import collections
 import json
 import pytest
 
+from collections import defaultdict, OrderedDict
 from mock.mock import Mock
 
 from insights.core import filters
@@ -30,15 +30,15 @@ RELATIVE_PATH = 'insights_commands/awx-manage_check_license_--data'
 
 
 def setup_function(func):
-    if Specs.awx_manage_check_license_data in filters._CACHE:
-        del filters._CACHE[Specs.awx_manage_check_license_data]
-    if Specs.awx_manage_check_license_data in filters.FILTERS:
-        del filters.FILTERS[Specs.awx_manage_check_license_data]
-
     if func is test_ansible_tower_license_datasource or func is test_ansible_tower_license_datasource_NG_output:
         filters.add_filter(Specs.awx_manage_check_license_data, ["license_type", "support_level", "instance_count", "time_remaining"])
     if func is test_ansible_tower_license_datasource_no_filter:
         filters.add_filter(Specs.awx_manage_check_license_data, [])
+
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_ansible_tower_license_datasource():
@@ -48,7 +48,7 @@ def test_ansible_tower_license_datasource():
     result = awx_manage_check_license_data_datasource(broker)
     assert result is not None
     assert isinstance(result, DatasourceProvider)
-    expected = DatasourceProvider(content=json.dumps(collections.OrderedDict(sorted(AWX_MANAGE_FILTER_JSON.items()))), relative_path=RELATIVE_PATH)
+    expected = DatasourceProvider(content=json.dumps(OrderedDict(sorted(AWX_MANAGE_FILTER_JSON.items()))), relative_path=RELATIVE_PATH)
     assert result.content == expected.content
     assert result.relative_path == expected.relative_path
 

--- a/insights/tests/datasources/test_cloud_init.py
+++ b/insights/tests/datasources/test_cloud_init.py
@@ -1,6 +1,7 @@
 import pytest
 import yaml
 
+from collections import defaultdict
 from mock.mock import Mock
 
 from insights.core import filters
@@ -76,11 +77,6 @@ RELATIVE_PATH = '/etc/cloud/cloud.cfg'
 
 
 def setup_function(func):
-    if Specs.cloud_cfg in filters._CACHE:
-        del filters._CACHE[Specs.cloud_cfg]
-    if Specs.cloud_cfg in filters.FILTERS:
-        del filters.FILTERS[Specs.cloud_cfg]
-
     if func is test_cloud_cfg:
         filters.add_filter(Specs.cloud_cfg, ['ssh_deletekeys', 'network', 'debug'])
     if func is test_cloud_cfg_no_filter:
@@ -90,8 +86,8 @@ def setup_function(func):
 
 
 def teardown_function(func):
-    if func is test_cloud_cfg_bad or func is test_cloud_cfg:
-        del filters.FILTERS[Specs.cloud_cfg]
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 @pytest.mark.parametrize("ssh_deletekeys", [0, 1])

--- a/insights/tests/datasources/test_dir_list.py
+++ b/insights/tests/datasources/test_dir_list.py
@@ -1,5 +1,7 @@
 import pytest
 
+from collections import defaultdict
+
 from insights.core import filters
 from insights.core.exceptions import SkipComponent
 from insights.specs import Specs
@@ -7,15 +9,15 @@ from insights.specs.datasources.dir_list import du_dir_list
 
 
 def setup_function(func):
-    if Specs.du_dirs in filters._CACHE:
-        del filters._CACHE[Specs.du_dirs]
-    if Specs.du_dirs in filters.FILTERS:
-        del filters.FILTERS[Specs.du_dirs]
-
     if func is test_du_dirs_list:
         filters.add_filter(Specs.du_dirs, ["/var/lib/pulp", "/etc/httpd"])
     if func is test_du_dirs_list_no_filter:
         filters.add_filter(Specs.du_dirs, [])
+
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_du_dirs_list():

--- a/insights/tests/datasources/test_kernel_module_list.py
+++ b/insights/tests/datasources/test_kernel_module_list.py
@@ -1,5 +1,7 @@
 import pytest
 
+from collections import defaultdict
+
 from insights.core import filters
 from insights.core.exceptions import SkipComponent
 from insights.parsers.lsmod import LsMod
@@ -29,11 +31,6 @@ tcp_diag               16384  0
 
 
 def setup_function(func):
-    if Specs.modinfo_modules in filters._CACHE:
-        del filters._CACHE[Specs.modinfo_modules]
-    if Specs.modinfo_modules in filters.FILTERS:
-        del filters.FILTERS[Specs.modinfo_modules]
-
     if func is test_module_filters:
         filters.add_filter(Specs.modinfo_modules, ["udp_diag", "binfmt_misc", "wireguard"])
     if func is test_module_filters_2:
@@ -42,6 +39,11 @@ def setup_function(func):
         filters.add_filter(Specs.modinfo_modules, ["udp_diag", "binfmt_misc", "wireguard"])
     if func is test_module_filters_empty:
         filters.add_filter(Specs.modinfo_modules, [])
+
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_module_filters():

--- a/insights/tests/datasources/test_ls.py
+++ b/insights/tests/datasources/test_ls.py
@@ -1,5 +1,7 @@
 import pytest
 
+from collections import defaultdict
+
 from insights.core import filters
 from insights.core.exceptions import SkipComponent
 from insights.specs import Specs
@@ -34,13 +36,8 @@ def setup_function(func):
 
 
 def teardown_function(func):
-    for spec in (
-            Specs.ls_la_dirs, Specs.ls_la_filtered, Specs.ls_la_filtered_dirs,
-            Specs.ls_lan_dirs, Specs.ls_lan_filtered, Specs.ls_lan_filtered_dirs,
-            Specs.ls_lanL_dirs, Specs.ls_lanR_dirs, Specs.ls_lanRL_dirs,
-            Specs.ls_laRZ_dirs, Specs.ls_laZ_dirs):
-        if spec in filters._CACHE:
-            del filters._CACHE[spec]
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_la_empty():
@@ -75,7 +72,7 @@ def test_lanL():
 
 def test_lanR():
     ret = list_with_lanR({})
-    assert '/ ' in ret
+    assert '/' == ret
 
 
 def test_lanRL():

--- a/insights/tests/datasources/test_lsattr.py
+++ b/insights/tests/datasources/test_lsattr.py
@@ -1,5 +1,7 @@
 import pytest
 
+from collections import defaultdict
+
 from insights.core import filters
 from insights.core.exceptions import SkipComponent
 from insights.specs import Specs
@@ -16,8 +18,8 @@ def setup_function(func):
 
 
 def teardown_function(func):
-    if Specs.lsattr_files_or_dirs in filters._CACHE:
-        del filters._CACHE[Specs.lsattr_files_or_dirs]
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_lsattr_empty():

--- a/insights/tests/datasources/test_machine_ids.py
+++ b/insights/tests/datasources/test_machine_ids.py
@@ -2,6 +2,7 @@ import json
 import pytest
 
 from mock.mock import patch
+from collections import defaultdict
 
 from insights.client.config import InsightsConfig
 from insights.core import filters
@@ -82,17 +83,17 @@ class Result(object):
 
 
 def setup_function(func):
-    if Specs.duplicate_machine_id in filters._CACHE:
-        del filters._CACHE[Specs.duplicate_machine_id]
-    if Specs.duplicate_machine_id in filters.FILTERS:
-        del filters.FILTERS[Specs.duplicate_machine_id]
-
     if func in [test_duplicate, test_non_duplicate, test_wrong_machine_id_content, test_machine_id_not_in_filters, test_api_result_not_in_json_format]:
         filters.add_filter(Specs.duplicate_machine_id, ["dc194312-8cdd-4e75-8cf1-2094bfsfsdeff"])
         filters.add_filter(Specs.duplicate_machine_id, ["dc194312-8cdd-4e75-8cf1-2094bf45678"])
         filters.add_filter(Specs.duplicate_machine_id, ["dc194312-8cdd-4e75-8cf1-2094bfwrong"])
     if func is test_module_filters_empty:
         filters.add_filter(Specs.duplicate_machine_id, [])
+
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 @patch('insights.specs.datasources.machine_ids.get_connection',

--- a/insights/tests/datasources/test_package_provides.py
+++ b/insights/tests/datasources/test_package_provides.py
@@ -1,5 +1,7 @@
 import pytest
 
+from collections import defaultdict
+
 from insights.combiners.ps import Ps
 from insights.core import dr, filters
 from insights.core.context import HostContext
@@ -52,11 +54,6 @@ class FakeContext(HostContext):
 
 
 def setup_function(func):
-    if Specs.package_provides_command in filters._CACHE:
-        del filters._CACHE[Specs.package_provides_command]
-    if Specs.package_provides_command in filters.FILTERS:
-        del filters.FILTERS[Specs.package_provides_command]
-
     if func is test_cmd_and_pkg:
         filters.add_filter(Specs.package_provides_command, ['httpd', 'java'])
     elif func is test_cmd_and_pkg_not_found:
@@ -64,8 +61,8 @@ def setup_function(func):
 
 
 def teardown_function(func):
-    if func is test_cmd_and_pkg or func is test_cmd_and_pkg_not_found:
-        del filters.FILTERS[Specs.package_provides_command]
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_get_package():

--- a/insights/tests/datasources/test_rpm_pkgs.py
+++ b/insights/tests/datasources/test_rpm_pkgs.py
@@ -2,6 +2,7 @@ import mock
 import pytest
 
 from mock.mock import Mock
+from collections import defaultdict
 
 from insights.core import filters
 from insights.core.exceptions import SkipComponent
@@ -24,6 +25,16 @@ RPM_BAD_CMD = "bash: rpm: command not found..."
 RPM_EMPTY_CMD = ""
 
 RELATIVE_PATH = "insights_commands/rpm_pkgs"
+
+
+def setup_function(func):
+    if func is test_rpm_v_pkgs:
+        filters.add_filter(Specs.rpm_V_package_list, ['coreutils', 'procps', 'procps-ng', 'shadow-utils', 'passwd', 'sudo', 'chrony', 'findutils', 'glibc'])
+
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def get_users():
@@ -57,18 +68,6 @@ def test_no_rpm(no_rpm):
 
     with pytest.raises(SkipComponent):
         pkgs_with_writable_dirs(broker)
-
-
-def setup_function(func):
-    if func is test_pkgs_list_empty:
-        pass
-    if func is test_rpm_v_pkgs:
-        filters.add_filter(Specs.rpm_V_package_list, ['coreutils', 'procps', 'procps-ng', 'shadow-utils', 'passwd', 'sudo', 'chrony', 'findutils', 'glibc'])
-
-
-def teardown_function():
-    if Specs.rpm_V_package_list in filters._CACHE:
-        del filters._CACHE[Specs.rpm_V_package_list]
 
 
 def test_pkgs_list_empty():

--- a/insights/tests/datasources/test_semanage.py
+++ b/insights/tests/datasources/test_semanage.py
@@ -2,6 +2,7 @@ import json
 import pytest
 
 from mock.mock import Mock
+from collections import defaultdict
 
 from insights.core import filters
 from insights.core.exceptions import SkipComponent
@@ -32,17 +33,17 @@ RELATIVE_PATH = 'insights_commands/linux_users_count_map_selinux_user'
 
 
 def setup_function(func):
-    if Specs.selinux_users in filters._CACHE:
-        del filters._CACHE[Specs.selinux_users]
-    if Specs.selinux_users in filters.FILTERS:
-        del filters.FILTERS[Specs.selinux_users]
-
     if func is test_linux_users_count_map_staff_u:
         filters.add_filter(Specs.selinux_users, ["staff_u"])
     if func is test_linux_users_count_map_more_selinux_users:
         filters.add_filter(Specs.selinux_users, ["staff_u", "unconfined_u"])
     if func is test_linux_users_count_map_staff_u_except:
         filters.add_filter(Specs.selinux_users, [])
+
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_linux_users_count_map_staff_u():

--- a/insights/tests/datasources/test_user_group.py
+++ b/insights/tests/datasources/test_user_group.py
@@ -1,5 +1,7 @@
 import pytest
 
+from collections import defaultdict
+
 from insights.core import filters
 from insights.core.exceptions import SkipComponent
 from insights.specs import Specs
@@ -7,15 +9,15 @@ from insights.specs.datasources.user_group import group_filters
 
 
 def setup_function(func):
-    if Specs.group_info in filters._CACHE:
-        del filters._CACHE[Specs.group_info]
-    if Specs.group_info in filters.FILTERS:
-        del filters.FILTERS[Specs.group_info]
-
     if func is test_group_filters:
         filters.add_filter(Specs.group_info, ["wheel", "mem"])
     if func is test_group_filters_empty:
         filters.add_filter(Specs.group_info, [])
+
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_group_filters():

--- a/insights/tests/parsers/test_dse_ldif_simple.py
+++ b/insights/tests/parsers/test_dse_ldif_simple.py
@@ -2,6 +2,8 @@
 
 import doctest
 
+from collections import defaultdict
+
 from insights.core import filters
 from insights.parsers import dse_ldif_simple
 from insights.parsers.dse_ldif_simple import DseLdifSimple
@@ -144,8 +146,8 @@ def setup_function(func):
 
 
 def teardown_function(func):
-    if func in [test_dse_ldif_filtered]:
-        del filters.FILTERS[Specs.dse_ldif]
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_dse_ldif_smoke():
@@ -185,7 +187,7 @@ def test_dse_ldif_coverage():
 def test_dse_ldif_filtered():
     dse_ldif_simple = DseLdifSimple(context_wrap(DSE_LDIF_REAL_EXAMPLE, filtered_spec=Specs.dse_ldif))
     assert dse_ldif_simple["nsslapd-security"] == "on"
-    assert len(dse_ldif_simple) == 9
+    assert len(dse_ldif_simple) == 6
     expected = {
         "cn": "config",  # just a canary to detect spec collection status
         "nsslapd-security": "on",
@@ -193,9 +195,6 @@ def test_dse_ldif_filtered():
         "sslVersionMax": "TLS1.1",
         "nsSSL3": "on",
         "nsSSL3Ciphers": "+all",
-        "dn": "cn=config",
-        "nsslapd-rootdn": "cn=Directory Manager",
-        "nsslapd-ldapimaprootdn": "cn=Directory Manager",
     }
     assert dict(dse_ldif_simple) == expected
 

--- a/insights/tests/parsers/test_ls_usr_bin.py
+++ b/insights/tests/parsers/test_ls_usr_bin.py
@@ -1,6 +1,8 @@
 import doctest
 
-from insights.core.filters import add_filter
+from collections import defaultdict
+
+from insights.core import filters
 from insights.parsers import ls_usr_bin
 from insights.parsers.ls_usr_bin import LsUsrBin
 from insights.specs import Specs
@@ -14,6 +16,11 @@ lrwxrwxrwx.  1 0  0        7 Oct 22  2019 python -> python2
 lrwxrwxrwx.  1 0  0       14 Oct 22  2019 python-config -> python2-config
 lrwxrwxrwx.  1 0  0        9 Oct 22  2019 python2 -> python2.7
 """
+
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_ls_usr_bin():
@@ -37,7 +44,7 @@ def test_ls_usr_bin():
 def test_ls_usr_bin_doc_examples():
     env = {
         'Specs': Specs,
-        'add_filter': add_filter,
+        'add_filter': filters.add_filter,
         'LsUsrBin': LsUsrBin,
         'ls_usr_bin': LsUsrBin(context_wrap(LS_USR_BIN, path='insights_commands/ls_-ln_.usr.bin')),
     }

--- a/insights/tests/parsers/test_ls_usr_sbin.py
+++ b/insights/tests/parsers/test_ls_usr_sbin.py
@@ -1,6 +1,8 @@
 import doctest
 
-from insights.core.filters import add_filter
+from collections import defaultdict
+
+from insights.core import filters
 from insights.parsers import ls_usr_sbin
 from insights.parsers.ls_usr_sbin import LsUsrSbin
 from insights.specs import Specs
@@ -14,6 +16,11 @@ total 41472
 -rwxr-xr-x. 1 0  0  371912 Jan 27  2014 postconf
 -rwxr-sr-x. 1 0 90  218552 Jan 27  2014 postdrop
 """
+
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_ls_usr_sbin():
@@ -37,7 +44,7 @@ def test_ls_usr_sbin():
 def test_ls_usr_sbin_doc_examples():
     env = {
         'Specs': Specs,
-        'add_filter': add_filter,
+        'add_filter': filters.add_filter,
         'LsUsrSbin': LsUsrSbin,
         'ls_usr_sbin': LsUsrSbin(context_wrap(LS_USR_SBIN, path='insights_commands/ls_-ln_.usr.sbin')),
     }

--- a/insights/tests/parsers/test_messages.py
+++ b/insights/tests/parsers/test_messages.py
@@ -1,6 +1,8 @@
 import doctest
 
-from insights import add_filter
+from collections import defaultdict
+
+from insights.core import filters
 from insights.parsers import messages
 from insights.specs import Specs
 from insights.tests import context_wrap
@@ -17,7 +19,7 @@ Apr 22 10:40:01 boy-bona CROND[30677]: (root) CMD (/usr/lib64/sa/sa1 -S DISK 1 1
 Apr 22 10:41:13 boy-bona crontab[32515]: (root) LIST (root)
 """.strip()
 
-add_filter(Specs.messages, [
+filters.add_filter(Specs.messages, [
     "LIST",
     "CROND",
     "jabberd",
@@ -25,6 +27,11 @@ add_filter(Specs.messages, [
     "Launching",
     "yum"
 ])
+
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_doc_examples():

--- a/insights/tests/parsers/test_rhsm_log.py
+++ b/insights/tests/parsers/test_rhsm_log.py
@@ -1,7 +1,9 @@
 import doctest
 from datetime import datetime
 
-from insights import add_filter
+from collections import defaultdict
+
+from insights.core import filters
 from insights.parsers import rhsm_log
 from insights.parsers.rhsm_log import RhsmLog
 from insights.specs import Specs
@@ -28,10 +30,15 @@ LOG3 = """
 2011-12-27-08:41:13,104 [ERROR]  @managercli.py:66 - certificate verify failed
 """
 
-add_filter(Specs.rhsm_log, [
+filters.add_filter(Specs.rhsm_log, [
     "[ERROR]",
     "[Errno"
 ])
+
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_rhsm_log():

--- a/insights/tests/test_context_wrap.py
+++ b/insights/tests/test_context_wrap.py
@@ -1,4 +1,6 @@
-from insights.core.filters import add_filter
+from collections import defaultdict
+
+from insights.core import filters
 from insights.specs import Specs
 from insights.tests import context_wrap, DEFAULT_RELEASE, DEFAULT_HOSTNAME
 
@@ -13,7 +15,10 @@ Two
 Four
 """
 
-add_filter(Specs.messages, ["Two", "Four", "Five"])
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(set)
 
 
 def test_context_wrap_unfiltered():
@@ -27,6 +32,7 @@ def test_context_wrap_unfiltered():
 
 
 def test_context_wrap_filtered():
+    filters.add_filter(Specs.messages, ["Two", "Four", "Five"])
     context = context_wrap(DATA, filtered_spec=Specs.messages)
     assert context is not None
     assert context.content == DATA_FILTERED.strip().splitlines()

--- a/insights/tests/test_specs.py
+++ b/insights/tests/test_specs.py
@@ -228,16 +228,7 @@ def setup_function(func):
 
 def teardown_function(func):
     filters._CACHE = {}
-
-    if func in [test_spec_factory, test_specs_collect, test_line_terminators]:
-        del filters.FILTERS[Stuff.smpl_cmd_w_filter]
-        del filters.FILTERS[Stuff.smpl_file_w_filter]
-        del filters.FILTERS[Stuff.first_file_spec_w_filter]
-        del filters.FILTERS[Stuff.first_of_spec_w_filter]
-        del filters.FILTERS[Stuff.many_glob_filter]
-        del filters.FILTERS[Stuff.many_foreach_exe_filter]
-        del filters.FILTERS[Stuff.many_foreach_clc_filter]
-        del filters.FILTERS[Stuff.cmd_w_args_filter]
+    filters.FILTERS = defaultdict(set)
 
     if func == test_specs_collect:
         os.remove(test_empty_file)

--- a/insights/tests/test_specs_save_as.py
+++ b/insights/tests/test_specs_save_as.py
@@ -125,11 +125,7 @@ with open(here + "/spec_tests.py") as f:
 
 def teardown_function(func):
     filters._CACHE = {}
-
-    if func in [test_specs_save_as_collect, test_specs_save_as_no_collect]:
-        del filters.FILTERS[Stuff.smpl_cmd_w_filter]
-        del filters.FILTERS[Stuff.smpl_file_w_filter]
-        del filters.FILTERS[Stuff.first_file_spec_w_filter]
+    filters.FILTERS = defaultdict(set)
 
     # Reset Test ENV
     dr.COMPONENTS = defaultdict(lambda: defaultdict(set))


### PR DESCRIPTION
- add_filter() is a method that will affect global filters,
  this PR resets the global FILTERS/CACHE for each test
  that added filters
- fix the test issue of PR #4255

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
