### PR TITLE
fix: remove useless code from client collection

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -10,13 +10,15 @@ import time
 import six
 from distutils.version import LooseVersion
 
-from .utilities import (generate_machine_id,
-                        write_to_disk,
-                        write_registered_file,
-                        write_unregistered_file,
-                        delete_cache_files,
-                        determine_hostname,
-                        get_version_info)
+from .utilities import (
+    generate_machine_id,
+    write_to_disk,
+    write_registered_file,
+    write_unregistered_file,
+    delete_cache_files,
+    determine_hostname,
+    get_version_info,
+)
 from .collection_rules import InsightsUploadConf
 from .core_collector import CoreCollector
 from .connection import InsightsConnection
@@ -24,14 +26,15 @@ from .support import registration_check
 from .constants import InsightsConstants as constants
 
 NETWORK = constants.custom_network_log_level
-LOG_FORMAT = ("%(asctime)s %(levelname)8s %(name)s:%(lineno)s %(message)s")
+LOG_FORMAT = "%(asctime)s %(levelname)8s %(name)s:%(lineno)s %(message)s"
 logger = logging.getLogger(__name__)
 
 
 class RotatingFileHandlerWithUMask(logging.handlers.RotatingFileHandler, object):
-    """ logging.handlers.RotatingFileHandler subclass with a modified
-        file permission mask.
+    """logging.handlers.RotatingFileHandler subclass with a modified
+    file permission mask.
     """
+
     def __init__(self, umask, *args, **kwargs):
         self._umask = umask
         super(RotatingFileHandlerWithUMask, self).__init__(*args, **kwargs)
@@ -49,9 +52,10 @@ class RotatingFileHandlerWithUMask(logging.handlers.RotatingFileHandler, object)
 
 
 class FileHandlerWithUMask(logging.FileHandler, object):
-    """ logging.FileHandler subclass with a modified
-        file permission mask.
+    """logging.FileHandler subclass with a modified
+    file permission mask.
     """
+
     def __init__(self, umask, *args, **kwargs):
         self._umask = umask
         super(FileHandlerWithUMask, self).__init__(*args, **kwargs)
@@ -89,7 +93,9 @@ def get_file_handler(config):
     # ensure the legacy rotating file handler is only used in older client versions
     # or if there is a problem retrieving the rpm version.
     rpm_version = get_version_info()['client_version']
-    if not rpm_version or (LooseVersion(rpm_version) < LooseVersion(constants.rpm_version_before_logrotate)):
+    if not rpm_version or (
+        LooseVersion(rpm_version) < LooseVersion(constants.rpm_version_before_logrotate)
+    ):
         file_handler = RotatingFileHandlerWithUMask(0o077, log_file, backupCount=3)
     else:
         file_handler = FileHandlerWithUMask(0o077, log_file)
@@ -153,7 +159,9 @@ def register(config, pconn):
     authmethod = config.authmethod
     auto_config = config.auto_config
     if not username and not password and not auto_config and authmethod == 'BASIC':
-        logger.debug('Username and password must be defined in configuration file with BASIC authentication method.')
+        logger.debug(
+            'Username and password must be defined in configuration file with BASIC authentication method.'
+        )
         return False
     return pconn.register()
 
@@ -174,8 +182,10 @@ def _legacy_handle_registration(config, pconn):
     machine_id_present = isfile(constants.machine_id_file)
 
     if machine_id_present and check['status'] is False:
-        logger.info("Machine-id found, insights-client can not be registered."
-                    " Please, unregister insights-client first: `insights-client --unregister`")
+        logger.info(
+            "Machine-id found, insights-client can not be registered."
+            " Please, unregister insights-client first: `insights-client --unregister`"
+        )
         return False
 
     logger.debug('Machine-id: %s', generate_machine_id())
@@ -204,11 +214,11 @@ def _legacy_handle_registration(config, pconn):
         if config.display_name is None and config.group is None:
             logger.info('Successfully registered host %s', hostname)
         elif config.display_name is None:
-            logger.info('Successfully registered host %s in group %s',
-                        hostname, group)
+            logger.info('Successfully registered host %s in group %s', hostname, group)
         else:
