### PR TITLE
fix: no exception for FilesDirsNumberOfDir

### DIFF
--- a/insights/parsers/files_dirs_number_of_dirs.py
+++ b/insights/parsers/files_dirs_number_of_dirs.py
@@ -4,6 +4,7 @@ Number of files or dirs from dirs
 
 Parses the output of files or dirs number from dirs.
 """
+
 from insights.core import JSONParser
 from insights.core.plugins import parser
 from insights.specs import Specs
@@ -30,14 +31,12 @@ class FilesDirsNumberOfDir(JSONParser):
         1
     """
 
-    def dirs_number_of(self, dir):
-        """Return the number of dirs under specified `dir`"""
-        if dir in self.data:
-            return self.data[dir]["dirs_number"]
-        raise KeyError("No such %s dir collected", dir)
+    def dirs_number_of(self, _dir):
+        """Return the number of dirs under specified `_dir`, None when no such `_dir`"""
+        if _dir in self.data:
+            return self.data[_dir]["dirs_number"]
 
-    def files_number_of(self, dir):
-        """Return the number of files under specified `dir`"""
-        if dir in self.data:
-            return self.data[dir]["files_number"]
-        raise KeyError("No such %s dir collected", dir)
+    def files_number_of(self, _dir):
+        """Return the number of files under specified `_dir`, None when no such `_dir`"""
+        if _dir in self.data:
+            return self.data[_dir]["files_number"]

--- a/insights/tests/parsers/test_files_dirs_number_of_dirs.py
+++ b/insights/tests/parsers/test_files_dirs_number_of_dirs.py
@@ -1,5 +1,4 @@
 import doctest
-import pytest
 
 from insights.parsers import files_dirs_number_of_dirs
 from insights.tests import context_wrap
@@ -19,15 +18,12 @@ def test_files_number_of_dir():
     assert output.data["/var/spool/clientmqueue/"]["dirs_number"] == 1
     assert output.files_number_of("/var/spool/postfix/maildrop/") == 5
     assert output.dirs_number_of("/var/spool/clientmqueue/") == 1
-    with pytest.raises(KeyError):
-        output.dirs_number_of("/var/spool/clienttest/")
-    with pytest.raises(KeyError):
-        output.files_number_of("/var/spool/clienttest/")
+    # no such dir
+    assert output.dirs_number_of("/var/spool/clienttest/") is None
+    assert output.files_number_of("/var/spool/clienttest/") is None
 
 
 def test_doc_examples():
-    env = {
-        'filesnumberofdir': files_dirs_number_of_dirs.FilesDirsNumberOfDir(context_wrap(OUTPUT))
-    }
+    env = {'filesnumberofdir': files_dirs_number_of_dirs.FilesDirsNumberOfDir(context_wrap(OUTPUT))}
     failed, total = doctest.testmod(files_dirs_number_of_dirs, globs=env)
     assert failed == 0


### PR DESCRIPTION
- exception will break the rules execution and is useless for engine

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
