### PR TITLE
fix: 'tail' filterable text files before filtering with 'grep'

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -268,7 +268,10 @@ class TextFileProvider(FileProvider):
         if self._filters:
             log.debug("Pre-filtering %s", self.relative_path)
             args.append(
-                ["grep", "-F", "\n".join(sorted(self._filters.keys(), reverse=True)), self.path]
+                ["tail", "-n" ,"1000000", self.path]
+            )
+            args.append(
+                ["grep", "-F", "\n".join(sorted(self._filters.keys(), reverse=True))]
             )
 
         return args

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -27,7 +27,7 @@ from insights.util.mangle import mangle_command
 
 log = logging.getLogger(__name__)
 
-
+MAX_LINES_FOR_FILTERABLE_FILE = 1000000
 SAFE_ENV = {
     "PATH": os.path.pathsep.join(
         [
@@ -268,7 +268,7 @@ class TextFileProvider(FileProvider):
         if self._filters:
             log.debug("Pre-filtering %s", self.relative_path)
             args.append(
-                ["tail", "-n", "1000000", self.path]
+                ["tail", "-n", str(MAX_LINES_FOR_FILTERABLE_FILE), self.path]
             )
             args.append(
                 ["grep", "-F", "\n".join(sorted(self._filters.keys(), reverse=True))]

--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -268,7 +268,7 @@ class TextFileProvider(FileProvider):
         if self._filters:
             log.debug("Pre-filtering %s", self.relative_path)
             args.append(
-                ["tail", "-n" ,"1000000", self.path]
+                ["tail", "-n", "1000000", self.path]
             )
             args.append(
                 ["grep", "-F", "\n".join(sorted(self._filters.keys(), reverse=True))]


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
As some logs files are not with log rotate setting, these files contain old logging and more than 100 million lines. Use the 'tail' command to get the last 1 million only. 
