### PR TITLE
fix: handle error from relied spec for container_nginx_conf

### DIFF
--- a/insights/tests/datasources/container/test_nginx_conf.py
+++ b/insights/tests/datasources/container/test_nginx_conf.py
@@ -3,7 +3,7 @@ import pytest
 from mock.mock import patch, PropertyMock
 
 from insights.core.context import HostContext
-from insights.core.exceptions import SkipComponent
+from insights.core.exceptions import SkipComponent, ContentException
 from insights.core.spec_factory import ContainerCommandProvider
 from insights.specs.datasources.container.nginx_conf import LocalSpecs, nginx_conf
 
@@ -22,47 +22,107 @@ find_list_ng = [
     '/opt/nginx/nginx.conf.d/ss-nginx.conf',
 ]
 
+# with spec keep_rc, cmd CalledProcessError would be kept as self._content
+find_cmd_exec_error = [
+    'Error: runc: exec failed: unable to start container process: exec: '
+    + '"find": executable file not found in $PATH: OCI runtime attempted to'
+    + 'invoke a command that was not found'
+]
+
+find_result_empty = ContentException(
+    "Empty after cleaning: insights_containers/03e2861336a6/insights_commands/find_.etc_.opt_-name_.conf"
+)
+
 
 @patch("insights.core.spec_factory.CommandOutputProvider.validate", return_value=None)
 @patch("insights.core.spec_factory.CommandOutputProvider.load", return_value=None)
-@patch("insights.core.spec_factory.CommandOutputProvider.content",
-        new_callable=PropertyMock, return_value=find_list)
+@patch(
+    "insights.core.spec_factory.CommandOutputProvider.content",
+    new_callable=PropertyMock,
+    return_value=find_list,
+)
 def test_nginx_conf(validate, load, find_l):
     find_nginx_confs = [
         ContainerCommandProvider(
-            'podman exec 03e2861336a7 find /etc/ /opt/ *.conf',
-            None, 'rhel8_nginx'),
+            'podman exec 03e2861336a7 find /etc/ /opt/ *.conf', None, 'rhel8_nginx'
+        ),
         ContainerCommandProvider(
-            'docker exec 03e2861336a8 find /etc/ /opt/ *.conf',
-            None, 'rhel7_nginx'),
+            'docker exec 03e2861336a8 find /etc/ /opt/ *.conf', None, 'rhel7_nginx'
+        ),
     ]
-    broker = {
-        LocalSpecs.container_find_etc_opt_conf: find_nginx_confs,
-        HostContext: None}
+    broker = {LocalSpecs.container_find_etc_opt_conf: find_nginx_confs, HostContext: None}
 
     ret = nginx_conf(broker)
     assert len(ret) == 8
     assert ('rhel8_nginx', 'podman', '03e2861336a7', '/etc/nginx/nginx.conf') in ret
-    assert ('rhel7_nginx', 'docker', '03e2861336a8', '/opt/rh-nginx/nginx.conf.d/ss-nginx.conf') in ret
+    assert (
+        'rhel7_nginx',
+        'docker',
+        '03e2861336a8',
+        '/opt/rh-nginx/nginx.conf.d/ss-nginx.conf',
+    ) in ret
 
 
 @patch("insights.core.spec_factory.CommandOutputProvider.validate", return_value=None)
 @patch("insights.core.spec_factory.CommandOutputProvider.load", return_value=None)
-@patch("insights.core.spec_factory.CommandOutputProvider.content",
-        new_callable=PropertyMock, return_value=find_list_ng)
+@patch(
+    "insights.core.spec_factory.CommandOutputProvider.content",
+    new_callable=PropertyMock,
+    return_value=find_list_ng,
+)
 def test_nginx_conf_empty(validate, load, find_l):
     find_nginx_confs_ng = [
         ContainerCommandProvider(
-            'podman exec 03e2861336a7 find /etc/ /opt/ *.conf',
-            None, 'rhel8_nginx'),
+            'podman exec 03e2861336a7 find /etc/ /opt/ *.conf', None, 'rhel8_nginx'
+        ),
         ContainerCommandProvider(
-            'docker exec 03e2861336a8 find /etc/ /opt/ *.conf',
-            None, 'rhel7_nginx'),
+            'docker exec 03e2861336a8 find /etc/ /opt/ *.conf', None, 'rhel7_nginx'
+        ),
     ]
