### PR TITLE
feat: enhance add_filter to support the max matched lines 

### DIFF
--- a/insights/core/filters.py
+++ b/insights/core/filters.py
@@ -107,6 +107,11 @@ def add_filter(component, patterns, max_match=MAX_MATCH):
 
         FILTERS[comp].update(max_matchs(FILTERS[comp], patterns))
 
+    if max_match is None or type(max_match) is not int or max_match <= 0:
+        raise Exception(
+            "Invalid argument: {0}. It can only be a positive integer.".format(max_match)
+        )
+
     if not plugins.is_datasource(component):
         deps = get_dependency_datasources(component)
         if deps:

--- a/insights/core/spec_cleaner.py
+++ b/insights/core/spec_cleaner.py
@@ -11,6 +11,8 @@ The following processes will be applied to clean the collected specs:
   Obfuscate the IP or Hostname appears in the spec content according to the
   specs native requirement and user configuration.
 
+- Filtering
+  Filter line as per the allow list got from the "filters.yaml"
 """
 
 import logging
@@ -360,7 +362,7 @@ class Cleaner(object):
             for a_key in list(allow_info.keys()):
                 # keep line when any filter match
                 # FIXME:
-                # Considering performance, din't handle multiple filters in one same line
+                # Considering performance, didn't handle multiple filters in one same line
                 if a_key in line:
                     allow_info[a_key] -= 1
                     # stop checking it when enough lines contain the key were found

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -61,7 +61,7 @@ class ContentProvider(object):
         self._content = None
         self._exception = None
         self._filterable = False
-        self._filters = set()
+        self._filters = dict()
 
     def load(self):
         raise NotImplementedError()
@@ -95,7 +95,7 @@ class ContentProvider(object):
             allowlist = None
             if self._filterable:
                 cleans.append("Filter")
-                allowlist = dict((f, filters.MATCH_COUNT) for f in self._filters)
+                allowlist = self._filters
             # Cleaning - Entry
             if cleans:
                 log.debug("Cleaning (%s) %s", "/".join(cleans), self.relative_path)
@@ -208,7 +208,7 @@ class FileProvider(ContentProvider):
             if self.ds and filters.ENABLED
             else False
         )
-        self._filters = filters.get_filters(self.ds) if self.ds else set()
+        self._filters = filters.get_filters(self.ds, True) if self.ds else set()
 
         self.validate()
 
@@ -361,7 +361,7 @@ class CommandOutputProvider(ContentProvider):
             if self.ds and filters.ENABLED
             else False
         )
-        self._filters = filters.get_filters(self.ds) if self.ds else set()
+        self._filters = filters.get_filters(self.ds, True) if self.ds else set()
 
         self.validate()
 

--- a/insights/tests/core/test_filters.py
+++ b/insights/tests/core/test_filters.py
@@ -200,6 +200,24 @@ def test_add_filter_exception_None():
         filters.add_filter(Specs.ps_aux, None)
 
 
+def test_add_filter_exception_with_invalid_max_match():
+    with pytest.raises(Exception) as ex:
+        filters.add_filter(Specs.ps_aux, 'abctest', 'str')
+    assert "Invalid argument: str" in str(ex)
+
+    with pytest.raises(Exception) as ex:
+        filters.add_filter(Specs.ps_aux, 'abctest', 0)
+    assert "Invalid argument: 0" in str(ex)
+
+    with pytest.raises(Exception) as ex:
+        filters.add_filter(Specs.ps_aux, 'abctest', -1)
+    assert "Invalid argument: -1" in str(ex)
+
+    with pytest.raises(Exception) as ex:
+        filters.add_filter(Specs.ps_aux, 'abctest', None)
+    assert "Invalid argument: None" in str(ex)
+
+
 def test_get_filters():
     _filter = 'A filter'
     filters.add_filter(MySpecs.has_filters, _filter)

--- a/insights/tests/datasources/container/test_containers_inspect.py
+++ b/insights/tests/datasources/container/test_containers_inspect.py
@@ -9,8 +9,11 @@ from insights.core.exceptions import SkipComponent
 from insights.core.spec_factory import DatasourceProvider
 from insights.specs import Specs
 from insights.specs.datasources.container import running_rhel_containers
-from insights.specs.datasources.container.containers_inspect import (LocalSpecs, containers_inspect_data_datasource,
-                                                                     running_rhel_containers_id)
+from insights.specs.datasources.container.containers_inspect import (
+    LocalSpecs,
+    containers_inspect_data_datasource,
+    running_rhel_containers_id,
+)
 
 
 INSPECT_1 = """
