### PR TITLE
feat: Add is_rhel_ai into parser os_release

### DIFF
--- a/insights/parsers/os_release.py
+++ b/insights/parsers/os_release.py
@@ -74,4 +74,4 @@ class OsRelease(Parser, dict):
         Returns:
             bool: True when the system is from RHEL AI image.
         """
-        return True if self.get("VARIANT", None) == "RHEL AI" and self.get("VARIANT_ID", None) == "rhel_ai" else False
+        return self.get("VARIANT", None) == "RHEL AI" and self.get("VARIANT_ID", None) == "rhel_ai"

--- a/insights/parsers/os_release.py
+++ b/insights/parsers/os_release.py
@@ -67,3 +67,11 @@ class OsRelease(Parser, dict):
             Deprecated, it will be removed from 3.7.0
         """
         return self
+
+    @property
+    def is_rhel_ai(self):
+        """
+        Returns:
+            bool: True when the system is from RHEL AI image.
+        """
+        return True if self.get("VARIANT", None) == "RHEL AI" and self.get("VARIANT_ID", None) == "rhel_ai" else False

--- a/insights/tests/parsers/test_os_release.py
+++ b/insights/tests/parsers/test_os_release.py
@@ -94,6 +94,7 @@ def test_rhel():
     rls = OsRelease(context_wrap(REHL_OS_RELEASE))
     assert rls.get("VARIANT_ID") is None
     assert rls.get("VERSION") == "7.2 (Maipo)"
+    assert rls.is_rhel_ai is False
 
 
 def test_rhevh():
@@ -115,6 +116,7 @@ def test_rhel_ai():
     assert rls.get("VARIANT_ID") == "rhel_ai"
     assert rls.get("VARIANT") == "RHEL AI"
     assert rls.get("BUILD_ID") == "v1.1.3"
+    assert rls.is_rhel_ai is True
 
 
 def test_empty():


### PR DESCRIPTION
rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
Add `is_rhel_ai` function to check if the system is from RHEL AI image
