### PR TITLE
chore: stop collecting ls_boot/ls_sys_firmware

### DIFF
--- a/insights/parsers/ls_boot.py
+++ b/insights/parsers/ls_boot.py
@@ -22,8 +22,8 @@ class LsBoot(CommandParser, FileListing):
     .. warning::
 
         For Insights Advisor Rules, it's recommended to use the
-        :class:`insights.parsers.ls.LSlanR` and add the ``"/boot"`` to
-        the filter list of `Specs.ls_lanR_dirs` instead.
+        :class:`insights.parsers.ls.LSlanFiltered` and add the ``"/boot"`` to
+        the filter list of `Specs.ls_lan_filtered_dirs` instead.
 
     Sample directory listing::
 

--- a/insights/parsers/ls_dev.py
+++ b/insights/parsers/ls_dev.py
@@ -8,6 +8,7 @@ The ``ls -lanR /dev`` or ``ls -alZR /dev`` command provides information for the 
 See :class:`insights.parsers.ls.FileListing` for more information.
 
 """
+
 from insights import CommandParser, parser
 from insights.parsers.ls import FileListing
 from insights.specs import Specs
@@ -21,8 +22,8 @@ class LsDev(CommandParser, FileListing):
     .. warning::
 
         For Insights Advisor Rules, it's recommended to use the
-        :class:`insights.parsers.ls.LSlanR` and add the ``"/dev"`` to
-        the filter list of `Specs.ls_lanR_dirs` instead.
+        :class:`insights.parsers.ls.LSlanFiltered` and add the ``"/dev"`` to
+        the filter list of `Specs.ls_lan_filtered_dirs` instead.
 
     Sample directory listing::
         /dev:

--- a/insights/parsers/ls_sys_firmware.py
+++ b/insights/parsers/ls_sys_firmware.py
@@ -22,8 +22,8 @@ class LsSysFirmware(CommandParser, FileListing):
     .. warning::
 
         For Insights Advisor Rules, it's recommended to use the
-        :class:`insights.parsers.ls.LSlanR` and add the ``"/sys/firmware"`` to
-        the filter list of `Specs.ls_lanR_dirs` instead.
+        :class:`insights.parsers.ls.LSlanFiltered` and add the ``"/sys/firmware"`` to
+        the filter list of `Specs.ls_lan_filtered_dirs` instead.
 
     Sample directory listing::
 

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -470,7 +470,6 @@ class DefaultSpecs(Specs):
     lpstat_p = simple_command("/usr/bin/lpstat -p")
     lpstat_protocol_printers = lpstat.lpstat_protocol_printers_info
     lpstat_queued_jobs_count = lpstat.lpstat_queued_jobs_count
-    # New `ls` Specs
     ls_la = command_with_args('/bin/ls -la %s', ls.list_with_la, keep_rc=True)
     ls_la_filtered = command_with_args(
         '/bin/ls -la %s', ls.list_with_la_filtered, keep_rc=True
@@ -484,10 +483,7 @@ class DefaultSpecs(Specs):
     ls_lanRL = command_with_args('/bin/ls -lanRL %s', ls.list_with_lanRL, keep_rc=True)
     ls_laRZ = command_with_args('/bin/ls -laRZ %s', ls.list_with_laRZ, keep_rc=True)
     ls_laZ = command_with_args('/bin/ls -laZ %s', ls.list_with_laZ, keep_rc=True)
-    # Useful individual `ls` Specs
-    ls_boot = simple_command("/bin/ls -lanR /boot")
-    ls_dev = simple_command("/bin/ls -lanR /dev")
-    ls_sys_firmware = simple_command("/bin/ls -lanR /sys/firmware")
+    ls_dev = simple_command("/bin/ls -lanR /dev")  # T.B.D
     lsattr = command_with_args("/bin/lsattr %s", lsattr.paths_to_lsattr)
     lsblk = simple_command("/bin/lsblk")
     lsblk_pairs = simple_command(


### PR DESCRIPTION
- In some edge cases, the 3 specs are extremely large, results in engine's OOM the "ls_lan_filtered" is an alternative. Hence, we stop collecting them and change to use the "ls_lan_filtered" instead.
- In this PR only ls_boot and ls_sys_firmware is removed from collection.
  For "ls_dev", more things should be done before removing it.
- See RHINENG-16906
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
