### PR TITLE
fix: drop issue option of Specs.nvidia_smi_query_gpu

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -641,8 +641,8 @@ class DefaultSpecs(Specs):
     )
     nvidia_smi_l = simple_command("/usr/bin/nvidia-smi -L")
     nvidia_smi_query_gpu = simple_command(
-        "/usr/bin/nvidia-smi --query-gpu=index,name,uuid,memory.total,clocks_event_reasons.active --format=csv,noheader"
-    )
+        "/usr/bin/nvidia-smi --query-gpu=index,name,uuid,memory.total --format=csv,noheader"
+    )  # make sure not break the command collection when adding new options
     nvme_core_io_timeout = simple_file("/sys/module/nvme_core/parameters/io_timeout")
     od_cpu_dma_latency = simple_command("/usr/bin/od -An -t d /dev/cpu_dma_latency")
     odbc_ini = simple_file("/etc/odbc.ini")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Observed on the spec collection results, the command can be collected for most cases. But there is still a case that the command collection failed with message: "Field \"clocks_event_reasons.active\" is not a valid field to query".

To make sure the basic gpu info be collected, drop this option `clocks_event_reasons` in this spec command.

to serve RHINENG-16372