### PR TITLE
fix: replace 'raw_entry' key with raw_entry_of method

### DIFF
--- a/insights/core/ls_parser.py
+++ b/insights/core/ls_parser.py
@@ -90,7 +90,7 @@ def parse_selinux(parts):
         "se_role": selinux[1] if lsel > 1 else None,
         "se_type": selinux[2] if lsel > 2 else None,
         "se_mls": selinux[3] if lsel > 3 else None,
-        "name": path
+        "name": path,
     }
     if link:
         result["link"] = link
@@ -131,14 +131,16 @@ def parse_rhel8_selinux(parts):
         result['size'] = int(size)
     date = last[:12]
     path, link = parse_path(last[13:])
-    result.update({
-        "se_user": selinux[0],
-        "se_role": selinux[1] if lsel > 1 else None,
-        "se_type": selinux[2] if lsel > 2 else None,
-        "se_mls": selinux[3] if lsel > 3 else None,
-        "name": path,
-        "date": date,
-    })
+    result.update(
+        {
+            "se_user": selinux[0],
+            "se_role": selinux[1] if lsel > 1 else None,
+            "se_type": selinux[2] if lsel > 2 else None,
+            "se_mls": selinux[3] if lsel > 3 else None,
+            "name": path,
+            "date": date,
+        }
+    )
     if link:
         result["link"] = link
     return result
@@ -158,10 +160,7 @@ class Directory(dict):
             parts = line.split(None, 4)
             perms = parts[0]
             typ = perms[0]
-            entry = {
-                "type": typ,
-                "perms": perms[1:]
-            }
+            entry = {"type": typ, "perms": perms[1:]}
             if parts[1][0].isdigit():
                 # We have to split the line again to see if this is a RHEL8
                 # selinux stanza. This assumes that the context section will
@@ -178,6 +177,9 @@ class Directory(dict):
             # Update our entry and put it into the correct buckets
             # based on its type.
             entry.update(rest)
+            # TODO
+            # - The `raw_entry` key is deprecated and will be removed from 3.6.0.
+            #   Please use the `insights.parsers.ls.FileListingParser.raw_entry_of` instead.
             entry["raw_entry"] = line
             entry["dir"] = name
             nm = entry["name"]
@@ -190,14 +192,14 @@ class Directory(dict):
                 specials.append(nm)
 
         super(Directory, self).__init__(
-                {
-                    "dirs": dirs,
-                    "entries": ents,
-                    "files": files,
-                    "name": name,
-                    "specials": specials,
-                    "total": total
-                }
+            {
+                "dirs": dirs,
+                "entries": ents,
+                "files": files,
+                "name": name,
+                "specials": specials,
+                "total": total,
+            }
         )
 
 

--- a/insights/parsers/lsinitrd.py
+++ b/insights/parsers/lsinitrd.py
@@ -46,7 +46,6 @@ class Lsinitrd(CommandParser):
         5
         >>> assert ls.search(name__contains='kernel') == [
         ...    {'group': 'root', 'name': 'kernel/x86', 'links': 3, 'perms': 'rwxr-xr-x',
-        ...     'raw_entry': 'drwxr-xr-x   3 root     root            0 Apr 20 15:58 kernel/x86',
         ...     'owner': 'root', 'date': 'Apr 20 15:58', 'type': 'd', 'dir': '', 'size': 0}
         ... ]
         >>> "udev-rules" in ls.unparsed_lines
@@ -88,7 +87,6 @@ class Lsinitrd(CommandParser):
             >>> dev_console = {
             ...     'type': 'c', 'perms': 'rw-r--r--', 'links': 1, 'owner': 'root', 'group': 'root',
             ...     'major': 5, 'minor': 1, 'date': 'Apr 20 15:57', 'name': 'dev/console', 'dir': '',
-            ...     'raw_entry': 'crw-r--r--   1 root     root       5,   1 Apr 20 15:57 dev/console'
             ... }
             >>> dev_console in lsdev
             True
