### PR TITLE
feat(client): --unregister should not delete inventory host

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -785,32 +785,18 @@ class InsightsConnection(object):
 
     def unregister(self):
         """
-        Unregister this system from the insights service
+        Unregister this host
         """
         if self.config.legacy_upload:
             return self._legacy_unregister()
 
-        results = self._fetch_system_by_machine_id()
-        if not results:
-            if machine_id_exists() or os.path.exists(constants.registered_files[0]):
-                write_unregistered_file()
-                write_to_disk(constants.machine_id_file, delete=True)
-                logger.info("Successfully unregistered from the Red Hat Insights Service")
-                return True
-            logger.info('This host could not be found.')
-            return False
-        try:
-            logger.debug("Unregistering host...")
-            url = self.inventory_url + "/hosts/" + results['id']
-            response = self.delete(url)
-            response.raise_for_status()
-            logger.info(
-                "Successfully unregistered from the Red Hat Insights Service")
+        if machine_id_exists() or os.path.exists(constants.registered_files[0]):
+            write_unregistered_file()
+            write_to_disk(constants.machine_id_file, delete=True)
+            logger.info("Successfully unregistered this host.")
             return True
-        except (requests.ConnectionError, requests.Timeout, requests.HTTPError) as e:
-            logger.debug(e)
-            logger.error("Could not unregister this system")
-            return False
+        logger.info('This host is not registered, unregistration is not applicable.')
+        return False
 
     # -LEGACY-
     def register(self):

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -248,15 +248,10 @@ def post_update(client, config):
 
     # put this first to avoid conflicts with register
     if config.unregister:
-        if reg_check:
-            logger.info('Unregistering this host from Insights.')
-            if client.unregister():
-                get_scheduler(config).remove_scheduling()
-                sys.exit(constants.sig_kill_ok)
-            else:
-                sys.exit(constants.sig_kill_bad)
+        if client.unregister():
+            get_scheduler(config).remove_scheduling()
+            sys.exit(constants.sig_kill_ok)
         else:
-            logger.info('This host is not registered, unregistration is not applicable.')
             sys.exit(constants.sig_kill_bad)
 
     # halt here if unregistered

--- a/insights/tests/client/phase/test_post_update.py
+++ b/insights/tests/client/phase/test_post_update.py
@@ -224,10 +224,12 @@ def test_post_update_unregister_registered(insights_config, insights_client, get
     """
     insights_config.return_value.load_all.return_value.unregister = True
     insights_client.return_value.get_registration_status = MagicMock(return_value=True)
+    insights_client.return_value.unregister = MagicMock(return_value=True)
     with raises(SystemExit) as exc_info:
         post_update()
     assert exc_info.value.code == 100
     insights_client.return_value.get_registration_status.assert_called_once()
+    insights_client.return_value.unregister.assert_called_once()
     insights_client.return_value.clear_local_registration.assert_not_called()
     insights_client.return_value.set_display_name.assert_not_called()
     get_scheduler.return_value.remove_scheduling.assert_called_once()
@@ -244,9 +246,11 @@ def test_post_update_unregister_unregistered(insights_config, insights_client, g
     """
     insights_config.return_value.load_all.return_value.unregister = True
     insights_client.return_value.get_registration_status = MagicMock(return_value=False)
+    insights_client.return_value.unregister = MagicMock(return_value=False)
     with raises(SystemExit) as exc_info:
         post_update()
     assert exc_info.value.code == 101
+    insights_client.return_value.unregister.assert_called_once()
     insights_client.return_value.clear_local_registration.assert_not_called()
     insights_client.return_value.set_display_name.assert_not_called()
     get_scheduler.return_value.remove_scheduling.assert_not_called()


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: CCT-870

The unregistration command now updates local files (.registered, .unregistered, machine-id) without calling the DELETE /hosts/UUID API endpoint and removing the host from Inventory. This reduces unnecessary load on the Inventory service.
