### PR TITLE
fix: Skip extraction of all device files in archive (#4468)

### DIFF
--- a/insights/core/archives.py
+++ b/insights/core/archives.py
@@ -60,7 +60,7 @@ class TarExtractor(object):
             tar_flag = self._tar_flag_for_content_type(self.content_type)
             self.tmp_dir = tempfile.mkdtemp(prefix="insights-", dir=extract_dir)
             self.created_tmp_dir = True
-            command = "tar --delay-directory-restore %s -x --exclude=*/dev/null -f %s -C %s" % (tar_flag, path, self.tmp_dir)
+            command = "tar --delay-directory-restore %s -x --exclude=*/dev/* -f %s -C %s" % (tar_flag, path, self.tmp_dir)
             logging.debug("Extracting files in '%s'", self.tmp_dir)
             subproc.call(command, timeout=self.timeout)
         return self


### PR DESCRIPTION
- RHINENG-18485

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Using insights-run in non-privileged systems raise an `insights.core.exceptions.CalledProcessError` exception, complaining about not being able to create device files.
Example:
`sosreport-.../dev/dm-7: Can't create 'sosreport-.../dev/dm-7'`

This change modifies the `tar` command used in `insights.core.archive` to skip extraction of all device files.