@@ -139,6 +137,7 @@ class LsinitrdKdumpImage(Lsinitrd):
         >>> result_list[0].get('raw_entry')
         'crw-r--r--   1 root     root       1,   9 Aug  4  2020 dev/urandom'
     """
+
     pass
 
 
@@ -157,4 +156,5 @@ class LsinitrdLvmConf(LvmConf):
         >>> lsinitrd_lvm_conf.get("volume_list")
         [ "vg2", "vg3/lvol3", "@tag2", "@*" ]
     """
+
     pass

--- a/insights/tests/parsers/test_ls_boot.py
+++ b/insights/tests/parsers/test_ls_boot.py
@@ -96,6 +96,10 @@ def test_ls_boot():
         "raw_entry": "-rwx------. 1 root root system_u:object_r:boot_t:s0     6535 Apr 21  2023 grub.cfg",
         "dir": "/boot/grub2",
     }
+    assert (
+        ls_alzr_boot.raw_entry_of("/boot/grub2", "grub.cfg")
+        == "-rwx------. 1 root root system_u:object_r:boot_t:s0 6535 Apr 21  2023 grub.cfg"
+    )
 
 
 def test_boot_links():
@@ -126,6 +130,10 @@ def test_boot_links():
         "raw_entry": "lrwxrwxrwx.  1 root root system_u:object_r:boot_t:s0              32 Apr 21  2023 dtb -> dtb-5.14.0-162.6.1.el9_1.aarch64",
         "dir": "/boot",
     }
+    assert (
+        ls_alzr_boot.raw_entry_of("/boot", "dtb")
+        == "lrwxrwxrwx. 1 root root system_u:object_r:boot_t:s0 32 Apr 21  2023 dtb -> dtb-5.14.0-162.6.1.el9_1.aarch64"
+    )
 
 
 def test_doc_examples():

--- a/insights/tests/parsers/test_ls_dev.py
+++ b/insights/tests/parsers/test_ls_dev.py
@@ -156,6 +156,10 @@ def test_ls_dev():
         "raw_entry": "lrwxrwxrwx.  1 root root system_u:object_r:device_t:s0    7 Sep 30 16:58 root -> ../dm-0",
         "dir": "/dev/rhel",
     }
+    assert (
+        ls_alzr_dev.raw_entry_of("/dev/rhel", "root")
+        == "lrwxrwxrwx. 1 root root system_u:object_r:device_t:s0 7 Sep 30 16:58 root -> ../dm-0"
+    )
 
 
 def test_doc_examples():

--- a/insights/tests/parsers/test_ls_file_listing.py
+++ b/insights/tests/parsers/test_ls_file_listing.py
@@ -1,5 +1,6 @@
 # -*- coding: UTF-8 -*-
 import doctest
+import pytest
 
 from insights.parsers import ls as ls_module
 from insights.parsers.ls import FileListing
