### PR TITLE
fix: container spec exec with env and cmd precheck

### DIFF
--- a/insights/specs/datasources/container/__init__.py
+++ b/insights/specs/datasources/container/__init__.py
@@ -1,9 +1,11 @@
 """
 Basic datasources for container specs
 """
+
 from insights.core.context import HostContext
 from insights.core.exceptions import SkipComponent
 from insights.core.plugins import datasource
+from insights.core.spec_factory import PATH_ENV_OVERRIDER
 from insights.parsers.docker_list import DockerListContainers
 from insights.parsers.podman_list import PodmanListContainers
 from insights.specs.datasources import DEFAULT_SHELL_TIMEOUT
@@ -24,20 +26,26 @@ def running_rhel_containers(broker):
     But sometimes, this line won't be outputted as expected, in this case, it's
     necessary to remove the duplicated containers from the output of "docker".
     """
+
     def _is_rhel_image(ctx, c_info):
         """Only collect the containers based from RHEL images"""
         try:
-            ret = ctx.shell_out("/usr/bin/%s exec %s cat /etc/redhat-release" % c_info, timeout=DEFAULT_SHELL_TIMEOUT)
+            engine, cid = c_info
+            # cmd with existence pre_check of `cat`
+            cmd = 'bash -c "command -v cat > /dev/null && cat /etc/redhat-release"'
+            # the_cmd = <podman|docker> exec -e <env> container_id cmd
+            the_cmd = '/usr/bin/%s exec -e "%s" %s %s' % (engine, PATH_ENV_OVERRIDER, cid, cmd)
+            ret = ctx.shell_out(the_cmd, timeout=DEFAULT_SHELL_TIMEOUT)
             if ret and len(ret) == 1 and "red hat enterprise linux" in ret[0].lower():
                 return True
         except Exception:
-            # return False when there is no such file "/etc/redhat-releas"
+            # return False when there is no such file "/etc/redhat-release"
             pass
         return False
 
     cs = []
     podman_container = set()
-    if (PodmanListContainers in broker):
+    if PodmanListContainers in broker:
         podman_c = broker[PodmanListContainers]
         for name in podman_c.running_containers:
             container_id = podman_c.containers[name]['CONTAINER ID']
@@ -47,13 +55,12 @@ def running_rhel_containers(broker):
                 # skip containers from non-rhel image
                 continue
             cs.append((podman_c.containers[name]['IMAGE'],) + c_info)
-    if (DockerListContainers in broker):
+    if DockerListContainers in broker:
         docker_c = broker[DockerListContainers]
         for name in docker_c.running_containers:
             container_id = docker_c.containers[name]['CONTAINER ID']
             c_info = ('docker', container_id[:12])
-            if (container_id in podman_container or
-                    not _is_rhel_image(broker[HostContext], c_info)):
+            if container_id in podman_container or not _is_rhel_image(broker[HostContext], c_info):
                 # skip containers from non-rhel image and
                 # skip duplicated containers managed by "podman"
                 continue

--- a/insights/tests/datasources/container/test_nginx_conf.py
+++ b/insights/tests/datasources/container/test_nginx_conf.py
@@ -7,6 +7,7 @@ from insights.core.exceptions import SkipComponent, ContentException
 from insights.core.spec_factory import ContainerCommandProvider
 from insights.specs.datasources.container.nginx_conf import LocalSpecs, nginx_conf
 
+CONTAINER_CMD = '%s exec -e "PATH=$PATH" %s bash -c "command -v find && find /etc/ /opt/ *.conf"'
 
 find_list = [
     '/etc/nginx/nginx.conf',
@@ -43,12 +44,8 @@ find_result_empty = ContentException(
 )
 def test_nginx_conf(validate, load, find_l):
     find_nginx_confs = [
-        ContainerCommandProvider(
-            'podman exec 03e2861336a7 find /etc/ /opt/ *.conf', None, 'rhel8_nginx'
-        ),
-        ContainerCommandProvider(
-            'docker exec 03e2861336a8 find /etc/ /opt/ *.conf', None, 'rhel7_nginx'
-        ),
+        ContainerCommandProvider(CONTAINER_CMD % ("podman", "03e2861336a7"), None, 'rhel8_nginx'),
+        ContainerCommandProvider(CONTAINER_CMD % ("docker", "03e2861336a8"), None, 'rhel7_nginx'),
     ]
     broker = {LocalSpecs.container_find_etc_opt_conf: find_nginx_confs, HostContext: None}
 
@@ -72,12 +69,8 @@ def test_nginx_conf(validate, load, find_l):
 )
 def test_nginx_conf_empty(validate, load, find_l):
     find_nginx_confs_ng = [
-        ContainerCommandProvider(
-            'podman exec 03e2861336a7 find /etc/ /opt/ *.conf', None, 'rhel8_nginx'
-        ),
-        ContainerCommandProvider(
-            'docker exec 03e2861336a8 find /etc/ /opt/ *.conf', None, 'rhel7_nginx'
-        ),
+        ContainerCommandProvider(CONTAINER_CMD % ("podman", "03e2861336a7"), None, 'rhel8_nginx'),
+        ContainerCommandProvider(CONTAINER_CMD % ("docker", "03e2861336a8"), None, 'rhel7_nginx'),
     ]
     broker = {LocalSpecs.container_find_etc_opt_conf: find_nginx_confs_ng, HostContext: None}
 
@@ -95,18 +88,10 @@ def test_nginx_conf_empty(validate, load, find_l):
 )
 def test_nginx_conf_on_cmd_error(validate, load, find_l):
     find_nginx_confs = [
-        ContainerCommandProvider(
-            'podman exec 03e2861336a5 find /etc/ /opt/ *.conf', None, 'rhel8_nginx'
-        ),
-        ContainerCommandProvider(
-            'docker exec 03e2861336a6 find /etc/ /opt/ *.conf', None, 'rhel7_nginx'
-        ),
-        ContainerCommandProvider(
-            'podman exec 03e2861336a7 find /etc/ /opt/ *.conf', None, 'rhel8_nginx'
-        ),
-        ContainerCommandProvider(
-            'docker exec 03e2861336a8 find /etc/ /opt/ *.conf', None, 'rhel7_nginx'
-        ),
+        ContainerCommandProvider(CONTAINER_CMD % ("podman", "03e2861336a5"), None, 'rhel8_nginx'),
+        ContainerCommandProvider(CONTAINER_CMD % ("docker", "03e2861336a6"), None, 'rhel7_nginx'),
+        ContainerCommandProvider(CONTAINER_CMD % ("podman", "03e2861336a7"), None, 'rhel8_nginx'),
+        ContainerCommandProvider(CONTAINER_CMD % ("docker", "03e2861336a8"), None, 'rhel7_nginx'),
     ]
     broker = {LocalSpecs.container_find_etc_opt_conf: find_nginx_confs, HostContext: None}
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

 - exec with env path PATH_ENV_OVERRIDER, derived from SAFE_ENV
 - pre-check on the existence of cmds in container exec
 - customize the relative_path for container type providers

Jira: RHINENG-19679
This can prevent from conmon log on cmd exec errors on containers 

## Summary by Sourcery

Add pre-exec command checks and absolute paths for container commands to prevent execution errors and conmon logs inside containers

Bug Fixes:
- Prevent conmon logging errors by verifying command existence before execution inside containers

Enhancements:
- Use absolute paths for core commands (cat, dotnet, rpm, ps, find) and wrap container_execute calls in bash -c conditionals to check command availability
- Standardize ContainerFileProvider to invoke /usr/bin/cat when reading files from containers
- Improve nginx_conf datasource to skip empty configuration paths during collection

## Summary by Sourcery

Add environment PATH overrides and command existence pre-checks to container exec routines to prevent execution errors and avoid conmon logging; standardize absolute engine paths and adjust providers and tests to the new wrapped command format

Bug Fixes:
- Pre-check command existence before executing inside containers to prevent conmon logging errors

Enhancements:
- Inject a PATH override via -e into all container exec calls and wrap commands in bash -c with `command -v` checks
- Use absolute /usr/bin paths for container engines and core commands and update ContainerFileProvider/ContainerCommandProvider parsing accordingly
- Update nginx_conf datasource to skip empty configuration paths during collection

Tests:
- Revise container spec tests to use a shared CONTAINER_CMD template reflecting the new exec command structure