### PR TITLE
feat: support more RHEL product key in subscription_manage_status

### DIFF
--- a/insights/parsers/subscription_manager.py
+++ b/insights/parsers/subscription_manager.py
@@ -134,6 +134,16 @@ class SubscriptionManagerStatus(CommandParser, dict):
                 self[key] = val
             elif line.startswith('Content Access Mode is set to'):
                 self['Content Access Mode'] = line.split('.', 1)[0].split('Content Access Mode is set to')[1].strip()
+            elif line.startswith("Red Hat Enterprise Linux for Virtual Datacenters"):
+                current_key = line.strip(':').strip()
+                current_value = []
+
+                for subsequent_line in content[content.index(line) + 1:]:
+                    if not subsequent_line.strip():
+                        break
+                    current_value.append(subsequent_line.strip())
+
+                self[current_key] = " ".join(current_value).strip()
 
         if not self:
             raise SkipComponent

--- a/insights/parsers/subscription_manager.py
+++ b/insights/parsers/subscription_manager.py
@@ -128,22 +128,23 @@ class SubscriptionManagerStatus(CommandParser, dict):
         True
     """
     def parse_content(self, content):
+        self.unparsed_lines = []
         for line in content:
+            line = line.strip()
+
+            if not line:
+                continue
+
             if ': ' in line:
                 key, val = [_l.strip() for _l in line.split(': ', 1)]
                 self[key] = val
             elif line.startswith('Content Access Mode is set to'):
                 self['Content Access Mode'] = line.split('.', 1)[0].split('Content Access Mode is set to')[1].strip()
             elif line.startswith("Red Hat Enterprise Linux for Virtual Datacenters"):
-                current_key = line.strip(':').strip()
-                current_value = []
-
-                for subsequent_line in content[content.index(line) + 1:]:
-                    if not subsequent_line.strip():
-                        break
-                    current_value.append(subsequent_line.strip())
-
-                self[current_key] = " ".join(current_value).strip()
+                subscription_type = line.split(',')[1].strip(':').strip() if ',' in line else ''
+                self['Red Hat Enterprise Linux for Virtual Datacenters'] = subscription_type
+            elif "Guest has not been reported on any host" in line:
+                self.unparsed_lines.append(line)
 
         if not self:
             raise SkipComponent

--- a/insights/tests/parsers/test_subscription_manager.py
+++ b/insights/tests/parsers/test_subscription_manager.py
@@ -113,8 +113,9 @@ def test_subman_status():
 
     ret = SubscriptionManagerStatus(context_wrap(SUBSCRIPTION_MANAGER_STATUS_PRODUCT_KEY))
     assert ret['Overall Status'] == 'Insufficient'
-    assert ret['Red Hat Enterprise Linux for Virtual Datacenters, Standard'] == '- Guest has not been reported on any host and is using a temporary unmapped guest subscription. For more information, please see https://access.redhat.com/solutions/XXXX'
+    assert ret['Red Hat Enterprise Linux for Virtual Datacenters'] == 'Standard'
     assert ret['System Purpose Status'] == 'Matched'
+    assert ret.unparsed_lines == [SUBSCRIPTION_MANAGER_STATUS_PRODUCT_KEY.splitlines()[-3]]
 
 
 def test_subman_facts_ng():

--- a/insights/tests/parsers/test_subscription_manager.py
+++ b/insights/tests/parsers/test_subscription_manager.py
@@ -62,6 +62,18 @@ SUBSCRIPTION_MANAGER_STATUS_EMPTY = """
 
 """.strip()
 
+SUBSCRIPTION_MANAGER_STATUS_PRODUCT_KEY = """
++-------------------------------------------+
+   System Status Details
++-------------------------------------------+
+Overall Status: Insufficient
+
+Red Hat Enterprise Linux for Virtual Datacenters, Standard:
+- Guest has not been reported on any host and is using a temporary unmapped guest subscription. For more information, please see https://access.redhat.com/solutions/XXXX
+
+System Purpose Status: Matched
+""".strip()
+
 
 def test_subman_facts():
     ret = SubscriptionManagerFacts(context_wrap(FACTS_NORMAL_1))
@@ -98,6 +110,11 @@ def test_subman_status():
     assert ret['Overall Status'] == 'Disabled'
     assert ret['Content Access Mode'] == 'Simple Content Access'
     assert ret['System Purpose Status'] == 'Disabled'
+
+    ret = SubscriptionManagerStatus(context_wrap(SUBSCRIPTION_MANAGER_STATUS_PRODUCT_KEY))
+    assert ret['Overall Status'] == 'Insufficient'
+    assert ret['Red Hat Enterprise Linux for Virtual Datacenters, Standard'] == '- Guest has not been reported on any host and is using a temporary unmapped guest subscription. For more information, please see https://access.redhat.com/solutions/XXXX'
+    assert ret['System Purpose Status'] == 'Matched'
 
 
 def test_subman_facts_ng():


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

**Product Key Parsing:** Added support for parsing certain product key lines that start with "Red Hat Enterprise Linux for Virtual Datacenters", handling them as keys and capturing the following description lines as their values.

Here are couple of examples:

Test data sample 1:
```
# subscription-manager status
+-------------------------------------------+
 System Status Details
+-------------------------------------------+
Overall Status: Insufficient

Red Hat Enterprise Linux for Virtual Datacenters, Premium:
- Guest has not been reported on any host and is using a temporary unmapped guest subscription. For more information, please see https://access.redhat.com/solutions/XXXX
```

Test data sample 2:
```
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Insufficient
Red Hat Enterprise Linux for Virtual Datacenters, Standard:
- Guest has not been reported on any host and is using a temporary unmapped guest subscription. For more information, please see https://access.redhat.com/solutions/XXXX
System Purpose Status: Matched
```

**Test Updates:** The test files have been updated to ensure that the new product key parsing is properly handled, ensuring correctness across different types of content.


Pytest report:
```
 insights-core   parser_enhance_subsmngrstatus  pytest -v insights/tests/parsers/test_subscription_manager.py
================================================= test session starts ==================================================
platform darwin -- Python 3.11.4, pytest-7.4.3, pluggy-1.3.0 -- /Users/rahushar/virtualenvs/gss-rules/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/rahushar/Projects/insights-core
configfile: setup.cfg
plugins: cov-4.1.0
collected 7 items

insights/tests/parsers/test_subscription_manager.py::test_subman_facts PASSED                                    [ 14%]
insights/tests/parsers/test_subscription_manager.py::test_subman_id PASSED                                       [ 28%]
insights/tests/parsers/test_subscription_manager.py::test_subman_status PASSED                                   [ 42%]
insights/tests/parsers/test_subscription_manager.py::test_subman_facts_ng PASSED                                 [ 57%]
insights/tests/parsers/test_subscription_manager.py::test_subman_id_ng PASSED                                    [ 71%]
insights/tests/parsers/test_subscription_manager.py::test_subman_status_ng PASSED                                [ 85%]
insights/tests/parsers/test_subscription_manager.py::test_doc_examples PASSED                                    [100%]

================================================== 7 passed in 0.04s ===================================================
```