### PR TITLE
fix: truncate lines longer than 1MB

### DIFF
--- a/insights/cleaner/__init__.py
+++ b/insights/cleaner/__init__.py
@@ -46,6 +46,7 @@ from insights.util.hostname import determine_hostname
 from insights.util.posix_regex import replace_posix
 
 logger = logging.getLogger(__name__)
+MAX_LINE_LENGTH = 1048576  # 1MB
 DEFAULT_OBFUSCATIONS = {
     'hostname',
     'ip',  # ipv4
@@ -109,6 +110,11 @@ class Cleaner(object):
         """
 
         def _clean_line(line):
+            if len(line) > MAX_LINE_LENGTH:
+                # Keep the first MAX_LINE_LENGTH chars only (it rarely happens)
+                line = line[:MAX_LINE_LENGTH]
+                logger.debug('Extra-long line is truncated ...')
+
             for parser, kwargs in parsers:
                 line = parser.parse_line(line, **kwargs)
             return line

--- a/insights/tests/cleaner/test_max_line_length.py
+++ b/insights/tests/cleaner/test_max_line_length.py
@@ -1,0 +1,31 @@
+from mock.mock import patch
+
+from insights.cleaner import Cleaner
+from insights.client.config import InsightsConfig
+
+hostname = 'test1.abc.com'
+line = "test1.abc.com, 10.0.0.1 test1.abc.loc 20.1.4.7 smtp.abc.com 10.1.2.7 lite.abc.com"
+
+
+@patch("insights.cleaner.MAX_LINE_LENGTH", len(hostname) + 1)
+@patch("insights.cleaner.logger")
+def test_max_line_length_less(logger):
+    c = InsightsConfig(obfuscate=True, obfuscate_hostname=True, hostname=hostname)
+    pp = Cleaner(c, {}, hostname)
+    result = pp.clean_content(line)
+    logger.debug.assert_called_once_with('Extra-long line is truncated ...')
+    assert 'example.com' in result
+    assert '10.230.230' not in result
+    assert result[-1] == ','
+
+
+@patch("insights.cleaner.MAX_LINE_LENGTH", len(line) + 10)
+@patch("insights.cleaner.logger")
+def test_max_line_length_good(logger):
+    c = InsightsConfig(obfuscate=True, obfuscate_hostname=True, hostname=hostname)
+    pp = Cleaner(c, {}, hostname)
+    result = pp.clean_content(line)
+    logger.debug.assert_not_called()
+    assert 'example.com' in result
+    assert '10.230.230' in result
+    assert result.endswith('example.com')


### PR DESCRIPTION
- for lines that are extra long, keep the first
  1048576 characters. And the truncation will be
  recorded in logs when occurring.
  See RHINENG-16178

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
