### PR TITLE
fix: set should be supported by add_filter

### DIFF
--- a/insights/core/filters.py
+++ b/insights/core/filters.py
@@ -91,19 +91,18 @@ def add_filter(component, patterns, max_match=MAX_MATCH):
         if comp in _CACHE:
             del _CACHE[comp]
 
-        types = six.string_types + (list, set)
-        if not isinstance(patterns, types):
+        if not isinstance(patterns, (six.string_types, list, set)):
             raise TypeError("Filter patterns must be of type string, list, or set.")
 
         if isinstance(patterns, six.string_types):
-            patterns = {patterns: max_match}
-        elif isinstance(patterns, list):
-            patterns = dict((pt, max_match) for pt in patterns)
-        # here patterns is a dict
+            patterns = [patterns]
 
         for pat in patterns:
             if not pat:
                 raise Exception("Filter patterns must not be empty.")
+
+        patterns = dict((pt, max_match) for pt in patterns)
+        # here patterns is a dict
 
         FILTERS[comp].update(max_matchs(FILTERS[comp], patterns))
 

--- a/insights/tests/core/test_filters.py
+++ b/insights/tests/core/test_filters.py
@@ -136,7 +136,7 @@ def test_add_filter_to_LocalSpecsHasFilters():
 
 
 # General Parser
-def test_add_filter_to_PsAux():
+def test_add_filter_to_parser_patterns_string():
     """
     "filters" added to Specs.x will add to DefaultSpecs.x
     """
@@ -165,6 +165,23 @@ def test_add_filter_to_parser_patterns_list():
 
     parser_filters = filters.get_filters(PsAux)
     assert not parser_filters
+
+
+def test_add_filter_to_parser_patterns_set():
+    filters_set = set(["bash", "systemd", "Network"])
+    filters.add_filter(PsAux, filters_set)
+
+    spec_filters = filters.get_filters(Specs.ps_aux)
+    assert all(f in spec_filters for f in filters_set)
+
+    parser_filters = filters.get_filters(PsAux)
+    assert not parser_filters
+
+
+def test_add_filter_to_parser_patterns_tupple():
+    filters_tup = ("bash", "systemd", "Network")
+    with pytest.raises(TypeError):
+        filters.add_filter(PsAux, filters_tup)
 
 
 def test_add_filter_exception_spec_not_filterable():


### PR DESCRIPTION
- Per the original design 'set()' should be supported by add_filter(). However, it was not supported in the code. Fixed it and added test.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
