### PR TITLE
feat: Use caplog to test log messages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,6 +133,7 @@ jobs:
         curl -L -O https://files.pythonhosted.org/packages/cb/85/8a1588a04172e0853352ecfe214264c65a62ab35374d9ad9c569cf94c2a3/python_gnupg-0.4.6-py2.py3-none-any.whl
         curl -L -O https://files.pythonhosted.org/packages/e6/35/f187bdf23be87092bd0f1200d43d23076cee4d0dec109f195173fd3ebc79/mock-2.0.0-py2.py3-none-any.whl
         curl -L -O https://files.pythonhosted.org/packages/f2/94/3af39d34be01a24a6e65433d19e107099374224905f1e0cc6bbe1fd22a2f/argparse-1.4.0-py2.py3-none-any.whl
+        curl -L -O https://files.pythonhosted.org/packages/86/84/6bd1384196a6871a9108157ec934a1e1ee0078582cd208b43352566a86dc/pytest_catchlog-1.2.2-py2.py3-none-any.whl
         cd ${CUR_DIR}
         mkdir ../collections_module
         curl -L -o ./../collections_module/collections.py https://raw.githubusercontent.com/RedHatInsights/insights-core/5c8ca0f2fb3de45908e8d931d40758af34a7997a/.collections.py

--- a/insights/tests/client/init/test_write_pidfile.py
+++ b/insights/tests/client/init/test_write_pidfile.py
@@ -1,3 +1,5 @@
+import os
+
 from insights.client import InsightsClient
 from insights.client.constants import InsightsConstants
 from mock.mock import call
@@ -6,17 +8,15 @@ from mock.mock import patch
 
 @patch("insights.client.atexit.register")
 @patch("insights.client.write_to_disk")
-@patch("insights.client.os.getpid")
 @patch("insights.client.get_parent_process")
-def test_write_pidfile(get_parent_process, getpid, write_to_disk, register):
+def test_write_pidfile(get_parent_process, write_to_disk, register):
     '''
     Test writing of the pidfile when InsightsClient
     is called initially (when from_phase=False)
     '''
     InsightsClient(from_phase=False)
-    getpid.assert_called_once()
     write_to_disk.assert_has_calls((
-        call(InsightsConstants.pidfile, content=str(getpid.return_value)),
+        call(InsightsConstants.pidfile, content=str(os.getpid())),
         call(InsightsConstants.ppidfile, content=get_parent_process.return_value)
     ))
 
@@ -37,15 +37,13 @@ def test_atexit_delete_pidfile(write_to_disk, register):
 
 @patch("insights.client.write_to_disk")
 @patch("insights.client.get_parent_process")
-@patch("insights.client.os.getpid")
-def test_write_pidfile_not_called(getpid, get_parent_process, write_to_disk):
+def test_write_pidfile_not_called(get_parent_process, write_to_disk):
     '''
     Test that the pidfile is not written when
     called from a phase (from-phase=True)
     '''
     InsightsClient(from_phase=True)
     get_parent_process.assert_not_called()
-    getpid.assert_not_called()
     write_to_disk.assert_not_called()
 
 

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ testing = set(
         'coverage==4.3.4; python_version < "2.7"',
         'coverage; python_version >= "2.7"',
         'pytest==3.0.6; python_version < "2.7"',
+        'pytest_catchlog; python_version < "2.7"',
         'pytest~=4.6.0; python_version == "2.7"',
         'pytest; python_version >= "3"',
         'pytest-cov==2.4.0; python_version < "2.7"',


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

Logger asserts are error-prone, because they assert calls, not actual messages. The `caplog` fixture is Pytest-native way to test logs. This makes integration-level unit tests easier to add.

For the `caplog` fixture to work on Python 2.6 (RHEL 6), `pytest_catchlog` needs to be installed. On more recent version of Python, the fixture is included in Pytest.

`pytest_catchlog` caused PID file write tests to fail. The fixture itself calls `os.getpid`, interfering with the patch. Every log message makes a `getpid` call that is recorded in the patch. `assert_not_called` patches then stopped working.

Fixed by removing the `os.getpid` patch. The original function is safe to use. `test_write_pidfile_not_called` verifies several calls among which `write_to_disk` is the important one, not `getpid`.

Card IDs:

* [CCT-774](https://issues.redhat.com/browse/CCT-774) closed at the time as WONTDO
* [CCT-963](https://issues.redhat.com/browse/CCT-963) blocked by this patch
* [CCT-1084](https://issues.redhat.com/browse/CCT-1084) duplicate of the original card, now relevant