### PR TITLE
fix: override LANG to 'C.UTF-8' for subscription-manager (RHEL 6)

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -862,17 +862,17 @@ class DefaultSpecs(Specs):
     sssd_config = simple_file("/etc/sssd/sssd.conf")
     sssd_conf_d = glob_file("/etc/sssd/conf.d/*.conf")
     subscription_manager_facts = simple_command(
-        "/usr/sbin/subscription-manager facts", override_env={"LC_ALL": "C.UTF-8"}
+        "/usr/sbin/subscription-manager facts", override_env={"LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"}
     )
     subscription_manager_id = simple_command(
         "/usr/sbin/subscription-manager identity",  # use "/usr/sbin" here, BZ#1690529
-        override_env={"LC_ALL": "C.UTF-8"},
+        override_env={"LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"},
     )
     subscription_manager_installed_product_ids = simple_command(
         r"/usr/bin/find /etc/pki/product-default/ /etc/pki/product/ -name '*pem' -exec rct cat-cert --no-content '{}' \;"
     )
     subscription_manager_status = simple_command(
-        "/usr/sbin/subscription-manager status", override_env={"LC_ALL": "C.UTF-8"}
+        "/usr/sbin/subscription-manager status", override_env={"LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"}
     )
     sudoers = glob_file(["/etc/sudoers", "/etc/sudoers.d/*"])
     swift_proxy_server_conf = first_file(


### PR DESCRIPTION
### All Pull Requests:

- The same change of #4506 for RHEL 6
- This is a workaround for RHEL-105530. Before it's fixed,
  setting LANG=C.UTF-8 for the command to get it output in English
- Jira: RHINENG-19631

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