@@ -180,45 +181,80 @@ def test_multiple_directories():
     # Testing the main features
     listing = dirs.listing_of('/etc/sysconfig')
     assert listing['..'] == {
-        'type': 'd', 'perms': 'rwxr-xr-x.', 'links': 77, 'owner': '0',
-        'group': '0', 'size': 8192, 'date': 'Jul 13 03:55', 'name': '..',
+        'type': 'd',
+        'perms': 'rwxr-xr-x.',
+        'links': 77,
+        'owner': '0',
+        'group': '0',
+        'size': 8192,
+        'date': 'Jul 13 03:55',
+        'name': '..',
         'raw_entry': 'drwxr-xr-x. 77 0 0 8192 Jul 13 03:55 ..',
-        'dir': '/etc/sysconfig'
+        'dir': '/etc/sysconfig',
     }
     assert listing['cbq'] == {
-        'type': 'd', 'perms': 'rwxr-xr-x.', 'links': 2, 'owner': '0',
-        'group': '0', 'size': 41, 'date': 'Jul  6 23:32', 'name': 'cbq',
+        'type': 'd',
+        'perms': 'rwxr-xr-x.',
+        'links': 2,
+        'owner': '0',
+        'group': '0',
+        'size': 41,
+        'date': 'Jul  6 23:32',
+        'name': 'cbq',
         'raw_entry': 'drwxr-xr-x.  2 0 0   41 Jul  6 23:32 cbq',
-        'dir': '/etc/sysconfig'
+        'dir': '/etc/sysconfig',
     }
     assert listing['firewalld'] == {
-        'type': '-', 'perms': 'rw-r--r--.', 'links': 1, 'owner': '0',
-        'group': '0', 'size': 72, 'date': 'Sep 15  2015',
-        'name': 'firewalld', 'raw_entry':
-        '-rw-r--r--.  1 0 0   72 Sep 15  2015 firewalld',
-        'dir': '/etc/sysconfig'
+        'type': '-',
+        'perms': 'rw-r--r--.',
+        'links': 1,
+        'owner': '0',
+        'group': '0',
+        'size': 72,
+        'date': 'Sep 15  2015',
+        'name': 'firewalld',
+        'raw_entry': '-rw-r--r--.  1 0 0   72 Sep 15  2015 firewalld',
+        'dir': '/etc/sysconfig',
     }
     assert listing['grub'] == {
-        'type': 'l', 'perms': 'rwxrwxrwx.', 'links': 1, 'owner': '0',
-        'group': '0', 'size': 17, 'date': 'Jul  6 23:32', 'name': 'grub',
-        'link': '/etc/default/grub', 'raw_entry':
-        'lrwxrwxrwx.  1 0 0   17 Jul  6 23:32 grub -> /etc/default/grub',
-        'dir': '/etc/sysconfig'
+        'type': 'l',
+        'perms': 'rwxrwxrwx.',
+        'links': 1,
+        'owner': '0',
+        'group': '0',
+        'size': 17,
+        'date': 'Jul  6 23:32',
+        'name': 'grub',
+        'link': '/etc/default/grub',
+        'raw_entry': 'lrwxrwxrwx.  1 0 0   17 Jul  6 23:32 grub -> /etc/default/grub',
+        'dir': '/etc/sysconfig',
     }
 
     listing = dirs.listing_of('/etc/rc.d/rc3.d')
     assert listing['..'] == {
-        'type': 'd', 'perms': 'rwxr-xr-x.', 'links': 10, 'owner': '0',
-        'group': '0', 'size': 4096, 'date': 'Sep 16  2015', 'name': '..',
+        'type': 'd',
+        'perms': 'rwxr-xr-x.',
+        'links': 10,
+        'owner': '0',
+        'group': '0',
+        'size': 4096,
+        'date': 'Sep 16  2015',
+        'name': '..',
         'raw_entry': 'drwxr-xr-x. 10 0 0 4096 Sep 16  2015 ..',
-        'dir': '/etc/rc.d/rc3.d'
+        'dir': '/etc/rc.d/rc3.d',
     }
     assert listing['K50netconsole'] == {
-        'type': 'l', 'perms': 'rwxrwxrwx.', 'links': 1, 'owner': '0',
-        'group': '0', 'size': 20, 'date': 'Jul  6 23:32',
-        'name': 'K50netconsole', 'link': '../init.d/netconsole', 'raw_entry':
-        'lrwxrwxrwx.  1 0 0   20 Jul  6 23:32 K50netconsole -> ../init.d/netconsole',
-        'dir': '/etc/rc.d/rc3.d'
+        'type': 'l',
+        'perms': 'rwxrwxrwx.',
+        'links': 1,
+        'owner': '0',
+        'group': '0',
+        'size': 20,
+        'date': 'Jul  6 23:32',
+        'name': 'K50netconsole',
+        'link': '../init.d/netconsole',
+        'raw_entry': 'lrwxrwxrwx.  1 0 0   20 Jul  6 23:32 K50netconsole -> ../init.d/netconsole',
+        'dir': '/etc/rc.d/rc3.d',
     }
 
     assert dirs.total_of('/etc/sysconfig') == 96
