### PR TITLE
fix(client): Always set rhsmCertificate.PATH attribute

### DIFF
--- a/insights/client/cert_auth.py
+++ b/insights/client/cert_auth.py
@@ -23,7 +23,7 @@ class rhsmCertificate:
     try:
         PATH = RHSM_CONFIG.get('rhsm', 'consumerCertDir')
     except:
-        pass
+        PATH = "/etc/pki/consumer/"
 
     KEY = 'key.pem'
     CERT = 'cert.pem'


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Some tests may fail when the attribute is missing. We should always be able to test whether an identity certificate exists or not.