### PR TITLE
fix(client): Display correct Insights URL

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -409,7 +409,7 @@ def upload(config, pconn, tar_file, content_type, collection_duration=None):
             logger.info("Successfully uploaded report for %s.", msg_name)
             if config.register:
                 # direct to console after register + upload
-                logger.info('View the Red Hat Insights console at https://console.redhat.com/insights/')
+                display_console_url(config)
             return
         elif upload.status_code in (413, 415):
             pconn.handle_fail_rcs(upload)
@@ -432,3 +432,10 @@ def display_upload_error_and_retry(config, tries, error_message):
         logger.error("All attempts to upload have failed!")
         print("Please see %s for additional information" % config.logging_file)
         raise RuntimeError('Upload failed.')
+
+
+def display_console_url(config):
+    console_url = "https://console.redhat.com/insights/"
+    if "stage" in config.base_url:
+        console_url = "https://console.stage.redhat.com/insights/"
+    logger.info("View the Red Hat Insights console at %s" % console_url)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
* Card ID: CCT-1008

With the introduction of IoP, the `insights-client` should display the correct URL for the respective environment. The client differentiates between Hosted, Stage Hosted, and IoP environments during registration.