### PR TITLE
fix: remove the 'fstab_mounted.dirs' from the final ls args

### DIFF
--- a/insights/specs/datasources/ls.py
+++ b/insights/specs/datasources/ls.py
@@ -1,6 +1,7 @@
 """
 Custom datasources for ``ls`` commands
 """
+
 from insights.core.context import HostContext
 from insights.core.dr import get_name
 from insights.core.exceptions import SkipComponent
@@ -56,6 +57,7 @@ def list_with_la_filtered(broker):
 def list_with_lan(broker):
     filters = set(_list_items(Specs.ls_lan_dirs))
     if 'fstab_mounted.dirs' in filters and FSTab in broker:
+        filters.remove('fstab_mounted.dirs')
         for mntp in broker[FSTab].mounted_on.keys():
             mnt_point = os.path.dirname(mntp)
             filters.add(mnt_point) if mnt_point else None

--- a/insights/tests/datasources/test_ls.py
+++ b/insights/tests/datasources/test_ls.py
@@ -7,10 +7,16 @@ from insights.core.exceptions import SkipComponent
 from insights.parsers.fstab import FSTab
 from insights.specs import Specs
 from insights.specs.datasources.ls import (
-        list_with_la, list_with_la_filtered,
-        list_with_lan, list_with_lan_filtered,
-        list_with_lanL, list_with_lanR, list_with_lanRL,
-        list_with_laRZ, list_with_laZ)
+    list_with_la,
+    list_with_la_filtered,
+    list_with_lan,
+    list_with_lan_filtered,
+    list_with_lanL,
+    list_with_lanR,
+    list_with_lanRL,
+    list_with_laRZ,
+    list_with_laZ,
+)
 from insights.tests import context_wrap
 
 
@@ -106,8 +112,6 @@ def test_lanZ():
 
 def test_lan_with_fstab_mounted_filter():
     fstab = FSTab(context_wrap(FSTAB_CONTEXT))
-    broker = {
-        FSTab: fstab
-    }
+    broker = {FSTab: fstab}
     ret = list_with_lan(broker)
-    assert ret == '/ /boot /hana/data fstab_mounted.dirs'
+    assert ret == '/ /boot /hana/data'


### PR DESCRIPTION
- the 'fstab_mounted.dirs' was parsed/extracted in the `datasources.ls` already
  should be removed from the args that passed to the `ls` command