@@ -908,34 +911,83 @@ CONTAINERS_ID_EXPECTED_RESULT = [
     ('podman', '28fb57be8bb204e652c472a406e0d99956c8d35d6e88abfc13253d101a00911e'),
     ('podman', '528890e93bf71736e00a87c7a1fa33e5bb03a9a196e5b10faaa9e545e749aa54'),
     ('docker', '38fb57be8bb204e652c472a406e0d99956c8d35d6e88abfc13253d101a00911e'),
-    ('docker', '538890e93bf71736e00a87c7a1fa33e5bb03a9a196e5b10faaa9e545e749aa54')
+    ('docker', '538890e93bf71736e00a87c7a1fa33e5bb03a9a196e5b10faaa9e545e749aa54'),
 ]
 
-EXPECTED_RESULT = [{'Id': 'aeaea3ead527', 'engine': 'podman', 'Image': '538460c14d75dee1504e56ad8ddb7fe039093b1530ef8f90442a454b9aa3dc8b', 'Config|Cmd': ["sleep", "1000000"], 'HostConfig|Privileged': False}, {'Id': '28fb57be8bb2', 'engine': 'podman', 'Image': '538460c14d75dee1504e56ad8ddb7fe039093b1530ef8f90442a454b9aa3dc8b', 'Config|Cmd': ["sleep", "1000000"], 'HostConfig|Privileged': True}, {'Id': 'c7efee959ea8', 'engine': 'docker', 'Image': 'acf3e09a39c95d354539b6591298be0b0814f5d74e95e722863241192b9a079b', 'Config|Cmd': ["sleep", "1000000"], 'HostConfig|Privileged': True}]
+EXPECTED_RESULT = [
+    {
+        'Id': 'aeaea3ead527',
+        'engine': 'podman',
+        'Image': '538460c14d75dee1504e56ad8ddb7fe039093b1530ef8f90442a454b9aa3dc8b',
+        'Config|Cmd': ["sleep", "1000000"],
+        'HostConfig|Privileged': False,
+    },
+    {
+        'Id': '28fb57be8bb2',
+        'engine': 'podman',
+        'Image': '538460c14d75dee1504e56ad8ddb7fe039093b1530ef8f90442a454b9aa3dc8b',
+        'Config|Cmd': ["sleep", "1000000"],
+        'HostConfig|Privileged': True,
+    },
+    {
+        'Id': 'c7efee959ea8',
+        'engine': 'docker',
+        'Image': 'acf3e09a39c95d354539b6591298be0b0814f5d74e95e722863241192b9a079b',
+        'Config|Cmd': ["sleep", "1000000"],
+        'HostConfig|Privileged': True,
+    },
+]
 
 EXPECTED_RESULT_NG = [{'Id': '28fb57be8bb2', 'engine': 'podman'}]
 
 
 def setup_function(func):
-    if func is test_containers_inspect_datasource or func is test_containers_inspect_datasource_NG_output_1 or func is test_containers_inspect_datasource_NG_output_2:
-        filters.add_filter(Specs.container_inspect_keys, ["HostConfig|Privileged", "NoSuchKey|Privileged", "Config|Cmd", "Id", "Image"])
+    if (
+        func is test_containers_inspect_datasource
+        or func is test_containers_inspect_datasource_NG_output_1
+        or func is test_containers_inspect_datasource_NG_output_2
+    ):
+        filters.add_filter(
+            Specs.container_inspect_keys,
+            ["HostConfig|Privileged", "NoSuchKey|Privileged", "Config|Cmd", "Id", "Image"],
+        )
     if func is test_containers_inspect_datasource_no_filter:
         filters.add_filter(Specs.container_inspect_keys, [])
 
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 def test_running_rhel_containers_id():
     broker = dr.Broker()
     containers_info = [
-        ("registry.access.redhat.com/rhel", "podman", "aeaea3ead52724bb525bb2b5c619d67836250756920f0cb9884431ba53b476d8"),
-        ("registry.access.redhat.com/rhel", "podman", "28fb57be8bb204e652c472a406e0d99956c8d35d6e88abfc13253d101a00911e"),
-        ("registry.access.redhat.com/rhel", "podman", "528890e93bf71736e00a87c7a1fa33e5bb03a9a196e5b10faaa9e545e749aa54"),
-        ("registry.access.redhat.com/rhel", "docker", "38fb57be8bb204e652c472a406e0d99956c8d35d6e88abfc13253d101a00911e"),
-        ("registry.access.redhat.com/rhel", "docker", "538890e93bf71736e00a87c7a1fa33e5bb03a9a196e5b10faaa9e545e749aa54")
+        (
+            "registry.access.redhat.com/rhel",
+            "podman",
+            "aeaea3ead52724bb525bb2b5c619d67836250756920f0cb9884431ba53b476d8",
+        ),
+        (
+            "registry.access.redhat.com/rhel",
+            "podman",
+            "28fb57be8bb204e652c472a406e0d99956c8d35d6e88abfc13253d101a00911e",
+        ),
+        (
+            "registry.access.redhat.com/rhel",
+            "podman",
+            "528890e93bf71736e00a87c7a1fa33e5bb03a9a196e5b10faaa9e545e749aa54",
+        ),
+        (
+            "registry.access.redhat.com/rhel",
+            "docker",
+            "38fb57be8bb204e652c472a406e0d99956c8d35d6e88abfc13253d101a00911e",
+        ),
+        (
+            "registry.access.redhat.com/rhel",
+            "docker",
+            "538890e93bf71736e00a87c7a1fa33e5bb03a9a196e5b10faaa9e545e749aa54",
+        ),
     ]
     broker[running_rhel_containers] = containers_info
     result = running_rhel_containers_id(broker)
