### PR TITLE
fix: hostname obfuscation issue in particular specs

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -1584,8 +1584,6 @@ def serialize_command_output(obj, root):
     rc = obj.write(dst)
     return {
         "rc": rc,
-        "cmd": obj.cmd,
-        "args": obj.args,
         "save_as": bool(obj.save_as),
         "relative_path": rel,
     }
@@ -1598,8 +1596,6 @@ def deserialize_command_output(_type, data, root, ctx, ds):
     res = SerializedOutputProvider(rel, root=root, ctx=ctx, ds=ds)
 
     res.rc = data["rc"]
-    res.cmd = data["cmd"]
-    res.args = data["args"]
     return res
 
 
@@ -1710,8 +1706,6 @@ def serialize_container_command(obj, root):
     rc = obj.write(dst)
     return {
         "rc": rc,
-        "cmd": obj.cmd,
-        "args": obj.args,
         "save_as": bool(obj.save_as),
         "relative_path": rel,
         "image": obj.image,
@@ -1725,8 +1719,6 @@ def deserialize_container_command(_type, data, root, ctx, ds):
     rel = data["relative_path"]
     res = SerializedOutputProvider(rel, root=root, ctx=ctx, ds=ds)
     res.rc = data["rc"]
-    res.cmd = data["cmd"]
-    res.args = data["args"]
     res.image = data["image"]
     res.engine = data["engine"]
     res.container_id = data["container_id"]

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -53,7 +53,7 @@ class Specs(SpecSet):
         multi_output=True, no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac']
     )
     bios_uuid = RegistryPoint()
