### PR TITLE
fix(setup): remove CONTRIBUTING.md from dynamic readme in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ mangle = "insights.util.mangle:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "insights.version._VERSION_"}
-readme = {file = ["README.rst", "CONTRIBUTING.md"]}
+readme = {file = ["README.rst"]}
 
 [tool.pytest.ini_options]
 addopts = "-rsxXfE --ignore=./build/"


### PR DESCRIPTION
- '.md' and '.rst' cannot be used the same time in pypi

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
