### PR TITLE
fix: Diagnosis argument should work only when registered

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -1105,6 +1105,12 @@ class InsightsConnection(object):
             Reach out to the platform and fetch a diagnosis.
             Spirtual successor to --to-json from the old client.
         '''
+        if not self._fetch_system_by_machine_id():
+            logger.error("Could not get diagnosis data.\n"
+                         "This host is not registered. Use --register to register this host:\n"
+                         "# insights-client --register")
+            return False
+
         # this uses machine id as identifier instead of inventory id
         diag_url = self.base_url + '/remediations/v1/diagnosis/' + generate_machine_id()
         try:

--- a/insights/tests/client/connection/test_diagnosis.py
+++ b/insights/tests/client/connection/test_diagnosis.py
@@ -89,8 +89,9 @@ def test_get_diagnosis_offline():
 @patch('insights.client.connection.InsightsConnection._init_session', Mock())
 @patch('insights.client.connection.InsightsConnection.get_proxies', Mock())
 @patch('insights.client.utilities.constants.machine_id_file', '/tmp/machine-id')
+@patch("insights.client.connection.InsightsConnection._fetch_system_by_machine_id", return_value=True)
 @patch('insights.client.connection.InsightsConnection.get')
-def test_get_diagnosis_success(get):
+def test_get_diagnosis_success(get, fetch_system_by_machine_id):
     '''
     Verify that fetching a diagnosis without an ID succeeds and
     returns a dict when HTTP response is valid
@@ -99,3 +100,15 @@ def test_get_diagnosis_success(get):
     c = InsightsConnection(conf)
     get.return_value = MockResponse(status_code=200, text="OK", content="{\"test\": \"test\"}")
     assert c.get_diagnosis() == {"test": "test"}
+
+
+@patch('insights.client.connection.InsightsConnection._init_session', Mock())
+@patch('insights.client.connection.InsightsConnection.get_proxies', Mock())
+@patch("insights.client.connection.InsightsConnection._fetch_system_by_machine_id", return_value=False)
+def test_get_diagnosis_not_registered(fetch_system_by_machine_id):
+    '''
+    Verify that fetching a diagnosis fails when the system is not registered
+    '''
+    conf = InsightsConfig()
+    c = InsightsConnection(conf)
+    assert c.get_diagnosis() is False


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: CCT-1195

Currently, diagnosis argument can be used even when the host is registered to subscription-manager but not to insights-client. This update ensures diagnosis argument can only be used when the host is registered to insights-client.

