### PR TITLE
fix: use tempfile.gettempdir as default tmpdir for obfuscation reports

### DIFF
--- a/insights/cleaner/__init__.py
+++ b/insights/cleaner/__init__.py
@@ -32,6 +32,7 @@ import logging
 import json
 import os
 import six
+import tempfile
 
 from insights.cleaner.filters import AllowFilter
 from insights.cleaner.hostname import Hostname
@@ -64,7 +65,7 @@ class Cleaner(object):
     """
 
     def __init__(self, config, rm_conf, fqdn=None):
-        self.report_dir = '/tmp'  # FIXME
+        self.report_dir = tempfile.gettempdir()
         self.rhsm_facts_file = getattr(
             config, 'rhsm_facts_file', os.path.join(self.report_dir, 'insights-client.facts')
         )

--- a/insights/tests/cleaner/test_reports.py
+++ b/insights/tests/cleaner/test_reports.py
@@ -1,6 +1,7 @@
 import csv
 import json
 import os
+import tempfile
 
 from mock.mock import patch
 from pytest import mark
@@ -32,7 +33,7 @@ test_file_data += 'mac: 10:20:02:15:f5:ab'
 )
 @mark.parametrize("test_umask", [0o000, 0o022])
 def test_rhsm_facts(test_umask, obfuscate, obfuscate_hostname, obfuscation_list, keywords):
-    rhsm_facts_file = '/tmp/insights_test_rhsm.facts'
+    rhsm_facts_file = os.path.join(tempfile.gettempdir(), 'insights_test_rhsm.facts')
     conf = InsightsConfig(
         obfuscate=obfuscate,
         obfuscate_hostname=obfuscate_hostname,
@@ -226,6 +227,6 @@ def test_all_csv_reports(rhsm_facts, obfuscate, obfuscate_hostname, obfuscation_
 
 
 def test_wirte_report_exp():
-    report_file = '/tmp/_test.csv'
+    report_file = os.path.join(tempfile.gettempdir(), '_test.csv')
     write_report(None, report_file)
     os.unlink(report_file)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
