### PR TITLE
Fix Compliance inventory data parsing

### DIFF
--- a/insights/specs/datasources/compliance/__init__.py
+++ b/insights/specs/datasources/compliance/__init__.py
@@ -183,9 +183,9 @@ class ComplianceClient:
         if self._inventory_id:
             return self._inventory_id
 
-        systems = self.conn._fetch_system_by_machine_id()
-        if type(systems) is list and len(systems) == 1 and 'id' in systems[0]:
-            self._inventory_id = systems[0].get('id')
+        system = self.conn._fetch_system_by_machine_id()
+        if isinstance(system, dict) and 'id' in system:
+            self._inventory_id = system.get('id')
             return self._inventory_id
         else:
             logger.error('Failed to find system in Inventory')

--- a/insights/tests/datasources/compliance/test_compliance.py
+++ b/insights/tests/datasources/compliance/test_compliance.py
@@ -281,15 +281,15 @@ def test_build_oscap_command_append_tailoring_path(config):
 @patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
 def test__inventory_id(config):
     compliance_client = ComplianceClient(config=config)
-    compliance_client.conn._fetch_system_by_machine_id = lambda: []
+    compliance_client.conn._fetch_system_by_machine_id = lambda: None
     with raises(SystemExit):
         compliance_client.inventory_id
 
-    compliance_client.conn._fetch_system_by_machine_id = lambda: [{}]
+    compliance_client.conn._fetch_system_by_machine_id = lambda: {}
     with raises(SystemExit):
         compliance_client.inventory_id
 
-    compliance_client.conn._fetch_system_by_machine_id = lambda: [{'id': '12345'}]
+    compliance_client.conn._fetch_system_by_machine_id = lambda: {'id': '12345'}
     assert compliance_client.inventory_id == '12345'
 
 


### PR DESCRIPTION
**How to test:**
1. Do `insights-client --register` on your machine
2. Install `yum install scap-security-guide -y`
3. Go to https://console.redhat.com/insights/compliance/scappolicies and Create policy and on Systems step associate your system that you registered, no need to change anything else while creating policy
4. Go back to VM and run `insights-client --compliance`
5. After a minute or less, observe that your system has been reported here https://console.redhat.com/insights/compliance/reports

Compliance recently started failing when we are running `insights-client --compliance` on missing inventory ID.
Issue:
```
2025-03-10 11:57:12,315  NETWORK insights.client.connection:188 GET https://cert-api.access.redhat.com/r/insights/platform/inventory/v1/host_exists?insights_id=c097a73b-7abd-43c1-b5ee-451ee26a3a54
2025-03-10 11:57:12,428  NETWORK insights.client.connection:193 HTTP Status: 200 OK
2025-03-10 11:57:12,429  NETWORK insights.client.connection:195 HTTP Response Text: {"id":"ad734ea9-79e1-483b-918b-06b8441e9fbb"}
2025-03-10 11:57:12,429    DEBUG insights.client.connection:445 No HTTP Response message present.
2025-03-10 11:57:12,429    ERROR insights.specs.datasources.compliance:191 Failed to find system in Inventory
```

While debugging I see that API call changed and now we get dictionary instead of a list:
```
187  	        systems = self.conn._fetch_system_by_machine_id()
188  	        logger.info(f'#### Something failed here: {systems}')
189  	        import pdb;pdb.set_trace()
190  ->	        if type(systems) is list and len(systems) == 1 and 'id' in systems[0]:
191  	            self._inventory_id = systems[0].get('id')
192  	            return self._inventory_id
193  	        else:
194  	            logger.error('Failed to find system in Inventory')
195  	            exit(constants.sig_kill_bad)
(Pdb) systems
{'id': 'ad734ea9-79e1-483b-918b-06b8441e9fbb', 'insights_id': 'c097a73b-7abd-43c1-b5ee-451ee26a3a54'}
```

Fix tested locally with generated egg and it worked.

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
