### PR TITLE
feat: New spec "/etc/watchdog.conf" and the parser

### DIFF
--- a/docs/shared_parsers_catalog/watchdog.rst
+++ b/docs/shared_parsers_catalog/watchdog.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.watchdog
+   :members:
+   :show-inheritance:

--- a/insights/parsers/watchdog.py
+++ b/insights/parsers/watchdog.py
@@ -1,0 +1,44 @@
+"""
+Parsers for watchdog configuration
+==================================
+
+WatchDogConf - file ``/etc/watchdog.conf``
+------------------------------------------
+"""
+
+from insights import parser, Parser, SkipComponent
+from insights.specs import Specs
+from insights.parsers import split_kv_pairs
+
+
+@parser(Specs.watchdog_conf)
+class WatchDogConf(Parser, dict):
+    """
+    Parsing the `/etc/watchdog.conf` file. It stores the data in a dict.
+
+    Sample content::
+
+        # The retry-timeout and repair limit are used to handle errors in a
+        # more robust manner. Errors must persist for longer than this to
+        # action a repair or reboot, and if repair-maximum attempts are
+        # made without the test passing a reboot is initiated anyway.
+
+        retry-timeout          = 60
+        repair-maximum         = 1
+        realtime               = yes
+        priority               = 1
+
+    Examples:
+        >>> 'retry-timeout' in watchdog_conf_obj
+        True
+        >>> 'test-timeout' in watchdog_conf_obj
+        False
+        >>> watchdog_conf_obj.get('retry-timeout')
+        '60'
+        >>> watchdog_conf_obj.get('realtime')
+        'yes'
+    """
+    def parse_content(self, content):
+        self.update(split_kv_pairs(content))
+        if not self:
+            raise SkipComponent('Not available data')

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -921,6 +921,7 @@ class Specs(SpecSet):
     vmware_tools_conf = RegistryPoint()
     vsftpd = RegistryPoint()
     vsftpd_conf = RegistryPoint(filterable=True)
+    watchdog_conf = RegistryPoint(filterable=True)
     watchdog_logs = RegistryPoint(filterable=True, multi_output=True)
     wc_proc_1_mountinfo = RegistryPoint()
     x86_ibpb_enabled = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -965,6 +965,7 @@ class DefaultSpecs(Specs):
     vma_ra_enabled = simple_file("/sys/kernel/mm/swap/vma_ra_enabled")
     vsftpd = simple_file("/etc/pam.d/vsftpd")
     vsftpd_conf = simple_file("/etc/vsftpd/vsftpd.conf")
+    watchdog_conf = simple_file("/etc/watchdog.conf")
     watchdog_logs = glob_file("/var/log/watchdog/*.std*")
     wc_proc_1_mountinfo = simple_command("/usr/bin/wc -l /proc/1/mountinfo")
     x86_ibpb_enabled = simple_file("sys/kernel/debug/x86/ibpb_enabled")

--- a/insights/tests/parsers/test_watchdog.py
+++ b/insights/tests/parsers/test_watchdog.py
@@ -1,0 +1,40 @@
+import doctest
+import pytest
+
+from insights.parsers import watchdog, SkipComponent
+from insights.parsers.watchdog import WatchDogConf
+from insights.tests import context_wrap
+
+WATCHDOG_CONF = """
+# The retry-timeout and repair limit are used to handle errors in a
+# more robust manner. Errors must persist for longer than this to
+# action a repair or reboot, and if repair-maximum attempts are
+# made without the test passing a reboot is initiated anyway.
+
+retry-timeout          = 60
+repair-maximum         = 1
+realtime               = yes
+priority               = 1
+""".strip()
+
+
+def test_watchdog_conf():
+    watchdog_conf = WatchDogConf(context_wrap(WATCHDOG_CONF))
+    assert len(watchdog_conf) == 4
+    assert watchdog_conf.get('retry-timeout') == '60'
+    assert watchdog_conf.get('repair-maximum') == '1'
+    assert watchdog_conf.get('realtime') == 'yes'
+    assert watchdog_conf.get('priority') == '1'
+
+
+def test_watchdog_skip():
+    with pytest.raises(SkipComponent):
+        WatchDogConf(context_wrap(''))
+
+
+def test_doc():
+    env = {
+        "watchdog_conf_obj": WatchDogConf(context_wrap(WATCHDOG_CONF))
+    }
+    failed_count, _ = doctest.testmod(watchdog, globs=env)
+    assert failed_count == 0


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

## Summary by Sourcery

Add support for parsing the /etc/watchdog.conf configuration by registering a new spec, providing a WatchDogConf parser, and including corresponding tests and documentation.

New Features:
- Introduce a watchdog_conf registry point for /etc/watchdog.conf in the specs
- Implement WatchDogConf parser to read key/value pairs from /etc/watchdog.conf

Enhancements:
- Register the new watchdog_conf spec in the default spec set

Documentation:
- Add documentation entry for the watchdog_conf parser

Tests:
- Add unit tests and doctests for the WatchDogConf parser