@@ -952,7 +1004,13 @@ def test_containers_inspect_datasource():
     containers_inspect_data_2.cmd = "/usr/bin/podman inspect 28fb57be8bb2"
     containers_inspect_data_3.content = INSPECT_3.splitlines()
     containers_inspect_data_3.cmd = "/usr/bin/docker inspect c7efee959ea8"
-    broker = {LocalSpecs.containers_inspect_data_raw: [containers_inspect_data_1, containers_inspect_data_2, containers_inspect_data_3]}
+    broker = {
+        LocalSpecs.containers_inspect_data_raw: [
+            containers_inspect_data_1,
+            containers_inspect_data_2,
+            containers_inspect_data_3,
+        ]
+    }
     result = containers_inspect_data_datasource(broker)
     assert result is not None
     assert isinstance(result, DatasourceProvider)
@@ -968,7 +1026,12 @@ def test_containers_inspect_datasource_no_filter():
     containers_inspect_data_1.cmd = "/usr/bin/docker inspect aeaea3ead527"
     containers_inspect_data_2.content = INSPECT_2.splitlines()
     containers_inspect_data_2.cmd = "/usr/bin/podman inspect 28fb57be8bb2"
-    broker = {LocalSpecs.containers_inspect_data_raw: [containers_inspect_data_1, containers_inspect_data_2]}
+    broker = {
+        LocalSpecs.containers_inspect_data_raw: [
+            containers_inspect_data_1,
+            containers_inspect_data_2,
+        ]
+    }
     with pytest.raises(SkipComponent) as e:
         containers_inspect_data_datasource(broker)
     assert 'SkipComponent' in str(e)
@@ -982,7 +1045,9 @@ def test_containers_inspect_datasource_NG_output_1():
     result = containers_inspect_data_datasource(broker)
     assert result is not None
     assert isinstance(result, DatasourceProvider)
-    expected = DatasourceProvider(content=json.dumps(EXPECTED_RESULT_NG), relative_path=RELATIVE_PATH)
+    expected = DatasourceProvider(
+        content=json.dumps(EXPECTED_RESULT_NG), relative_path=RELATIVE_PATH
+    )
     assert result.content[0] == expected.content[0]
     assert result.relative_path == expected.relative_path
 

--- a/insights/tests/datasources/test_awx_manage.py
+++ b/insights/tests/datasources/test_awx_manage.py
@@ -8,7 +8,10 @@ from insights.core import filters
 from insights.core.exceptions import SkipComponent
 from insights.core.spec_factory import DatasourceProvider
 from insights.specs import Specs
