### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -233,13 +233,14 @@ class InsightsConnection(object):
         """
         Generates and returns a string suitable for use as a request user-agent
         """
-        import pkg_resources
-        core_version = "insights-core"
-        pkg = pkg_resources.working_set.find(pkg_resources.Requirement.parse(core_version))
-        if pkg is not None:
-            core_version = "%s %s" % (pkg.project_name, pkg.version)
-        else:
+        import importlib.metadata
+
+        try:
+            pkg = importlib.metadata.distribution("insights-core")
+        except ModuleNotFoundError:
             core_version = "Core %s" % package_info["VERSION"]
+        else:
+            core_version = "%s %s" % (pkg.name, pkg.version)
 
         try:
             from insights_client import constants as insights_client_constants
@@ -253,10 +254,12 @@ class InsightsConnection(object):
         else:
             parent_process = "unknown"
 
-        requests_version = None
-        pkg = pkg_resources.working_set.find(pkg_resources.Requirement.parse("requests"))
-        if pkg is not None:
-            requests_version = "%s %s" % (pkg.project_name, pkg.version)
+        try:
+            pkg = importlib.metadata.distribution("requests")
+        except ModuleNotFoundError:
+            requests_version = None
+        else:
+            requests_version = "%s %s" % (pkg.name, pkg.version)
 
         python_version = "%s %s" % (platform.python_implementation(), platform.python_version())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "pyyaml",
     "redis",
     "requests",
-    "setuptools; python_version >= '3.12'",  # FIXME: remove after removed distutils
     "six",
 ]
 


### PR DESCRIPTION
Also, don't put the name of the project to core_version variable first, it's rather confusing.

Fixes https://issues.redhat.com/browse/CCT-1528

This requires Python 3.8+.
If support of 2.7 and similarly old Python 3 versions is desired, fallback imports of importlib_metadata and a conditional dependency on https://pypi.org/project/importlib-metadata/ is needed. (I can do that, just let me know.)

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

This is untested and provided as proof of concept.
