### PR TITLE
fix: no attribute 'type' error in CloudInstance combiner

### DIFF
--- a/insights/combiners/cloud_instance.py
+++ b/insights/combiners/cloud_instance.py
@@ -87,7 +87,7 @@ class CloudInstance(object):
                 raise ContentException("Unmatched/unsupported types!")
             self.id = facts[key]
             if self.type is None:
-                self.type = facts.get("{0}_instance_type".format(self.provider), '')
+                self.type = facts.get("{0}_instance_type".format(self.provider))
         # The instance id is the key attribute of this Combiner
         if self.id is None:
             raise SkipComponent

--- a/insights/combiners/cloud_instance.py
+++ b/insights/combiners/cloud_instance.py
@@ -13,6 +13,7 @@ results of the following combiners and parsers:
 * :py:class:`insights.parsers.subscription_manager.SubscriptionManagerFacts`
 
 """
+
 from insights.combiners.cloud_provider import CloudProvider
 from insights.core.exceptions import ContentException, SkipComponent
 from insights.core.filters import add_filter
@@ -22,7 +23,7 @@ from insights.parsers.azure_instance import AzureInstanceID, AzureInstanceType
 from insights.parsers.gcp_instance_type import GCPInstanceType
 from insights.parsers.subscription_manager import SubscriptionManagerFacts
 
-add_filter(SubscriptionManagerFacts, 'instance_id')
+add_filter(SubscriptionManagerFacts, ['instance_id', 'instance_type'])
 
 
 @combiner(
@@ -33,7 +34,7 @@ add_filter(SubscriptionManagerFacts, 'instance_id')
         AzureInstanceType,
         GCPInstanceType,
         SubscriptionManagerFacts,
-    ]
+    ],
 )
 class CloudInstance(object):
     """
@@ -65,10 +66,11 @@ class CloudInstance(object):
         >>> ci.size == 't2.micro'
         True
     """
-    def __init__(self, cp, aws=None, azure_id=None, azure_type=None,
-                 gcp=None, facts=None):
+
+    def __init__(self, cp, aws=None, azure_id=None, azure_type=None, gcp=None, facts=None):
         self.provider = cp.cloud_provider
         self.id = None
+        self.type = None
         # 1. Get from the Cloud REST API at first
         if aws:
             self.id = aws.get('instanceId')
@@ -84,6 +86,8 @@ class CloudInstance(object):
             if key not in facts:
                 raise ContentException("Unmatched/unsupported types!")
             self.id = facts[key]
+            if self.type is None:
+                self.type = facts.get("{0}_instance_type".format(self.provider), '')
         # The instance id is the key attribute of this Combiner
         if self.id is None:
             raise SkipComponent

--- a/insights/tests/combiners/test_cloud_instance.py
+++ b/insights/tests/combiners/test_cloud_instance.py
@@ -115,8 +115,8 @@ def test_cloud_instance_aws_from_submanfacts_no_type():
     ret = CloudInstance(cp, None, None, None, None, facts)
     assert ret.provider == CloudProvider.AWS
     assert ret.id == "i-01234567890abcdef"
-    assert ret.type == ""
-    assert ret.size == ""
+    assert ret.type is None
+    assert ret.size is None
 
 
 def test_cloud_instance_ex():


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

RHINENG-17169 , fix for: 
| count| component| exception|
|------|---------------------|--------------------------------------------------|
|  7545|     insights.combiners.cloud_instance.CloudInstance|        AttributeError("'CloudInstance' object has no attribute 'type'")|