### PR TITLE
chore(rpmcmp): use rpm.labelCompare first

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
         python-version: ${{ matrix.python-versions }}
     - name: Install dependencies
       run: |
+        sudo apt-get install python3-rpm  # required on Ubuntu
         python -m pip install --upgrade pip
     - name: flake8
       run: |

--- a/insights/tests/parsers/test_installed_rpms.py
+++ b/insights/tests/parsers/test_installed_rpms.py
@@ -1,6 +1,11 @@
 import doctest
 import pytest
-from insights.parsers.installed_rpms import InstalledRpms, InstalledRpm, pad_version, ContainerInstalledRpms
+from insights.parsers.installed_rpms import (
+    ContainerInstalledRpms,
+    InstalledRpm,
+    InstalledRpms,
+    pad_version,
+)
 from insights.parsers import installed_rpms
 from insights.tests import context_wrap
 
@@ -281,10 +286,8 @@ def test_corrupt_db():
 def test_rpm_manifest():
     rpms = InstalledRpms(context_wrap(RPM_MANIFEST))
     assert 'gpg-pubkey' in rpms
-    assert rpms.packages['vmware-tools'][0].package == \
-        'vmware-tools-8.3.19-1310361.el6'
-    assert rpms.packages['vmware-tools'][0].installtime == \
-        'Sat Aug 29 19:10:11 2015'
+    assert rpms.packages['vmware-tools'][0].package == 'vmware-tools-8.3.19-1310361.el6'
+    assert rpms.packages['vmware-tools'][0].installtime == 'Sat Aug 29 19:10:11 2015'
 
 
 def test_package_property_aliases():
@@ -325,6 +328,8 @@ def test_release_compare():
     rpm7 = InstalledRpm.from_package('kernel-3.10.0-327.1')
     rpm8 = InstalledRpm.from_package('kernel-3.10.0-327.x86_64')
     rpm9 = InstalledRpm.from_package('kernel-3.10.0-327.1.x86_64')
+    rpm9_e0 = InstalledRpm.from_package('kernel-0:3.10.0-327.1.x86_64')
+    rpm9_e1 = InstalledRpm.from_package('kernel-1:3.10.0-327.1.x86_64')
     with pytest.raises(ValueError) as ve:
         rpm1 > rpm7
     assert "differing names" in str(ve)
@@ -349,6 +354,11 @@ def test_release_compare():
     assert rpm6 <= rpm8
     assert rpm6 >= rpm8
     assert not (rpm7 != rpm9)
+    # with epoch explicitly
+    assert rpm9 == rpm9_e0
+    assert rpm9 >= rpm9_e0
+    assert rpm9 <= rpm9_e1
+    assert rpm9_e0 < rpm9_e1
 
 
 def test_version_compare():
@@ -362,7 +372,7 @@ def test_version_compare():
         "buildtime": "1436354006",
         "rsaheader": "RSA/SHA256,Wed 07 Oct 2015 01:14:10 PM EDT,Key ID 199e2f91fd431d51",
         "dsaheader": "(none)",
-        "srpm": "bash-4.2.46-19.el7.src.rpm"
+        "srpm": "bash-4.2.46-19.el7.src.rpm",
     }
 
     d2 = d1.copy()
@@ -591,7 +601,7 @@ def test_container_installed_rpms():
             container_id='39310f3ccc12',
             image='registry.access.redhat.com/rhel9',
             engine='podman',
-            path='insights_containers/39310f3ccc12/insights_commands/rpm_-qa_--qf_name_NAME_epoch_EPOCH_version_VERSION_release_RELEASE_arch_ARCH_installtime_INSTALLTIME_date_buildtime_BUILDTIME_vendor_VENDOR_buildhost_BUILDHOST_sigpgp_SIGPGP_pgpsig'
+            path='insights_containers/39310f3ccc12/insights_commands/rpm_-qa_--qf_name_NAME_epoch_EPOCH_version_VERSION_release_RELEASE_arch_ARCH_installtime_INSTALLTIME_date_buildtime_BUILDTIME_vendor_VENDOR_buildhost_BUILDHOST_sigpgp_SIGPGP_pgpsig',
         )
     )
     assert rpms.image == "registry.access.redhat.com/rhel9"
