### PR TITLE
fix: reverse the filters order when grep

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -208,7 +208,7 @@ class FileProvider(ContentProvider):
             if self.ds and filters.ENABLED
             else False
         )
-        self._filters = filters.get_filters(self.ds, True) if self.ds else set()
+        self._filters = filters.get_filters(self.ds, True) if self.ds else dict()
 
         self.validate()
 
@@ -267,7 +267,9 @@ class TextFileProvider(FileProvider):
         args = []
         if self._filters:
             log.debug("Pre-filtering %s", self.relative_path)
-            args.append(["grep", "-F", "\n".join(self._filters), self.path])
+            args.append(
+                ["grep", "-F", "\n".join(sorted(self._filters.keys(), reverse=True)), self.path]
+            )
 
         return args
 
@@ -361,7 +363,7 @@ class CommandOutputProvider(ContentProvider):
             if self.ds and filters.ENABLED
             else False
         )
-        self._filters = filters.get_filters(self.ds, True) if self.ds else set()
+        self._filters = filters.get_filters(self.ds, True) if self.ds else dict()
 
         self.validate()
 
@@ -389,7 +391,7 @@ class CommandOutputProvider(ContentProvider):
 
         if self.split and self._filters:
             log.debug("Pre-filtering  %s", self.relative_path)
-            command.append(["grep", "-F", "\n".join(self._filters)])
+            command.append(["grep", "-F", "\n".join(sorted(self._filters.keys(), reverse=True))])
 
         return command
 


### PR DESCRIPTION
- this is to avoid the first keyword from starting with a dash ('-')
- see RHINENG-15287

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
