### PR TITLE
fix: add six.text_type to the check of command_with_args

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E501,E126,E127,E128,E722,E741,W503,W504
+ignore = E203,E501,E126,E127,E128,E722,E741,W503,W504
 exclude = insights/contrib,bin,docs,include,lib,lib64,.git,.collections.py,insights/parsers/tests/lvm_test_data.py,insights/client/apps/ansible/playbook_verifier/contrib,insights/tools/coverage.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     # inherit from original .flake8
     # add news:
     # - W503 black conflicts with "line break before operator" rule
-    '--ignore=E501,E126,E127,E128,E722,E741,W503,W504']
+    '--ignore=E203,E501,E126,E127,E128,E722,E741,W503,W504']
 
 - repo: https://github.com/gitleaks/gitleaks
   rev: v8.21.2


### PR DESCRIPTION
- the type of 'provider' is unicode in python2 env, use 'six.text_type' for compatibility
- add E203 to flake8.ignore as per 
  https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#slices

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
- as it contains changes made by `black`, the major change of this pr is
   https://github.com/RedHatInsights/insights-core/pull/4290/files#diff-139617115fa36c187b7abb769836928aff6051c743356cdf643582c0ba74f1daR1119-R1123

