### PR TITLE
feat: add spec nvidia_smi_query_gpu

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -496,6 +496,7 @@ class Specs(SpecSet):
     numeric_user_group_name = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     nvidia_smi_active_clocks_event_reasons = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     nvidia_smi_l = RegistryPoint(no_obfuscate=['hostname', 'ip'])
+    nvidia_smi_query_gpu = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     nvme_core_io_timeout = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     oc_get_bc = RegistryPoint()
     oc_get_build = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -638,6 +638,9 @@ class DefaultSpecs(Specs):
         "/usr/bin/nvidia-smi --query-gpu=name,clocks_event_reasons.active --format=csv,noheader"
     )
     nvidia_smi_l = simple_command("/usr/bin/nvidia-smi -L")
+    nvidia_smi_query_gpu = simple_command(
+        "/usr/bin/nvidia-smi --query-gpu=index,name,uuid,memory.total,clocks_event_reasons.active --format=csv,noheader"
+    )
     nvme_core_io_timeout = simple_file("/sys/module/nvme_core/parameters/io_timeout")
     od_cpu_dma_latency = simple_command("/usr/bin/od -An -t d /dev/cpu_dma_latency")
     odbc_ini = simple_file("/etc/odbc.ini")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Add spec only for now, to serve RHINENG-16372

This new spec can also cover the collection of existing specs:    
 - `Sepc.nvidia_smi_l`
 - `Spec.nvidia_smi_active_clocks_event_reasons` 

A typical output of this command looks like:
```
$ /usr/bin/nvidia-smi --query-gpu=index,name,uuid,memory.total,clocks_event_reasons.active --format=csv,noheader
0, NVIDIA L4, GPU-24598a07-f97d-fc79-86de-485c4c82d01c, 23034 MiB, 0x0000000000000001
```
