### PR TITLE
feat: suppress link message after upload

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -558,23 +558,6 @@ class InsightsClient(object):
                             "# insights-client --register")
         print(json.dumps(content, indent=1))
 
-    def show_inventory_deep_link(self):
-        """
-        Show a deep link to this host inventory record
-        """
-        system = self.connection._fetch_system_by_machine_id()
-        if system:
-            try:
-                id = system["id"]
-                logger.info("View details about this system on console.redhat.com:")
-                logger.info(
-                    "https://console.redhat.com/insights/inventory/{0}".format(id)
-                )
-            except Exception as e:
-                logger.error(
-                    "Error: malformed system record: {0}: {1}".format(system, e)
-                )
-
     def copy_to_output_dir(self, insights_archive):
         '''
         Copy the collected data from temp to the directory

--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -390,11 +390,6 @@ def _legacy_upload(config, pconn, tar_file, content_type, collection_duration=No
                 )
             else:
                 logger.info("Successfully uploaded report for %s.", msg_name)
-            if config.register:
-                # direct to console after register + upload
-                logger.info(
-                    'View the Red Hat Insights console at https://console.redhat.com/insights/'
-                )
             break
 
         elif upload.status_code in (412, 413):
@@ -427,10 +422,6 @@ def upload(config, pconn, tar_file, content_type, collection_duration=None):
             os.chmod(constants.lastupload_file, 0o644)
             msg_name = determine_hostname(config.display_name)
             logger.info("Successfully uploaded report for %s.", msg_name)
-            if config.register:
-                # direct to console after register + upload
-                display_console_url(config)
-            return
         elif upload.status_code in (413, 415):
             pconn.handle_fail_rcs(upload)
             raise RuntimeError('Upload failed.')
@@ -452,10 +443,3 @@ def display_upload_error_and_retry(config, tries, error_message):
         logger.error("All attempts to upload have failed!")
         print("Please see %s for additional information" % config.logging_file)
         raise RuntimeError('Upload failed.')
-
-
-def display_console_url(config):
-    console_url = "https://console.redhat.com/insights/"
-    if "stage" in config.base_url:
-        console_url = "https://console.stage.redhat.com/insights/"
-    logger.info("View the Red Hat Insights console at %s" % console_url)

--- a/insights/client/phase/v1.py
+++ b/insights/client/phase/v1.py
@@ -350,7 +350,6 @@ def collect_and_output(client, config):
         if resp:
             if config.to_json:
                 print(json.dumps(resp))
-            client.show_inventory_deep_link()
 
     client.delete_cached_branch_info()
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* CardID: CCT-1469

* Suppressed message linking to https://console.redhat.com/insights/ after upload. Because with the introduction of Insights on-prem, there is no guarantee that a system registering to Insights is registering to console.redhat.com. We will suppress until CCT-1296 is designed and implemented in RHC.

## Summary by Sourcery

Silence the informational message directing users to the Red Hat Insights console after report uploads, deferring its reintroduction pending the CCT-1296 design

Enhancements:
- Suppress the post-upload link message to console.redhat.com/insights in both legacy and new upload flows
- Comment out the console URL logging and display calls until CCT-1296 is designed and implemented