### PR TITLE
feat: Print config on connection test

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -326,7 +326,7 @@ def collect(config):
     pc = InsightsUploadConf(config)
     dc = CoreCollector(config)
 
-    logger.info('Starting to collect Insights data for %s' % determine_hostname(config.display_name))
+    logger.info('* Starting to collect Insights data for %s' % detsermine_hostname(config.display_name))
 
     dc.run_collection(pc.get_rm_conf(),
                       get_branch_info(config),

--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -388,6 +388,76 @@ class InsightsConnection(object):
             raise
 
     def test_connection(self, rc=0):
+        logger.info("Running Connection Tests...")
+        if self.config.legacy_upload:
+            return self._legacy_test_connection(rc)
+
+        authentication_failures = []
+        if self.authmethod == "BASIC":
+            logger.info("\nAuthentication: login credentials ({})".format(self.authmethod))
+
+            for credential_description, var, placeholder in [
+                ("Username", self.username, None),
+                ("Password", self.password, "********"),
+            ]:
+                if not var:
+                    authentication_failure = "{} not set.".format(credential_description)
+                    authentication_failures.append(authentication_failure)
+
+                val = placeholder or var if var else "not set"
+                logger.info("  %s: %s", credential_description, val)
+        elif self.authmethod == "CERT":
+            logger.info("\nAuthentication: identity certificate ({})".format(self.authmethod))
+
+            for path_description, path_func in [
+                ("Certificate", rhsmCertificate.certpath),
+                ("Key", rhsmCertificate.keypath),
+            ]:
+                path = path_func()
+                exists = os.path.exists(path)
+                if exists:
+                    exists_description = "exists"
+                else:
+                    exists_description = "NOT FOUND"
+                    authentication_failure = "{} file '{}' missing.".format(path_description, path)
+                    authentication_failures.append(authentication_failure)
+                logger.info("  %s: %s (%s)", path_description, path, exists_description)
+        else:
+            logger.info("\nAuthentication: unknown")
+            authentication_failures = ["Unknown authentication method '{}'.".format(self.authmethod)]
+
+        if authentication_failures:
+            logger.error("\nERROR. Cannot authenticate:")
+            for authentication_failure in authentication_failures:
+                logger.error("  %s", authentication_failure)
+
+            return 1
+
+        base_url_parsed = urlparse(self.base_url)
+        if base_url_parsed.hostname.endswith("stage.redhat.com"):
+            hostname_description = "Red Hat staging"
+        elif base_url_parsed.hostname.endswith("redhat.com"):
+            hostname_description = "Red Hat production"
+        else:
+            hostname_description = "Satellite 6 server"
+        logger.info("\nConnecting to: %s", hostname_description)
+
+        logger.info("  Base URL: %s", self.base_url)
+        logger.info("  Upload URL: %s", self.upload_url)
+        logger.info("  Inventory URL: %s", self.inventory_url)
+
+        ping_url = self.base_url + '/apicast-tests/ping'
+        logger.info("  Ping URL: %s", ping_url)
+
+        if self.proxies:
+            for proxy_type, proxy_url in self.proxies.items():
+                logger.info("  %s proxy: %s", proxy_type.upper(), proxy_url)
+        else:
+            logger.info("  Proxy: not set")
+
+        return rc
+
+    def _legacy_test_connection(self, rc=0):
         """
         Test connection to Red Hat
         """
@@ -1184,3 +1254,15 @@ class InsightsConnection(object):
         cleaner = spec_cleaner.Cleaner(self.config, pc.get_rm_conf())
         obf_funcs = cleaner.get_obfuscate_functions()
         return _deep_clean(cfacts)
+
+
+URL_DESCRIPTIONS = {
+    "": "Red Hat production (default)",
+    "production": "Red Hat production",
+    "staging": "Red Hat staging",
+    "satellite": "Satellite",
+}
+
+def url_description(url):
+    environment = os.getenv("FAKE_ENVIRONMENT", "").lower()
+    return URL_DESCRIPTIONS[environment] if environment in URL_DESCRIPTIONS else URL_DESCRIPTIONS[""]

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -97,7 +97,6 @@ def pre_update(client, config):
 
     # test the insights connection
     if config.test_connection:
-        logger.info("Running Connection Tests...")
         rc = client.test_connection()
         if rc == 0:
             sys.exit(constants.sig_kill_ok)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

For non-legacy, `--test-connection` dumps a user-friendly connection configuration.

First, the authentication information is printed starting with type. For `BASIC`, username is printed. For `CERT`, certificate and key paths are verified and printed. In case of missing files or credentials, the connection test fails immediately.

Second, tested URLs (base, Ingress, Inventory, API cast) are listed and server type (production, staging, Satellite) is determined. HTTPS proxy information is included.

Card IDs:
* [CCT-963](https://issues.redhat.com/browse/CCT-963)