### PR TITLE
fix(client): Ensure unregistration is always explicit

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -26,6 +26,7 @@ except ImportError:
 from .utilities import (determine_hostname,
                         generate_machine_id,
                         machine_id_exists,
+                        write_to_disk,
                         write_unregistered_file,
                         write_registered_file,
                         os_release_info,
@@ -818,6 +819,11 @@ class InsightsConnection(object):
 
         results = self._fetch_system_by_machine_id()
         if not results:
+            if machine_id_exists() or os.path.exists(constants.registered_files[0]):
+                write_unregistered_file()
+                write_to_disk(constants.machine_id_file, delete=True)
+                logger.info("Successfully unregistered from the Red Hat Insights Service")
+                return True
             logger.info('This host could not be found.')
             return False
         try:
@@ -1050,6 +1056,10 @@ class InsightsConnection(object):
 
         system = self._fetch_system_by_machine_id()
         if not system:
+            if machine_id_exists() or os.path.exists(constants.registered_files[0]):
+                logger.error("Could not update display name.\n"
+                             "The system was not found in Inventory. Please, register the system again:\n"
+                             "# insights-client --register")
             return system
         inventory_id = system['id']
 
@@ -1071,6 +1081,10 @@ class InsightsConnection(object):
         '''
         system = self._fetch_system_by_machine_id()
         if not system:
+            if machine_id_exists() or os.path.exists(constants.registered_files[0]):
+                logger.error("Could not update Ansible hostname.\n"
+                             "The system was not found in Inventory. Please, register the system again:\n"
+                             "# insights-client --register")
             return system
         inventory_id = system['id']
 

--- a/insights/client/support.py
+++ b/insights/client/support.py
@@ -15,7 +15,7 @@ from subprocess import Popen, PIPE, STDOUT
 
 from .constants import InsightsConstants as constants
 from .connection import InsightsConnection
-from .utilities import write_registered_file, write_unregistered_file, write_to_disk
+from .utilities import machine_id_exists, write_registered_file, write_unregistered_file, write_to_disk
 
 APP_NAME = constants.app_name
 logger = logging.getLogger(__name__)
@@ -67,6 +67,8 @@ def registration_check(pconn):
             reg_status = None
     # --- end legacy ---
     else:
+        if not status and machine_id_exists() and os.path.exists(constants.registered_files[0]):
+            status = True
         reg_status = status
     if reg_status:
         write_registered_file()


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: CCT-1122

Some commands, such as `--status`, could unintentionally unregister the system if the host was missing from Inventory, which led to the creation of a `.unregistered` file without user intent. This change ensures that unregistration only occurs when explicitly triggered via the `--unregister` command.