### PR TITLE
fix(client): Serialize properly escape characters

### DIFF
--- a/insights/client/apps/ansible/playbook_verifier/serializer.py
+++ b/insights/client/apps/ansible/playbook_verifier/serializer.py
@@ -49,7 +49,20 @@ class PlaybookSerializer:
         # single'quote  "single'quote"
         # double"quote  'double"quote'
         # both"'quotes  'both"\'quotes'
+        # \backslash    '\\backslash'
+        # new\nline     'new\\nline'
+        # tab\tchar     'tab\\tchar'
 
+        special_chars = {
+            "\\": "\\\\",
+            "\n": "\\n",
+            "\t": "\\t",
+        }
+        escaped_string = ""
+        for char in value:
+            escaped_string += special_chars.get(char, char)
+
+        value = escaped_string
         quote = "'"
         if "'" in value:
             if '"' not in value:

--- a/insights/tests/client/apps/test_playbook_verifier.py
+++ b/insights/tests/client/apps/test_playbook_verifier.py
@@ -366,7 +366,10 @@ class TestPlaybookSerializer:
             ("no quote", "'no quote'"),
             ("single'quote", '''"single'quote"'''),
             ("double\"quote", """'double"quote'"""),
-            ("both\"'quotes", r"""'both"\'quotes'""")
+            ("both\"'quotes", r"""'both"\'quotes'"""),
+            ("\\backslash", "'\\\\backslash'"),
+            ("new\nline", "'new\\nline'"),
+            ("tab\tchar", "'tab\\tchar'"),
         ]
     )
     def test_strings(self, source, expected):


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: CCT-1065

Backslashes in regex patterns were not properly escaped, causing inconsistencies between Fedora 40 and CentOS Stream 9 environments. This commit ensures that all escape characters are properly serialized.

This pull request is a backport from [insights-ansible-playbook-verifier#27](https://github.com/RedHatInsights/insights-ansible-playbook-verifier/pull/27)
