### PR TITLE
test(client): Fix unusual race condition in tests

### DIFF
--- a/insights/tests/client/test_crypto.py
+++ b/insights/tests/client/test_crypto.py
@@ -147,7 +147,7 @@ def test_valid_signature():
         signature=home + "/file.txt.asc",
         key=home + "/key.public.gpg",
     )
-    shutil.rmtree(home)
+    shutil.rmtree(home, ignore_errors=True)
 
     # Verify results
     assert True is result.ok
@@ -182,7 +182,7 @@ def test_no_file(file):
     assert result.return_code > 0
     assert "file '{path}' does not exist".format(path=home + file) == result.stderr
 
-    shutil.rmtree(home)
+    shutil.rmtree(home, ignore_errors=True)
 
 
 @mock.patch("insights.client.crypto.GPGCommand.TEMPORARY_GPG_HOME_PARENT_DIRECTORY", "/tmp/")
@@ -220,7 +220,7 @@ def test_invalid_signature():
         signature=home + "/file.txt.asc",
         key=home + "/key.public.gpg",
     )
-    shutil.rmtree(home)
+    shutil.rmtree(home, ignore_errors=True)
 
     # Verify results
     assert not result.ok


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This change fixes an occasional test failure due to a race condition with the gpg command. The tests in `test_crypto.py` were updated to include the `ignore_errors=True` parameter in `shutil.rmtree(home)`.
