### PR TITLE
fix: add more candidates to CloudProvider combiner

### DIFF
--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -156,7 +156,10 @@ def run_input_data(component, input_data, store_skips=False):
 COMPONENT_FILTERED_PARSERS = {
     'BootLoaderEntries': ['insights.specs.Specs.ls_lan_filtered'],
     'CloudInstance': ['insights.parsers.subscription_manager.SubscriptionManagerFacts'],
-    'CloudProvider': ['insights.parsers.rhsm_conf.RHSMConf'],
+    'CloudProvider': [
+        'insights.parsers.rhsm_conf.RHSMConf',
+        'insights.parsers.subscription_manager.SubscriptionManagerFacts',
+    ],
     'GrubConf': ['insights.specs.Specs.ls_lan_filtered'],
     'OSRelease': ['insights.parsers.dmesg.DmesgLineList'],
     'Sap': ['insights.parsers.saphostctrl.SAPHostCtrlInstances'],

--- a/insights/tests/components/test_cloud_provider.py
+++ b/insights/tests/components/test_cloud_provider.py
@@ -3,25 +3,28 @@ from insights.parsers.dmidecode import DMIDecode
 from insights.combiners.cloud_provider import CloudProvider
 from insights.components.cloud_provider import IsAWS, IsAzure, IsGCP
 from insights.tests.combiners.test_cloud_provider import (
-        DMIDECODE_AWS, DMIDECODE_GOOGLE, DMIDECODE_AZURE_ASSET_TAG)
+    DMIDECODE_AWS,
+    DMIDECODE_GOOGLE,
+    DMIDECODE_AZURE_ASSET_TAG,
+)
 
 
 def test_is_aws():
     dmi = DMIDecode(context_wrap(DMIDECODE_AWS))
-    cp = CloudProvider(None, dmi, None, None)
+    cp = CloudProvider(None, dmi, None, None, None, None)
     result = IsAWS(cp)
     assert isinstance(result, IsAWS)
 
 
 def test_is_azure():
     dmi = DMIDecode(context_wrap(DMIDECODE_AZURE_ASSET_TAG))
-    cp = CloudProvider(None, dmi, None, None)
+    cp = CloudProvider(None, dmi, None, None, None, None)
     result = IsAzure(cp)
     assert isinstance(result, IsAzure)
 
 
 def test_is_gcp():
     dmi = DMIDecode(context_wrap(DMIDECODE_GOOGLE))
-    cp = CloudProvider(None, dmi, None, None)
+    cp = CloudProvider(None, dmi, None, None, None, None)
     result = IsGCP(cp)
     assert isinstance(result, IsGCP)


### PR DESCRIPTION
- add 'cloud init query' and 'subman facts' as optional candidates,
  Check the 'subman facts' first to identify the CP more accurately.
  Check the 'cloud init query' result the last.
- do not check RPM for Azure, as the 'walinuxagent' package can be
  installed on other cloud instance
- refine the "_select_provider" method to use the checking results
- Jira: RHINENG-13705

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
