### PR TITLE
fix: ls_lan_filters as another input for uefi_boot checking

### DIFF
--- a/insights/tests/combiners/test_grub_conf.py
+++ b/insights/tests/combiners/test_grub_conf.py
@@ -1,8 +1,13 @@
 from insights.combiners.grub_conf import GrubConf, BootLoaderEntries
-from insights.parsers.grub_conf import (Grub1Config, Grub2Config, Grub2EFIConfig, Grub1EFIConfig,
-                                        BootLoaderEntries as BLE)
+from insights.parsers.grub_conf import (
+    Grub1Config,
+    Grub2Config,
+    Grub2EFIConfig,
+    Grub1EFIConfig,
+    BootLoaderEntries as BLE,
+)
 from insights.parsers.grubenv import GrubEnv
-from insights.parsers.ls_sys_firmware import LsSysFirmware
+from insights.parsers.ls import LSlanFiltered
 from insights.parsers.installed_rpms import InstalledRpms
 from insights.parsers.cmdline import CmdLine
 from insights.tests import context_wrap
@@ -287,7 +292,7 @@ drwxr-xr-x.  5 0 0 0 May 30 11:50 .
 dr-xr-xr-x. 13 0 0 0 May 30 11:50 ..
 drwxr-xr-x.  5 0 0 0 May 30 11:50 acpi
 drwxr-xr-x.  3 0 0 0 May 30 11:51 dmi
-drwxr-xr-x.  7 0 0 0 May 30 12:31 memmap
+drwxr-xr-x.  7 0 0 0 May 30 12:31 efi
 
 /sys/firmware/efi:
 total 0
@@ -366,7 +371,7 @@ tuned_initrd=
 def test_grub1_only1():
     grub1 = Grub1Config(context_wrap(GRUB1_TEMPLATE))
     cmdline = CmdLine(context_wrap(CMDLINE_V1))
-    result = GrubConf(grub1, None, None, None, None, None, cmdline, None)
+    result = GrubConf(grub1, None, None, None, None, None, cmdline, None, None)
     assert result.kernel_initrds['grub_kernels'][0] == 'vmlinuz-2.6.32-642.el6.x86_64'
     assert result.kernel_initrds['grub_initrds'][0] == 'initramfs-2.6.32-642.el6.x86_64.img'
     assert result.is_kdump_iommu_enabled is True
@@ -382,8 +387,8 @@ def test_grub1_cmdline():
     grub1e = Grub1EFIConfig(context_wrap(GRUB1_EFI_CFG))
     grub2e = Grub2EFIConfig(context_wrap(GRUB2_EFI_CFG))
     cmdline = CmdLine(context_wrap(CMDLINE_V1))
