### PR TITLE
fix(client): Serialize properly playbooks with empty maps

### DIFF
--- a/insights/client/apps/ansible/playbook_verifier/serializer.py
+++ b/insights/client/apps/ansible/playbook_verifier/serializer.py
@@ -78,6 +78,8 @@ class PlaybookSerializer:
         :type value: dict | yaml.comments.CommentedMap
         :rtype: str
         """
+        if not value:
+            return "ordereddict()"
         result = "ordereddict(["
         result += ", ".join(
             "('{key}', {value})".format(key=k, value=cls._obj(v))

--- a/insights/tests/client/apps/test_playbook_verifier.py
+++ b/insights/tests/client/apps/test_playbook_verifier.py
@@ -329,6 +329,12 @@ class TestPlaybookSerializer:
         expected = "['value1', 'value2']"
         assert result == expected
 
+    def test_dict_empty(self):
+        source = {}
+        result = playbook_verifier.PlaybookSerializer.serialize(source)
+        expected = "ordereddict()"
+        assert result == expected
+
     def test_dict_empty_value(self):
         source = {"key": None}
         result = playbook_verifier.PlaybookSerializer.serialize(source)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: CCT-1101

Empty maps in playbooks were not being correctly handled by the serializer. To maintain compatibility across various environments, they are now serialized as `ordereddict()`.

This pull request is a backport from [insights-ansible-playbook-verifier#29](https://github.com/RedHatInsights/insights-ansible-playbook-verifier/pull/29).