### PR TITLE
fix: Improve error message for too long rule responses

### DIFF
--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -471,21 +471,15 @@ class Response(dict):
         """
         length = len(str(kwargs))
         if length > settings.defaults["max_detail_length"]:
-            self._log_length_error(key, length)
+            self._log_length_error(key, length, settings.defaults["max_detail_length"])
             r["max_detail_length_error"] = length
             return r
         return kwargs
 
-    def _log_length_error(self, key, length):
+    def _log_length_error(self, key, length, limit):
         """ Helper function for logging a response length error. """
-        extra = {
-            "max_detail_length": settings.defaults["max_detail_length"],
-            "len": length
-        }
-        if self.key_name:
-            extra[self.key_name] = key
-        msg = "Length of data in %s is too long." % self.__class__.__name__
-        log.error(msg, extra=extra)
+        msg = "Data length %d in rule response %s(%s) exceeds the limit of %d characters."
+        log.error(msg, length, self.__class__.__name__, key, settings.defaults["max_detail_length"])
 
     def __str__(self):
         key_val = self.get_key()


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

Original behavior:
- The log message was "Length of data in make_info is too long." This message was not actionable without further details.
- Additional data was added as extra log record attributes, which were available only through log formatter configuration or debugger.
- This was incorrect use of extra log record attributes. These attributes are intended for common context attributes shared by many log messages, not for custom data of each individual log message.

New behavior:
- The log message includes relevant information directly:
  - Rule respons type
  - Response key (if available)
  - Current data length
  - Data length limit
