### PR TITLE
chore: improve listdir and listglob tests

### DIFF
--- a/insights/tests/core/spec_factory/test_listdir.py
+++ b/insights/tests/core/spec_factory/test_listdir.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import tempfile
 
 from insights.core import dr
 from insights.core.context import HostContext
@@ -8,14 +7,14 @@ from insights.core.exceptions import ContentException
 from insights.core.spec_factory import listdir
 
 
-@pytest.fixture
-def sample_directory(scope="module"):
+@pytest.fixture(scope="module")
+def sample_directory(tmpdir_factory):
     def touch(fpath):
         fd = open(fpath, "w")
         fd.close()
 
     # Python2 does not have tempfile.TemporaryDirectory
-    tmpdir = tempfile.mkdtemp()
+    tmpdir = str(tmpdir_factory.mktemp("test_listglob"))
     os.mkdir(tmpdir + "/dir1")
     os.mkdir(tmpdir + "/dir2")
     touch(tmpdir + "/dir1/file_a")

--- a/insights/tests/core/spec_factory/test_listglob.py
+++ b/insights/tests/core/spec_factory/test_listglob.py
@@ -1,28 +1,24 @@
 import os
 import pytest
-import tempfile
 
 from insights.core import dr
 from insights.core.context import HostContext
 from insights.core.spec_factory import listglob
 
 
-@pytest.fixture
-def sample_directory(scope="module"):
-    tmpdir = tempfile.mkdtemp()
+@pytest.fixture(scope="module")
+def sample_directory(tmpdir_factory):
+    def touch(fpath):
+        fd = open(fpath, "w")
+        fd.close()
+
+    tmpdir = str(tmpdir_factory.mktemp("test_listglob"))
     os.mkdir(tmpdir + "/dir1")
     os.mkdir(tmpdir + "/dir2")
     for d in ["dir1", "dir2"]:
         for f in ["file_a", "file_b"]:
-            fd = open(tmpdir + "/" + d + "/" + f, "w")
-            fd.close()
-    yield tmpdir
-    for d in ["dir1", "dir2"]:
-        for f in ["file_a", "file_b"]:
-            os.remove(tmpdir + "/" + d + "/" + f)
-    os.rmdir(tmpdir + "/dir1")
-    os.rmdir(tmpdir + "/dir2")
-    os.rmdir(tmpdir)
+            touch(tmpdir + "/" + d + "/" + f)
+    return tmpdir
 
 
 def run_listglob_test(sample_directory, spec):


### PR DESCRIPTION
- Fix fixture scopes to be actually "module". The `scope` argument was passed to the test function instead of the `fixture` decorator by mistake.
- Use the standard tmpdir_factory fixture to create temporary directories. The advantages of the standard fixture is that it has customizable retention policy [1]:
  - Our tests do not have to include cleanup code
  - Test data remain available after test run for troubleshooting
  - Pytest cleans up old test data eventually

[1] https://docs.pytest.org/en/latest/how-to/tmp_path.html#temporary-directory-location-and-retention

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
See above.
