### PR TITLE
fix: Enhance "IpLinkInfo" to keep the bond or slave options

### DIFF
--- a/insights/parsers/ip.py
+++ b/insights/parsers/ip.py
@@ -93,6 +93,10 @@ def parse_ip_addr(content):
             tx_next_line = True
         elif line.startswith("vf "):
             current['vf_enabled'] = True
+        elif line.startswith('bond mode') and current:
+            current['bond_options'] = line.strip()
+        elif line.startswith('bond_slave') and current:
+            current['bond_slave_options'] = line.strip()
     for k, v in r.items():
         if_details[k] = NetworkInterface(v)
     return if_details


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

## Summary by Sourcery

Enhance the IpLinkInfo parser to capture bond and slave option lines and add tests to validate this behavior

Bug Fixes:
- Retain 'bond mode' and 'bond_slave' option lines in the IpLinkInfo parser

Tests:
- Add unit tests to verify that bond and slave interfaces expose 'options' fields with bond settings