### PR TITLE
Feat: add new parser WcPcpConfigPmda

### DIFF
--- a/docs/shared_parsers_catalog/wc.rst
+++ b/docs/shared_parsers_catalog/wc.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.wc
+   :members:
+   :show-inheritance:

--- a/docs/shared_parsers_catalog/wc_proc_1_mountinfo.rst
+++ b/docs/shared_parsers_catalog/wc_proc_1_mountinfo.rst
@@ -1,3 +1,0 @@
-.. automodule:: insights.parsers.wc_proc_1_mountinfo
-   :members:
-   :show-inheritance:

--- a/insights/parsers/wc.py
+++ b/insights/parsers/wc.py
@@ -46,15 +46,24 @@ class WcProc1Mountinfo(Parser):
 @parser(Specs.wc_var_lib_pcp_config_pmda)
 class WcPcpConfigPmda(Parser, dict):
     """
-    Provides the line counts of file ``/proc/1/mountinfo`` by parsing the
-    output of command ``/usr/bin/wc -l /proc/1/mountinfo``.
-
-    Attributes:
-        line_count(int): the line counts of file ``/proc/1/mountinfo``
+    Provides the line counts of file ``/var/lib/pcp/config/pmda/*`` by parsing the
+    output of command ``/usr/bin/wc -l /var/lib/pcp/config/pmda/*``.
 
     Typical content looks like::
-
-        37 /proc/1/mountinfo
+        6 /var/lib/pcp/config/pmda/144.0.py
+        3 /var/lib/pcp/config/pmda/60.1
+        5 /var/lib/pcp/config/pmda/60.10
+        3 /var/lib/pcp/config/pmda/60.11
+        275 /var/lib/pcp/config/pmda/60.12
+        16 /var/lib/pcp/config/pmda/60.17
+        3 /var/lib/pcp/config/pmda/60.24
+        6 /var/lib/pcp/config/pmda/60.28
+        17 /var/lib/pcp/config/pmda/60.3
+        21 /var/lib/pcp/config/pmda/60.32
+        974 /var/lib/pcp/config/pmda/60.4
+        140113 /var/lib/pcp/config/pmda/60.40
+        24 /var/lib/pcp/config/pmda/62.0
+        141466 total
 
     Examples:
         >>> type(wc_pcp_config_pmda)
@@ -64,7 +73,6 @@ class WcPcpConfigPmda(Parser, dict):
 
     Raises:
         SkipComponent: if the command output is empty or missing file
-        ParseException: if the command output is unparsable
     """
 
     def parse_content(self, content):

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -830,6 +830,7 @@ class Specs(SpecSet):
     vsftpd_conf = RegistryPoint(filterable=True)
     watchdog_logs = RegistryPoint(filterable=True, multi_output=True)
     wc_proc_1_mountinfo = RegistryPoint()
+    wc_var_lib_pcp_config_pmda = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     x86_ibpb_enabled = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     x86_ibrs_enabled = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     x86_pti_enabled = RegistryPoint(no_obfuscate=['hostname', 'ip'])

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -972,6 +972,7 @@ class DefaultSpecs(Specs):
     vsftpd_conf = simple_file("/etc/vsftpd/vsftpd.conf")
     watchdog_logs = glob_file("/var/log/watchdog/*.std*")
     wc_proc_1_mountinfo = simple_command("/usr/bin/wc -l /proc/1/mountinfo")
+    wc_var_lib_pcp_config_pmda = simple_command("/usr/bin/wc -l /var/lib/pcp/config/pmda/*")
     x86_ibpb_enabled = simple_file("sys/kernel/debug/x86/ibpb_enabled")
     x86_ibrs_enabled = simple_file("sys/kernel/debug/x86/ibrs_enabled")
     x86_pti_enabled = simple_file("sys/kernel/debug/x86/pti_enabled")

--- a/insights/tests/parsers/test_wc.py
+++ b/insights/tests/parsers/test_wc.py
@@ -2,8 +2,8 @@ import doctest
 import pytest
 
 from insights.core.exceptions import ParseException, SkipComponent
-from insights.parsers import wc_proc_1_mountinfo
-from insights.parsers.wc_proc_1_mountinfo import WcProc1Mountinfo
+from insights.parsers import wc
+from insights.parsers.wc import WcProc1Mountinfo, WcPcpConfigPmda
 from insights.tests import context_wrap
 
 WC_PROC_1_MOUNTINFO_ERR1 = """
@@ -20,6 +20,27 @@ unknow /proc/1/mountinfo
 
 WC_PROC_1_MOUNTINFO = """
 37 /proc/1/mountinfo
+""".strip()
+
+WC_PCP_CONFIG_PMDA = """
+6 /var/lib/pcp/config/pmda/144.0.py
+3 /var/lib/pcp/config/pmda/60.1
+5 /var/lib/pcp/config/pmda/60.10
+3 /var/lib/pcp/config/pmda/60.11
+275 /var/lib/pcp/config/pmda/60.12
+16 /var/lib/pcp/config/pmda/60.17
+3 /var/lib/pcp/config/pmda/60.24
+6 /var/lib/pcp/config/pmda/60.28
+17 /var/lib/pcp/config/pmda/60.3
+21 /var/lib/pcp/config/pmda/60.32
+974 /var/lib/pcp/config/pmda/60.4
+140113 /var/lib/pcp/config/pmda/60.40
+24 /var/lib/pcp/config/pmda/62.0
+141466 total
+""".strip()
+
+WC_PCP_CONFIG_PMDA_ERROR = """
+wc: 'var/lib/pcp/config/pmda/*': No such file or directory
 """.strip()
 
 
@@ -42,9 +63,21 @@ def test_wc_proc_1_mountinfo_errors():
         assert WC_PROC_1_MOUNTINFO_ERR3 in str(pe)
 
 
+def test_wc_var_lib_pcp_config_pmda():
+    results = WcPcpConfigPmda(context_wrap(WC_PCP_CONFIG_PMDA))
+    assert results['/var/lib/pcp/config/pmda/144.0.py'] == 6
+
+
+def test_wc_var_lib_pcp_config_pmda_error():
+    with pytest.raises(SkipComponent) as pe:
+        WcPcpConfigPmda(context_wrap(WC_PCP_CONFIG_PMDA_ERROR))
+        assert WC_PCP_CONFIG_PMDA_ERROR in str(pe)
+
+
 def test_doc_examples():
     env = {
             'wc_info': WcProc1Mountinfo(context_wrap(WC_PROC_1_MOUNTINFO)),
+            'wc_pcp_config_pmda': WcPcpConfigPmda(context_wrap(WC_PCP_CONFIG_PMDA)),
           }
-    failed, total = doctest.testmod(wc_proc_1_mountinfo, globs=env)
+    failed, total = doctest.testmod(wc, globs=env)
     assert failed == 0


### PR DESCRIPTION
Signed-off-by: xintli <xintli@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Add new parser WcPcpConfigPmda to parse command ``/usr/bin/wc -l /var/lib/pcp/config/pmda/*`` and rename file 'wc_proc_1_mountinfo' to 'wc'
See RHINENG-15121