-    broker = {
-        LocalSpecs.container_find_etc_opt_conf: find_nginx_confs_ng,
-        HostContext: None}
+    broker = {LocalSpecs.container_find_etc_opt_conf: find_nginx_confs_ng, HostContext: None}
 
     with pytest.raises(SkipComponent):
         ret = nginx_conf(broker)
         assert len(ret) == 0
+
+
+@patch("insights.core.spec_factory.CommandOutputProvider.validate", return_value=None)
+@patch("insights.core.spec_factory.CommandOutputProvider.load", return_value=None)
+@patch(
+    "insights.core.spec_factory.CommandOutputProvider.content",
+    new_callable=PropertyMock,
+    side_effect=[find_cmd_exec_error, find_result_empty, find_list_ng, find_list],
+)
+def test_nginx_conf_on_cmd_error(validate, load, find_l):
+    find_nginx_confs = [
+        ContainerCommandProvider(
+            'podman exec 03e2861336a5 find /etc/ /opt/ *.conf', None, 'rhel8_nginx'
+        ),
+        ContainerCommandProvider(
+            'docker exec 03e2861336a6 find /etc/ /opt/ *.conf', None, 'rhel7_nginx'
+        ),
+        ContainerCommandProvider(
+            'podman exec 03e2861336a7 find /etc/ /opt/ *.conf', None, 'rhel8_nginx'
+        ),
+        ContainerCommandProvider(
+            'docker exec 03e2861336a8 find /etc/ /opt/ *.conf', None, 'rhel7_nginx'
+        ),
+    ]
+    broker = {LocalSpecs.container_find_etc_opt_conf: find_nginx_confs, HostContext: None}
+
+    ret = nginx_conf(broker)
+    assert len(ret) == 4
+    assert ('rhel8_nginx', 'podman', '03e2861336a5', '/etc/nginx/nginx.conf') not in ret
+    assert (
+        'rhel7_nginx',
+        'docker',
+        '03e2861336a6',
+        '/opt/rh-nginx/nginx.conf.d/ss-nginx.conf',
+    ) not in ret
+    assert ('rhel8_nginx', 'podman', '03e2861336a7', '/etc/nginx/nginx.conf') not in ret
+    assert (
+        'rhel7_nginx',
+        'docker',
+        '03e2861336a8',
+        '/opt/rh-nginx/nginx.conf.d/ss-nginx.conf',
+    ) in ret


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

- make container nginx_conf ds be able to continue on the processing for next container when the relied spec `container_find_etc_opt_conf` failed for this container 
- add mock test for dep spec error case

- Jira: RHINENG-19822

## Summary by Sourcery

Continue processing other containers in the nginx_conf datasource when the container_find_etc_opt_conf spec fails by adding granular exception handling.

Enhancements:
- Wrap iteration over conf_list.content in try/except to catch errors and skip faulty containers
- Reformat container_find_etc_opt_conf spec assignment for improved readability

## Summary by Sourcery

Add error handling to the nginx_conf datasource to catch and ignore failures from the container_find_etc_opt_conf spec so that processing continues for other containers; reformat the spec definition for readability; and add a test to validate this behavior.

Bug Fixes:
- Continue processing other containers when container_find_etc_opt_conf fails instead of aborting the datasource

Enhancements:
- Reformat container_find_etc_opt_conf spec assignment for improved readability

Tests:
- Add test_nginx_conf_on_error to verify the datasource skips a container on spec errors and processes remaining containers