### PR TITLE
fix: endless loop caused by Mount.get_dir()

### DIFF
--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -189,7 +189,10 @@ class MountedFileSystems(CommandParser):
         Returns:
             MountEntry: The mount point that contains the given path.
         """
-        path = "/".join(list(set(path.split("/"))))
+        if path.startswith("/"):
+            path_list = path.split("/")
+            path_list = [x for x in path_list if x.strip()]
+            path = "/" + "/".join(path_list)
         while path != '':
             if path in self.mounts:
                 return self.mounts[path]

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -189,6 +189,7 @@ class MountedFileSystems(CommandParser):
         Returns:
             MountEntry: The mount point that contains the given path.
         """
+        path = "/".join(list(set(path.split("/"))))
         while path != '':
             if path in self.mounts:
                 return self.mounts[path]

--- a/insights/parsers/mount.py
+++ b/insights/parsers/mount.py
@@ -189,14 +189,12 @@ class MountedFileSystems(CommandParser):
         Returns:
             MountEntry: The mount point that contains the given path.
         """
-        if path.startswith("/"):
-            path_list = path.split("/")
-            path_list = [x for x in path_list if x.strip()]
-            path = "/" + "/".join(path_list)
+        path = os.path.normpath(path)
         while path != '':
             if path in self.mounts:
                 return self.mounts[path]
             path = os.path.split(path)[0]
+            path = '/' if path == '//' else path
         return None
 
     def search(self, **kwargs):

--- a/insights/tests/parsers/test_mount.py
+++ b/insights/tests/parsers/test_mount.py
@@ -97,7 +97,6 @@ MOUNTINFO_DATA = """
 56 21 0:19 / /shared/dir2 rw,nosuid,relatime - nfs hostname2:/shared/some/dir2 rw,sync,vers=3,rsize=32768,wsize=32
 57 21 0:21 / /misc rw,relatime - autofs /etc/auto.misc rw,fd=7,pgrp=4826,timeout=300,minproto=5,maxproto=5,indirect
 58 21 0:22 / /autofshost rw,relatime - autofs -hosts rw,fd=13,pgrp=4826,timeout=300,minproto=5,maxproto=5,indirect
-37 36 253:72 / //MARIADB/tmp rw,relatime - ext4 /dev/mapper/vgsys-var_log rw,barrier=1,stripe=64,data=ordered
 """.strip()
 
 MOUNTINFO_ERR_DATA = """
@@ -319,7 +318,7 @@ def test_proc_mount_exception3():
 def test_mountinfo():
     results = MountInfo(context_wrap(MOUNTINFO_DATA))
     assert results is not None
-    assert len(results) == 17
+    assert len(results) == 16
 
     sda1 = results.search(mount_source='/dev/sda1')[0]
     assert sda1 is not None

--- a/insights/tests/parsers/test_mount.py
+++ b/insights/tests/parsers/test_mount.py
@@ -363,6 +363,7 @@ def test_mountinfo():
     # Test get_dir
     assert results.get_dir('/var/log/some_dir') == results.search(mount_point='/var/log')[0]
     assert results.get_dir('//MARIADB/tmp') == results['/']
+    assert results.get_dir('///MARIADB/tmp') == results['/']
     assert results.get_dir('/etc') == results['/']
 
     # Test search

--- a/insights/tests/parsers/test_mount.py
+++ b/insights/tests/parsers/test_mount.py
@@ -97,6 +97,7 @@ MOUNTINFO_DATA = """
 56 21 0:19 / /shared/dir2 rw,nosuid,relatime - nfs hostname2:/shared/some/dir2 rw,sync,vers=3,rsize=32768,wsize=32
 57 21 0:21 / /misc rw,relatime - autofs /etc/auto.misc rw,fd=7,pgrp=4826,timeout=300,minproto=5,maxproto=5,indirect
 58 21 0:22 / /autofshost rw,relatime - autofs -hosts rw,fd=13,pgrp=4826,timeout=300,minproto=5,maxproto=5,indirect
+37 36 253:72 / //MARIADB/tmp rw,relatime - ext4 /dev/mapper/vgsys-var_log rw,barrier=1,stripe=64,data=ordered
 """.strip()
 
 MOUNTINFO_ERR_DATA = """
@@ -318,7 +319,7 @@ def test_proc_mount_exception3():
 def test_mountinfo():
     results = MountInfo(context_wrap(MOUNTINFO_DATA))
     assert results is not None
-    assert len(results) == 16
+    assert len(results) == 17
 
     sda1 = results.search(mount_source='/dev/sda1')[0]
     assert sda1 is not None
@@ -362,6 +363,7 @@ def test_mountinfo():
 
     # Test get_dir
     assert results.get_dir('/var/log/some_dir') == results.search(mount_point='/var/log')[0]
+    assert results.get_dir('//MARIADB/tmp') == results['/']
     assert results.get_dir('/etc') == results['/']
 
     # Test search


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:
When the file path contains multiple slashes like "//MARIADB/tmp", the current "get_dir" will get in endless state as "os.path.split(path)[0]" always gets "//". This PR can fix this issue