@@ -226,23 +262,71 @@ def test_multiple_directories():
 
     assert dirs.dir_contains('/etc/sysconfig', 'firewalld')
     assert dirs.dir_entry('/etc/sysconfig', 'grub') == {
-        'type': 'l', 'perms': 'rwxrwxrwx.', 'links': 1, 'owner': '0',
-        'group': '0', 'size': 17, 'date': 'Jul  6 23:32', 'name': 'grub',
-        'link': '/etc/default/grub', 'raw_entry':
-        'lrwxrwxrwx.  1 0 0   17 Jul  6 23:32 grub -> /etc/default/grub',
-        'dir': '/etc/sysconfig'
+        'type': 'l',
+        'perms': 'rwxrwxrwx.',
+        'links': 1,
+        'owner': '0',
+        'group': '0',
+        'size': 17,
+        'date': 'Jul  6 23:32',
+        'name': 'grub',
+        'link': '/etc/default/grub',
+        'raw_entry': 'lrwxrwxrwx.  1 0 0   17 Jul  6 23:32 grub -> /etc/default/grub',
+        'dir': '/etc/sysconfig',
     }
 
     assert dirs.path_entry('/etc/sysconfig/cbq') == {
-        'type': 'd', 'perms': 'rwxr-xr-x.', 'links': 2, 'owner': '0',
-        'group': '0', 'size': 41, 'date': 'Jul  6 23:32', 'name': 'cbq',
+        'type': 'd',
+        'perms': 'rwxr-xr-x.',
+        'links': 2,
+        'owner': '0',
+        'group': '0',
+        'size': 41,
+        'date': 'Jul  6 23:32',
+        'name': 'cbq',
         'raw_entry': 'drwxr-xr-x.  2 0 0   41 Jul  6 23:32 cbq',
-        'dir': '/etc/sysconfig'
+        'dir': '/etc/sysconfig',
     }
     assert dirs.path_entry('no_slash') is None
     assert dirs.path_entry('/') is None
     assert dirs.path_entry('/foo') is None
     assert dirs.path_entry('/etc/sysconfig/notfound') is None
+
+
+def test_raw_entry_of():
+    dirs = FileListing(context_wrap(MULTIPLE_DIRECTORIES, path='ls_-la_.etc'))
+
+    assert dirs.raw_entry_of('/etc/sysconfig', '..') == 'drwxr-xr-x. 77 0 0 8192 Jul 13 03:55 ..'
+    assert dirs.raw_entry_of('/etc/sysconfig', 'cbq') == 'drwxr-xr-x. 2 0 0 41 Jul  6 23:32 cbq'
+    assert (
+        dirs.raw_entry_of('/etc/sysconfig', 'firewalld')
+        == '-rw-r--r--. 1 0 0 72 Sep 15  2015 firewalld'
+    )
+    assert (
+        dirs.raw_entry_of('/etc/sysconfig', 'grub')
+        == 'lrwxrwxrwx. 1 0 0 17 Jul  6 23:32 grub -> /etc/default/grub'
+    )
+
+    with pytest.raises(KeyError):
+        dirs.raw_entry_of('/etc/sysconfig', 'test')
+
+    with pytest.raises(KeyError):
+        dirs.raw_entry_of('/etc/test', 'grub')
+
+    dirs = FileListing(context_wrap(COMPLICATED_FILES))
+    assert dirs.raw_entry_of('/tmp', 'dm-10') == 'brw-rw----. 1 0 6 253, 10 Aug  4 16:56 dm-10'
+
+    dirs = FileListing(context_wrap(SELINUX_DIRECTORY))
+    assert (
+        dirs.raw_entry_of('/boot', 'grub2')
+        == 'drwxr-xr-x. root root system_u:object_r:boot_t:s0 grub2'
+    )
+
+    dirs = FileListing(context_wrap(FILES_CREATED_WITH_SELINUX_DISABLED))
+    assert (
+        dirs.raw_entry_of('/dev/mapper', 'lv_cpwtk001_data01')
+        == 'lrwxrwxrwx 1 0 0 7 Apr 27 05:34 lv_cpwtk001_data01 -> ../dm-7'
+    )
 
 
 def test_complicated_directory():
