### PR TITLE
chore: update corosync datasource to use RedHatRelease only

### DIFF
--- a/insights/tests/datasources/test_corosync.py
+++ b/insights/tests/datasources/test_corosync.py
@@ -2,36 +2,44 @@ import pytest
 
 from mock.mock import patch
 
-from insights.components.rhel_version import IsRhel6, IsRhel7
 from insights.combiners.redhat_release import RedHatRelease
 from insights.core.exceptions import SkipComponent
+from insights.parsers.redhat_release import RedhatRelease
 from insights.specs.datasources.corosync import corosync_cmapctl_cmds
+from insights.tests import context_wrap
 
 COROSYNC_CMD_RHEL7 = [
     "/usr/sbin/corosync-cmapctl",
     "/usr/sbin/corosync-cmapctl -d runtime.schedmiss.timestamp",
-    "/usr/sbin/corosync-cmapctl -d runtime.schedmiss.delay"
+    "/usr/sbin/corosync-cmapctl -d runtime.schedmiss.delay",
 ]
 
 COROSYNC_CMD_RHEL9 = [
     "/usr/sbin/corosync-cmapctl",
     "/usr/sbin/corosync-cmapctl -m stats",
-    "/usr/sbin/corosync-cmapctl -C schedmiss"
+    "/usr/sbin/corosync-cmapctl -C schedmiss",
 ]
+
+RHEL6 = "Red Hat Enterprise Linux Server release 6.5 (Santiago)"
+RHEL7 = "Red Hat Enterprise Linux Server release 7.0 (Maipo)"
+RHEL9 = "Red Hat Enterprise Linux release 9.0 (Plow)"
 
 
 @patch('insights.specs.datasources.corosync.os.path.exists')
 def test_corosync_cmapctl_cmds(path_exists):
     path_exists.return_value = True
-    broker = {IsRhel6: True}
+    rhel = RedHatRelease(None, RedhatRelease(context_wrap(RHEL6)))
+    broker = {RedHatRelease: rhel}
     with pytest.raises(SkipComponent):
         corosync_cmapctl_cmds(broker)
 
-    broker = {IsRhel7: True}
+    rhel = RedHatRelease(None, RedhatRelease(context_wrap(RHEL7)))
+    broker = {RedHatRelease: rhel}
     result = corosync_cmapctl_cmds(broker)
     assert result == COROSYNC_CMD_RHEL7
 
-    broker = {RedHatRelease: True}
+    rhel = RedHatRelease(None, RedhatRelease(context_wrap(RHEL9)))
+    broker = {RedHatRelease: rhel}
     result = corosync_cmapctl_cmds(broker)
     assert result == COROSYNC_CMD_RHEL9
 
@@ -39,10 +47,12 @@ def test_corosync_cmapctl_cmds(path_exists):
 @patch('insights.specs.datasources.corosync.os.path.exists')
 def test_corosync_cmapctl_cmds_no_such_cmd(path_exists):
     path_exists.return_value = False
-    broker = {IsRhel7: True}
+    rhel = RedHatRelease(None, RedhatRelease(context_wrap(RHEL7)))
+    broker = {RedHatRelease: rhel}
     with pytest.raises(SkipComponent):
         corosync_cmapctl_cmds(broker)
 
-    broker = {RedHatRelease: True}
+    rhel = RedHatRelease(None, RedhatRelease(context_wrap(RHEL9)))
+    broker = {RedHatRelease: rhel}
     with pytest.raises(SkipComponent):
         corosync_cmapctl_cmds(broker)


### PR DESCRIPTION
- it originally depends/uses IsRhel6/7 too.  Since IsRhel* depends on RedHatRelease too, remove the IsRhel* to make it a bit simple.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
- See the original [comment](https://github.com/RedHatInsights/insights-core/pull/4483#discussion_r2162890119)
