### PR TITLE
fix: do not print collection messages for compliance apiv2 options

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -326,11 +326,15 @@ def collect(config):
     pc = InsightsUploadConf(config)
     dc = CoreCollector(config)
 
-    logger.info('Starting to collect Insights data for %s' % determine_hostname(config.display_name))
+    rm_conf = {}
+    # Do not print collection relevant messages for compliance apiv2 options
+    if not (config.compliance_policies or config.compliance_assign or config.compliance_unassign):
+        rm_conf = pc.get_rm_conf()
+        logger.info(
+            'Starting to collect Insights data for %s' % determine_hostname(config.display_name)
+        )
 
-    dc.run_collection(pc.get_rm_conf(),
-                      get_branch_info(config),
-                      pc.create_report())
+    dc.run_collection(rm_conf, get_branch_info(config), pc.create_report())
 
     return dc.done()
 

--- a/insights/tests/client/test_log_messages.py
+++ b/insights/tests/client/test_log_messages.py
@@ -1,0 +1,109 @@
+# -*- coding: UTF-8 -*-
+try:
+    from unittest.mock import patch
+except Exception:
+    from mock import patch
+
+from insights.client.client import collect
+from insights.client.config import InsightsConfig
+from insights.client.utilities import determine_hostname
+
+
+def patch_get_branch_info():
+    """
+    Sets a static response to get_branch_info method.
+    """
+
+    def decorator(old_function):
+        patcher = patch("insights.client.client.get_branch_info")
+        return patcher(old_function)
+
+    return decorator
+
+
+def patch_get_rm_conf():
+    """
+    Mocks InsightsUploadConf.get_rm_conf so it returns a fixed configuration.
+    """
+
+    def decorator(old_function):
+        patcher = patch("insights.client.client.InsightsUploadConf.get_rm_conf")
+        return patcher(old_function)
+
+    return decorator
+
+
+def patch_core_collector():
+    """
+    Replaces CoreCollector with a dummy mock.
+    """
+
+    def decorator(old_function):
+        patcher = patch("insights.client.client.CoreCollector")
+        return patcher(old_function)
+
+    return decorator
+
+
+@patch_core_collector()
+@patch_get_rm_conf()
+@patch_get_branch_info()
+@patch('insights.client.client.logger')
+def test_log_msgs_general(log, get_branch_info, get_rm_conf, core_collector):
+    config = InsightsConfig()
+    collect(config)
+    get_branch_info.assert_called_once_with(config)
+    get_rm_conf.assert_called_once_with()
+    log.info.assert_called_once_with(
+        'Starting to collect Insights data for %s' % determine_hostname(config.display_name)
+    )
+
+
+@patch_core_collector()
+@patch_get_rm_conf()
+@patch_get_branch_info()
+@patch('insights.client.client.logger')
+def test_log_msgs_compliance(log, get_branch_info, get_rm_conf, core_collector):
+    config = InsightsConfig(compliance=True)
+    collect(config)
+    get_branch_info.assert_called_once_with(config)
+    get_rm_conf.assert_called_once_with()
+    log.info.assert_called_once_with(
+        'Starting to collect Insights data for %s' % determine_hostname(config.display_name)
+    )
+
+
+@patch_core_collector()
+@patch_get_rm_conf()
+@patch_get_branch_info()
+@patch('insights.client.client.logger')
+def test_log_msgs_compliance_policies(log, get_branch_info, get_rm_conf, core_collector):
+    config = InsightsConfig(compliance_policies=True)
+    collect(config)
+    get_branch_info.assert_called_once_with(config)
+    get_rm_conf.assert_not_called()
+    log.info.assert_not_called()
+
+
+@patch_core_collector()
+@patch_get_rm_conf()
+@patch_get_branch_info()
+@patch('insights.client.client.logger')
+def test_log_msgs_compliance_assign(log, get_branch_info, get_rm_conf, core_collector):
+    config = InsightsConfig(compliance_assign=['abc'])
+    collect(config)
+    get_branch_info.assert_called_once_with(config)
+    get_rm_conf.assert_not_called()
+    log.info.assert_not_called()
+
+
+@patch_core_collector()
+@patch_get_rm_conf()
+@patch_get_branch_info()
+@patch('insights.client.client.logger')
+def test_log_msgs_compliance_unassign(log, get_branch_info, get_rm_conf, core_collector):
+    config = InsightsConfig(compliance_unassign=['abc'])
+    collect(config)
+    get_branch_info.assert_called_once_with(config)
+    get_rm_conf.assert_not_called()
+    log.info.assert_not_called()


### PR DESCRIPTION
- RHINENG-14959
- When any compliance apiv2 options is specified nothing will be collected, hence data collection relevant messages should not be printed to console. The rm_conf which includes the file/content redaction is also cleared for compliance apiv2 for this reason.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