@@ -254,10 +338,17 @@ def test_complicated_directory():
     assert listing['menu.lst']['type'] == 'l'
     assert listing['menu.lst']['link'] == './grub.conf'
     assert dirs.dir_entry('/tmp', 'dm-10') == {
-        'type': 'b', 'perms': 'rw-rw----.', 'links': 1, 'owner': '0',
-        'group': '6', 'major': 253, 'minor': 10, 'date': 'Aug  4 16:56',
-        'name': 'dm-10', 'dir': '/tmp', 'raw_entry':
-        'brw-rw----.  1 0 6 253,  10 Aug  4 16:56 dm-10'
+        'type': 'b',
+        'perms': 'rw-rw----.',
+        'links': 1,
+        'owner': '0',
+        'group': '6',
+        'major': 253,
+        'minor': 10,
+        'date': 'Aug  4 16:56',
+        'name': 'dm-10',
+        'dir': '/tmp',
+        'raw_entry': 'brw-rw----.  1 0 6 253,  10 Aug  4 16:56 dm-10',
     }
     assert listing['dm-10']['type'] == 'b'
     assert listing['dm-10']['major'] == 253
@@ -298,11 +389,17 @@ def test_selinux_directory():
 
     # Test that one entry is exactly what we expect it to be.
     expected = {
-        'type': 'd', 'perms': 'rwxr-xr-x.', 'owner': 'root', 'group': 'root',
-        'se_user': 'system_u', 'se_role': 'object_r', 'se_type': 'boot_t',
-        'se_mls': 's0', 'name': 'grub2', 'raw_entry':
-        'drwxr-xr-x. root root system_u:object_r:boot_t:s0      grub2',
-        'dir': '/boot'
+        'type': 'd',
+        'perms': 'rwxr-xr-x.',
+        'owner': 'root',
+        'group': 'root',
+        'se_user': 'system_u',
+        'se_role': 'object_r',
+        'se_type': 'boot_t',
+        'se_mls': 's0',
+        'name': 'grub2',
+        'raw_entry': 'drwxr-xr-x. root root system_u:object_r:boot_t:s0      grub2',
+        'dir': '/boot',
     }
     actual = dirs.dir_entry('/boot', 'grub2')
     assert actual == expected
@@ -313,9 +410,17 @@ def test_files_created_with_selinux_disabled():
 
     # Test that one entry is exactly what we expect it to be.
     assert dirs.dir_entry('/dev/mapper', 'lv_cpwtk001_data01') == {
-        'group': '0', 'name': 'lv_cpwtk001_data01', 'links': 1, 'perms': 'rwxrwxrwx',
-        'raw_entry': 'lrwxrwxrwx 1 0 0 7 Apr 27 05:34 lv_cpwtk001_data01 -> ../dm-7', 'owner': '0',
-        'link': '../dm-7', 'date': 'Apr 27 05:34', 'type': 'l', 'dir': '/dev/mapper', 'size': 7
+        'group': '0',
+        'name': 'lv_cpwtk001_data01',
+        'links': 1,
+        'perms': 'rwxrwxrwx',
+        'raw_entry': 'lrwxrwxrwx 1 0 0 7 Apr 27 05:34 lv_cpwtk001_data01 -> ../dm-7',
+        'owner': '0',
+        'link': '../dm-7',
+        'date': 'Apr 27 05:34',
+        'type': 'l',
+        'dir': '/dev/mapper',
+        'size': 7,
     }
 
 

--- a/insights/tests/parsers/test_ls_sys_firmware.py
+++ b/insights/tests/parsers/test_ls_sys_firmware.py
@@ -72,6 +72,10 @@ def test_ls_sys_firmware():
         "raw_entry": "drwxr-xr-x.  3 root root system_u:object_r:sysfs_t:s0   0 Sep 30 16:58 efi",
         "dir": "/sys/firmware",
     }
+    assert (
+        ls_alzr_sys_firmware.raw_entry_of("/sys/firmware", "efi")
+        == "drwxr-xr-x. 3 root root system_u:object_r:sysfs_t:s0 0 Sep 30 16:58 efi"
+    )
 
 
 def test_doc_examples():


### PR DESCRIPTION
- it's mem/size consuming to story the 'raw_entry' for each line
- add a raw_entry_of() method to return the rough raw line instead
- mark the "raw_entry" as deprecated in comment

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
