### PR TITLE
chore: deprecate LazyLogFileOutput

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -1438,6 +1438,10 @@ class LazyLogFileOutput(LogFileOutput):
         [{'raw_line': 'Text file line three, and more'}]
     """
 
+    def __init__(self, *args, **kwargs):
+        deprecated(LazyLogFileOutput, "Use LogFileOutput instead.", "3.7.0")
+        super(LazyLogFileOutput, self).__init__(*args, **kwargs)
+
     def _handle_content(self, context):
         self._lines = None
         self._context = context


### PR DESCRIPTION
The class was added based on the requirements of a downstream project. It didn't meet the requirements of the project; the project uses their own limited implementation now (no scans supported).

Specifically, LazyLogFileOutput is not a drop-in replacement for LogFileOutput. It requires each and every rule to call LazyLogFileOutput.do_scan() before using scans. This is error-prone; if a rule forgets to do it, everything might work until the rule is executed alone or until it is the first one executed.

LazyLogFileOutput should be deprecated and removed until we can invest the effor into developing an implementation that will work as a full drop-in replacement for LogFileOutput. We do not want downstream project to become dependent on the current implementation.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
See above.
