### PR TITLE
fix: error msg for compliance apiv2 assign/unassign

### DIFF
--- a/insights/specs/datasources/compliance/__init__.py
+++ b/insights/specs/datasources/compliance/__init__.py
@@ -1,13 +1,15 @@
+import os
+import six
+import tempfile
+
 from glob import glob
-from insights.client.connection import InsightsConnection
-from insights.client.constants import InsightsConstants as constants
 from logging import getLogger
 from re import findall
 from sys import exit
-import tempfile
+
+from insights.client.connection import InsightsConnection
+from insights.client.constants import InsightsConstants as constants
 from insights.util.subproc import call
-import os
-import six
 
 
 NONCOMPLIANT_STATUS = 2
@@ -211,21 +213,21 @@ class ComplianceClient:
                     print("%-12s %-40s %s" % (is_assigned, policy['id'], policy['title']))
             return 0
         else:
-            logger.error("An error has occured while communicating with the API.\n")
+            logger.error("An error has occurred while communicating with the API.\n")
             return constants.sig_kill_bad
 
-    def policy_link(self, policy_id, dir):
+    def policy_link(self, policy_id, opt):
         url = "https://{0}/compliance/v2/policies/{1}/systems/{2}"
         full_url = url.format(self.config.base_url, policy_id, self.inventory_id)
         logger.debug("Fetching: {0}".format(full_url))
-        response = getattr(self.conn.session, dir)(full_url)
+        response = getattr(self.conn.session, opt)(full_url)
         logger.debug("Content of the response {0} - {1}".format(response, response.content))
 
         if response.status_code == 202:
             logger.info("Operation completed successfully.\n")
             return 0
         else:
-            logger.error("An error has occured while communicating with the API.\n")
+            logger.error("Policy ID {0} does not exist.".format(policy_id))
             return constants.sig_kill_bad
 
     def get_system_policies(self):


### PR DESCRIPTION
Jira: RHINENG-14834
- the assign/unassign api will return 404 when failed, which
  means the specified `policy_id` doesn't exist.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
