### PR TITLE
fix: add missed optional deps for ls datasources

### DIFF
--- a/insights/specs/datasources/ls.py
+++ b/insights/specs/datasources/ls.py
@@ -85,7 +85,7 @@ def list_with_la_filtered(broker):
     return ' '.join(_list_items(Specs.ls_la_filtered_dirs))
 
 
-@datasource(HostContext)
+@datasource(HostContext, optional=[FSTab])
 def list_with_lan(broker):
     filters = set(_list_items(Specs.ls_lan_dirs))
     if 'fstab_mounted.dirs' in filters and FSTab in broker:
@@ -126,7 +126,7 @@ def list_with_laZ(broker):
     return ' '.join(_list_items(Specs.ls_laZ_dirs))
 
 
-@datasource(HostContext)
+@datasource(HostContext, optional=[FSTab, BlockIDInfo, Pvs])
 def list_files_with_lH(broker):
     filters = set(_list_items(Specs.ls_lH_files))
     files = set(_f for _f in filters if not os.path.isdir(_f))

--- a/insights/specs/manifests.py
+++ b/insights/specs/manifests.py
@@ -190,7 +190,8 @@ plugins:
     - name: insights.parsers.docker_list.DockerListContainers
       enabled: true
 
-    # needed for specs: luks_data_sources, smartctl_health spec
+    # needed for specs: luks_data_sources, smartctl_health, 'fstab_mounted.devices' to 'ls_lH_files'
+    #  'fstab_mounted.devices' to 'ls_lH_files''
     - name: insights.parsers.blkid.BlockIDInfo
       enabled: true
     - name: insights.components.cryptsetup.HasCryptsetupWithTokens
@@ -218,8 +219,12 @@ plugins:
     - name: insights.components.selinux.SELinuxEnabled
       enabled: true
 
-    # needed for the 'fstab_mounted.dirs' to the 'ls_lan' spec
+    # needed for 'fstab_mounted.dirs' to 'ls_lan', 'fstab_mounted.devices' to 'ls_lH_files'
     - name: insights.parsers.fstab.FSTab
+      enabled: true
+
+    # needed for 'pvs.devices' to 'ls_lH_files' spec
+    - name: insights.parsers.lvm.Pvs
       enabled: true
 """.strip()
 

--- a/insights/tests/datasources/test_ls.py
+++ b/insights/tests/datasources/test_ls.py
@@ -85,11 +85,18 @@ def setup_function(func):
     if func is test_lan_with_fstab_mounted_filter:
         filters.add_filter(Specs.ls_lan_dirs, ["/", '/boot', 'fstab_mounted.dirs'])
     if func is test_lH_files:
-        filters.add_filter(Specs.ls_lH_files, ["/etc/redhat-release", '/var/log/messages'])
+        filters.add_filter(
+            Specs.ls_lH_files,
+            ["/etc/redhat-release", '/var/log/messages', 'fstab_mounted.devices', 'pvs.devices'],
+        )
     if func is test_lH_files_pvs:
-        filters.add_filter(Specs.ls_lH_files, ["/etc/redhat-release", '/var/log/messages', 'pvs.devices'])
+        filters.add_filter(
+            Specs.ls_lH_files, ["/etc/redhat-release", '/var/log/messages', 'pvs.devices']
+        )
     if func is test_lH_files_fstab_blkid:
-        filters.add_filter(Specs.ls_lH_files, ["/etc/redhat-release", '/var/log/messages', 'fstab_mounted.devices'])
+        filters.add_filter(
+            Specs.ls_lH_files, ["/etc/redhat-release", '/var/log/messages', 'fstab_mounted.devices']
+        )
 
 
 def teardown_function(func):
@@ -148,6 +155,9 @@ def test_lanZ():
 
 
 def test_lan_with_fstab_mounted_filter():
+    ret = list_with_lan({})
+    assert ret == '/ /boot fstab_mounted.dirs'
+
     fstab = FSTab(context_wrap(FSTAB_CONTEXT))
     broker = {FSTab: fstab}
     ret = list_with_lan(broker)
@@ -157,7 +167,7 @@ def test_lan_with_fstab_mounted_filter():
 @patch("os.path.isdir", return_value=False)
 def test_lH_files(_):
     ret = list_files_with_lH({})
-    assert ret == '/etc/redhat-release /var/log/messages'
+    assert ret == '/etc/redhat-release /var/log/messages fstab_mounted.devices pvs.devices'
 
 
 @patch("os.path.isdir", return_value=False)
@@ -174,4 +184,7 @@ def test_lH_files_fstab_blkid(_):
     blkid_info = BlockIDInfo(context_wrap(BLKID_DATA))
     broker = {FSTab: fstab_info, BlockIDInfo: blkid_info}
     ret = list_files_with_lH(broker)
-    assert ret == '/dev/mapper/rhel-home /dev/mapper/rhel-root /dev/mapper/rhel-var /dev/sdb2 /etc/redhat-release /var/log/messages'
+    assert (
+        ret
+        == '/dev/mapper/rhel-home /dev/mapper/rhel-root /dev/mapper/rhel-var /dev/sdb2 /etc/redhat-release /var/log/messages'
+    )


### PR DESCRIPTION
- without these optional deps, the `ls` datasources may fail to collect

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
