### PR TITLE
fix: Simplify error message for too long rule responses

### DIFF
--- a/insights/core/plugins.py
+++ b/insights/core/plugins.py
@@ -478,8 +478,16 @@ class Response(dict):
 
     def _log_length_error(self, key, length, limit):
         """ Helper function for logging a response length error. """
-        msg = "Data length %d in rule response %s(%s) exceeds the limit of %d characters."
-        log.error(msg, length, self.__class__.__name__, key, settings.defaults["max_detail_length"])
+        msg = (
+            "Rule response %(response_type)s(%(response_key)s) "
+            "exceeds the size limit of %(limit)d characters."
+        )
+        data = {
+            "response_type": self.__class__.__name__,
+            "response_key": key,
+            "limit": settings.defaults["max_detail_length"]
+        }
+        log.error(msg, data, extra=data)
 
     def __str__(self):
         key_val = self.get_key()


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
PR #4463 focused on improving the error message for the command line use case - important details about the error were not available in the command line.

However, insights-core is used also in services that are connected to log analysis software. Log analysis software requires reasonably static log messages for events aggregation to work properly. Specifically, a log message containing the actual response size has proven to break the aggregation because the response size can change in time even for archives from a single system.

This commit is aiming at a compromise between the CLI and service use cases within the constraints of the current logging setup used by the insights-core:

- The response type and response key are included in the message because it is desirable to aggregate only events coming from the same rule.
- The size limit is included in the message to address the original issue that #4463 was solving. The size limit is expected to be stable enough in the service use cases not to compromise events aggregation.
- The actual rule response size is not included in the log message; it will not be available in the CLI use case for now. It is passed to log analysis software in the `extra` data.

A solution that would print log messages with variable data in the CLI use case while not compromising events aggregation in log analysis software is deferred to (a) future change(s).