-from insights.specs.datasources.awx_manage import LocalSpecs, awx_manage_check_license_data_datasource
+from insights.specs.datasources.awx_manage import (
+    LocalSpecs,
+    awx_manage_check_license_data_datasource,
+)
 
 
 AWX_MANAGE_LICENSE = """
@@ -23,22 +26,28 @@ AWX_MANAGE_FILTER_JSON = {
     "license_type": "enterprise",
     "time_remaining": 29885220,
     "instance_count": 100,
-    "support_level": "Standard"
+    "support_level": "Standard",
 }
 
 RELATIVE_PATH = 'insights_commands/awx-manage_check_license_--data'
 
 
 def setup_function(func):
-    if func is test_ansible_tower_license_datasource or func is test_ansible_tower_license_datasource_NG_output:
-        filters.add_filter(Specs.awx_manage_check_license_data, ["license_type", "support_level", "instance_count", "time_remaining"])
+    if (
+        func is test_ansible_tower_license_datasource
+        or func is test_ansible_tower_license_datasource_NG_output
+    ):
+        filters.add_filter(
+            Specs.awx_manage_check_license_data,
+            ["license_type", "support_level", "instance_count", "time_remaining"],
+        )
     if func is test_ansible_tower_license_datasource_no_filter:
         filters.add_filter(Specs.awx_manage_check_license_data, [])
 
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 def test_ansible_tower_license_datasource():
@@ -48,7 +57,10 @@ def test_ansible_tower_license_datasource():
     result = awx_manage_check_license_data_datasource(broker)
     assert result is not None
     assert isinstance(result, DatasourceProvider)
-    expected = DatasourceProvider(content=json.dumps(OrderedDict(sorted(AWX_MANAGE_FILTER_JSON.items()))), relative_path=RELATIVE_PATH)
+    expected = DatasourceProvider(
+        content=json.dumps(OrderedDict(sorted(AWX_MANAGE_FILTER_JSON.items()))),
+        relative_path=RELATIVE_PATH,
+    )
     assert result.content == expected.content
     assert result.relative_path == expected.relative_path
 

--- a/insights/tests/datasources/test_cloud_init.py
+++ b/insights/tests/datasources/test_cloud_init.py
@@ -87,7 +87,7 @@ def setup_function(func):
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 @pytest.mark.parametrize("ssh_deletekeys", [0, 1])

--- a/insights/tests/datasources/test_dir_list.py
+++ b/insights/tests/datasources/test_dir_list.py
@@ -17,7 +17,7 @@ def setup_function(func):
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 def test_du_dirs_list():

--- a/insights/tests/datasources/test_kernel_module_list.py
+++ b/insights/tests/datasources/test_kernel_module_list.py
@@ -43,7 +43,7 @@ def setup_function(func):
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 def test_module_filters():

--- a/insights/tests/datasources/test_ls.py
+++ b/insights/tests/datasources/test_ls.py
@@ -57,7 +57,7 @@ def setup_function(func):
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 def test_la_empty():

--- a/insights/tests/datasources/test_lsattr.py
+++ b/insights/tests/datasources/test_lsattr.py
@@ -14,12 +14,14 @@ def setup_function(func):
     if func is test_lsattr_one_file:
         filters.add_filter(Specs.lsattr_files_or_dirs, ["/etc/default/grub"])
     if func is test_lsattr_more_files:
-        filters.add_filter(Specs.lsattr_files_or_dirs, ["/etc/default/grub", "/etc/httpd/httpd.conf"])
+        filters.add_filter(
+            Specs.lsattr_files_or_dirs, ["/etc/default/grub", "/etc/httpd/httpd.conf"]
+        )
 
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 def test_lsattr_empty():

--- a/insights/tests/datasources/test_machine_ids.py
+++ b/insights/tests/datasources/test_machine_ids.py
@@ -32,13 +32,10 @@ class MockInsightsConnection(object):
                             "insights_id": "95160ae3-1ee1-40e1-9666-316dbb9270dd",
                             "subscription_manager_id": "a5a71082-1d09-4fc8-bffc-ad326e24df6a",
                             "satellite_id": None,
-                            "ip_addresses": [
-                                "10.0.222.82"
-                            ],
+                            "ip_addresses": ["10.0.222.82"],
                             "fqdn": "hostname1.compute.internal",
-
                         }
-                    ]
+                    ],
                 }
             )
         elif url.endswith('deff'):
@@ -53,23 +50,17 @@ class MockInsightsConnection(object):
                             "insights_id": "95160ae3-1ee1-40e1-9666-316dbb927ff1",
                             "subscription_manager_id": "sfwerwfsf-1d09-4fc8-bffc-sfxcsfsf",
                             "satellite_id": None,
-                            "ip_addresses": [
-                                "10.0.222.82"
-                            ],
+                            "ip_addresses": ["10.0.222.82"],
                             "fqdn": "hostname1.compute.internal",
-
                         },
                         {
                             "insights_id": "95160ae3-1ee1-40e1-9666-316dbb927ff1",
                             "subscription_manager_id": "sfweswersf-1d09-4fc8-bffc-sfxcssdf",
                             "satellite_id": None,
-                            "ip_addresses": [
-                                "10.0.222.83"
-                            ],
+                            "ip_addresses": ["10.0.222.83"],
                             "fqdn": "hostname2.compute.internal",
-
-                        }
-                    ]
+                        },
+                    ],
                 }
             )
         elif url.endswith('wrong'):
@@ -83,7 +74,13 @@ class Result(object):
 
 
 def setup_function(func):
-    if func in [test_duplicate, test_non_duplicate, test_wrong_machine_id_content, test_machine_id_not_in_filters, test_api_result_not_in_json_format]:
+    if func in [
+        test_duplicate,
+        test_non_duplicate,
+        test_wrong_machine_id_content,
+        test_machine_id_not_in_filters,
+        test_api_result_not_in_json_format,
+    ]:
         filters.add_filter(Specs.duplicate_machine_id, ["dc194312-8cdd-4e75-8cf1-2094bfsfsdeff"])
         filters.add_filter(Specs.duplicate_machine_id, ["dc194312-8cdd-4e75-8cf1-2094bf45678"])
         filters.add_filter(Specs.duplicate_machine_id, ["dc194312-8cdd-4e75-8cf1-2094bfwrong"])
@@ -93,81 +90,100 @@ def setup_function(func):
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
-@patch('insights.specs.datasources.machine_ids.get_connection',
-       return_value=MockInsightsConnection())
+@patch(
+    'insights.specs.datasources.machine_ids.get_connection', return_value=MockInsightsConnection()
+)
 def test_duplicate(conn):
     broker = {
         Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsdeff']),
-        'client_config': InsightsConfig(legacy_upload=False)
+        'client_config': InsightsConfig(legacy_upload=False),
     }
     result = dup_machine_id_info(broker)
-    expected = DatasourceProvider(content=["dc194312-8cdd-4e75-8cf1-2094bfsfsdeff hostname1.compute.internal,hostname2.compute.internal"], relative_path='insights_commands/duplicate_machine_id_info')
+    expected = DatasourceProvider(
+        content=[
+            "dc194312-8cdd-4e75-8cf1-2094bfsfsdeff hostname1.compute.internal,hostname2.compute.internal"
+        ],
+        relative_path='insights_commands/duplicate_machine_id_info',
+    )
     assert expected.content == result.content
     assert expected.relative_path == result.relative_path
 
     broker = {
         Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsdeff']),
-        'client_config': InsightsConfig(legacy_upload=True)
+        'client_config': InsightsConfig(legacy_upload=True),
     }
     result = dup_machine_id_info(broker)
-    expected = DatasourceProvider(content=["dc194312-8cdd-4e75-8cf1-2094bfsfsdeff hostname1.compute.internal,hostname2.compute.internal"], relative_path='insights_commands/duplicate_machine_id_info')
+    expected = DatasourceProvider(
+        content=[
+            "dc194312-8cdd-4e75-8cf1-2094bfsfsdeff hostname1.compute.internal,hostname2.compute.internal"
+        ],
+        relative_path='insights_commands/duplicate_machine_id_info',
+    )
     assert expected.content == result.content
     assert expected.relative_path == result.relative_path
 
 
-@patch('insights.specs.datasources.machine_ids.get_connection',
-       return_value=MockInsightsConnection())
+@patch(
+    'insights.specs.datasources.machine_ids.get_connection', return_value=MockInsightsConnection()
+)
 def test_non_duplicate(conn):
     broker = {
         Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bf45678']),
-        'client_config': InsightsConfig(legacy_upload=False)
+        'client_config': InsightsConfig(legacy_upload=False),
     }
     with pytest.raises(SkipComponent):
         dup_machine_id_info(broker)
 
 
-@patch('insights.specs.datasources.machine_ids.get_connection',
-       return_value=MockInsightsConnection())
+@patch(
+    'insights.specs.datasources.machine_ids.get_connection', return_value=MockInsightsConnection()
+)
 def test_module_filters_empty(conn):
     broker = {
         Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsdeff']),
-        'client_config': InsightsConfig(legacy_upload=False)
+        'client_config': InsightsConfig(legacy_upload=False),
     }
     with pytest.raises(SkipComponent):
         dup_machine_id_info(broker)
 
 
-@patch('insights.specs.datasources.machine_ids.get_connection',
-       return_value=MockInsightsConnection())
+@patch(
+    'insights.specs.datasources.machine_ids.get_connection', return_value=MockInsightsConnection()
+)
 def test_wrong_machine_id_content(conn):
     broker = {
-        Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsdeff', 'dc194312-8cdd-4e75-8cf1-2094bfsf45678']),
-        'client_config': InsightsConfig(legacy_upload=False)
+        Specs.machine_id: context_wrap(
+            lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsdeff', 'dc194312-8cdd-4e75-8cf1-2094bfsf45678']
+        ),
+        'client_config': InsightsConfig(legacy_upload=False),
     }
     with pytest.raises(SkipComponent):
         dup_machine_id_info(broker)
 
 
-@patch('insights.specs.datasources.machine_ids.get_connection',
-       return_value=MockInsightsConnection())
+@patch(
+    'insights.specs.datasources.machine_ids.get_connection', return_value=MockInsightsConnection()
+)
 def test_machine_id_not_in_filters(conn):
     broker = {
         Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfsfsabc']),
-        'client_config': InsightsConfig(legacy_upload=False)
+        'client_config': InsightsConfig(legacy_upload=False),
     }
     with pytest.raises(SkipComponent):
         dup_machine_id_info(broker)
 
 
-@patch('insights.specs.datasources.machine_ids.get_connection',
-       return_value=MockInsightsConnection("wrong"))
+@patch(
+    'insights.specs.datasources.machine_ids.get_connection',
+    return_value=MockInsightsConnection("wrong"),
+)
 def test_api_result_not_in_json_format(conn):
     broker = {
         Specs.machine_id: context_wrap(lines=['dc194312-8cdd-4e75-8cf1-2094bfwrong']),
-        'client_config': InsightsConfig(legacy_upload=False)
+        'client_config': InsightsConfig(legacy_upload=False),
     }
     with pytest.raises(SkipComponent):
         dup_machine_id_info(broker)

--- a/insights/tests/datasources/test_package_provides.py
+++ b/insights/tests/datasources/test_package_provides.py
@@ -28,27 +28,63 @@ class FakeContext(HostContext):
         arg = tmp_cmd[-1]
         if 'readlink' in shell_cmd:
             if arg == JAVA_PATH_1:
-                return (0, [JAVA_PATH_2, ])
+                return (
+                    0,
+                    [
+                        JAVA_PATH_2,
+                    ],
+                )
             elif arg == JAVA_PATH_ERR:
-                return (1, ['file not found', ])
+                return (
+                    1,
+                    [
+                        'file not found',
+                    ],
+                )
             elif arg.startswith('/'):
-                return (0, [arg, ])
+                return (
+                    0,
+                    [
+                        arg,
+                    ],
+                )
         elif 'rpm' in shell_cmd:
             if arg == JAVA_PATH_2:
-                return (0, [JAVA_PKG_2, ])
+                return (
+                    0,
+                    [
+                        JAVA_PKG_2,
+                    ],
+                )
             elif arg == HTTPD_PATH:
-                return (0, [HTTPD_PKG, ])
+                return (
+                    0,
+                    [
+                        HTTPD_PKG,
+                    ],
+                )
             else:
-                return (1, ['file {0} is not owned by any package'.format(arg), ])
+                return (
+                    1,
+                    [
+                        'file {0} is not owned by any package'.format(arg),
+                    ],
+                )
         elif 'which' in shell_cmd:
             if 'exception' in arg:
                 raise Exception()
             elif arg.startswith('/'):
-                return [tmp_cmd[-1], ]
+                return [
+                    tmp_cmd[-1],
+                ]
             elif arg.endswith('java'):
-                return ['/usr/bin/java', ]
+                return [
+                    '/usr/bin/java',
+                ]
             elif arg.endswith('httpd'):
-                return ['/usr/sbin/httpd', ]
+                return [
+                    '/usr/sbin/httpd',
+                ]
 
         raise Exception()
 
@@ -62,7 +98,7 @@ def setup_function(func):
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 def test_get_package():
@@ -71,7 +107,9 @@ def test_get_package():
     result = get_package(ctx, '/usr/bin/java')
     assert result == 'java-1.8.0-openjdk-headless-1.8.0.292.b10-1.el7_9.x86_64'
 
-    result = get_package(ctx, '/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.292.b10-1.el7_9.x86_64/jre/bin/java')
+    result = get_package(
+        ctx, '/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.292.b10-1.el7_9.x86_64/jre/bin/java'
+    )
     assert result == 'java-1.8.0-openjdk-headless-1.8.0.292.b10-1.el7_9.x86_64'
 
 
@@ -106,12 +144,14 @@ PS_EO_CMD = """
 """
 
 EXPECTED = DatasourceProvider(
-    "\n".join([
-        "{0} {1}".format(HTTPD_PATH, HTTPD_PKG),
-        "{0} {1}".format(JAVA_PATH_1, JAVA_PKG_2),
-        "{0} {1}".format(JAVA_PATH_2, JAVA_PKG_2)
-    ]),
-    relative_path='insights_commands/package_provides_command'
+    "\n".join(
+        [
+            "{0} {1}".format(HTTPD_PATH, HTTPD_PKG),
+            "{0} {1}".format(JAVA_PATH_1, JAVA_PKG_2),
+            "{0} {1}".format(JAVA_PATH_2, JAVA_PKG_2),
+        ]
+    ),
+    relative_path='insights_commands/package_provides_command',
 )
 
 

--- a/insights/tests/datasources/test_rpm_pkgs.py
+++ b/insights/tests/datasources/test_rpm_pkgs.py
@@ -29,12 +29,25 @@ RELATIVE_PATH = "insights_commands/rpm_pkgs"
 
 def setup_function(func):
     if func is test_rpm_v_pkgs:
-        filters.add_filter(Specs.rpm_V_package_list, ['coreutils', 'procps', 'procps-ng', 'shadow-utils', 'passwd', 'sudo', 'chrony', 'findutils', 'glibc'])
+        filters.add_filter(
+            Specs.rpm_V_package_list,
+            [
+                'coreutils',
+                'procps',
+                'procps-ng',
+                'shadow-utils',
+                'passwd',
+                'sudo',
+                'chrony',
+                'findutils',
+                'glibc',
+            ],
+        )
 
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 def get_users():
@@ -77,4 +90,14 @@ def test_pkgs_list_empty():
 
 def test_rpm_v_pkgs():
     ret = rpm_v_pkg_list({})
-    assert ret == ['chrony', 'coreutils', 'findutils', 'glibc', 'passwd', 'procps', 'procps-ng', 'shadow-utils', 'sudo']
+    assert ret == [
+        'chrony',
+        'coreutils',
+        'findutils',
+        'glibc',
+        'passwd',
+        'procps',
+        'procps-ng',
+        'shadow-utils',
+        'sudo',
+    ]

--- a/insights/tests/datasources/test_semanage.py
+++ b/insights/tests/datasources/test_semanage.py
@@ -43,15 +43,13 @@ def setup_function(func):
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 def test_linux_users_count_map_staff_u():
     selinux_list = Mock()
     selinux_list.content = SEMANGE_LOGIN_LIST_OUTPUT1.splitlines()
-    broker = {
-        LocalSpecs.selinux_user_mapping: selinux_list
-    }
+    broker = {LocalSpecs.selinux_user_mapping: selinux_list}
     result = users_count_map_selinux_user(broker)
     assert result is not None
     assert isinstance(result, DatasourceProvider)
@@ -64,9 +62,7 @@ def test_linux_users_count_map_staff_u():
 def test_linux_users_count_map_more_selinux_users():
     selinux_list = Mock()
     selinux_list.content = SEMANGE_LOGIN_LIST_OUTPUT1.splitlines()
-    broker = {
-        LocalSpecs.selinux_user_mapping: selinux_list
-    }
+    broker = {LocalSpecs.selinux_user_mapping: selinux_list}
     result = users_count_map_selinux_user(broker)
     assert result is not None
     assert isinstance(result, DatasourceProvider)
@@ -79,8 +75,6 @@ def test_linux_users_count_map_more_selinux_users():
 def test_linux_users_count_map_staff_u_except():
     selinux_list = Mock()
     selinux_list.content = SEMANGE_LOGIN_LIST_OUTPUT2.splitlines()
-    broker = {
-        LocalSpecs.selinux_user_mapping: selinux_list
-    }
+    broker = {LocalSpecs.selinux_user_mapping: selinux_list}
     with pytest.raises(SkipComponent):
         users_count_map_selinux_user(broker)

--- a/insights/tests/datasources/test_user_group.py
+++ b/insights/tests/datasources/test_user_group.py
@@ -17,7 +17,7 @@ def setup_function(func):
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 def test_group_filters():

--- a/insights/tests/parsers/test_messages.py
+++ b/insights/tests/parsers/test_messages.py
@@ -19,26 +19,16 @@ Apr 22 10:40:01 boy-bona CROND[30677]: (root) CMD (/usr/lib64/sa/sa1 -S DISK 1 1
 Apr 22 10:41:13 boy-bona crontab[32515]: (root) LIST (root)
 """.strip()
 
