### PR TITLE
fix: rpm_vercmp can't compare pkgs with different version length

### DIFF
--- a/insights/tests/parsers/test_installed_rpms.py
+++ b/insights/tests/parsers/test_installed_rpms.py
@@ -594,6 +594,16 @@ def test_vmaas():
     assert rpm.release == "1.el7"
 
 
+def test_rpm_with_diff_length_version():
+    rpm1 = InstalledRpm.from_package('kernel-3.10-327.204.el7.1')
+    rpm2 = InstalledRpm.from_package('kernel-3.10.1-327.204.el7.1')
+    assert rpm1 < rpm2
+
+    rpm1 = InstalledRpm.from_package('fapolicyd-1.1.3-6.el8_6.1')
+    rpm2 = InstalledRpm.from_package('fapolicyd-1.1-6.el8_6.1')
+    assert rpm1 > rpm2
+
+
 def test_container_installed_rpms():
     rpms = ContainerInstalledRpms(
         context_wrap(


### PR DESCRIPTION
- Split the "novr" when new version_compare is not available
  As the old _rpm_vercmp doesn't support comparing packages with different length of versions.
  E.g., with the old implementation, it cannot compare "fapolicyd-1.1-6.el8_6.1" < "fapolicyd-1.1.1-6.el8_6.1" correctly

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Ensure rpm_version_compare correctly handles packages with differing version segment lengths by using the new version_compare when available and falling back to the old algorithm otherwise, and add tests for these scenarios.

Bug Fixes:
- Fix rpm_version_compare to compare packages with different version length correctly by iterating over epoch, version, and release when new comparison isn't available.

Enhancements:
- Add fallback logic in rpm_version_compare to choose between new version_compare and old _rpm_vercmp based on environment.

Tests:
- Add unit tests verifying rpm_version_compare for packages with different version segment lengths.