### PR TITLE
add dnf_module_list spec file path for sos_archive

### DIFF
--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -73,6 +73,7 @@ class SosSpecs(Specs):
     dmsetup_info = simple_file("sos_commands/devicemapper/dmsetup_info_-c")
     dmsetup_status = simple_file("sos_commands/devicemapper/dmsetup_status")
     dnf_modules = glob_file("/etc/dnf/modules.d/*.module")
+    dnf_module_list = simple_file("/sos_commands/dnf/dnf_module_list")
     dnsmasq_config = glob_file(["/etc/dnsmasq.conf", "/etc/dnsmasq.d/*.conf"])
     docker_host_machine_id = simple_file("/etc/redhat-access-insights/machine-id")
     docker_info = simple_file("sos_commands/docker/docker_info")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

The **DnfModuleList** parser is well-implemented for handling the content of the sosreport file.
Initially, the file path for the insights archive was specified only in` /insights/specs/insights_archive.py `and `/insights/specs/default.py`
To extend support for the sos archives, the corresponding file path is added to `/insights/specs/sos_archive.py.`