### PR TITLE
fix: improve wording for unassignable Policy

### DIFF
--- a/insights/specs/datasources/compliance/__init__.py
+++ b/insights/specs/datasources/compliance/__init__.py
@@ -235,10 +235,14 @@ class ComplianceClient:
         logger.debug("Content of the response {0} - {1}".format(response, response.content))
 
         if response.status_code == 202:
-            logger.info("Operation completed successfully.\n")
+            logger.info("System successfully assigned to policy.\n")
             return 0
         else:
-            logger.error("Policy ID {0} does not exist.".format(policy_id))
+            logger.error(
+                "Policy ID {0} can not be assigned. "
+                "Refer to the /var/log/insights-client/insights-client.log for more details."
+                .format(policy_id)
+            )
             return constants.sig_kill_bad
 
     def get_system_policies(self):

--- a/insights/tests/datasources/compliance/test_compliance.py
+++ b/insights/tests/datasources/compliance/test_compliance.py
@@ -390,7 +390,7 @@ def test_policy_link_assign(config, log):
         policy_id, compliance_client.inventory_id
     )
     compliance_client.conn.session.patch.assert_called_with(url)
-    log.info.assert_called_with("Operation completed successfully.\n")
+    log.info.assert_called_with("System successfully assigned to policy.\n")
 
 
 @patch('insights.specs.datasources.compliance.logger')
@@ -407,7 +407,11 @@ def test_policy_link_assign_invalid_policy_id(config, log):
         policy_id, compliance_client.inventory_id
     )
     compliance_client.conn.session.patch.assert_called_with(url)
-    log.error.assert_called_with("Policy ID {0} does not exist.".format(policy_id))
+    log.error.assert_called_with(
+        "Policy ID {0} can not be assigned. "
+        "Refer to the /var/log/insights-client/insights-client.log for more details."
+        .format(policy_id)
+    )
 
 
 @patch('insights.specs.datasources.compliance.logger')
@@ -424,7 +428,7 @@ def test_policy_link_unassign(config, log):
         policy_id, compliance_client.inventory_id
     )
     compliance_client.conn.session.delete.assert_called_with(url)
-    log.info.assert_called_with("Operation completed successfully.\n")
+    log.info.assert_called_with("System successfully assigned to policy.\n")
 
 
 @patch('insights.specs.datasources.compliance.logger')
@@ -441,4 +445,8 @@ def test_policy_link_unassign_invalid_policy_id(config, log):
         policy_id, compliance_client.inventory_id
     )
     compliance_client.conn.session.delete.assert_called_with(url)
-    log.error.assert_called_with("Policy ID {0} does not exist.".format(policy_id))
+    log.error.assert_called_with(
+        "Policy ID {0} can not be assigned. "
+        "Refer to the /var/log/insights-client/insights-client.log for more details."
+        .format(policy_id)
+    )


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-10847

When Compliance tries to assign Host to a Policy, it returns either 202 in case of success or 404 in any other case.

When one tries to assign a Host that already has a Policy assigned, the Policy is not anymore in the list of available options, hence the process can not succeed with creating the link and returns 404.

That in the logic of insights-client seems as failure, and it returns non-zero error status with the confusing message `"Policy ... does not exist"`.

This commit is to improve the message sent in such case to make it less misleading.