### PR TITLE
fix: datasource filters should not pass to 'ls -lH'

### DIFF
--- a/insights/specs/datasources/ls.py
+++ b/insights/specs/datasources/ls.py
@@ -130,15 +130,14 @@ def list_with_laZ(broker):
 def list_files_with_lH(broker):
     filters = set(_list_items(Specs.ls_lH_files))
     files = set(_f for _f in filters if not os.path.isdir(_f))
-    if 'fstab_mounted.devices' in filters and FSTab in broker and BlockIDInfo in broker:
+    if 'fstab_mounted.devices' in filters:
         files.remove('fstab_mounted.devices')
-        fstab_mounts = broker[FSTab]
-        blkid_info = broker[BlockIDInfo]
-        files.update(_get_fstab_mounted_device_files(fstab_mounts, blkid_info))
-    if 'pvs.devices' in filters and Pvs in broker:
+        if FSTab in broker and BlockIDInfo in broker:
+            files.update(_get_fstab_mounted_device_files(broker[FSTab], broker[BlockIDInfo]))
+    if 'pvs.devices' in filters:
         files.remove('pvs.devices')
-        pvs_info = broker[Pvs]
-        files.update(set([item['PV'] for item in pvs_info]))
+        if Pvs in broker:
+            files.update(set([item['PV'] for item in broker[Pvs]]))
     if files:
         return ' '.join(sorted(files))
     raise SkipComponent

--- a/insights/tests/datasources/test_ls.py
+++ b/insights/tests/datasources/test_ls.py
@@ -85,11 +85,18 @@ def setup_function(func):
     if func is test_lan_with_fstab_mounted_filter:
         filters.add_filter(Specs.ls_lan_dirs, ["/", '/boot', 'fstab_mounted.dirs'])
     if func is test_lH_files:
-        filters.add_filter(Specs.ls_lH_files, ["/etc/redhat-release", '/var/log/messages'])
+        filters.add_filter(
+            Specs.ls_lH_files,
+            ["/etc/redhat-release", '/var/log/messages', 'pvs.devices', 'fstab_mounted.devices'],
+        )
     if func is test_lH_files_pvs:
-        filters.add_filter(Specs.ls_lH_files, ["/etc/redhat-release", '/var/log/messages', 'pvs.devices'])
+        filters.add_filter(
+            Specs.ls_lH_files, ["/etc/redhat-release", '/var/log/messages', 'pvs.devices']
+        )
     if func is test_lH_files_fstab_blkid:
-        filters.add_filter(Specs.ls_lH_files, ["/etc/redhat-release", '/var/log/messages', 'fstab_mounted.devices'])
+        filters.add_filter(
+            Specs.ls_lH_files, ["/etc/redhat-release", '/var/log/messages', 'fstab_mounted.devices']
+        )
 
 
 def teardown_function(func):
@@ -174,4 +181,7 @@ def test_lH_files_fstab_blkid(_):
     blkid_info = BlockIDInfo(context_wrap(BLKID_DATA))
     broker = {FSTab: fstab_info, BlockIDInfo: blkid_info}
     ret = list_files_with_lH(broker)
-    assert ret == '/dev/mapper/rhel-home /dev/mapper/rhel-root /dev/mapper/rhel-var /dev/sdb2 /etc/redhat-release /var/log/messages'
+    assert (
+        ret
+        == '/dev/mapper/rhel-home /dev/mapper/rhel-root /dev/mapper/rhel-var /dev/sdb2 /etc/redhat-release /var/log/messages'
+    )


### PR DESCRIPTION
- RHINENG-16909
 The two datasource filters 'pvs.devices' and 'fstab_mounted.devices'
 should be removed no matter the result of Pvs and FStab

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
