### PR TITLE
fix(RHINENG-15343): Limit compliance policies to 100

### DIFF
--- a/insights/specs/datasources/compliance/__init__.py
+++ b/insights/specs/datasources/compliance/__init__.py
@@ -192,7 +192,7 @@ class ComplianceClient:
             exit(constants.sig_kill_bad)
 
     def assignable_policies(self):
-        url = "https://{0}/compliance/v2/policies?filter=(os_major_version={1} and os_minor_version={2})"
+        url = "https://{0}/compliance/v2/policies?filter=(os_major_version={1} and os_minor_version={2})&limit=100"
         full_url = url.format(self.config.base_url, self.os_major, self.os_minor)
         logger.debug("Fetching policies with: {0}".format(full_url))
         response = self.conn.session.get(full_url)

--- a/insights/tests/datasources/compliance/test_compliance.py
+++ b/insights/tests/datasources/compliance/test_compliance.py
@@ -310,7 +310,7 @@ def test_assignable_policies(config, log):
         )
     )
     assert compliance_client.assignable_policies() == 0
-    url = "https://localhost/app/compliance/v2/policies?filter=(os_major_version=9 and os_minor_version=3)"
+    url = "https://localhost/app/compliance/v2/policies?filter=(os_major_version=9 and os_minor_version=3)&limit=100"
     compliance_client.conn.session.get.assert_called_with(url)
     log.warning.assert_not_called()
     log.error.assert_not_called()
@@ -333,7 +333,7 @@ def test_assignable_policies_failed_code(config, log):
         )
     )
     assert compliance_client.assignable_policies() == constants.sig_kill_bad
-    url = "https://localhost/app/compliance/v2/policies?filter=(os_major_version=9 and os_minor_version=3)"
+    url = "https://localhost/app/compliance/v2/policies?filter=(os_major_version=9 and os_minor_version=3)&limit=100"
     compliance_client.conn.session.get.assert_called_with(url)
     log.error.assert_called_with("An error has occurred while communicating with the API.\n")
 
@@ -355,7 +355,7 @@ def test_assignable_policies_failed_empty(config, log):
         )
     )
     assert compliance_client.assignable_policies() == constants.sig_kill_bad
-    url = "https://localhost/app/compliance/v2/policies?filter=(os_major_version=9 and os_minor_version=3)"
+    url = "https://localhost/app/compliance/v2/policies?filter=(os_major_version=9 and os_minor_version=3)&limit=100"
     compliance_client.conn.session.get.assert_called_with(url)
     log.warning.assert_called_with("System is not assignable to any policy. Create supported policy using the Compliance web UI.\n")
     log.error.assert_not_called()


### PR DESCRIPTION
Currently default compliance limit is `10`. There are sometimes more than 10 policies so customers need to see all of them. At the same time, number of policies is reasonable and not going to be more than 100 for sure. So instead of having batch requests here, setting limit to `100` will be enough.

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
