### PR TITLE
fix(test): failures of test_eap_reports in some test env

### DIFF
--- a/insights/tests/datasources/compliance/test_compliance.py
+++ b/insights/tests/datasources/compliance/test_compliance.py
@@ -11,7 +11,23 @@ from pytest import raises
 
 from insights.specs.datasources.compliance import ComplianceClient
 
+ENV_TZ = None
 PATH = '/usr/share/xml/scap/ref_id.xml'
+
+
+def setup_function(func):
+    global ENV_TZ
+    ENV_TZ = os.environ.get("TZ")
+
+
+def teardown_function(func):
+    global ENV_TZ
+    env = os.environ
+    if "TZ" in env:
+        if ENV_TZ is None:
+            env.pop("TZ")
+        else:
+            env.update(TZ=ENV_TZ)
 
 
 @patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)


### PR DESCRIPTION
- the timezone update in compliance tests breaks the
  eap_reports tests which are time-sensitive

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

- in some test env, the eap_report test always fail as below:
```
FAILED insights/tests/datasources/test_eap_reports.py::test_eap_one_match_paths - AssertionError: assert 2 == 1
 +  where 2 = len(['/var/tmp/insights-runtimes/uploads/file_a.json', '/var/tmp/insights-runtimes/uploads/file_b.json'])
FAILED insights/tests/datasources/test_eap_reports.py::test_eap_zero_match_paths - assert <function eap_report_files at 0x7fa4499e7420> not in <insights.core.dr.Broker object at 0x7fa44962e910>
```
- it's because that the two tests are time-sensitive, 
  however the change of "TZ" in compliance test breaks
  the timestamp of file creating in the eap_reports tests.