@@ -611,7 +621,7 @@ def test_container_installed_rpms():
             container_id='cc2883a1a369',
             image='quay.io/rhel8',
             engine='podman',
-            path='insights_containers/cc2883a1a369/insights_commands/rpm_-qa_--qf_name_NAME_epoch_EPOCH_version_VERSION_release_RELEASE_arch_ARCH_installtime_INSTALLTIME_date_buildtime_BUILDTIME_vendor_VENDOR_buildhost_BUILDHOST_sigpgp_SIGPGP_pgpsig'
+            path='insights_containers/cc2883a1a369/insights_commands/rpm_-qa_--qf_name_NAME_epoch_EPOCH_version_VERSION_release_RELEASE_arch_ARCH_installtime_INSTALLTIME_date_buildtime_BUILDTIME_vendor_VENDOR_buildhost_BUILDHOST_sigpgp_SIGPGP_pgpsig',
         )
     )
     assert rpms_json.image == "quay.io/rhel8"
@@ -630,9 +640,9 @@ def test_doc_examples():
                 RPMS_DOCTEST_EXAMPLE,
                 container_id='cc2883a1a369',
                 image='quay.io/rhel8',
-                engine='podman'
+                engine='podman',
             )
-        )
+        ),
     }
     failed, total = doctest.testmod(installed_rpms, globs=env)
     assert failed == 0

--- a/insights/util/rpm_vercmp.py
+++ b/insights/util/rpm_vercmp.py
@@ -1,5 +1,11 @@
 """
-Nearly direct translation of rpm comparison code in the rpm project at
+RPM Version Comparison
+======================
+Compare the RPM version with `rpm.labelCompare` first, when the `rpm` module is
+not available, try the local `_rpm_vercmp`.
+
+The `_rpm_vercmp` is a nearly direct translation of rpm comparison code in the
+rpm project at:
 https://github.com/rpm-software-management/rpm/blob/master/lib/rpmvercmp.c
 
 Handles all of the cases in the rpm test file, including the "buggy" tests
@@ -122,21 +128,20 @@ def _rpm_vercmp(a, b):
     return 1
 
 
+def version_compare(left, right):
+    try:
+        import rpm
+        from functools import cmp_to_key
+
+        _l = cmp_to_key(rpm.labelCompare)(left)
+        _r = cmp_to_key(rpm.labelCompare)(right)
+
+        return -1 if _l < _r else 1 if _l > _r else 0
+    except Exception:  # pragma: no cover
+        return _rpm_vercmp(left, right)
+
+
 def rpm_version_compare(left, right):
     if left is right:
         return 0
-
-    le, re = int(left.epoch), int(right.epoch)
-    if le < re:
-        return -1
-    elif le > re:
-        return 1
-
-    rc = _rpm_vercmp(left.version, right.version)
-    if rc != 0:
-        return rc
-
-    return _rpm_vercmp(left.release, right.release)
-
-
-version_compare = _rpm_vercmp
+    return version_compare(left.package_with_epoch, right.package_with_epoch)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "pyyaml",
     "redis",
     "requests",
+    "rpm; python_version >= '3.6'",
     "setuptools; python_version >= '3.12'",  # FIXME: remove after removed distutils
     "six",
 ]

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ runtime = set(
         'six',
         'requests',
         'redis',
+        'rpm; python_version >= "3.6"',
         'cachecontrol',
         'cachecontrol[redis]',
         'cachecontrol[filecache]',


### PR DESCRIPTION
- follow up of #4490 (RHINENG-6913)
  use rpm.labelCompare for comparing RPM versions when the
  `rpm` module is available.
- deprecate the unused pad_version
- add rpm to runtime dependencies

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
