### PR TITLE
fix(ci/cd): revert to use "license" in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-license-files = ["LICENSE", "NOTICE"]
+license = {file = "LICENSE"}
 dynamic = ["version", "readme"]
 requires-python = ">=2.7"
 dependencies = [


### PR DESCRIPTION
- "license-files" is too new and not supported by old setuptools yet

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Below error is reported when building egg:
```
ValueError: invalid pyproject.toml config: `project`.
configuration error: `project` must not contain {'license-files'} properties
cp: cannot stat 'insights_core.egg-info/*': No such file or directory
```

## Summary by Sourcery

Modify pyproject.toml configuration to resolve compatibility issues with older setuptools versions

Bug Fixes:
- Resolve build configuration error by replacing 'license-files' with a compatible 'license' configuration in pyproject.toml

CI:
- Update GitHub Actions workflow to explicitly set Python 3.12 for egg build process