### PR TITLE
fix(spec): inherit HOME env when collecting ilab commands

### DIFF
--- a/insights/collect.py
+++ b/insights/collect.py
@@ -26,26 +26,11 @@ from insights.core import blacklist
 from insights.core import dr
 from insights.core import filters
 from insights.core.serde import Hydration
+from insights.core.spec_factory import SAFE_ENV
 from insights.util import fs
 from insights.util import utc
 from insights.util.hostname import determine_hostname
 from insights.util.subproc import call
-
-SAFE_ENV = {
-    "PATH": os.path.pathsep.join(
-        [
-            "/bin",
-            "/usr/bin",
-            "/sbin",
-            "/usr/sbin",
-            "/usr/share/Modules/bin",
-        ]
-    ),
-    "LC_ALL": "C",
-}
-
-if "LANG" in os.environ:
-    SAFE_ENV["LANG"] = os.environ["LANG"]
 
 log = logging.getLogger(__name__)
 

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -398,8 +398,8 @@ class DefaultSpecs(Specs):
     ibm_lparcfg = simple_file("/proc/powerpc/lparcfg")
     ifcfg = glob_file("/etc/sysconfig/network-scripts/ifcfg-*")
     ifcfg_static_route = glob_file("/etc/sysconfig/network-scripts/route-*")
-    ilab_config_show = simple_command("/usr/bin/ilab config show")
-    ilab_model_list = simple_command("/usr/bin/ilab model list")
+    ilab_config_show = simple_command("/usr/bin/ilab config show", inherit_env=['HOME'])
+    ilab_model_list = simple_command("/usr/bin/ilab model list", inherit_env=['HOME'])
     imagemagick_policy = glob_file(
         ["/etc/ImageMagick/policy.xml", "/usr/lib*/ImageMagick-6.5.4/config/policy.xml"]
     )
@@ -919,7 +919,9 @@ class DefaultSpecs(Specs):
     tmpfilesd = glob_file(
         ["/etc/tmpfiles.d/*.conf", "/usr/lib/tmpfiles.d/*.conf", "/run/tmpfiles.d/*.conf"]
     )
-    tomcat_web_xml = first_of([glob_file("/etc/tomcat*/web.xml"), glob_file("/conf/tomcat/tomcat*/web.xml")])
+    tomcat_web_xml = first_of(
+        [glob_file("/etc/tomcat*/web.xml"), glob_file("/conf/tomcat/tomcat*/web.xml")]
+    )
     tomcat_vdc_fallback = simple_command(
         "/usr/bin/find /usr/share -maxdepth 1 -name 'tomcat*' -exec /bin/grep -R -s 'VirtualDirContext' --include '*.xml' '{}' +"
     )


### PR DESCRIPTION
- `ilab` command needs the pre-initialized configuration file which can be located as per the "HOME" env by default

- fix below issue when collection `ilab` specs
```mkdir: cannot create directory '/.cache'```

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
