### PR TITLE
fix(setup): change to license_files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,4 @@ addopts = "-rsxXfE --ignore=./build/"
 testpaths = "insights"
 
 [metadata]
-license_file = LICENSE
+license_files = LICENSE


### PR DESCRIPTION
when setting up some venv, it's reported 'license_file' is deprecated

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
