### PR TITLE
fix(client): Status code should indicate registration status

### DIFF
--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -244,9 +244,10 @@ def post_update(client, config):
     if config.status:
         if reg_check:
             logger.info('This host is registered.')
+            sys.exit(constants.sig_kill_ok)
         else:
             logger.info('This host is unregistered.')
-        sys.exit(constants.sig_kill_ok)
+            sys.exit(constants.sig_kill_bad)
 
     # put this first to avoid conflicts with register
     if config.unregister:

--- a/insights/tests/client/phase/test_post_update.py
+++ b/insights/tests/client/phase/test_post_update.py
@@ -105,13 +105,13 @@ def test_post_update_check_status_registered(insights_config, insights_client, _
 def test_post_update_check_status_unregistered(insights_config, insights_client, _isfile):
     """
     Just check status.
-        If unregistered, exit with 100 exit code (kill parent)
+        If unregistered, exit with 101 exit code (kill parent)
     """
     insights_config.return_value.load_all.return_value.status = True
     insights_client.return_value.get_registration_status = MagicMock(return_value=False)
     with raises(SystemExit) as exc_info:
         post_update()
-    assert exc_info.value.code == 100
+    assert exc_info.value.code == 101
     insights_client.return_value.clear_local_registration.assert_not_called()
     insights_client.return_value.set_display_name.assert_not_called()
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: CCT-1059

Status code returned by `insights-client --status` should indicate whether a host is registered or not. This change ensures that the exit code is 0 if the host is registered and 1 if it is not.

