### PR TITLE
feat: Add a new parser LruGenEnabled

### DIFF
--- a/docs/shared_parsers_catalog/lru_gen_enabled.rst
+++ b/docs/shared_parsers_catalog/lru_gen_enabled.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.lru_gen_enabled
+   :members:
+   :show-inheritance:

--- a/insights/parsers/lru_gen_enabled.py
+++ b/insights/parsers/lru_gen_enabled.py
@@ -1,0 +1,64 @@
+"""
+LruGenEnabled - file ``/sys/kernel/mm/lru_gen/enabled``
+=======================================================
+
+Parser to parse the output of file ``/sys/kernel/mm/lru_gen/enabled``
+"""
+
+from insights.core import Parser
+from insights.core.exceptions import ParseException, SkipComponent
+from insights.core.plugins import parser
+from insights.specs import Specs
+
+
+@parser(Specs.lru_gen_enabled)
+class LruGenEnabled(Parser):
+    """
+    The parser for  ``/sys/kernel/mm/lru_gen/enabled`` file.
+
+    The content of ``/sys/kernel/mm/lru_gen/enabled`` file is a hexadecimal number.
+    Values , Feature
+    ----------------
+    0x0000, the multi-gen LRU feature is disabled
+    0x0001, the multi-gen LRU feture is enabled
+    0x0002, the feature of clearing the accessed bit in leaf page table entries in large batches is enabled
+    0x0004, the feature of clearing the accessed bit in non-leaf page table entries as well is enabled
+    0x0007, all the features are enabled
+
+    Sample Content::
+        0x0004
+
+    Examples:
+        >>> type(lru_gen_enabled)
+        <class 'insights.parsers.lru_gen_enabled.LruGenEnabled'>
+        >>> lru_gen_enabled.enabled
+        True
+        >>> lru_gen_enabled.features
+        4
+
+    Attributes:
+        enabled (bool): False means multi-gen LRU feature is disabled,
+            otherwise, any of feature is enabled.
+        features (int): when enabled is True, checking the features to see
+            which features are enabled.
+
+    Raises:
+        ParseException: When running into an unparsable line.
+        SkipComponent: When file content is empty or has multiple lines.
+
+    """
+
+    def parse_content(self, content):
+        if len(content) != 1:
+            raise SkipComponent("Input content should only contain one line")
+
+        if not content[0].startswith("0x"):
+            raise ParseException("Input content is not a hex number")
+
+        try:
+            features = int(content[0], 16)
+        except:
+            raise ParseException("Input content is not a hex number")
+
+        self.features = features
+        self.enabled = features > 0

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -402,7 +402,7 @@ class Specs(SpecSet):
     lpstat_p = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     lpstat_protocol_printers = RegistryPoint()
     lpstat_queued_jobs_count = RegistryPoint()
-    lru_gen_enabled = RegistryPoint(no_obfuscate=['hostname', 'ip'])
+    lru_gen_enabled = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     # New `ls` Specs
     ls_files = RegistryPoint()
     ls_la = RegistryPoint()

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -402,6 +402,7 @@ class Specs(SpecSet):
     lpstat_p = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     lpstat_protocol_printers = RegistryPoint()
     lpstat_queued_jobs_count = RegistryPoint()
+    lru_gen_enabled = RegistryPoint(no_obfuscate=['hostname', 'ip'])
     # New `ls` Specs
     ls_files = RegistryPoint()
     ls_la = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -473,6 +473,7 @@ class DefaultSpecs(Specs):
     lpstat_p = simple_command("/usr/bin/lpstat -p")
     lpstat_protocol_printers = lpstat.lpstat_protocol_printers_info
     lpstat_queued_jobs_count = lpstat.lpstat_queued_jobs_count
+    lru_gen_enabled = simple_file("/sys/kernel/mm/lru_gen/enabled")
     ls_la = command_with_args('/bin/ls -la %s', ls.list_with_la, keep_rc=True)
     ls_la_filtered = command_with_args(
         '/bin/ls -la %s', ls.list_with_la_filtered, keep_rc=True

--- a/insights/tests/parsers/test_lru_gen_enabled.py
+++ b/insights/tests/parsers/test_lru_gen_enabled.py
@@ -1,0 +1,52 @@
+import doctest
+import pytest
+
+from insights.core.exceptions import ParseException, SkipComponent
+from insights.parsers import lru_gen_enabled
+from insights.parsers.lru_gen_enabled import LruGenEnabled
+from insights.tests import context_wrap
+
+LRU_GEN_DISABLED = "0x0000"
+LRU_GEN_ENABLED = "0x0004"
+
+
+def test_lru_gen_enabled():
+    lru_gen_enabled = LruGenEnabled(context_wrap(LRU_GEN_DISABLED))
+    assert lru_gen_enabled.enabled is False
+    assert lru_gen_enabled.features == 0
+
+    lru_gen_enabled = LruGenEnabled(context_wrap(LRU_GEN_ENABLED))
+    assert lru_gen_enabled.enabled is True
+    assert lru_gen_enabled.features == 4
+
+
+LRU_GEN_MULTIPLE_LINES = """
+line 1
+line 2
+""".strip()
+
+
+def test_lru_gen_exceptions():
+    with pytest.raises(SkipComponent) as err:
+        LruGenEnabled(context_wrap(LRU_GEN_MULTIPLE_LINES))
+    assert "Input content should only contain one line" in str(err)
+
+    with pytest.raises(SkipComponent) as err:
+        LruGenEnabled(context_wrap(""))
+    assert "Input content should only contain one line" in str(err)
+
+    with pytest.raises(ParseException) as err:
+        LruGenEnabled(context_wrap("1"))
+    assert "Input content is not a hex number" in str(err)
+
+    with pytest.raises(ParseException) as err:
+        LruGenEnabled(context_wrap("0xtest"))
+    assert "Input content is not a hex number" in str(err)
+
+
+def test_lru_gen_enabled_doc_examples():
+    env = {
+        'lru_gen_enabled': LruGenEnabled(context_wrap(LRU_GEN_ENABLED)),
+    }
+    failed, total = doctest.testmod(lru_gen_enabled, globs=env)
+    assert failed == 0


### PR DESCRIPTION
Signed-off-by: Ping Qin <piqin@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Add a new parser to parse the content of `/sys/kernel/mm/lru_gen/enabled` file.
It's required by a new advisor rule described in RHINENG-18456.