### PR TITLE
fix: compatibility of version_compare

### DIFF
--- a/insights/tests/util/test_rpm_vercmp.py
+++ b/insights/tests/util/test_rpm_vercmp.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
-from insights.util.rpm_vercmp import _rpm_vercmp
+from insights.util.rpm_vercmp import _rpm_vercmp, version_compare
 
 
 # data copied from
@@ -176,3 +176,14 @@ def test_rpm_vercmp(rpm_data):
     for l, r, expected in rpm_data:
         actual = _rpm_vercmp(l, r)
         assert actual == expected, (l, r, actual, expected)
+
+
+def test_version_compare():
+    rpm1 = 'kernel-rt-debug-3.10.0-327.rt56.204.el7_2.1'
+    rpm2 = 'kernel-rt-debug-3.10.0-327.rt56.204.el7_2.2'
+    rpm3 = 'kernel-3.10.0-327.10.1.el7'
+    rpm4 = 'kernel-3.10.0-327.el7'
+    rpm5 = 'kernel-3.10.1-327.el7'
+    assert version_compare(rpm1, rpm2) == -1
+    assert version_compare(rpm3, rpm4) == 1
+    assert version_compare(rpm4, rpm5) == -1


### PR DESCRIPTION
- with the latest rpm.labelCompare, it only accepts the tuple format in (epoch, version, release), when the passed arguments are not in this format, convert them by force.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Automatically convert non-tuple inputs into (epoch, version, release) tuples in version_compare for compatibility with the updated rpm.labelCompare and ensure a working fallback when rpm import fails.

Bug Fixes:
- Coerce string arguments into the required tuple format before calling rpm.labelCompare to fix compatibility issues.

Enhancements:
- Relocate and simplify fallback assignment of version_compare when rpm is unavailable.