### PR TITLE
fix(client): remove unused format_config() function

### DIFF
--- a/insights/client/__init__.py
+++ b/insights/client/__init__.py
@@ -663,17 +663,6 @@ class InsightsClient(object):
         return self.connection.checkin()
 
 
-def format_config(config):
-    # Log config except the password
-    # and proxy as it might have a pw as well
-    config_copy = config.copy()
-    try:
-        del config_copy["password"]
-        del config_copy["proxy"]
-    finally:
-        return json.dumps(config_copy, indent=4)
-
-
 def _init_client_config_dirs():
     '''
     Initialize log and lib dirs


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* Card ID: CCT-1455

The function format_config() was never used and is triggering PEP 765 SyntaxWarning in Python 3.14 due to return statement in finally block.

## Summary by Sourcery

Replace the try/finally block in format_config with dict.pop to remove sensitive keys and avoid a PEP 765 SyntaxWarning in Python 3.14

Bug Fixes:
- Prevent PEP 765 SyntaxWarning in format_config

Enhancements:
- Simplify sensitive-key removal in format_config by using dict.pop