### PR TITLE
fix: support filters that start with minus sign

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -275,7 +275,7 @@ class TextFileProvider(FileProvider):
             # Pre-filtering ONLY when collecting data
             log.debug("Pre-filtering %s", self.relative_path)
             args.append(
-                ["grep", "-F", "\n".join(sorted(self._filters.keys(), reverse=True)), self.path]
+                ["grep", "-F", "--", "\n".join(self._filters.keys()), self.path]
             )
 
         return args
@@ -409,7 +409,7 @@ class CommandOutputProvider(ContentProvider):
 
         if self.split and self._filters:
             log.debug("Pre-filtering  %s", self.relative_path)
-            command.append(["grep", "-F", "\n".join(sorted(self._filters.keys(), reverse=True))])
+            command.append(["grep", "-F", "--", "\n".join(self._filters.keys())])
 
         return command
 

--- a/insights/tests/specs/test_specs.py
+++ b/insights/tests/specs/test_specs.py
@@ -366,6 +366,21 @@ def test_exp_no_filters():
     assert exception_cnt == 11111111
 
 
+def test_filter_starts_with_minus_sign():
+    # if interpreted as a grep command line option,
+    # broker[self_spec].content would raise ContentException
+    # because grep output would be empty
+    filter_message = "--quiet"
+
+    broker = dr.Broker()
+    broker[HostContext] = HostContext()
+    self_spec = simple_file(this_file, filterable=True)
+    add_filter(self_spec, filter_message)
+    broker = dr.run(dr.get_dependency_graph(self_spec), broker)
+
+    assert '    filter_message = "{}"'.format(filter_message) in broker[self_spec].content
+
+
 @pytest.mark.parametrize("obfuscate", [True, False])
 @patch('insights.cleaner.Cleaner.generate_report', return_value=None)
 def test_specs_collect(gen, obfuscate):


### PR DESCRIPTION
The issue was the root cause of RHINENG-15287.

Commit d1065f5ec25ece259acd38c9cef78ac0721da863 resolved the issue using reversed sorting, making a silent assumption that each component would have at least one filter message that starts with a character with lower precedence than `-`.

This commit uses the `grep` command line option `--` which causes all following arguments to be interpreted as operands (positional arguments) even if they start with `-`. See `info grep`. This works even if a component has a single filter message and the filter message starts with `-`.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Call `grep` with `--` command line options delimiter.

## Summary by Sourcery

Fix grep filtering for filter messages that start with a minus sign by using the `--` delimiter

Bug Fixes:
- Resolve an issue with grep filtering when filter messages start with a minus sign, which could previously cause incorrect filtering or empty content

Tests:
- Add a test case to verify filtering works correctly for filter messages starting with a minus sign