### PR TITLE
fix(test): no filter required for ls_lan_filtered when using GrubConf&SELinux combiner

### DIFF
--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -154,10 +154,13 @@ def run_input_data(component, input_data, store_skips=False):
 
 
 COMPONENT_FILTERED_PARSERS = {
+    'BootLoaderEntries': ['insights.specs.Specs.ls_lan_filtered'],
     'CloudInstance': ['insights.parsers.subscription_manager.SubscriptionManagerFacts'],
     'CloudProvider': ['insights.parsers.rhsm_conf.RHSMConf'],
+    'GrubConf': ['insights.specs.Specs.ls_lan_filtered'],
     'OSRelease': ['insights.parsers.dmesg.DmesgLineList'],
     'Sap': ['insights.parsers.saphostctrl.SAPHostCtrlInstances'],
+    'SELinux': ['insights.specs.Specs.ls_lan_filtered'],
 }
 
 


### PR DESCRIPTION

- add them to the test exclude list, so in corresponding test of rule, it's not necessary to add filters to ls_lan_filtered spec when using the combiner

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
