### PR TITLE
fix: proper error handling of AzurePublicIpv4Addresses

### DIFF
--- a/insights/parsers/azure_instance.py
+++ b/insights/parsers/azure_instance.py
@@ -196,7 +196,12 @@ class AzurePublicIpv4Addresses(CommandParser, list):
 
         try:
             plan = json.loads(' '.join(content))
-            for pair in plan["loadbalancer"]["publicIpAddresses"]:
-                self.append(pair["frontendIpAddress"])
         except:
             raise ParseException("Unable to parse JSON")
+
+        for pair in plan.get("loadbalancer", {}).get("publicIpAddresses", {}):
+            if pair.get("frontendIpAddress"):
+                self.append(pair["frontendIpAddress"])
+
+        if len(self) == 0:
+            raise SkipComponent("No 'frontendIpAddress'.")

--- a/insights/tests/parsers/test_azure_instance.py
+++ b/insights/tests/parsers/test_azure_instance.py
@@ -87,6 +87,9 @@ AZURE_LB_ERR3 = """
 curl: (28) connect() timed out!
 """.strip()
 AZURE_LB_ERR4 = "}}}"
+AZURE_LB_ERR5 = """
+{ "error": "No load balancer metadata is found. Please check if your VM is using any non-basic SKU load balancer and retry later." }
+""".strip()
 
 
 # Test AzureInstanceID
@@ -212,6 +215,9 @@ def test_azure_public_ipv4():
 
     with pytest.raises(ParseException):
         AzurePublicIpv4Addresses(context_wrap(AZURE_LB_ERR4))
+
+    with pytest.raises(SkipComponent):
+        AzurePublicIpv4Addresses(context_wrap(AZURE_LB_ERR5))
 
     azure = AzurePublicIpv4Addresses(context_wrap(AZURE_LB_1))
     assert azure[0] == "137.116.118.209"

--- a/insights/tests/parsers/test_azure_instance.py
+++ b/insights/tests/parsers/test_azure_instance.py
@@ -90,6 +90,23 @@ AZURE_LB_ERR4 = "}}}"
 AZURE_LB_ERR5 = """
 { "error": "No load balancer metadata is found. Please check if your VM is using any non-basic SKU load balancer and retry later." }
 """.strip()
+AZURE_LB_ERR6 = """
+{
+  "loadbalancer": {
+    "publicIpAddresses": [
+      {
+        "frontendIpAddress": "",
+        "privateIpAddress": "10.0.0.4"
+      },
+      {
+        "privateIpAddress": "10.0.0.4"
+      }
+    ],
+    "inboundRules": [],
+    "outboundRules": []
+  }
+}
+""".strip()
 
 
 # Test AzureInstanceID
@@ -218,6 +235,9 @@ def test_azure_public_ipv4():
 
     with pytest.raises(SkipComponent):
         AzurePublicIpv4Addresses(context_wrap(AZURE_LB_ERR5))
+
+    with pytest.raises(SkipComponent):
+        AzurePublicIpv4Addresses(context_wrap(AZURE_LB_ERR6))
 
     azure = AzurePublicIpv4Addresses(context_wrap(AZURE_LB_1))
     assert azure[0] == "137.116.118.209"


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
See the following line in Errors report: 
| count| component| request_id| exception|
| -------- | ------- | -------- | ------- |
|26780|insights.parsers.azure_instance.AzurePublicIpv4Addresses|xxx| ParseException('Unable to parse JSON')|

An example input of this `AzurePublicIpv4Addresses`: 
```
{ "error": "No load balancer metadata is found. Please check if your VM is using any non-basic SKU load balancer and retry later." }
```

To proper handle such content in parser `AzurePublicIpv4Addresses`.  

RHINENG-14573 