### PR TITLE
feat(client): Exclude vendor libs from coverage stats

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,8 @@ omit = insights/contrib/*
        insights/*/__main__.py
        # Exclude test files from coverage.
        insights/tests/*
+       # Exclude vendor libs from coverage
+       insights/client/apps/ansible/playbook_verifier/contrib/*
 branch = True
 
 [report]


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

* CardID: CCT-1503

* This commit excludes vendor libraries from insights/client from coverage statistics because they were already tested upstream

## Summary by Sourcery

Enhancements:
- Update .coveragerc to ignore vendor library directories for coverage in the client package