### PR TITLE
Improve load tests

### DIFF
--- a/insights/tests/core/spec_factory/test_content_provider_load.py
+++ b/insights/tests/core/spec_factory/test_content_provider_load.py
@@ -77,7 +77,8 @@ def test_load(log, reset_filters):
     # Less lines are load
     assert len(broker[Stuff.large_file].content) < CONTENT_LINES
     log.debug.assert_called_with("Extra-huge file is truncated %s", test_large_file)
-    assert broker[Stuff.large_file].content[0][0] == '-'  # the first line is complete (non-broken)
+    # skip the beginning of a large file, start with a complete line
+    assert broker[Stuff.large_file].content[0] == '- 949Some test data'
     assert len(broker[Stuff.large_file_wf].content) < len(
         [
             '{0}{1}'.format(i, FILTER_DATA)

--- a/insights/tests/core/spec_factory/test_content_provider_load.py
+++ b/insights/tests/core/spec_factory/test_content_provider_load.py
@@ -79,13 +79,15 @@ def test_load(log, reset_filters):
     log.debug.assert_called_with("Extra-huge file is truncated %s", test_large_file)
     # skip the beginning of a large file, start with a complete line
     assert broker[Stuff.large_file].content[0] == '- 949Some test data'
-    assert len(broker[Stuff.large_file_wf].content) < len(
+    assert len(broker[Stuff.large_file].content) < len(
         [
             '{0}{1}'.format(i, FILTER_DATA)
             for i in range(CONTENT_LINES + 10)
             if filter_kw in '{0}Some'.format(i)
         ]
     )
+    # call content on large_file_wf to produce the log message
+    broker[Stuff.large_file_wf].content
     log.debug.assert_called_with("Extra-huge file is truncated %s", test_large_file_wf)
     # Clean up
     shutil.rmtree(temp_dir)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Addressed:
- Create the large file just once
- Test that load() skips the beginning of large files
- Test that filters are applied
- Use the standard `tmpdir_factory` fixture to maintain temporary
  directories (with automatic cleanup and retention for successful and
  failed tests alike)
    
Unaddressed:
- This is a test for a low-level provider class. It SHOULD NOT require
  the setup of specs and `RegistryPoint`s. If it does, there is something
  wrong about separation of responsibilities. The code is too convoluted
  for me to tell for sure and address this within the time I could spend
  on this change.
- The tests do not check that there is an additional filter on the
  number of lines per filter term. This is INTENTIONAL. I would like to
  see performance data before committing to this feature of the current
  implementation.

Please review individual commits and their commit messages. They include additional details about the problems of the original tests.