-            logger.info('Successfully registered host %s as %s in group %s',
-                        hostname, display_name, group)
+            logger.info(
+                'Successfully registered host %s as %s in group %s', hostname, display_name, group
+            )
         if message:
             logger.info(message)
         write_registered_file()
@@ -219,13 +229,17 @@ def _legacy_handle_registration(config, pconn):
         # print messaging and exit
         if check['unreg_date']:
             # registered and then unregistered
-            logger.info('This machine has been unregistered. '
-                        'Use --register if you would like to '
-                        're-register this machine.')
+            logger.info(
+                'This machine has been unregistered. '
+                'Use --register if you would like to '
+                're-register this machine.'
+            )
         else:
             # not yet registered
-            logger.info('This machine has not yet been registered. '
-                        'Use --register to register this machine.')
+            logger.info(
+                'This machine has not yet been registered. '
+                'Use --register to register this machine.'
+            )
         return False
 
 
@@ -239,11 +253,11 @@ def handle_registration(config, pconn):
 
 def get_registration_status(config, pconn):
     '''
-        Handle the registration process
-        Returns:
-            True - machine is registered
-            False - machine is unregistered
-            None - could not reach the API
+    Handle the registration process
+    Returns:
+        True - machine is registered
+        False - machine is unregistered
+        None - could not reach the API
     '''
     return registration_check(pconn)
 
@@ -258,7 +272,7 @@ def __cleanup_local_files():
 # -LEGACY-
 def _legacy_handle_unregistration(config, pconn):
     """
-        returns (bool): True success, False failure
+    returns (bool): True success, False failure
     """
 
     check = get_registration_status(config, pconn)
@@ -334,7 +348,7 @@ def collect(config):
             'Starting to collect Insights data for %s' % determine_hostname(config.display_name)
         )
 
-    dc.run_collection(rm_conf, get_branch_info(config), pc.create_report())
+    dc.run_collection(rm_conf)
 
     return dc.done()
 
