### PR TITLE
fix: handle empty value in krb5 config

### DIFF
--- a/insights/parsers/krb5.py
+++ b/insights/parsers/krb5.py
@@ -157,7 +157,7 @@ class Krb5Configuration(Parser, LegacyItemAccess):
                 elif "=" in line and not line.endswith("{"):
                     key, value = [i.strip() for i in line.split('=', 1)]
                     if key not in unchangeable_tags:
-                        value = value.split()[0].strip()
+                        value = value.split()[0] if value else value
                         section_value[key] = _handle_key_value(section_value, key, value)
                     if line.endswith("*"):
                         unchangeable_tags.append(key)

--- a/insights/parsers/krb5.py
+++ b/insights/parsers/krb5.py
@@ -130,7 +130,7 @@ class Krb5Configuration(Parser, LegacyItemAccess):
                 if "=" in line:
                     key, value = [i.strip() for i in line.split('=', 1)]
                     if key not in unchangeable_tags:
-                        value = value.split()[0].strip()
+                        value = value.split()[0] if value else value
                         squ_value[key] = _handle_key_value(squ_value, key, value)
                     if line.endswith("*"):
                         unchangeable_tags.append(key)

--- a/insights/tests/parsers/test_krb5.py
+++ b/insights/tests/parsers/test_krb5.py
@@ -108,6 +108,16 @@ KRB5_DCONF_2 = """[libdefaults]
 permitted_enctypes = """
 KRB5_DCONF_2_PATH = "etc/krb5.conf.d/crypto-policies"
 
+KRB5_DCONF_3_FAKE = """
+[libdefaults]
+ EXAMPLE2.COM = {
+  kdc = kerberos.example2.com
+  permitted_enctypes =
+  admin_server = kerberos.example2.com
+ }
+"""
+KRB5_DCONF_3_PATH = "etc/krb5.conf.d/crypto-policies"
+
 
 def test_krb5configuration():
     common_conf_info = krb5.Krb5Configuration(context_wrap(KRB5CONFIG, path=KRB5_CONF_PATH))
@@ -156,6 +166,9 @@ def test_krb5Dconfiguration():
 def test_krb5configuration_2():
     common_conf_info = krb5.Krb5Configuration(context_wrap(KRB5_DCONF_2, path=KRB5_DCONF_2_PATH))
     assert common_conf_info["libdefaults"]["permitted_enctypes"] == ""
+
+    common_conf_info = krb5.Krb5Configuration(context_wrap(KRB5_DCONF_3_FAKE, path=KRB5_DCONF_3_PATH))
+    assert common_conf_info["libdefaults"]["EXAMPLE2.COM"]["permitted_enctypes"] == ""
 
 
 def test_handle_krb5_bool():

--- a/insights/tests/parsers/test_krb5.py
+++ b/insights/tests/parsers/test_krb5.py
@@ -104,6 +104,10 @@ KRB5CONFIG3 = """
 KRB5_CONF_PATH = "etc/krb5.conf"
 KRB5_DCONF_PATH = "etc/krb5.conf.d/test.conf"
 
+KRB5_DCONF_2 = """[libdefaults]
+permitted_enctypes = """
+KRB5_DCONF_2_PATH = "etc/krb5.conf.d/crypto-policies"
+
 
 def test_krb5configuration():
     common_conf_info = krb5.Krb5Configuration(context_wrap(KRB5CONFIG, path=KRB5_CONF_PATH))
@@ -147,6 +151,11 @@ def test_krb5Dconfiguration():
     assert common_conf_info["realms"]["EXAMPLE.COM"]["kdc"] == ['kerberos.example.com', 'test2.example.com', 'test3.example.com']
     assert common_conf_info.has_option("logging", "admin_server")
     assert common_conf_info["logging"]["kdc"] == "FILE:/var/log/krb5kdc.log"
+
+
+def test_krb5configuration_2():
+    common_conf_info = krb5.Krb5Configuration(context_wrap(KRB5_DCONF_2, path=KRB5_DCONF_2_PATH))
+    assert common_conf_info["libdefaults"]["permitted_enctypes"] == ""
 
 
 def test_handle_krb5_bool():


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

See the following line in Errors report: 
| count| component| request_id| exception|
| -------- | ------- | -------- | ------- |
|33315| insights.parsers.krb5.Krb5Configuration|a9bd78cbb38e4c438e5f0e9c3b9eb57e| IndexError('list index out of range')|

An example input of this `Krb5Configuration`: 
```
[libdefaults]
permitted_enctypes =  
```

To proper handle such content in parser `Krb5Configuration`.  

RHINENG-14573 