### PR TITLE
fix: default return value type of ls.listing_of()

### DIFF
--- a/insights/parsers/ls.py
+++ b/insights/parsers/ls.py
@@ -218,7 +218,7 @@ class FileListing(Parser, dict):
         """
         if directory in self:
             return self[directory]['entries']
-        return []
+        return {}
 
     def dir_contains(self, directory, name):
         """

--- a/insights/tests/parsers/test_ls.py
+++ b/insights/tests/parsers/test_ls.py
@@ -442,7 +442,7 @@ def test_ls_lanR():
     assert ls.files_of('non-exist') == []
     assert ls.dirs_of('non-exist') == []
     assert ls.specials_of('non-exist') == []
-    assert ls.listing_of('non-exist') == []
+    assert ls.listing_of('non-exist') == {}
     assert ls.total_of('non-exist') == 0
     assert ls.dir_contains('non-exist', 'test') is False
     assert ls.dir_entry('non-exist', 'test') == {}

--- a/insights/tests/parsers/test_ls_file_listing.py
+++ b/insights/tests/parsers/test_ls_file_listing.py
@@ -172,7 +172,7 @@ def test_multiple_directories():
     assert dirs.files_of('non-exist') == []
     assert dirs.dirs_of('non-exist') == []
     assert dirs.specials_of('non-exist') == []
-    assert dirs.listing_of('non-exist') == []
+    assert dirs.listing_of('non-exist') == {}
     assert dirs.total_of('non-exist') == 0
     assert dirs.dir_contains('non-exist', 'test') is False
     assert dirs.dir_entry('non-exist', 'test') == {}


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The following error was raised from a @condition dependency usage: 
| count| component| request_id| exception|
| -------- | ------- | -------- | ------- |
| 54299| insights.specs.Specs.ls_lanL|bc586c1df4aa4b6e8ac0456954d60487|AttributeError("'list' object has no attribute 'items'")|

Fix to restore the consistent of the return value type of `ls.listing_of()`.    

RHINENG-15244 