### PR TITLE
--check-results should call Inventory API only when the host is registered

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -1101,6 +1101,11 @@ class InsightsConnection(object):
         '''
             Retrieve advisor report
         '''
+        if not os.path.isfile(constants.registered_files[0]):
+            raise Exception("Could not retrieve advisor report.\n"
+                            "This host is not registered. Use --register to register this host:\n"
+                            "# insights-client --register")
+
         url = self.inventory_url + "/hosts?insights_id=%s" % generate_machine_id()
         res = self.get(url)
         if res.status_code not in [requests.codes.OK, requests.codes.NOT_MODIFIED]:

--- a/insights/tests/client/connection/test_advisor_report.py
+++ b/insights/tests/client/connection/test_advisor_report.py
@@ -1,0 +1,22 @@
+import os
+import pytest
+from mock.mock import patch
+from insights.client.constants import InsightsConstants as constants
+from insights.client.connection import InsightsConnection
+from insights.client.config import InsightsConfig
+
+
+@patch("insights.client.connection.InsightsConnection._init_session")
+@patch('insights.client.utilities.generate_machine_id')
+@patch('insights.client.connection.InsightsConnection.get')
+@patch('insights.client.connection.os.path.isfile', return_value=False)
+def test_unregistered_check_results(_is_file, get, generate_machine_id, _init_session):
+    config = InsightsConfig()
+    connection = InsightsConnection(config)
+
+    with pytest.raises(Exception):
+        connection.get_advisor_report()
+
+    assert not os.path.isfile(constants.registered_files[0])
+    generate_machine_id.assert_not_called()
+    get.assert_not_called()


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
* Card ID: CCT-1286

- When calling --check-results and the client is not registered to the
system, insights-client will no longer call Inventory API
(/api/inventory/v1/hosts?insights_id=<machine-id>)