-filters.add_filter(Specs.messages, [
-    "LIST",
-    "CROND",
-    "jabberd",
-    "Wrapper",
-    "Launching",
-    "yum"
-])
+filters.add_filter(Specs.messages, ["LIST", "CROND", "jabberd", "Wrapper", "Launching", "yum"])
 
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 def test_doc_examples():
-    env = {
-        'msgs': messages.Messages(context_wrap(MSGINFO)),
-        'Messages': messages.Messages
-    }
+    env = {'msgs': messages.Messages(context_wrap(MSGINFO)), 'Messages': messages.Messages}
     failed, total = doctest.testmod(messages, globs=env)
     assert failed == 0
 
@@ -54,5 +44,8 @@ def test_messages():
     assert crond[0].get('procname') == "CROND[27921]"
     assert msg_info.get('jabberd/sm[11057]')[0].get('hostname') == "lxc-rhel68-sat56"
     assert msg_info.get('Wrapper')[0].get('message') == "--> Wrapper Started as Daemon"
-    assert msg_info.get('Launching')[0].get('raw_message') == "May 18 15:13:36 lxc-rhel68-sat56 wrapper[11375]: Launching a JVM..."
+    assert (
+        msg_info.get('Launching')[0].get('raw_message')
+        == "May 18 15:13:36 lxc-rhel68-sat56 wrapper[11375]: Launching a JVM..."
+    )
     assert 2 == len(msg_info.get('yum'))

