### PR TITLE
fix: Update combiner httpd_conf include

### DIFF
--- a/insights/combiners/httpd_conf.py
+++ b/insights/combiners/httpd_conf.py
@@ -12,7 +12,7 @@ consolidated configuration tree.
 """
 from insights.core import ConfigCombiner
 from insights.core.plugins import combiner
-from insights.parsr.query import startswith
+from insights.parsr.query import istartswith
 from insights.parsers.httpd_conf import HttpdConf, HttpdConfSclHttpd24, HttpdConfSclJbcsHttpd24
 
 
@@ -25,7 +25,7 @@ class HttpdConfTree(ConfigCombiner):
     See the :py:class:`insights.core.ConfigComponent` class for example usage.
     """
     def __init__(self, confs):
-        includes = startswith("Include")
+        includes = istartswith("Include")
         super(HttpdConfTree, self).__init__(confs, "httpd.conf", includes)
 
     @property
@@ -43,7 +43,7 @@ class HttpdConfSclHttpd24Tree(ConfigCombiner):
     See the :py:class:`insights.core.ConfigComponent` class for example usage.
     """
     def __init__(self, confs):
-        includes = startswith("Include")
+        includes = istartswith("Include")
         super(HttpdConfSclHttpd24Tree, self).__init__(confs, "httpd.conf", includes)
 
     @property
@@ -61,7 +61,7 @@ class HttpdConfSclJbcsHttpd24Tree(ConfigCombiner):
     See the :py:class:`insights.core.ConfigComponent` class for example usage.
     """
     def __init__(self, confs):
-        includes = startswith("Include")
+        includes = istartswith("Include")
         super(HttpdConfSclJbcsHttpd24Tree, self).__init__(confs, "httpd.conf", includes)
 
     @property


### PR DESCRIPTION
Signed-off-by: jiazhang <jiazhang@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Options in httpd configuration files are not case sensitive. To avoid configuration files parsing missing, it is necessary to use `istartswith("Include")` instead of `startswith("Include")`.

Besides Options nginx configuration files are case sensitive, no need to update the nginx combiner.