-    sys_firmware = LsSysFirmware(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
-    result = GrubConf(grub1, grub2, grub1e, grub2e, None, None, cmdline, sys_firmware)
+    ls_lan = LSlanFiltered(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
+    result = GrubConf(grub1, grub2, grub1e, grub2e, None, None, cmdline, ls_lan, None)
     assert result.kernel_initrds['grub_kernels'][0] == 'vmlinuz-2.6.32-642.el6.x86_64'
     assert result.kernel_initrds['grub_initrds'][0] == 'initramfs-2.6.32-642.el6.x86_64.img'
     assert result.is_kdump_iommu_enabled is True
@@ -399,8 +404,8 @@ def test_grub1_efi_cmdline():
     grub1e = Grub1EFIConfig(context_wrap(GRUB1_EFI_CFG))
     grub2e = Grub2EFIConfig(context_wrap(GRUB2_EFI_CFG))
     cmdline = CmdLine(context_wrap(CMDLINE_V1))
-    sys_firmware = LsSysFirmware(context_wrap(SYS_FIRMWARE_DIR_EFI))
-    result = GrubConf(grub1, grub2, grub1e, grub2e, None, None, cmdline, sys_firmware)
+    ls_lan = LSlanFiltered(context_wrap(SYS_FIRMWARE_DIR_EFI))
+    result = GrubConf(grub1, grub2, grub1e, grub2e, None, None, cmdline, ls_lan, None)
     assert result.kernel_initrds['grub_kernels'][0] == 'vmlinuz-2.6.32-71.el6.x86_64'
     assert result.kernel_initrds['grub_initrds'][0] == 'initramfs-2.6.32-71.el6.x86_64.img'
     assert result.is_kdump_iommu_enabled is False
@@ -416,8 +421,8 @@ def test_grub1_rpms():
     grub2e = Grub2EFIConfig(context_wrap(GRUB2_EFI_CFG))
     rpms = InstalledRpms(context_wrap(INSTALLED_RPMS_V1))
     cmdline = CmdLine(context_wrap(CMDLINE_V2))
-    sys_firmware = LsSysFirmware(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
-    result = GrubConf(grub1, grub2, grub1e, grub2e, None, rpms, cmdline, sys_firmware)
+    ls_lan = LSlanFiltered(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
+    result = GrubConf(grub1, grub2, grub1e, grub2e, None, rpms, cmdline, ls_lan, None)
     assert result.kernel_initrds['grub_kernels'][0] == 'vmlinuz-2.6.32-642.el6.x86_64'
     assert result.kernel_initrds['grub_initrds'][0] == 'initramfs-2.6.32-642.el6.x86_64.img'
     assert result.is_kdump_iommu_enabled is True
@@ -434,8 +439,8 @@ def test_grub1_efi_rpms():
     grub2e = Grub2EFIConfig(context_wrap(GRUB2_EFI_CFG))
     rpms = InstalledRpms(context_wrap(INSTALLED_RPMS_V1))
     cmdline = CmdLine(context_wrap(CMDLINE_V2))
-    sys_firmware = LsSysFirmware(context_wrap(SYS_FIRMWARE_DIR_EFI))
-    result = GrubConf(grub1, grub2, grub1e, grub2e, None, rpms, cmdline, sys_firmware)
+    ls_lan = LSlanFiltered(context_wrap(SYS_FIRMWARE_DIR_EFI))
+    result = GrubConf(grub1, grub2, grub1e, grub2e, None, rpms, cmdline, ls_lan, None)
     assert result.kernel_initrds['grub_kernels'][0] == 'vmlinuz-2.6.32-71.el6.x86_64'
     assert result.kernel_initrds['grub_initrds'][0] == 'initramfs-2.6.32-71.el6.x86_64.img'
     assert result.is_kdump_iommu_enabled is False
@@ -451,12 +456,15 @@ def test_grub2_cmdline():
     grub1e = Grub1EFIConfig(context_wrap(GRUB1_EFI_CFG))
     grub2e = Grub2EFIConfig(context_wrap(GRUB2_EFI_CFG))
     cmdline = CmdLine(context_wrap(CMDLINE_V2))
-    sys_firmware = LsSysFirmware(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
-    result = GrubConf(grub1, grub2, grub1e, grub2e, None, None, cmdline, sys_firmware)
+    ls_lan = LSlanFiltered(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
+    result = GrubConf(grub1, grub2, grub1e, grub2e, None, None, cmdline, ls_lan, None)
     assert result.kernel_initrds['grub_kernels'][0] == 'vmlinuz-3.10.0-327.el7.x86_64'
     assert result.kernel_initrds['grub_initrds'][0] == 'initramfs-3.10.0-327.el7.x86_64.img'
     assert result.is_kdump_iommu_enabled is False
-    assert result.get_grub_cmdlines('/vmlinuz-3.10.0')[0].name == "'Red Hat Enterprise Linux Server (3.10.0-327.el7.x86_64) 7.2 (Maipo)' --class red --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'gnulinux-3.10.0-327.el7.x86_64-advanced-4f80b3d4-90ba-4545-869c-febdecc586ce'"  # noqa
+    assert (
+        result.get_grub_cmdlines('/vmlinuz-3.10.0')[0].name
+        == "'Red Hat Enterprise Linux Server (3.10.0-327.el7.x86_64) 7.2 (Maipo)' --class red --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'gnulinux-3.10.0-327.el7.x86_64-advanced-4f80b3d4-90ba-4545-869c-febdecc586ce'"
+    )  # noqa
     assert result.get_grub_cmdlines('test') == []
     assert result.get_grub_cmdlines('') == []
     assert len(result.get_grub_cmdlines()) == 2
@@ -470,10 +478,12 @@ def test_grub2_efi_cmdline():
     grub1e = Grub1EFIConfig(context_wrap(GRUB1_EFI_CFG))
     grub2e = Grub2EFIConfig(context_wrap(GRUB2_EFI_CFG))
     cmdline = CmdLine(context_wrap(CMDLINE_V2))
-    sys_firmware = LsSysFirmware(context_wrap(SYS_FIRMWARE_DIR_EFI))
-    result = GrubConf(grub1, grub2, grub1e, grub2e, None, None, cmdline, sys_firmware)
+    ls_lan = LSlanFiltered(context_wrap(SYS_FIRMWARE_DIR_EFI))
+    result = GrubConf(grub1, grub2, grub1e, grub2e, None, None, cmdline, ls_lan, None)
     assert result.get_grub_cmdlines() == result.get_grub_cmdlines('/vmlinuz')
-    assert result.get_grub_cmdlines('rescue')[0].name.startswith("'Red Hat Enterprise Linux Server (0-rescue")
+    assert result.get_grub_cmdlines('rescue')[0].name.startswith(
+        "'Red Hat Enterprise Linux Server (0-rescue"
+    )
     assert len(result.get_grub_cmdlines()) == 4
     assert result.version == 2
     assert result.is_efi is True
@@ -486,11 +496,14 @@ def test_grub2_rpms():
     grub2e = Grub2EFIConfig(context_wrap(GRUB2_EFI_CFG))
     rpms = InstalledRpms(context_wrap(INSTALLED_RPMS_V2))
     cmdline = CmdLine(context_wrap(CMDLINE_V1))
-    result = GrubConf(grub1, grub2, grub1e, grub2e, None, rpms, cmdline, None)
+    result = GrubConf(grub1, grub2, grub1e, grub2e, None, rpms, cmdline, None, None)
     assert result.kernel_initrds['grub_kernels'][0] == 'vmlinuz-3.10.0-327.el7.x86_64'
     assert result.kernel_initrds['grub_initrds'][0] == 'initramfs-3.10.0-327.el7.x86_64.img'
     assert result.is_kdump_iommu_enabled is False
-    assert result.get_grub_cmdlines('/vmlinuz-3.10.0')[0].name == "'Red Hat Enterprise Linux Server (3.10.0-327.el7.x86_64) 7.2 (Maipo)' --class red --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'gnulinux-3.10.0-327.el7.x86_64-advanced-4f80b3d4-90ba-4545-869c-febdecc586ce'"  # noqa
+    assert (
+        result.get_grub_cmdlines('/vmlinuz-3.10.0')[0].name
+        == "'Red Hat Enterprise Linux Server (3.10.0-327.el7.x86_64) 7.2 (Maipo)' --class red --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'gnulinux-3.10.0-327.el7.x86_64-advanced-4f80b3d4-90ba-4545-869c-febdecc586ce'"
+    )  # noqa
     assert result.get_grub_cmdlines('test') == []
     assert result.get_grub_cmdlines('') == []
     assert len(result.get_grub_cmdlines()) == 2
@@ -505,11 +518,13 @@ def test_grub2_efi_rpms():
     grub2e = Grub2EFIConfig(context_wrap(GRUB2_EFI_CFG))
     rpms = InstalledRpms(context_wrap(INSTALLED_RPMS_V2))
     cmdline = CmdLine(context_wrap(CMDLINE_V1))
-    sys_firmware = LsSysFirmware(context_wrap(SYS_FIRMWARE_DIR_EFI))
-    result = GrubConf(grub1, grub2, grub1e, grub2e, None, rpms, cmdline, sys_firmware)
+    ls_lan = LSlanFiltered(context_wrap(SYS_FIRMWARE_DIR_EFI))
+    result = GrubConf(grub1, grub2, grub1e, grub2e, None, rpms, cmdline, ls_lan, None)
     assert result.kernel_initrds['grub_initrds'][0] == 'initramfs-3.10.0-514.16.1.el7.x86_64.img'
     assert result.get_grub_cmdlines() == result.get_grub_cmdlines('/vmlinuz')
-    assert result.get_grub_cmdlines('rescue')[0].name.startswith("'Red Hat Enterprise Linux Server (0-rescue")
+    assert result.get_grub_cmdlines('rescue')[0].name.startswith(
+        "'Red Hat Enterprise Linux Server (0-rescue"
+    )
     assert len(result.get_grub_cmdlines()) == 4
     assert result.version == 2
     assert result.is_efi is True
@@ -519,21 +534,21 @@ def test_get_grub_cmdlines_none():
     grub1 = Grub1Config(context_wrap(GRUB1_TEMPLATE))
     grub2 = Grub2Config(context_wrap(GRUB2_TEMPLATE))
     cmdline = CmdLine(context_wrap(CMDLINE_V2))
-    sys_firmware = LsSysFirmware(context_wrap(SYS_FIRMWARE_DIR_EFI))
+    ls_lan = LSlanFiltered(context_wrap(SYS_FIRMWARE_DIR_EFI))
     with pytest.raises(Exception) as pe:
-        GrubConf(grub1, grub2, None, None, None, None, cmdline, sys_firmware)
+        GrubConf(grub1, grub2, None, None, None, None, cmdline, ls_lan, None)
     assert "No valid grub configuration is found." in str(pe.value)
 
     grub1e = Grub1EFIConfig(context_wrap(GRUB1_TEMPLATE))
     grub2e = Grub2EFIConfig(context_wrap(GRUB2_TEMPLATE))
     rpms = InstalledRpms(context_wrap(INSTALLED_RPMS_V2))
     with pytest.raises(Exception) as pe:
-        GrubConf(None, None, grub1e, grub2e, None, rpms, None, None)
+        GrubConf(None, None, grub1e, grub2e, None, rpms, None, None, None)
     assert "No valid grub configuration is found." in str(pe.value)
 
     grub2e = Grub2EFIConfig(context_wrap(GRUB2_EFI_CFG))
     with pytest.raises(Exception) as pe:
-        GrubConf(grub1, None, grub1e, grub2e, None, rpms, None, None)
+        GrubConf(grub1, None, grub1e, grub2e, None, rpms, None, None, None)
     assert "No valid grub configuration is found." in str(pe.value)
 
 
@@ -542,10 +557,10 @@ def test_grub2_grubenv():
     grub2 = Grub2Config(context_wrap(GRUB2_TEMPLATE))
     grub_ble1 = BLE(context_wrap(BOOT_LOADER_ENTRIES_1))
     grub_ble2 = BLE(context_wrap(BOOT_LOADER_ENTRIES_2))
-    grub_bles = BootLoaderEntries([grub_ble1, grub_ble2], grubenv, None)
+    grub_bles = BootLoaderEntries([grub_ble1, grub_ble2], grubenv, None, None)
     rpms = InstalledRpms(context_wrap(INSTALLED_RPMS_V2))
-    sys_firmware = LsSysFirmware(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
-    result = GrubConf(None, grub2, None, None, grub_bles, rpms, None, sys_firmware)
+    ls_lan = LSlanFiltered(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
+    result = GrubConf(None, grub2, None, None, grub_bles, rpms, None, ls_lan, None)
     assert len(result.get_grub_cmdlines()) == 2
     assert 'noapic' not in result.get_grub_cmdlines()[1]['cmdline']
     assert 'transparent_hugepages' not in result.get_grub_cmdlines()[0]['cmdline']
@@ -559,10 +574,10 @@ def test_grub2_grubenv_with_kernelopts():
     grub_ble1 = BLE(context_wrap(BOOT_LOADER_ENTRIES_1))
     grub_ble2 = BLE(context_wrap(BOOT_LOADER_ENTRIES_2))
     grub_ble3 = BLE(context_wrap(BOOT_LOADER_ENTRIES_3))
-    grub_bles = BootLoaderEntries([grub_ble1, grub_ble2, grub_ble3], grubenv, None)
+    grub_bles = BootLoaderEntries([grub_ble1, grub_ble2, grub_ble3], grubenv, None, None)
     rpms = InstalledRpms(context_wrap(INSTALLED_RPMS_V2))
-    sys_firmware = LsSysFirmware(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
-    result = GrubConf(None, grub2, None, None, grub_bles, rpms, None, sys_firmware)
+    ls_lan = LSlanFiltered(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
+    result = GrubConf(None, grub2, None, None, grub_bles, rpms, None, ls_lan, None)
     assert len(result.get_grub_cmdlines()) == 3
     assert 'noapic' in result.get_grub_cmdlines()[2]['cmdline']
     assert 'transparent_hugepages' in result.get_grub_cmdlines()[2]['cmdline']
@@ -575,10 +590,10 @@ def test_grub2_with_blscfg():
     grub_ble1 = BLE(context_wrap(BOOT_LOADER_ENTRIES_1))
     grub_ble2 = BLE(context_wrap(BOOT_LOADER_ENTRIES_2))
     grub_ble3 = BLE(context_wrap(BOOT_LOADER_ENTRIES_3))
-    grub_bles = BootLoaderEntries([grub_ble1, grub_ble2, grub_ble3], None, None)
+    grub_bles = BootLoaderEntries([grub_ble1, grub_ble2, grub_ble3], None, None, None)
     rpms = InstalledRpms(context_wrap(INSTALLED_RPMS_V2))
-    sys_firmware = LsSysFirmware(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
-    result = GrubConf(None, grub2, None, None, grub_bles, rpms, None, sys_firmware)
+    ls_lan = LSlanFiltered(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
+    result = GrubConf(None, grub2, None, None, grub_bles, rpms, None, ls_lan, None)
     assert len(result.get_grub_cmdlines()) == 3
     assert 'noapic' in result.get_grub_cmdlines()[0]['cmdline']
     assert 'transparent_hugepages' not in result.get_grub_cmdlines()[0]['cmdline']
@@ -590,10 +605,10 @@ def test_grub2_boot_loader_entries():
     grub2 = Grub2Config(context_wrap(GRUB2_TEMPLATE_BLSCFG))
     grub_ble1 = BLE(context_wrap(BOOT_LOADER_ENTRIES_1))
     grub_ble2 = BLE(context_wrap(BOOT_LOADER_ENTRIES_2))
-    grub_bles = BootLoaderEntries([grub_ble1, grub_ble2], None, None)
+    grub_bles = BootLoaderEntries([grub_ble1, grub_ble2], None, None, None)
     rpms = InstalledRpms(context_wrap(INSTALLED_RPMS_V2))
-    sys_firmware = LsSysFirmware(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
-    result = GrubConf(None, grub2, None, None, grub_bles, rpms, None, sys_firmware)
+    ls_lan = LSlanFiltered(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
+    result = GrubConf(None, grub2, None, None, grub_bles, rpms, None, ls_lan, None)
     assert len(result.get_grub_cmdlines()) == 2
     assert 'noapic' in result.get_grub_cmdlines()[0]['cmdline']
     assert result.version == 2
@@ -605,10 +620,10 @@ def test_grub2_boot_loader_entries_with_grubenv():
     grub2 = Grub2Config(context_wrap(GRUB2_TEMPLATE_BLSCFG))
     grub_ble1 = BLE(context_wrap(BOOT_LOADER_ENTRIES_1))
     grub_ble3 = BLE(context_wrap(BOOT_LOADER_ENTRIES_3))
-    grub_bles = BootLoaderEntries([grub_ble1, grub_ble3], grubenv, None)
+    grub_bles = BootLoaderEntries([grub_ble1, grub_ble3], grubenv, None, None)
     rpms = InstalledRpms(context_wrap(INSTALLED_RPMS_V2))
-    sys_firmware = LsSysFirmware(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
-    result = GrubConf(None, grub2, None, None, grub_bles, rpms, None, sys_firmware)
+    ls_lan = LSlanFiltered(context_wrap(SYS_FIRMWARE_DIR_NOEFI))
+    result = GrubConf(None, grub2, None, None, grub_bles, rpms, None, ls_lan, None)
     assert len(result.get_grub_cmdlines()) == 2
     assert 'noapic' in result.get_grub_cmdlines()[0]['cmdline']
     assert 'transparent_hugepages' in result.get_grub_cmdlines()[0]['cmdline']

--- a/insights/tests/combiners/test_selinux.py
+++ b/insights/tests/combiners/test_selinux.py
@@ -101,10 +101,13 @@ SELINUXTYPE=targeted
 """
 
 SESTATUS_TEMPLATE = {
-    'loaded_policy_name': 'targeted', 'selinux_root_directory': '/etc/selinux',
-    'selinuxfs_mount': '/sys/fs/selinux', 'mode_from_config_file': 'enforcing',
+    'loaded_policy_name': 'targeted',
+    'selinux_root_directory': '/etc/selinux',
+    'selinuxfs_mount': '/sys/fs/selinux',
+    'mode_from_config_file': 'enforcing',
     'policy_mls_status': 'enabled',
-    'policy_deny_unknown_status': 'allowed', 'max_kernel_policy_version': '30'
+    'policy_deny_unknown_status': 'allowed',
+    'max_kernel_policy_version': '30',
 }
 
 
@@ -140,15 +143,19 @@ GRUB1_OUTPUTS = [
     # Problematic.
     (
         {'kernel_boot_options': 'selinux=0'},
-        {GRUB_DISABLED: [
-            '/vmlinuz-2.6.32-642.el6.x86_64 selinux=0 ro root=/dev/mapper/VolGroup-lv_root rd_NO_LUKS LANG=en_US.UTF-8 rd_NO_MD rd_LVM_LV=VolGroup/lv_swap SYSFONT=latarcyrheb-sun16 crashkernel=auto rd_LVM_LV=VolGroup/lv_root  KEYBOARDTYPE=pc KEYTABLE=us rd_NO_DM rhgb quiet',
-        ]},
+        {
+            GRUB_DISABLED: [
+                '/vmlinuz-2.6.32-642.el6.x86_64 selinux=0 ro root=/dev/mapper/VolGroup-lv_root rd_NO_LUKS LANG=en_US.UTF-8 rd_NO_MD rd_LVM_LV=VolGroup/lv_swap SYSFONT=latarcyrheb-sun16 crashkernel=auto rd_LVM_LV=VolGroup/lv_root  KEYBOARDTYPE=pc KEYTABLE=us rd_NO_DM rhgb quiet',
+            ]
+        },
     ),
     (
         {'kernel_boot_options': 'enforcing=0'},
-        {GRUB_NOT_ENFORCING: [
-            '/vmlinuz-2.6.32-642.el6.x86_64 enforcing=0 ro root=/dev/mapper/VolGroup-lv_root rd_NO_LUKS LANG=en_US.UTF-8 rd_NO_MD rd_LVM_LV=VolGroup/lv_swap SYSFONT=latarcyrheb-sun16 crashkernel=auto rd_LVM_LV=VolGroup/lv_root  KEYBOARDTYPE=pc KEYTABLE=us rd_NO_DM rhgb quiet',
-        ]},
+        {
+            GRUB_NOT_ENFORCING: [
+                '/vmlinuz-2.6.32-642.el6.x86_64 enforcing=0 ro root=/dev/mapper/VolGroup-lv_root rd_NO_LUKS LANG=en_US.UTF-8 rd_NO_MD rd_LVM_LV=VolGroup/lv_swap SYSFONT=latarcyrheb-sun16 crashkernel=auto rd_LVM_LV=VolGroup/lv_root  KEYBOARDTYPE=pc KEYTABLE=us rd_NO_DM rhgb quiet',
+            ]
+        },
     ),
     (
         {'kernel_boot_options': 'selinux=0 enforcing=0'},
@@ -158,7 +165,7 @@ GRUB1_OUTPUTS = [
             ],
             GRUB_NOT_ENFORCING: [
                 '/vmlinuz-2.6.32-642.el6.x86_64 selinux=0 enforcing=0 ro root=/dev/mapper/VolGroup-lv_root rd_NO_LUKS LANG=en_US.UTF-8 rd_NO_MD rd_LVM_LV=VolGroup/lv_swap SYSFONT=latarcyrheb-sun16 crashkernel=auto rd_LVM_LV=VolGroup/lv_root  KEYBOARDTYPE=pc KEYTABLE=us rd_NO_DM rhgb quiet',
-            ]
+            ],
         },
     ),
 ]
@@ -316,17 +323,21 @@ GRUB2_OUTPUTS = [
     # Problematic.
     (
         {'kernel_boot_options': 'selinux=0'},
-        {GRUB_DISABLED: [
-            '/vmlinuz-3.10.0-327.el7.x86_64 selinux=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet LANG=en_US.UTF-8',
-            '/vmlinuz-0-rescue-9f20b35c9faa49aebe171f62a11b236f selinux=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet',
-        ]},
+        {
+            GRUB_DISABLED: [
+                '/vmlinuz-3.10.0-327.el7.x86_64 selinux=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet LANG=en_US.UTF-8',
+                '/vmlinuz-0-rescue-9f20b35c9faa49aebe171f62a11b236f selinux=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet',
+            ]
+        },
     ),
     (
         {'kernel_boot_options': 'enforcing=0'},
-        {GRUB_NOT_ENFORCING: [
-            '/vmlinuz-3.10.0-327.el7.x86_64 enforcing=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet LANG=en_US.UTF-8',
-            '/vmlinuz-0-rescue-9f20b35c9faa49aebe171f62a11b236f enforcing=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet',
-        ]},
+        {
+            GRUB_NOT_ENFORCING: [
+                '/vmlinuz-3.10.0-327.el7.x86_64 enforcing=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet LANG=en_US.UTF-8',
+                '/vmlinuz-0-rescue-9f20b35c9faa49aebe171f62a11b236f enforcing=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet',
+            ]
+        },
     ),
     (
         {'kernel_boot_options': 'selinux=0 enforcing=0'},
@@ -338,51 +349,98 @@ GRUB2_OUTPUTS = [
             GRUB_NOT_ENFORCING: [
                 '/vmlinuz-3.10.0-327.el7.x86_64 selinux=0 enforcing=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet LANG=en_US.UTF-8',
                 '/vmlinuz-0-rescue-9f20b35c9faa49aebe171f62a11b236f selinux=0 enforcing=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet',
-            ]
+            ],
         },
     ),
 ]
 
 TEST_CASES_1 = [
-    ((SESTATUS_OUT, SELINUX_CONF, GRUB1_TEMPLATE),
-     (True, {})),
-    ((SESTATUS_OUT, SELINUX_CONF, GRUB1_TEMPLATE.format(kernel_boot_options='selinux=0')),
-     (False, {GRUB_DISABLED: ['/vmlinuz-2.6.32-642.el6.x86_64 selinux=0 ro root=/dev/mapper/VolGroup-lv_root rd_NO_LUKS LANG=en_US.UTF-8 rd_NO_MD rd_LVM_LV=VolGroup/lv_swap SYSFONT=latarcyrheb-sun16 crashkernel=auto rd_LVM_LV=VolGroup/lv_root  KEYBOARDTYPE=pc KEYTABLE=us rd_NO_DM rhgb quiet']})),
-    ((SESTATUS_OUT, SELINUX_CONF, GRUB1_TEMPLATE.format(kernel_boot_options='enforcing=0')),
-     (False, {GRUB_NOT_ENFORCING: ['/vmlinuz-2.6.32-642.el6.x86_64 enforcing=0 ro root=/dev/mapper/VolGroup-lv_root rd_NO_LUKS LANG=en_US.UTF-8 rd_NO_MD rd_LVM_LV=VolGroup/lv_swap SYSFONT=latarcyrheb-sun16 crashkernel=auto rd_LVM_LV=VolGroup/lv_root  KEYBOARDTYPE=pc KEYTABLE=us rd_NO_DM rhgb quiet']})),
-    ((SESTATUS_OUT, SELINUX_CONF_DISABLED, GRUB1_TEMPLATE),
-     (False, {BOOT_DISABLED: 'disabled'})),
-    ((SESTATUS_OUT, SELINUX_CONF_NOT_ENFORCING, GRUB1_TEMPLATE),
-     (False, {BOOT_NOT_ENFORCING: 'permissive'})),
-    ((SESTATUS_OUT, SELINUX_CONF_COMMENTED, GRUB1_TEMPLATE),
-     (False, {BOOT_NOT_ENFORCING: 'Missing in config (Permissive by default)'})),
-    ((SESTATUS_OUT_DISABLED, SELINUX_CONF_NOT_ENFORCING, GRUB1_TEMPLATE),
-     (False, {RUNTIME_DISABLED: 'disabled', BOOT_NOT_ENFORCING: 'permissive'})),
-    ((SESTATUS_OUT_NOT_ENFORCING, SELINUX_CONF_DISABLED, GRUB1_TEMPLATE.format(kernel_boot_options='selinux=0')),
-     (False, {GRUB_DISABLED: ['/vmlinuz-2.6.32-642.el6.x86_64 selinux=0 ro root=/dev/mapper/VolGroup-lv_root rd_NO_LUKS LANG=en_US.UTF-8 rd_NO_MD rd_LVM_LV=VolGroup/lv_swap SYSFONT=latarcyrheb-sun16 crashkernel=auto rd_LVM_LV=VolGroup/lv_root  KEYBOARDTYPE=pc KEYTABLE=us rd_NO_DM rhgb quiet'],
-              RUNTIME_NOT_ENFORCING: 'permissive',
-              BOOT_DISABLED: 'disabled'
-              })),
+    ((SESTATUS_OUT, SELINUX_CONF, GRUB1_TEMPLATE), (True, {})),
+    (
+        (SESTATUS_OUT, SELINUX_CONF, GRUB1_TEMPLATE.format(kernel_boot_options='selinux=0')),
+        (
+            False,
+            {
+                GRUB_DISABLED: [
+                    '/vmlinuz-2.6.32-642.el6.x86_64 selinux=0 ro root=/dev/mapper/VolGroup-lv_root rd_NO_LUKS LANG=en_US.UTF-8 rd_NO_MD rd_LVM_LV=VolGroup/lv_swap SYSFONT=latarcyrheb-sun16 crashkernel=auto rd_LVM_LV=VolGroup/lv_root  KEYBOARDTYPE=pc KEYTABLE=us rd_NO_DM rhgb quiet'
+                ]
+            },
+        ),
+    ),
+    (
+        (SESTATUS_OUT, SELINUX_CONF, GRUB1_TEMPLATE.format(kernel_boot_options='enforcing=0')),
+        (
+            False,
+            {
+                GRUB_NOT_ENFORCING: [
+                    '/vmlinuz-2.6.32-642.el6.x86_64 enforcing=0 ro root=/dev/mapper/VolGroup-lv_root rd_NO_LUKS LANG=en_US.UTF-8 rd_NO_MD rd_LVM_LV=VolGroup/lv_swap SYSFONT=latarcyrheb-sun16 crashkernel=auto rd_LVM_LV=VolGroup/lv_root  KEYBOARDTYPE=pc KEYTABLE=us rd_NO_DM rhgb quiet'
+                ]
+            },
+        ),
+    ),
+    ((SESTATUS_OUT, SELINUX_CONF_DISABLED, GRUB1_TEMPLATE), (False, {BOOT_DISABLED: 'disabled'})),
+    (
+        (SESTATUS_OUT, SELINUX_CONF_NOT_ENFORCING, GRUB1_TEMPLATE),
+        (False, {BOOT_NOT_ENFORCING: 'permissive'}),
+    ),
+    (
+        (SESTATUS_OUT, SELINUX_CONF_COMMENTED, GRUB1_TEMPLATE),
+        (False, {BOOT_NOT_ENFORCING: 'Missing in config (Permissive by default)'}),
+    ),
+    (
+        (SESTATUS_OUT_DISABLED, SELINUX_CONF_NOT_ENFORCING, GRUB1_TEMPLATE),
+        (False, {RUNTIME_DISABLED: 'disabled', BOOT_NOT_ENFORCING: 'permissive'}),
+    ),
+    (
+        (
+            SESTATUS_OUT_NOT_ENFORCING,
+            SELINUX_CONF_DISABLED,
+            GRUB1_TEMPLATE.format(kernel_boot_options='selinux=0'),
+        ),
+        (
+            False,
+            {
+                GRUB_DISABLED: [
+                    '/vmlinuz-2.6.32-642.el6.x86_64 selinux=0 ro root=/dev/mapper/VolGroup-lv_root rd_NO_LUKS LANG=en_US.UTF-8 rd_NO_MD rd_LVM_LV=VolGroup/lv_swap SYSFONT=latarcyrheb-sun16 crashkernel=auto rd_LVM_LV=VolGroup/lv_root  KEYBOARDTYPE=pc KEYTABLE=us rd_NO_DM rhgb quiet'
+                ],
+                RUNTIME_NOT_ENFORCING: 'permissive',
+                BOOT_DISABLED: 'disabled',
+            },
+        ),
+    ),
 ]
 TEST_CASES_2 = [
-    ((SESTATUS_OUT, SELINUX_CONF, GRUB2_TEMPLATE % ('selinux=0', 'selinux=0')),
-     (False, {GRUB_DISABLED: ['/vmlinuz-3.10.0-327.el7.x86_64 selinux=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet LANG=en_US.UTF-8',
-                              '/vmlinuz-0-rescue-9f20b35c9faa49aebe171f62a11b236f selinux=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet',
-                              ]})),
-    ((SESTATUS_OUT_DISABLED, SELINUX_CONF, GRUB2_TEMPLATE),
-     (False, {RUNTIME_DISABLED: 'disabled'})),
-    ((SESTATUS_OUT_NOT_ENFORCING, SELINUX_CONF, GRUB2_TEMPLATE),
-     (False, {RUNTIME_NOT_ENFORCING: 'permissive'})),
+    (
+        (SESTATUS_OUT, SELINUX_CONF, GRUB2_TEMPLATE % ('selinux=0', 'selinux=0')),
+        (
+            False,
+            {
+                GRUB_DISABLED: [
+                    '/vmlinuz-3.10.0-327.el7.x86_64 selinux=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet LANG=en_US.UTF-8',
+                    '/vmlinuz-0-rescue-9f20b35c9faa49aebe171f62a11b236f selinux=0 root=/dev/mapper/rhel-root ro crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet',
+                ]
+            },
+        ),
+    ),
+    (
+        (SESTATUS_OUT_DISABLED, SELINUX_CONF, GRUB2_TEMPLATE),
+        (False, {RUNTIME_DISABLED: 'disabled'}),
+    ),
+    (
+        (SESTATUS_OUT_NOT_ENFORCING, SELINUX_CONF, GRUB2_TEMPLATE),
+        (False, {RUNTIME_NOT_ENFORCING: 'permissive'}),
+    ),
 ]
 
 
 def test_integration():
     import pprint
+
     for inputs, outputs in TEST_CASES_1:
         sestatus = SEStatus(context_wrap(inputs[0]))
         selinux_config = SelinuxConfig(context_wrap(inputs[1]))
         grub_config = Grub1Config(context_wrap(inputs[2]))
-        grub_conf = GrubConf(grub_config, None, None, None, None, None, None, None)
+        grub_conf = GrubConf(grub_config, None, None, None, None, None, None, None, None)
         selinux = SELinux(sestatus, selinux_config, grub_conf)
         assert selinux.ok() == outputs[0]
         assert selinux.problems == outputs[1]
@@ -392,7 +450,7 @@ def test_integration():
         sestatus = SEStatus(context_wrap(inputs[0]))
         selinux_config = SelinuxConfig(context_wrap(inputs[1]))
         grub_config = Grub2Config(context_wrap(inputs[2]))
-        grub_conf = GrubConf(None, grub_config, None, None, None, None, None, None)
+        grub_conf = GrubConf(None, grub_config, None, None, None, None, None, None, None)
         selinux = SELinux(sestatus, selinux_config, grub_conf)
         assert selinux.ok() == outputs[0]
         assert selinux.problems == outputs[1]

--- a/insights/tests/core/test_get_dependency_specs.py
+++ b/insights/tests/core/test_get_dependency_specs.py
@@ -12,7 +12,6 @@ from insights.parsers.lsof import Lsof
 from insights.parsers.lscpu import LsCPU
 from insights.parsers.lsblk import LSBlock
 from insights.parsers.ls_boot import LsBoot
-from insights.parsers.ls_sys_firmware import LsSysFirmware
 from insights.parsers.dmidecode import DMIDecode
 from insights.parsers.os_release import OsRelease
 from insights.parsers.mount import Mount
@@ -39,7 +38,7 @@ def condition_03(*args):
     return True
 
 
-@condition(PsEf, [LsSysFirmware, DMIDecode], optional=[PsEo])
+@condition(PsEf, [DMIDecode], optional=[PsEo])
 def condition_04(*args):
     return True
 


### PR DESCRIPTION
The 'ls_sys_firmware' is not suggested to collect in core collection, use the 'ls_lan_filtered' as another alternative input for combiners that depends on 'ls_sys_firmware'.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