--- a/insights/tests/parsers/test_rhsm_log.py
+++ b/insights/tests/parsers/test_rhsm_log.py
@@ -30,24 +30,27 @@ LOG3 = """
 2011-12-27-08:41:13,104 [ERROR]  @managercli.py:66 - certificate verify failed
 """
 
-filters.add_filter(Specs.rhsm_log, [
-    "[ERROR]",
-    "[Errno"
-])
+filters.add_filter(Specs.rhsm_log, ["[ERROR]", "[Errno"])
 
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 def test_rhsm_log():
     rlog = RhsmLog(context_wrap(LOG1))
     ern_list = rlog.get('[Errno -2]')
     assert 1 == len(ern_list)
-    assert ern_list[0]['raw_message'] == "2016-07-31 04:07:21,245 [ERROR] rhsmcertd-worker:24440 @entcertlib.py:121 - [Errno -2] Name or service not known"
+    assert (
+        ern_list[0]['raw_message']
+        == "2016-07-31 04:07:21,245 [ERROR] rhsmcertd-worker:24440 @entcertlib.py:121 - [Errno -2] Name or service not known"
+    )
     assert ern_list[0]['timestamp'] == datetime(2016, 7, 31, 4, 7, 21, 245000)
-    assert ern_list[0]['message'] == "[ERROR] rhsmcertd-worker:24440 @entcertlib.py:121 - [Errno -2] Name or service not known"
+    assert (
+        ern_list[0]['message']
+        == "[ERROR] rhsmcertd-worker:24440 @entcertlib.py:121 - [Errno -2] Name or service not known"
+    )
 
     rlog = RhsmLog(context_wrap(LOG2))
     ern_list = rlog.get('[Errno -2]')
