### PR TITLE
fix(client): Serialize properly playbooks with empty values

### DIFF
--- a/insights/client/apps/ansible/playbook_verifier/serializer.py
+++ b/insights/client/apps/ansible/playbook_verifier/serializer.py
@@ -37,7 +37,7 @@ class PlaybookSerializer:
         logger.debug("Value type not recognized, it may misbehave: {value} ({typ})".format(
             value=value, typ=type(value).__name__)
         )
-        return "'" + str(value) + "'"
+        return str(value)
 
     @classmethod
     def _str(cls, value):

--- a/insights/tests/client/apps/test_playbook_verifier.py
+++ b/insights/tests/client/apps/test_playbook_verifier.py
@@ -329,6 +329,12 @@ class TestPlaybookSerializer:
         expected = "['value1', 'value2']"
         assert result == expected
 
+    def test_dict_empty_value(self):
+        source = {"key": None}
+        result = playbook_verifier.PlaybookSerializer.serialize(source)
+        expected = "ordereddict([('key', None)])"
+        assert result == expected
+
     def test_dict_single_key(self):
         source = {"key": "value"}
         result = playbook_verifier.PlaybookSerializer.serialize(source)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: CCT-1102

Empty values in playbooks were not serialized correctly. This commit resolves the issue by ensuring that empty values are not enclosed in quotes in the serialized output.

This pull request is a backport from [insights-ansible-playbook-verifier#30](https://github.com/RedHatInsights/insights-ansible-playbook-verifier/pull/30).