@@ -370,20 +384,25 @@ def _legacy_upload(config, pconn, tar_file, content_type, collection_duration=No
             msg_name = determine_hostname(config.display_name)
             account_number = config.account_number
             if account_number:
-                logger.info("Successfully uploaded report from %s to account %s.",
-                            msg_name, account_number)
+                logger.info(
+                    "Successfully uploaded report from %s to account %s.", msg_name, account_number
+                )
             else:
                 logger.info("Successfully uploaded report for %s.", msg_name)
             if config.register:
                 # direct to console after register + upload
-                logger.info('View the Red Hat Insights console at https://console.redhat.com/insights/')
+                logger.info(
+                    'View the Red Hat Insights console at https://console.redhat.com/insights/'
+                )
             break
 
         elif upload.status_code in (412, 413):
             pconn.handle_fail_rcs(upload)
             raise RuntimeError('Upload failed.')
         else:
-            display_upload_error_and_retry(config, tries, "%s: %s" % (upload.status_code, upload.reason))
+            display_upload_error_and_retry(
+                config, tries, "%s: %s" % (upload.status_code, upload.reason)
+            )
     return api_response
 
 
@@ -422,11 +441,11 @@ def upload(config, pconn, tar_file, content_type, collection_duration=None):
 
 
 def display_upload_error_and_retry(config, tries, error_message):
-    logger.error("Upload attempt %d of %d failed! Reason: %s",
-                 tries + 1, config.retries, error_message)
+    logger.error(
+        "Upload attempt %d of %d failed! Reason: %s", tries + 1, config.retries, error_message
+    )
     if tries + 1 < config.retries:
-        logger.info("Waiting %d seconds then retrying",
-                    constants.sleep_time)
+        logger.info("Waiting %d seconds then retrying", constants.sleep_time)
         time.sleep(constants.sleep_time)
     else:
         logger.error("All attempts to upload have failed!")

--- a/insights/client/core_collector.py
+++ b/insights/client/core_collector.py
@@ -1,6 +1,7 @@
 """
 Collect all the interesting data for analysis - Core version
 """
+
 from __future__ import absolute_import
 
 import logging
@@ -18,11 +19,12 @@ class CoreCollector(object):
     """
     Collector for core collection
     """
+
     def __init__(self, config):
         self.config = config
         self.archive = InsightsArchive(config)
 
-    def run_collection(self, rm_conf, branch_info, blacklist_report):
+    def run_collection(self, rm_conf):
         '''
         Initialize core collection here and generate the
         output directory with collected data.

--- a/insights/tests/client/core_collector/test_run_collection.py
+++ b/insights/tests/client/core_collector/test_run_collection.py
@@ -11,7 +11,7 @@ from insights.client.core_collector import CoreCollector
 def test_run_collection(collect, create_archive_dir, systemd_notify_init_thread, logger):
     conf = InsightsConfig()
     cc = CoreCollector(conf)
-    cc.run_collection({}, {}, {})
+    cc.run_collection({})
     systemd_notify_init_thread.assert_called_once()
     create_archive_dir.assert_called_once()
     collect.collect.assert_called_once()

--- a/insights/tests/client/test_collect.py
+++ b/insights/tests/client/test_collect.py
@@ -14,31 +14,25 @@ def collect_args(*insights_config_args, **insights_config_custom_kwargs):
     """
     Instantiates InsightsConfig with a default logging_file argument.
     """
-    all_insights_config_kwargs = {"logging_file": "/tmp/insights.log",
-                                  "remove_file": conf_remove_file,
-                                  "redaction_file": conf_file_redaction_file,
-                                  "content_redaction_file": conf_file_content_redaction_file}
+    all_insights_config_kwargs = {
+        "logging_file": "/tmp/insights.log",
+        "remove_file": conf_remove_file,
+        "redaction_file": conf_file_redaction_file,
+        "content_redaction_file": conf_file_content_redaction_file,
+    }
     all_insights_config_kwargs.update(insights_config_custom_kwargs)
     return InsightsConfig(*insights_config_args, **all_insights_config_kwargs)
-
-
-def patch_get_branch_info():
-    """
-    Sets a static response to get_branch_info method.
-    """
-    def decorator(old_function):
-        patcher = patch("insights.client.client.get_branch_info")
-        return patcher(old_function)
-    return decorator
 
 
 def patch_get_rm_conf():
     """
     Mocks InsightsUploadConf.get_rm_conf so it returns a fixed configuration.
     """
+
     def decorator(old_function):
         patcher = patch("insights.client.client.InsightsUploadConf.get_rm_conf")
         return patcher(old_function)
+
     return decorator
 
 
@@ -46,16 +40,17 @@ def patch_core_collector():
     """
     Replaces CoreCollector with a dummy mock.
     """
+
     def decorator(old_function):
         patcher = patch("insights.client.client.CoreCollector")
         return patcher(old_function)
+
     return decorator
 
 
 @patch_core_collector()
 @patch_get_rm_conf()
-@patch_get_branch_info()
-def test_get_rm_conf_file(get_branch_info, get_rm_conf, core_collector):
+def test_get_rm_conf_file(get_rm_conf, core_collector):
     """
     Load configuration of files removed from collection when collection rules are loaded from a file.
     """
@@ -65,11 +60,9 @@ def test_get_rm_conf_file(get_branch_info, get_rm_conf, core_collector):
     get_rm_conf.assert_called_once_with()
 
 
-@patch("insights.client.client.InsightsUploadConf.create_report")
 @patch_core_collector()
 @patch_get_rm_conf()
-@patch_get_branch_info()
-def test_core_collector_file(get_branch_info, get_rm_conf, core_collector, create_report):
+def test_core_collector_file(get_rm_conf, core_collector):
     """
     Configuration from a file is passed to the CoreCollector along with removed files configuration.
     """
@@ -77,17 +70,13 @@ def test_core_collector_file(get_branch_info, get_rm_conf, core_collector, creat
     collect(config)
 
     rm_conf = get_rm_conf.return_value
-    branch_info = get_branch_info.return_value
-    blacklist_report = create_report.return_value
-    core_collector.return_value.run_collection.assert_called_once_with(rm_conf, branch_info, blacklist_report)
+    core_collector.return_value.run_collection.assert_called_once_with(rm_conf)
     core_collector.return_value.done.assert_called_once_with()
 
 
 @patch("insights.client.client.CoreCollector")
-@patch("insights.client.client.InsightsUploadConf.create_report")
 @patch_get_rm_conf()
-@patch_get_branch_info()
-def test_correct_collector_loaded(get_branch_info, get_rm_conf, create_report, core_collector):
+def test_correct_collector_loaded(get_rm_conf, core_collector):
     '''
     Verify that core collection is loaded
     '''

--- a/insights/tests/client/test_log_messages.py
+++ b/insights/tests/client/test_log_messages.py
@@ -9,18 +9,6 @@ from insights.client.config import InsightsConfig
 from insights.client.utilities import determine_hostname
 
 
-def patch_get_branch_info():
-    """
-    Sets a static response to get_branch_info method.
-    """
-
-    def decorator(old_function):
-        patcher = patch("insights.client.client.get_branch_info")
-        return patcher(old_function)
-
-    return decorator
-
-
 def patch_get_rm_conf():
     """
     Mocks InsightsUploadConf.get_rm_conf so it returns a fixed configuration.
@@ -47,12 +35,10 @@ def patch_core_collector():
 
 @patch_core_collector()
 @patch_get_rm_conf()
-@patch_get_branch_info()
 @patch('insights.client.client.logger')
-def test_log_msgs_general(log, get_branch_info, get_rm_conf, core_collector):
+def test_log_msgs_general(log, get_rm_conf, core_collector):
     config = InsightsConfig()
     collect(config)
-    get_branch_info.assert_called_once_with(config)
     get_rm_conf.assert_called_once_with()
     log.info.assert_called_once_with(
         'Starting to collect Insights data for %s' % determine_hostname(config.display_name)
@@ -61,12 +47,10 @@ def test_log_msgs_general(log, get_branch_info, get_rm_conf, core_collector):
 
 @patch_core_collector()
 @patch_get_rm_conf()
-@patch_get_branch_info()
 @patch('insights.client.client.logger')
-def test_log_msgs_compliance(log, get_branch_info, get_rm_conf, core_collector):
+def test_log_msgs_compliance(log, get_rm_conf, core_collector):
     config = InsightsConfig(compliance=True)
     collect(config)
-    get_branch_info.assert_called_once_with(config)
     get_rm_conf.assert_called_once_with()
     log.info.assert_called_once_with(
         'Starting to collect Insights data for %s' % determine_hostname(config.display_name)
@@ -75,35 +59,29 @@ def test_log_msgs_compliance(log, get_branch_info, get_rm_conf, core_collector):
 
 @patch_core_collector()
 @patch_get_rm_conf()
-@patch_get_branch_info()
 @patch('insights.client.client.logger')
-def test_log_msgs_compliance_policies(log, get_branch_info, get_rm_conf, core_collector):
+def test_log_msgs_compliance_policies(log, get_rm_conf, core_collector):
     config = InsightsConfig(compliance_policies=True)
     collect(config)
-    get_branch_info.assert_called_once_with(config)
     get_rm_conf.assert_not_called()
     log.info.assert_not_called()
 
 
 @patch_core_collector()
 @patch_get_rm_conf()
-@patch_get_branch_info()
 @patch('insights.client.client.logger')
-def test_log_msgs_compliance_assign(log, get_branch_info, get_rm_conf, core_collector):
+def test_log_msgs_compliance_assign(log, get_rm_conf, core_collector):
     config = InsightsConfig(compliance_assign=['abc'])
     collect(config)
-    get_branch_info.assert_called_once_with(config)
     get_rm_conf.assert_not_called()
     log.info.assert_not_called()
 
 
 @patch_core_collector()
 @patch_get_rm_conf()
-@patch_get_branch_info()
 @patch('insights.client.client.logger')
-def test_log_msgs_compliance_unassign(log, get_branch_info, get_rm_conf, core_collector):
+def test_log_msgs_compliance_unassign(log, get_rm_conf, core_collector):
     config = InsightsConfig(compliance_unassign=['abc'])
     collect(config)
-    get_branch_info.assert_called_once_with(config)
     get_rm_conf.assert_not_called()
     log.info.assert_not_called()


### PR DESCRIPTION
- this is a follow up of #4250

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Remove deprecated and unused code from the insights client collection module, simplifying the codebase and removing unnecessary functionality.

Enhancements:
- Simplified method signatures by removing unnecessary parameters in core collector and client modules
- Cleaned up logging and error message formatting

Chores:
- Removed the deprecated `create_report()` method from collection rules
- Removed unused code and commented-out sections