### PR TITLE
feat: add new command fwupdmgr to spec.fw_security

### DIFF
--- a/insights/parsers/fwupdagent.py
+++ b/insights/parsers/fwupdagent.py
@@ -129,7 +129,9 @@ class FwupdagentDevices(CommandParser, JSONParser):
 @parser(Specs.fw_security)
 class FwupdagentSecurity(CommandParser, JSONParser):
     """
-    Class ``FwupdagentSecurity`` parses the output of the ``/bin/fwupdagent get-devices`` command.
+    Class ``FwupdagentSecurity`` parses the output of any of the commands:
+        - ``/usr/bin/fwupdmgr security --force --json``
+        - ``/bin/fwupdagent security --force``
 
     Attributes:
         data (dict): The parsed output of the command.

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -356,7 +356,10 @@ class DefaultSpecs(Specs):
     firewalld_conf = simple_file("/etc/firewalld/firewalld.conf")
     foreman_production_log = simple_file("/var/log/foreman/production.log")
     fstab = simple_file("/etc/fstab")
-    fw_security = simple_command("/bin/fwupdagent security --force", deps=[IsBareMetal])
+    fw_security = first_of([
+        simple_command("/usr/bin/fwupdmgr security --force --json", deps=[IsBareMetal]),
+        simple_command("/bin/fwupdagent security --force", deps=[IsBareMetal])
+    ])
     galera_cnf = first_file(
         [
             "/var/lib/config-data/puppet-generated/mysql/etc/my.cnf.d/galera.cnf",

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -79,7 +79,10 @@ class InsightsArchiveSpecs(Specs):
     findmnt_lo_propagation = simple_file("insights_commands/findmnt_-lo_PROPAGATION")
     firewall_cmd_list_all_zones = simple_file("insights_commands/firewall-cmd_--list-all-zones")
     fw_devices = simple_file("insights_commands/fwupdagent_get-devices")
-    fw_security = simple_file("insights_commands/fwupdagent_security_--force")
+    fw_security = first_file([
+        "insights_commands/fwupdmgr_security_--force_--json",
+        "insights_commands/fwupdagent_security_--force",
+    ])
     gcp_instance_type = simple_file("insights_commands/python_-m_insights.tools.cat_--no-header_gcp_instance_type")
     gcp_license_codes = simple_file("insights_commands/python_-m_insights.tools.cat_--no-header_gcp_license_codes")
     getcert_list = simple_file("insights_commands/getcert_list")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

RHINENG-15022 , rely on the merge of https://github.com/RedHatInsights/insights-core/pull/4317 

From [KCS#5436071](https://access.redhat.com/solutions/5436071), the command `fwupdmgr` supports since RHEL7.4. 
As we need to keep both command for spec `fw_security` for a while, use `first_of` instead of creating another spec for command  `fwupdmgr`.