@@ -62,7 +65,5 @@ def test_rhsm_log():
 
 
 def test_doc():
-    failed_count, tests = doctest.testmod(
-        rhsm_log, globs={'rhsm_log': RhsmLog(context_wrap(LOG1))}
-    )
+    failed_count, tests = doctest.testmod(rhsm_log, globs={'rhsm_log': RhsmLog(context_wrap(LOG1))})
     assert failed_count == 0

--- a/insights/tests/specs/test_specs.py
+++ b/insights/tests/specs/test_specs.py
@@ -243,7 +243,7 @@ def setup_function(func):
 def teardown_function(func):
     # Reset Test ENV
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
     dr.COMPONENTS = defaultdict(lambda: defaultdict(set))
     dr.TYPE_OBSERVERS = defaultdict(set)
     dr.ENABLED = defaultdict(lambda: True)

--- a/insights/tests/specs/test_specs_save_as.py
+++ b/insights/tests/specs/test_specs_save_as.py
@@ -145,7 +145,7 @@ with open(here + "/../spec_tests.py") as f:
 def teardown_function(func):
     # Reset Test ENV
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
     dr.COMPONENTS = defaultdict(lambda: defaultdict(set))
     dr.TYPE_OBSERVERS = defaultdict(set)
     dr.ENABLED = defaultdict(lambda: True)

