### PR TITLE
fix: add a backslash to the first '-' in filter keyword

### DIFF
--- a/insights/core/filters.py
+++ b/insights/core/filters.py
@@ -96,9 +96,8 @@ def add_filter(component, patterns, max_match=MAX_MATCH):
             raise TypeError("Filter patterns must be of type string, list, or set.")
 
         if isinstance(patterns, six.string_types):
-            patterns = {patterns: max_match}
-        elif isinstance(patterns, list):
-            patterns = dict((pt, max_match) for pt in patterns)
+            patterns = [patterns]
+        patterns = dict(('\\' + pt if pt and pt[0] == '-' else pt, max_match) for pt in patterns)
         # here patterns is a dict
 
         for pat in patterns:

--- a/insights/tests/tools/test_apply_spec_filters.py
+++ b/insights/tests/tools/test_apply_spec_filters.py
@@ -65,7 +65,10 @@ yaml_file = os.path.join(os.path.dirname(insights.__file__), filters._filename)
 
 
 def setup_function():
-    filters.add_filter(Specs.ps_alxwww, ['COMMAND', 'CMD'])
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(dict)
+
+    filters.add_filter(Specs.ps_alxwww, ['COMMAND', 'CMD', '-ma'])
     filters.add_filter(Specs.ps_aux, 'COMMAND')
     filters.add_filter(Specs.yum_conf, '[')
     filters.add_filter(Specs.yum_log, ['Installed', 'Updated', 'Erased'])
@@ -93,7 +96,8 @@ def test_apply_specs_filters_json():
     with open(JSON_file, 'r') as f:
         ret = json.load(f)
         # ps_alxwww
-        assert len(ret['commands'][0]['pattern']) == 2
+        assert len(ret['commands'][0]['pattern']) == 3
+        assert '\\-ma' in ret['commands'][0]['pattern']
         count += 1
         # ps_aux
         assert len(ret['commands'][1]['pattern']) == 1
@@ -121,7 +125,8 @@ def test_apply_specs_filters_yaml():
     with open(YAML_file, 'r') as f:
         ret = yaml.safe_load(f)
         # ps_alxwww
-        assert len(ret['insights.specs.Specs.ps_alxwww']) == 2
+        assert len(ret['insights.specs.Specs.ps_alxwww']) == 3
+        assert '\\-ma' in ret['insights.specs.Specs.ps_alxwww']
         count += 1
         # ps_aux
         assert len(ret['insights.specs.Specs.ps_aux']) == 1
@@ -147,7 +152,8 @@ def test_apply_specs_filters_yaml():
     with open(yaml_file, 'r') as f:
         ret = yaml.safe_load(f)
         # ps_alxwww
-        assert len(ret['insights.specs.Specs.ps_alxwww']) == 2
+        assert len(ret['insights.specs.Specs.ps_alxwww']) == 3
+        assert '\\-ma' in ret['insights.specs.Specs.ps_alxwww']
         count += 1
         # ps_aux
         assert len(ret['insights.specs.Specs.ps_aux']) == 1


### PR DESCRIPTION
- If the first character to 'grep -F' is a dash ('-'), the string will be treated as an option.  To avoid such cases, add a single backslash (escape character) when the first char is '-'.
- Jira: RHINENG-15287

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
