### PR TITLE
feat(client): Improve test coverage of crypto.py

### DIFF
--- a/insights/client/crypto.py
+++ b/insights/client/crypto.py
@@ -99,6 +99,7 @@ class GPGCommand(object):
         )
         stdout, stderr = version_process.communicate()
         if version_process.returncode != 0:
+            stderr = stderr.decode("utf-8") if isinstance(stderr, bytes) else stderr
             stderr = "\n".join("stderr: {line}".format(line=line) for line in stderr.split("\n") if len(line))
             logger.debug("could not query for gpg version:\n{err}".format(err=stderr))
             return False


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: CCT-967

While existing tests catch basic invalid playbook scenarios, this update aims to create more tests that cover specific verification failure points. Adding new unit tests helps "freeze" expected verification behavior, making it easier to detect unintended changes in the future. This PR is a modified version of [insights-ansible-playbook-verifier#24](https://github.com/RedHatInsights/insights-ansible-playbook-verifier/pull/24).