-    blkid = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
+    blkid = RegistryPoint(no_obfuscate=['ipv4', 'ipv6', 'mac'])
     bond = RegistryPoint(multi_output=True)
     bond_dynamic_lb = RegistryPoint(
         multi_output=True, no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac']
@@ -405,6 +405,7 @@ class Specs(SpecSet):
     lru_gen_enabled = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     # New `ls` Specs
     ls_files = RegistryPoint()
+    ls_lH_files = RegistryPoint(filterable=True)
     ls_la = RegistryPoint()
     ls_la_dirs = RegistryPoint(filterable=True)
     ls_la_filtered = RegistryPoint(filterable=True)
@@ -423,8 +424,7 @@ class Specs(SpecSet):
     ls_laRZ_dirs = RegistryPoint(filterable=True)
     ls_laZ = RegistryPoint()
     ls_laZ_dirs = RegistryPoint(filterable=True)
-    ls_lH_files = RegistryPoint(filterable=True)
-    # Useful individual `ls` Specs
+    # Useful for SoS
     ls_boot = RegistryPoint()
     ls_dev = RegistryPoint()
     ls_rsyslog_errorfile = RegistryPoint()
@@ -859,8 +859,8 @@ class Specs(SpecSet):
     systemctl_cat_dnsmasq_service = RegistryPoint()
     systemctl_cat_rpcbind_socket = RegistryPoint()
     systemctl_get_default = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
-    systemctl_list_unit_files = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
-    systemctl_list_units = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
+    systemctl_list_unit_files = RegistryPoint(no_obfuscate=['ipv4', 'ipv6', 'mac'])
+    systemctl_list_units = RegistryPoint(no_obfuscate=['ipv4', 'ipv6', 'mac'])
     systemctl_show_all_services = RegistryPoint()
     systemctl_show_all_services_with_limited_properties = RegistryPoint()
     systemctl_show_target = RegistryPoint()
@@ -927,7 +927,7 @@ class Specs(SpecSet):
     x86_ibrs_enabled = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     x86_pti_enabled = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     x86_retp_enabled = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
-    xfs_info = RegistryPoint(multi_output=True, no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
+    xfs_info = RegistryPoint(multi_output=True, no_obfuscate=['ipv4', 'ipv6', 'mac'])
     xfs_quota_state = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     xinetd_conf = RegistryPoint(multi_output=True)
     yum_conf = RegistryPoint(filterable=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -474,21 +474,21 @@ class DefaultSpecs(Specs):
     lpstat_protocol_printers = lpstat.lpstat_protocol_printers_info
     lpstat_queued_jobs_count = lpstat.lpstat_queued_jobs_count
     lru_gen_enabled = simple_file("/sys/kernel/mm/lru_gen/enabled")
-    ls_la = command_with_args('/bin/ls -la %s', ls.list_with_la, keep_rc=True)
+    ls_files = command_with_args('/bin/ls -lH %s', ls.list_files_with_lH, save_as='ls_files', keep_rc=True)
+    ls_la = command_with_args('/bin/ls -la %s', ls.list_with_la, save_as='ls_la', keep_rc=True)
     ls_la_filtered = command_with_args(
-        '/bin/ls -la %s', ls.list_with_la_filtered, keep_rc=True
+        '/bin/ls -la %s', ls.list_with_la_filtered, save_as='ls_la_filtered', keep_rc=True
     )  # Result is filtered
-    ls_lan = command_with_args('/bin/ls -lan %s', ls.list_with_lan, keep_rc=True)
+    ls_lan = command_with_args('/bin/ls -lan %s', ls.list_with_lan, save_as='ls_lan', keep_rc=True)
     ls_lan_filtered = command_with_args(
-        '/bin/ls -lan %s', ls.list_with_lan_filtered, keep_rc=True
+        '/bin/ls -lan %s', ls.list_with_lan_filtered, save_as='ls_lan_filtered', keep_rc=True
     )  # Result is filtered
-    ls_lanL = command_with_args('/bin/ls -lanL %s', ls.list_with_lanL, keep_rc=True)
-    ls_lanR = command_with_args('/bin/ls -lanR %s', ls.list_with_lanR, keep_rc=True)
-    ls_lanRL = command_with_args('/bin/ls -lanRL %s', ls.list_with_lanRL, keep_rc=True)
-    ls_laRZ = command_with_args('/bin/ls -laRZ %s', ls.list_with_laRZ, keep_rc=True)
-    ls_laZ = command_with_args('/bin/ls -laZ %s', ls.list_with_laZ, keep_rc=True)
+    ls_lanL = command_with_args('/bin/ls -lanL %s', ls.list_with_lanL, save_as='ls_lanL', keep_rc=True)
+    ls_lanR = command_with_args('/bin/ls -lanR %s', ls.list_with_lanR, save_as='ls_lanR', keep_rc=True)
+    ls_lanRL = command_with_args('/bin/ls -lanRL %s', ls.list_with_lanRL, save_as='ls_lanRL', keep_rc=True)
+    ls_laRZ = command_with_args('/bin/ls -laRZ %s', ls.list_with_laRZ, save_as='ls_laRZ', keep_rc=True)
+    ls_laZ = command_with_args('/bin/ls -laZ %s', ls.list_with_laZ, save_as='ls_laZ', keep_rc=True)
     ls_dev = simple_command("/bin/ls -lanR /dev")  # T.B.D
-    ls_files = command_with_args('/bin/ls -lH %s', ls.list_files_with_lH, keep_rc=True)
     lsattr = command_with_args("/bin/lsattr %s", lsattr.paths_to_lsattr)
     lsblk = simple_command("/bin/lsblk")
     lsblk_pairs = simple_command(


### PR DESCRIPTION
- Remove the "hostname" from "no_obfuscate" list of below specs, as on some hosts, "hostname" may appear in their content
  - xfs_info, blkid, systemctl_list_units, and systemctl_list_unit_files
- Remove the "cmd" and "args" from the meta_data JSON result of CommandOutputProvider based datasources, as "hostname" may appear
- Add "save_as" option to all new "LS" specs, as "hostname" may appear in some file path.
- Jira: RHINENG-19542

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
