### PR TITLE
Bug: Re-adding 'ls_rsyslog_errorfile = RegistryPoint()' 

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -384,6 +384,7 @@ class Specs(SpecSet):
     # Useful individual `ls` Specs
     ls_boot = RegistryPoint()
     ls_dev = RegistryPoint()
+    ls_rsyslog_errorfile = RegistryPoint()
     ls_sys_firmware = RegistryPoint()
     # ^ End of ls
     lsattr = RegistryPoint(no_obfuscate=['hostname', 'ip'])


### PR DESCRIPTION
Re-adding 'ls_rsyslog_errorfile = RegistryPoint()' since it being missing causes an exception when loading parsers due to usage by 'LsRsyslogErrorfile' parser.

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] No Sensitive Data in this change?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The removal of ls_rsyslog_errorfile = RegistryPoint() caused an exception when loading parser LsRsyslogErrorfile since it has a dependency on that spec