--- a/insights/tests/test_context_wrap.py
+++ b/insights/tests/test_context_wrap.py
@@ -18,7 +18,7 @@ Four
 
 def teardown_function(func):
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 def test_context_wrap_unfiltered():

--- a/insights/tests/tools/test_apply_spec_filters.py
+++ b/insights/tests/tools/test_apply_spec_filters.py
@@ -82,7 +82,7 @@ def teardown_function():
         os.remove(yaml_file)
 
     filters._CACHE = {}
-    filters.FILTERS = defaultdict(set)
+    filters.FILTERS = defaultdict(dict)
 
 
 @pytest.mark.skipif(sys.version_info < (2, 7), reason='Skip py26')


### PR DESCRIPTION
- Added a new keyword argument "max_match=MAX_MATCH" to `add_filter`.
  By declaring the max_match, at most `max_match` number of lines that
  contain the patterns will be filtered out in the collection.
  For redundant declarations the maximum `max_match` will be kept as the
  final scanning number.  If no `max_match` is declared when `add_filter`,
  the filters.MAX_MATCH (=10000) will be take as the default value.
- Added a new keyword argument "with_matches=False" to the `get_filters`.
  When "with_matches=True" is specified, the return value of the
  `get_filters` will be dict in which the max scanning numbers for each
  filter pattern are included as the dict value.
- update the exiting tests
- RHINENG-14669


### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
