### PR TITLE
fix: remove extra quotation marks in FileProvider.__repr__

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -237,7 +237,7 @@ class FileProvider(ContentProvider):
             raise ContentException("Cannot access %s" % self.path)
 
     def __repr__(self):
-        return '%s("%r")' % (self.__class__.__name__, self.path)
+        return '%s(%r)' % (self.__class__.__name__, self.path)
 
 
 class RawFileProvider(FileProvider):

--- a/insights/tests/core/spec_factory/test_file_provider.py
+++ b/insights/tests/core/spec_factory/test_file_provider.py
@@ -1,0 +1,28 @@
+import os
+import os.path
+import pytest
+
+from insights.core.spec_factory import FileProvider
+
+
+@pytest.fixture(scope="module")
+def sample_file(tmpdir_factory):
+    # str() required for Python 2.7
+    root = str(tmpdir_factory.mktemp("test_file_provider"))
+    relpath = "sample_file.txt"
+    abspath = os.path.join(root, relpath)
+    fd = open(abspath, "w")
+    fd.close()
+    return root, relpath
+
+
+class DummyFileProvider(FileProvider):
+    def load():
+        return ""
+
+
+def test_repr(sample_file):
+    root, relpath = sample_file
+    provider = DummyFileProvider(relpath, root=root)
+    # example: DummyFileProvider('/tmp/pytest0/test_file_provider/sample_file.txt')
+    assert repr(provider) == "DummyFileProvider('%s/%s')" % (root, relpath)


### PR DESCRIPTION
The repr string effectively includes `repr(self.path)` (note `%r`) because `self.path` can be `str` or `bytest`. Since `repr()` adds quotation marks to `str` and `bytes` values, using `"%r"` adds extra quotation marks.

Original:

```
DummyFileProvider("'/some/path/sample_file.txt'")
```

Fixed:
```
DummyFileProvider('/some/path/sample_file.txt')
```

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
See above.
