### PR TITLE
feat: Feature to allow malware detection run scans on 3rd party rules

### DIFF
--- a/insights/specs/datasources/malware_detection/__init__.py
+++ b/insights/specs/datasources/malware_detection/__init__.py
@@ -2,178 +2,111 @@ import os
 import re
 import time
 import json
-import yaml
 from sys import exit
 import logging
 from glob import glob
 from datetime import datetime
 from tempfile import NamedTemporaryFile, gettempdir
+
 try:
     # python 2
     from urllib import quote as urlencode
-    from urlparse import urlparse, urlunparse
 except ImportError:
     # python 3
-    from urllib.parse import urlparse, urlunparse, quote as urlencode
+    from urllib.parse import quote as urlencode
 
 from insights.client.connection import InsightsConnection
 from insights.client.constants import InsightsConstants as constants
-from insights.client.utilities import (
-    generate_machine_id, write_data_to_file, get_time
-)
+from insights.client.utilities import generate_machine_id, write_data_to_file, get_time
 from insights.core.exceptions import CalledProcessError
 from insights.util.subproc import call
+from insights.specs.datasources.malware_detection import utils
+from insights.specs.datasources.malware_detection import config
+from insights.specs.datasources.malware_detection import rules as rules_utils
 
 logger = logging.getLogger(__name__)
-MIN_YARA_VERSION = "4.1.0"
-MALWARE_APP_URL = 'https://console.redhat.com/insights/malware'
-MALWARE_CONFIG_FILE = os.path.join(constants.default_conf_dir, "malware-detection-config.yml")
-LAST_FILESYSTEM_SCAN_FILE = os.path.join(constants.default_conf_dir, '.last_malware-detection_filesystem_scan')
-LAST_PROCESSES_SCAN_FILE = os.path.join(constants.default_conf_dir, '.last_malware-detection_processes_scan')
-RULE_DOWNLOAD_DIR = constants.insights_core_lib_dir
-DEFAULT_MALWARE_CONFIG = """
-# Configuration file for the Red Hat Insights Malware Detection Client app
-# File format is YAML
----
-# Perform a simple test scan of the insights-client config directory and process to verify installation and scanning
-# are working correctly.  The results from this scan do not show up in the webUI.
-# Once verified, disable this option to perform actual malware scans.
-test_scan: true
-
-# Scan the filesystem?
-# When it is false, the filesystem isn't scanned and the filesystem_* options that follow are ignored
-scan_filesystem: true
-
-# filesystem_scan_only: a single or list of files/directories to be scanned and no others, for example:
-# filesystem_scan_only:
-# - /var/www
-# - /home
-# ... means only scan files in /var/www and /home.  May also be written as filesystem_scan_only: [/var/www, /home]
-# No value means scan all files and directories
-filesystem_scan_only:
-
-# filesystem_scan_exclude: a single or list of files/directories to be excluded from filesystem scanning
-# If an item appears in both filesystem_scan_only and filesystem_scan_exclude, filesystem_scan_exclude takes precedence
-# and the item will be excluded
-# filesystem_scan_exclude is pre-populated with a list of top level directories that are recommended to be excluded
-filesystem_scan_exclude:
-- /proc
-- /sys
-- /cgroup
-- /selinux
-- /net
-- /mnt
-- /media
-
-# filesystem_scan_since: scan files created or modified since X days ago or since the 'last' scan.
-# Valid values are integers >= 1 or the string 'last'.  For example:
-# filesystem_scan_since: 1
-# ... means scan files created/modified since 1 day ago
-# filesystem_scan_since: last
-# ... means scan files created/modified since the last successful scan
-# No value means scan all files regardless of created/modified date
-filesystem_scan_since:
-
-# Exclude mounted network/external filesystems mountpoints?
-# Scanning files within mounted network filesystems may be slow and cause extra network traffic.
-# They are excluded by default, meaning that files in network/externally mounted filesystems are not scanned.
-# Their mountpoints will be added to the scan_exclude list of directories to be excluded from scanning
-exclude_network_filesystem_mountpoints: true
-
-# List of network/external filesystem types to search for mountpoints on the system.
-# If any mountpoints are found for these filesystem types, the value of the exclude_network_filesystem_mountpoints
-# option will determine if files within the mountpoints are scanned or not.
-network_filesystem_types: [nfs, nfs4, cifs, smbfs, fuse.sshfs, ceph, glusterfs, gfs, gfs2]
-
-# Scan the running processes?
-# Scan_process is disabled by default to prevent an impact on system performance when scanning numerous or large processes.
-# When it is false, no processes are scanned and the processes_scan_* options that follow are ignored
-scan_processes: false
-
-# processes_scan_only: processes to be scanned and no others, for example:
-# processes_scan_only:
-# - 123
-# - 1..100
-# - 10000..
-# - docker
-# - chrome
-#... means only scan PID 123, PIDs from 1 to 100 inclusive, PIDs >= 10000 and process names containing the strings docker or chrome
-# No value means scan all processes
-processes_scan_only:
-
-# processes_scan_exclude: processes to be excluded from scanning.  Uses the same syntax as processes_scan_only.
-# If an item appears in both processes_scan_only and processes_scan_exclude, processes_scan_exclude takes precedence
-# and the item will be excluded
-# No value means don't exclude any processes
-processes_scan_exclude:
-
-# processes_scan_since: scan processes created since X days ago or since the 'last' scan.
-# Valid values are integers >= 1 or the string 'last'.  For example:
-# processes_scan_since: 1
-# ... means scan processes created since 1 day ago
-# processes_scan_since: last
-# ... means scan processes created since the last successful scan
-# No value means scan all processes regardless of created date
-processes_scan_since:
-
-# Add extra metadata about each scan match (if possible), eg file type & md5sum, matching line numbers, process name
-# The extra metadata will display in the webUI along with the scan matches
-add_metadata: true
-
-# Abort a particular scan if it takes longer than scan_timeout seconds.  Default is 3600 seconds (1 hour)
-scan_timeout: # 3600
-
-# Run the yara process with this nice priority value.  Default is 19 (lowest priority)
-nice_value: # 19
-
-# The max number of CPUs threads used by yara when scanning.  Autodetected, but default is 2
-cpu_thread_limit: # 2
-""".lstrip()
-
-# All the config options have corresponding environment variables
-# Env vars are initially strings and need to be parsed to their appropriate type to match the yaml types
-ENV_VAR_TYPES = {
-    'boolean': ['SCAN_FILESYSTEM', 'SCAN_PROCESSES', 'TEST_SCAN', 'ADD_METADATA',
-                'EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'],
-    'list': ['FILESYSTEM_SCAN_ONLY', 'FILESYSTEM_SCAN_EXCLUDE', 'PROCESSES_SCAN_ONLY', 'PROCESSES_SCAN_EXCLUDE',
-             'NETWORK_FILESYSTEM_TYPES'],
-    'integer': ['SCAN_TIMEOUT', 'NICE_VALUE', 'CPU_THREAD_LIMIT', 'STRING_MATCH_LIMIT'],
-    'int_or_str': ['FILESYSTEM_SCAN_SINCE', 'PROCESSES_SCAN_SINCE']
-}
 
 
 class MalwareDetectionClient:
-    def __init__(self, insights_config):
+    def __init__(
+        self,
+        insights_config,
+        malware_detection_config,
+        yara_binary_location,
+        yara_version,
+    ):
         # insights_config is used to access insights-client auth and network config when downloading rules
         self.insights_config = insights_config
 
-        # Load the malware-detection config file
-        self.config = self._load_config()
+        # set the malware-detection config file
+        self.config = malware_detection_config
 
-        # Early check if the yara binary exists.  No point continuing if it doesn't
-        self.yara_binary = self._find_yara()
+        # Set location of yara binary and the version of yara
+        self.yara_binary = yara_binary_location
+        self.yara_version = yara_version
 
-        # Get/set the values of assorted integer config values - mainly options used with the yara command
-        for option, value in [('nice_value', 19),
-                              ('scan_timeout', 3600),
-                              ('cpu_thread_limit', 2),
-                              ('string_match_limit', 10)]:
-            try:
-                setattr(self, option, int(self._get_config_option(option, value)))
-            except Exception as e:
-                logger.error("Problem setting configuration option %s: %s", option, str(e))
-                exit(constants.sig_kill_bad)
+        self.nice_value = self._validate_option("nice_value", 19)
+        self.scan_timeout = self._validate_option("scan_timeout", 3600)
+        self.cpu_thread_limit = self._validate_option("cpu_thread_limit", 2)
+        self.string_match_limit = self._validate_option("string_match_limit", 10)
+        # # Get/set the values of assorted integer config values - mainly options used with the yara command
+
+        # new
+        self.test_scan = self._get_config_option("test_scan", False)
+        self.filesystem_scan_exclude_list = []
+        self.processes_scan_exclude_list = []
+        self.filesystem_scan_since_dict = {}
+        self.processes_scan_since_dict = {}
+        self.network_filesystem_mountpoints = []
+        # new
+        self.do_filesystem_scan = self._get_config_option("scan_filesystem", True)
+        self.scan_fsobjects = []
+        self.do_process_scan = self._get_config_option("scan_processes", False)
+        self.scan_pids = []
 
         # If doing a test scan, then ignore the other scan_* options because test scan sets its own values for them
-        if not self._parse_test_scan_option():
-            self._parse_scan_options()
+        # if not self._parse_test_scan_option():
+        #     self._parse_scan_options()
 
         # Obtain the rules to be used by yara & the list of disabled rules, if any
-        self.rules_file = self._get_rules()
-        self.disabled_rules = self._get_disabled_rules()
+        self.rules_files = []
+        # new
+        self.use_remote_rules = self._get_config_option("use_remote_rules", "True")
+        self.remote_rules_location = self._get_config_option(
+            "remote_rules_location", ""
+        )
+        # todo should this be False or ''
+        self.rules_location = self._get_config_option("rules_location", "/etc/insights-client/signatures")
 
-        # Build the yara command, with its various command line options, that will be run
-        self.yara_cmd = self._build_yara_command()
+        # exclude rules directory from scans
+        if self.rules_location:
+            self.filesystem_scan_exclude_list.append(self.rules_location)
+
+        self.disabled_rules = []
+
+        # new setup connection
+        self.conn = None
+
+        if self.use_remote_rules or self.test_scan:
+            # Check if insights-config is defined first because we need to access its auth and network config
+            if not self.insights_config:
+                logger.error("Couldn't access the insights-client configuration")
+                exit(constants.sig_kill_bad)
+            self.conn = InsightsConnection(self.insights_config)
+
+        ca_cert = rules_utils.get_ca_certificate()
+        self.cert_verify = rules_utils.get_cert_verify_value(
+            self.insights_config
+        )  # can be none
+        self.custom_cert = self._get_config_option("ca_cert", ca_cert)  # can be none
+        self.compiled_rules_flags = []
+        self.non_compiled_files = []
+        self.compiled_files = []
+
+        # # Build the yara command, with its various command line options, that will be run
+        # self._parse_rules_file()
+        self.yara_cmd = []
+        self.yara_compiled_cmds = []
 
         # host_scan is a dictionary into which all the scan matches are stored.  Its structure is like:
         # host_scan = {rule_name: [{source: ..., stringData: ..., stringIdentifier: ..., stringOffset: ...},
@@ -182,22 +115,132 @@ class MalwareDetectionClient:
         #              ... }
         # host_scan_mutation is the host_scan dict converted to a GraphQL mutation query string
         self.host_scan = {}
-        self.host_scan_mutation = ''
+        self.host_scan_mutation = ""
 
         # Check if we are adding extra metadata to each scan match
-        self.add_metadata = self._get_config_option('add_metadata', False)
+        self.add_metadata = self._get_config_option("add_metadata", False)
 
         self.matches = 0
         self.potential_matches = 0
 
-    def run(self):
-        # Start the scans and record the time they were started
-        filesystem_scan_start = get_time()
-        self.scan_filesystem()
-        processes_scan_start = get_time()
-        self.scan_processes()
+    def parse_scan_options(self):
+        if self.test_scan:
+            return self._parse_test_scan_option()
+        return self._parse_scan_options()
 
-        if self.do_filesystem_scan or self.do_process_scan:
+    def load_rules(self):
+        rules_utils.remove_old_rules_files()
+
+        if rules_utils.is_local_file(self.rules_location):
+            self.rules_files = rules_utils.use_local_rules(self.rules_location)
+
+        if self.use_remote_rules or self.test_scan:
+            # Check if insights-config is defined first because we need to access its auth and network config
+            if not self.insights_config:
+                logger.error("Couldn't access the insights-client configuration")
+                exit(constants.sig_kill_bad)
+            if rules_utils.is_local_file(self.remote_rules_location):
+                logger.error("REMOTE_RULES_LOCATION should be an url not local file")
+                exit(constants.sig_kill_bad)
+            self.remote_rules_location = rules_utils.set_remote_rules_location(
+                self.insights_config, self.remote_rules_location, self.yara_version
+            )
+            self.remote_rules_location, authmethod = (
+                rules_utils.validate_rules_location(
+                    self.insights_config, self.remote_rules_location
+                )
+            )
+            if authmethod == "CERT":
+                self.insights_config.authmethod = "CERT"
+
+            # If doing a test scan, replace signatures.yar (or any other file suffix) with test-rule.yar
+            log_rule_contents, self.remote_rules_location = (
+                rules_utils.handle_test_scan(self.test_scan, self.remote_rules_location)
+            )
+
+            logger.debug("Downloading rules from: %s", self.remote_rules_location)
+            logger.debug("Using cert_verify value %s ...", self.cert_verify)
+
+            response = rules_utils.download_rules(
+                self.conn,
+                self.insights_config,
+                log_rule_contents,
+                self.remote_rules_location,
+                self.cert_verify,
+                self.custom_cert,
+            )
+
+            # Can't abstract further as context manager closes deleting temp file
+            self.temp_rules_file = NamedTemporaryFile(
+                prefix="malware-detection_yara_rules.",
+                mode="wb",
+                delete=True,
+                dir=config.RULE_DOWNLOAD_DIR,
+            )
+            self.temp_rules_file.write(response.content)
+            self.temp_rules_file.flush()
+
+            self.rules_files.append(self.temp_rules_file.name)
+
+    def load_disabled_rules(self):
+        """
+        Download the list of disabled rules, if any.
+        Doesn't apply if doing a test scan or if the rules are in a local file
+        Uses network connection information set via the _get_rules method, eg conn, rules_location & cert_verify
+        """
+        disabled_rules = []
+        if self.test_scan or not self.use_remote_rules:
+            return disabled_rules
+
+        graphql_url = self._set_url_path(self.remote_rules_location, "graphql")
+
+        disabled_rules_query = (
+            "query { rulesList(condition: {isDisabled: true}) { name } }"
+        )
+        for attempt in range(1, self.insights_config.retries + 1):
+            try:
+                response = self.conn.post(
+                    graphql_url,
+                    json={"query": disabled_rules_query},
+                    headers={"Content-Type": "application/json"},
+                    verify=self.cert_verify,
+                    stream=True,
+                )
+                if response.status_code != 200:
+                    raise Exception(
+                        "%s %s: %s"
+                        % (response.status_code, response.reason, response.text)
+                    )
+
+                # Retrieved response from graphql endpoint, parse out the list of disabled rules
+                payload = response.json()
+                if payload.get("data", {}).get("rulesList", []):
+                    disabled_rules = list(
+                        map(lambda x: x["name"], payload["data"]["rulesList"])
+                    )
+                break
+            except Exception as e:
+                if attempt < self.insights_config.retries:
+                    logger.debug(
+                        "Unable to get disabled rules list from %s: %s",
+                        graphql_url,
+                        str(e),
+                    )
+                    logger.debug("Trying again in %d seconds ...", attempt)
+                    time.sleep(attempt)
+                else:
+                    logger.debug("Unable to get disabled rules list.  Skipping ...")
+
+        logger.debug("Disabled rules: %s", disabled_rules)
+        self.disabled_rules = sorted(map(lambda x: x.lower(), disabled_rules))
+
+    def build_yara_commands(self):
+        self._parse_rules_file()
+        self.yara_cmd = self._build_yara_command()
+        self.yara_compiled_cmds = self._build_compiled_yara_command()
+
+    def run(self):
+        def _process_scan_results():
             # If any scans were performed then get the results as a GraphQL mutation query
             # This mutation query is what is uploaded to the malware backend
             host_scan_mutation = self._create_host_scan_mutation()
@@ -207,119 +250,119 @@ class MalwareDetectionClient:
                 if self.potential_matches == 0:
                     logger.info("No rule matches found.\n")
                 else:
-                    logger.info("Rule matches potentially found but problems encountered parsing them, so no match data to upload.")
+                    logger.info(
+                        "Rule matches potentially found but problems encountered parsing them, so no match data to upload."
+                    )
                     logger.info("Please contact support.\n")
             else:
-                logger.info("Found %d rule match%s.", self.matches, 'es' if self.matches > 1 else '')
+                logger.info(
+                    "Found %d rule match%s.",
+                    self.matches,
+                    "es" if self.matches > 1 else "",
+                )
                 if not self.test_scan:
-                    logger.info("Please visit %s for more information\n", MALWARE_APP_URL)
-
-            # Write the scan start times to disk if scans were performed
-            # (used by the 'filesystem_scan_since: last' and 'processes_scan_since: last' options)
-            # Only write the scan time after scans have completed without error or interruption, and its not a test scan
-            if not self.test_scan:
-                if self.do_filesystem_scan:
-                    write_data_to_file(filesystem_scan_start, LAST_FILESYSTEM_SCAN_FILE)
-                    os.chmod(LAST_FILESYSTEM_SCAN_FILE, 0o644)
-                if self.do_process_scan:
-                    write_data_to_file(processes_scan_start, LAST_PROCESSES_SCAN_FILE)
-                    os.chmod(LAST_PROCESSES_SCAN_FILE, 0o644)
-            else:
-                logger.info("\nRed Hat Insights malware-detection app test scan complete.\n"
-                            "Test scan results are not recorded in the Insights UI (%s)\n"
-                            "To perform proper scans, please set test_scan: false in %s\n",
-                            MALWARE_APP_URL, MALWARE_CONFIG_FILE)
+                    logger.info(
+                        "Please visit %s for more information\n", config.MALWARE_APP_URL
+                    )
 
             # This is what is uploaded to the malware backend
             return (host_scan_mutation, self.host_scan)
-        else:
+
+        if not self.do_filesystem_scan and not self.do_process_scan:
             logger.error("No scans performed, no results to upload.")
             exit(constants.sig_kill_bad)
 
-    @staticmethod
-    def _load_config():
-        # Load the malware-detection config file.  Write out a default one first if it doesn't already exist
-        if not os.path.isfile(MALWARE_CONFIG_FILE):
-            logger.info("Writing the malware-detection app default configuration to %s", MALWARE_CONFIG_FILE)
-            write_data_to_file(DEFAULT_MALWARE_CONFIG, MALWARE_CONFIG_FILE)
-            os.chmod(MALWARE_CONFIG_FILE, 0o644)
+        results = []
+        logger.debug("rules found: %s", self.rules_files)
 
-        try:
-            with open(MALWARE_CONFIG_FILE) as m:
-                return yaml.safe_load(m)
-        except Exception as e:
-            logger.error("Error encountered loading the malware-detection app config file %s:\n%s",
-                         MALWARE_CONFIG_FILE, str(e))
-            exit(constants.sig_kill_bad)
+        # Run at most two iterations for filesystem and processes. Concantenate the results.
+        for idx, scan_op in enumerate([self.scan_filesystem, self.scan_processes]):
+            if idx == 0:
+                filesystem_scan_start = get_time()
+            else:
+                processes_scan_start = get_time()
 
-    def _find_yara(self):
-        """
-        Find the yara binary in particular locations on the local system.  Don't use 'which yara'
-        and rely on the system path in case it finds a malicious yara.
-        Also, don't let the user specify where yara is, again in case it is a malicious version of yara
-        If found, check it's version >= MIN_YARA_VERSION
-        """
-        def yara_version_ok(yara):
-            # Check the installed yara version >= MIN_YARA_VERSION
-            self.yara_version = call([[yara, '--version']]).strip()
-            try:
-                # Check the installed yara X.Y version > the minimal recommended yara version
-                if float('.'.join(self.yara_version.split('.')[:2])) < float(MIN_YARA_VERSION[:3]):
-                    raise RuntimeError("Found %s with version %s, but malware-detection requires version >= %s\n"
-                                       "Please install a later version of yara."
-                                       % (yara, self.yara_version, MIN_YARA_VERSION))
-            except RuntimeError as e:
-                logger.error(str(e))
-                exit(constants.sig_kill_bad)
-            except Exception as e:
-                logger.error("Error getting the version of the specified yara binary %s: %s", yara, str(e))
-                exit(constants.sig_kill_bad)
-            # If we are here then the version of yara was ok
-            return True
+            if self.yara_cmd:
+                scan_results = scan_op()  # Perform scan operation
+                if scan_results:
+                    results = _process_scan_results()
 
-        # Try to find yara in only these usual locations.
-        # /bin/yara and /usr/bin/yara will exist if yara is installed via rpm
-        # /usr/local/bin/yara will (likely) exist if the user has compiled and installed yara manually
-        for yara in ['/bin/yara', '/usr/bin/yara']:
-            if os.path.exists(yara) and yara_version_ok(yara):
-                logger.debug("Using yara binary: %s", yara)
-                return yara
+            # Run scan for compiled rules
+            for cmd in self.yara_compiled_cmds:
+                self.yara_cmd = cmd
+                scan_results = scan_op()  # Perform scan operation
+                if scan_results:
+                    results = _process_scan_results()
 
-        logger.error("Couldn't find yara.  Please ensure the yara package is installed")
-        exit(constants.sig_kill_bad)
+        # Write the scan start times to disk if scans were performed
+        # (used by the 'filesystem_scan_since: last' and 'processes_scan_since: last' options)
+        # Only write the scan time after scans have completed without error or interruption, and its not a test scan
+        if not self.test_scan:
+            if self.do_filesystem_scan:
+                write_data_to_file(
+                    filesystem_scan_start, config.LAST_FILESYSTEM_SCAN_FILE
+                )
+                os.chmod(config.LAST_FILESYSTEM_SCAN_FILE, 0o644)
+            if self.do_process_scan:
+                write_data_to_file(
+                    processes_scan_start, config.LAST_PROCESSES_SCAN_FILE
+                )
+                os.chmod(config.LAST_PROCESSES_SCAN_FILE, 0o644)
+        else:
+            logger.info(
+                "\nRed Hat Insights malware-detection app test scan complete.\n"
+                "Test scan results are not recorded in the Insights UI (%s)\n"
+                "To perform proper scans, please set test_scan: false in %s\n",
+                config.MALWARE_APP_URL,
+                config.MALWARE_CONFIG_FILE,
+            )
+
+        return results
 
     def _parse_scan_options(self):
         """
         Initialize the various scan flags and lists and run methods that may change/populate them
         """
-        self.do_filesystem_scan = self._get_config_option('scan_filesystem', True)
-        self.do_process_scan = self._get_config_option('scan_processes', False)
-        self.scan_fsobjects = []
-        self.scan_pids = []
+        # self.do_filesystem_scan = self._get_config_option("scan_filesystem", True)
+        # self.do_process_scan = self._get_config_option("scan_processes", False)
 
         if not (self.do_filesystem_scan or self.do_process_scan):
-            logger.error("Both scan_filesystem and scan_processes are disabled.  Nothing to scan.")
+            logger.error(
+                "Both scan_filesystem and scan_processes are disabled.  Nothing to scan."
+            )
             exit(constants.sig_kill_bad)
 
         # Check if old options are still in use and inform the user of their replacements
-        for replaced_scan_option in ('scan_only', 'scan_exclude', 'scan_since'):
+        for replaced_scan_option in ("scan_only", "scan_exclude", "scan_since"):
             if self._get_config_option(replaced_scan_option):
-                logger.error("The '{0}' option has been replaced with the 'filesystem_{0}' and 'processes_{0}' options in {1}"
-                             .format(replaced_scan_option, MALWARE_CONFIG_FILE))
-                logger.error("Please remove the %s file and a new config file will be written with the new options", MALWARE_CONFIG_FILE)
+                logger.error(
+                    "The '{0}' option has been replaced with the 'filesystem_{0}' and 'processes_{0}' options in {1}".format(
+                        replaced_scan_option, config.MALWARE_CONFIG_FILE
+                    )
+                )
+                logger.error(
+                    "Please remove the %s file and a new config file will be written with the new options",
+                    config.MALWARE_CONFIG_FILE,
+                )
                 exit(constants.sig_kill_bad)
 
         # Try parsing the filesystem and processes scan_only options and exit under certain conditions
         parse_filesystem_scan_only = self._parse_filesystem_scan_only_option()
         parse_processes_scan_only = self._parse_processes_scan_only_option()
         if not (parse_filesystem_scan_only or parse_processes_scan_only):
-            logger.error("Nothing to scan with the filesystem_scan_only and processes_scan_only options")
+            logger.error(
+                "Nothing to scan with the filesystem_scan_only and processes_scan_only options"
+            )
             exit(constants.sig_kill_bad)
         if not (parse_filesystem_scan_only or self.do_process_scan):
-            logger.error("Nothing to scan with filesystem_scan_only option and scan_processes is disabled")
+            logger.error(
+                "Nothing to scan with filesystem_scan_only option and scan_processes is disabled"
+            )
             exit(constants.sig_kill_bad)
         if not (self.do_filesystem_scan or parse_processes_scan_only):
-            logger.error("Nothing to scan with processes_scan_only option and scan_filesystem is disabled")
+            logger.error(
+                "Nothing to scan with processes_scan_only option and scan_filesystem is disabled"
+            )
             exit(constants.sig_kill_bad)
 
         # If we've made it here we are still doing scans, but disable scans if there were problems with scan_only
@@ -335,31 +378,26 @@ class MalwareDetectionClient:
         self._parse_exclude_network_filesystem_mountpoints_option()
 
     def _parse_test_scan_option(self):
-        self.test_scan = self._get_config_option('test_scan', False)
-        if not self.test_scan:
-            return False
-
-        self.filesystem_scan_exclude_list = []
-        self.processes_scan_exclude_list = []
-        self.filesystem_scan_since_dict = {'timestamp': None}
-        self.processes_scan_since_dict = {'timestamp': None}
-        self.network_filesystem_mountpoints = []
+        self.filesystem_scan_since_dict = {"timestamp": None}
+        self.processes_scan_since_dict = {"timestamp": None}
 
         # For matching the test rule, scan the insights config file and the currently running process
         # Make sure the config file exists first though!
-        if os.path.isfile(MALWARE_CONFIG_FILE):
+        if os.path.isfile(config.MALWARE_CONFIG_FILE):
             self.do_filesystem_scan = True
-            self.scan_fsobjects = [MALWARE_CONFIG_FILE]
+            self.scan_fsobjects = [config.MALWARE_CONFIG_FILE]
         else:
             self.do_filesystem_scan = False
             self.scan_fsobjects = []
 
         self.do_process_scan = True
         self.scan_pids = [str(os.getpid())]
-        logger.info("\nPerforming a test scan of %sthe current process (PID %s) "
-                    "to verify the malware-detection app is installed and scanning correctly ...\n",
-                    "%s and " % self.scan_fsobjects[0] if self.do_filesystem_scan else "", self.scan_pids[0])
-        return True
+        logger.info(
+            "\nPerforming a test scan of %sthe current process (PID %s) "
+            "to verify the malware-detection app is installed and scanning correctly ...\n",
+            "%s and " % self.scan_fsobjects[0] if self.do_filesystem_scan else "",
+            self.scan_pids[0],
+        )
 
     def _parse_filesystem_scan_only_option(self):
         """
@@ -367,31 +405,43 @@ class MalwareDetectionClient:
         If parsing was successful, then self.scan_fsobjects is populated and true is returned
         If parsing was not successful, self.scan_fsobjects remains empty and false is returned
         """
-        filesystem_scan_only = self._get_config_option('filesystem_scan_only')
+        filesystem_scan_only = self._get_config_option("filesystem_scan_only")
         if filesystem_scan_only:
             if not self.do_filesystem_scan:
-                logger.error("Skipping filesystem_scan_only option because scan_filesystem is false")
+                logger.error(
+                    "Skipping filesystem_scan_only option because scan_filesystem is false"
+                )
                 return False
             # Process the filesystem_scan_only option as a list of files/dirs
             if not isinstance(filesystem_scan_only, list):
                 filesystem_scan_only = [filesystem_scan_only]
             for item in filesystem_scan_only:
                 # Remove extras slashes (/) in the file name and leading double slashes too (normpath doesn't)
-                item = os.path.normpath(item).replace('//', '/')
+                item = os.path.normpath(item).replace("//", "/")
                 # Assume the item represents a filesystem item
                 if not os.path.exists(item):
-                    logger.info("Skipping missing filesystem_scan_only item: '%s'", item)
+                    logger.info(
+                        "Skipping missing filesystem_scan_only item: '%s'", item
+                    )
                 elif os.path.islink(item):
-                    logger.info("Skipping symlink filesystem_scan_only item: '%s'.  Please use non-symlink items", item)
+                    logger.info(
+                        "Skipping symlink filesystem_scan_only item: '%s'.  Please use non-symlink items",
+                        item,
+                    )
                 else:
                     self.scan_fsobjects.append(item)
 
             if self.scan_fsobjects:
-                logger.info("Scan only the specified filesystem item%s: %s", "s" if len(self.scan_fsobjects) > 1 else "",
-                            self.scan_fsobjects)
+                logger.info(
+                    "Scan only the specified filesystem item%s: %s",
+                    "s" if len(self.scan_fsobjects) > 1 else "",
+                    self.scan_fsobjects,
+                )
                 return True
             else:
-                logger.error("Unable to find the items specified for the filesystem_scan_only option.  Skipping ...")
+                logger.error(
+                    "Unable to find the items specified for the filesystem_scan_only option.  Skipping ..."
+                )
                 return False
         return True
 
@@ -402,25 +452,34 @@ class MalwareDetectionClient:
         if not self.do_filesystem_scan:
             return
 
-        self.filesystem_scan_exclude_list = []
-        filesystem_scan_exclude = self._get_config_option('filesystem_scan_exclude')
+        filesystem_scan_exclude = self._get_config_option("filesystem_scan_exclude")
         if filesystem_scan_exclude:
             if not isinstance(filesystem_scan_exclude, list):
                 # Convert filesystem_scan_exclude to a list if only a single non-list item was specified
                 filesystem_scan_exclude = [filesystem_scan_exclude]
             for item in filesystem_scan_exclude:
-                item = os.path.normpath(item).replace('//', '/')
+                item = os.path.normpath(item).replace("//", "/")
                 if not os.path.exists(item):
-                    logger.info("Skipping missing filesystem_scan_exclude item: '%s'", item)
+                    logger.info(
+                        "Skipping missing filesystem_scan_exclude item: '%s'", item
+                    )
                 elif os.path.islink(item):
-                    logger.info("Skipping symlink filesystem_scan_exclude item: '%s'.  Please use non-symlink items", item)
+                    logger.info(
+                        "Skipping symlink filesystem_scan_exclude item: '%s'.  Please use non-symlink items",
+                        item,
+                    )
                 else:
                     self.filesystem_scan_exclude_list.append(item)
             if self.filesystem_scan_exclude_list:
-                logger.info("Excluding specified filesystem item%s: %s", "s" if len(self.filesystem_scan_exclude_list) > 1 else "",
-                            self.filesystem_scan_exclude_list)
+                logger.info(
+                    "Excluding specified filesystem item%s: %s",
+                    "s" if len(self.filesystem_scan_exclude_list) > 1 else "",
+                    self.filesystem_scan_exclude_list,
+                )
             else:
-                logger.info("Unable to find the items specified for the filesystem_scan_exclude option.  Not excluding any filesystem items")
+                logger.info(
+                    "Unable to find the items specified for the filesystem_scan_exclude option.  Not excluding any filesystem items"
+                )
 
     @staticmethod
     def _parse_processes_scan_option(option_items):
@@ -434,8 +493,13 @@ class MalwareDetectionClient:
         A list of PIDs is returned representing all the PIDs that were matched from parsing the items
         """
         pids = []
-        ps_output = call([['ps', '-eo', 'pid=', '-o', 'comm=']]).splitlines()
-        proc_names = list(map(lambda x: (int(x[0]), str(x[1])), map(lambda x: tuple(x.split()), ps_output)))
+        ps_output = call([["ps", "-eo", "pid=", "-o", "comm="]]).splitlines()
+        proc_names = list(
+            map(
+                lambda x: (int(x[0]), str(x[1])),
+                map(lambda x: tuple(x.split()), ps_output),
+            )
+        )
         proc_pids = list(map(lambda x: x[0], proc_names))
         if not isinstance(option_items, list):
             option_items = [str(option_items)]
@@ -450,15 +514,23 @@ class MalwareDetectionClient:
                     pids.append(str(item))
                 else:
                     logger.info("Skipping missing PID: %s", item)
-            elif '..' in item:
+            elif ".." in item:
                 # Assume the item represents a range of process IDs
                 try:
-                    start, end = item.split('..', 1)
-                    start = 1 if not start else int(start.strip('.'))
-                    end = int(open('/proc/sys/kernel/pid_max').read()) if not end else int(end.strip('.'))
-                    pid_matches = [str(proc) for proc in proc_pids if start <= proc <= end]
+                    start, end = item.split("..", 1)
+                    start = 1 if not start else int(start.strip("."))
+                    end = (
+                        int(open("/proc/sys/kernel/pid_max").read())
+                        if not end
+                        else int(end.strip("."))
+                    )
+                    pid_matches = [
+                        str(proc) for proc in proc_pids if start <= proc <= end
+                    ]
                 except Exception as err:
-                    logger.error("Unable to parse '%s' in to a range of PIDs: %s", item, str(err))
+                    logger.error(
+                        "Unable to parse '%s' in to a range of PIDs: %s", item, str(err)
+                    )
                     continue
                 logger.debug("Found PID(s) in range '%s': %s", item, pid_matches)
                 if pid_matches:
@@ -480,20 +552,27 @@ class MalwareDetectionClient:
         """
         Parse the processes_scan_only option, if specified, to get a list of processes to scan
         """
-        processes_scan_only = self._get_config_option('processes_scan_only')
+        processes_scan_only = self._get_config_option("processes_scan_only")
         if processes_scan_only:
             if not self.do_process_scan:
-                logger.error("Skipping processes_scan_only option because scan_processes is false")
+                logger.error(
+                    "Skipping processes_scan_only option because scan_processes is false"
+                )
                 return False
 
             pids = self._parse_processes_scan_option(processes_scan_only)
             if pids:
                 self.scan_pids = sorted(set(pids), key=lambda pid: int(pid))
-                logger.info("Scan only the specified process ID%s: %s", "s" if len(self.scan_pids) > 1 else "",
-                            self.scan_pids)
+                logger.info(
+                    "Scan only the specified process ID%s: %s",
+                    "s" if len(self.scan_pids) > 1 else "",
+                    self.scan_pids,
+                )
                 return True
             else:
-                logger.error("Unable to find the items specified for the processes_scan_only option.  Skipping ...")
+                logger.error(
+                    "Unable to find the items specified for the processes_scan_only option.  Skipping ..."
+                )
                 return False
         return True
 
@@ -505,19 +584,28 @@ class MalwareDetectionClient:
             return
 
         self.processes_scan_exclude_list = []
-        processes_scan_exclude = self._get_config_option('processes_scan_exclude')
+        processes_scan_exclude = self._get_config_option("processes_scan_exclude")
         if processes_scan_exclude:
             if not self.do_process_scan:
-                logger.error("Skipping processes_scan_exclude option because scan_processes is false")
+                logger.error(
+                    "Skipping processes_scan_exclude option because scan_processes is false"
+                )
                 return
 
             pids = self._parse_processes_scan_option(processes_scan_exclude)
             if pids:
-                self.processes_scan_exclude_list = sorted(set(pids), key=lambda pid: int(pid))
-                logger.info("Excluding specified process ID%s: %s", "s" if len(self.processes_scan_exclude_list) > 1 else "",
-                            self.processes_scan_exclude_list)
+                self.processes_scan_exclude_list = sorted(
+                    set(pids), key=lambda pid: int(pid)
+                )
+                logger.info(
+                    "Excluding specified process ID%s: %s",
+                    "s" if len(self.processes_scan_exclude_list) > 1 else "",
+                    self.processes_scan_exclude_list,
+                )
             else:
-                logger.error("Unable to find the items specified for the processes_scan_exclude option.  Not excluding any processes.")
+                logger.error(
+                    "Unable to find the items specified for the processes_scan_exclude option.  Not excluding any processes."
+                )
 
     def _parse_filesystem_scan_since_option(self):
         """
@@ -528,19 +616,28 @@ class MalwareDetectionClient:
         if not self.do_filesystem_scan:
             return
 
-        self.filesystem_scan_since_dict = {'timestamp': None, 'datetime': None}
-        filesystem_scan_since = self._get_config_option('filesystem_scan_since')
+        self.filesystem_scan_since_dict = {"timestamp": None, "datetime": None}
+        filesystem_scan_since = self._get_config_option("filesystem_scan_since")
         if filesystem_scan_since is not None:
-            timestamp = get_scan_since_timestamp('filesystem_scan_since', filesystem_scan_since)
+            timestamp = utils.get_scan_since_timestamp(
+                "filesystem_scan_since", filesystem_scan_since
+            )
             if timestamp:
-                self.filesystem_scan_since_dict['timestamp'] = timestamp
-                self.filesystem_scan_since_dict['datetime'] = datetime.fromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
+                self.filesystem_scan_since_dict["timestamp"] = timestamp
+                self.filesystem_scan_since_dict["datetime"] = datetime.fromtimestamp(
+                    timestamp
+                ).strftime("%Y-%m-%d %H:%M:%S")
                 message = "Scan for files created/modified since %s%s"
                 if isinstance(filesystem_scan_since, str):
-                    submessage = 'last successful scan on '
+                    submessage = "last successful scan on "
                 else:
-                    submessage = '%s day%s ago on ' % (filesystem_scan_since, "s" if filesystem_scan_since > 1 else "")
-                logger.info(message, submessage, self.filesystem_scan_since_dict['datetime'])
+                    submessage = "%s day%s ago on " % (
+                        filesystem_scan_since,
+                        "s" if filesystem_scan_since > 1 else "",
+                    )
+                logger.info(
+                    message, submessage, self.filesystem_scan_since_dict["datetime"]
+                )
 
     def _parse_processes_scan_since_option(self):
         """
@@ -551,19 +648,28 @@ class MalwareDetectionClient:
         if not self.do_process_scan:
             return
 
-        self.processes_scan_since_dict = {'timestamp': None, 'datetime': None}
-        processes_scan_since = self._get_config_option('processes_scan_since')
+        self.processes_scan_since_dict = {"timestamp": None, "datetime": None}
+        processes_scan_since = self._get_config_option("processes_scan_since")
         if processes_scan_since is not None:
-            timestamp = get_scan_since_timestamp('processes_scan_since', processes_scan_since)
+            timestamp = utils.get_scan_since_timestamp(
+                "processes_scan_since", processes_scan_since
+            )
             if timestamp:
-                self.processes_scan_since_dict['timestamp'] = timestamp
-                self.processes_scan_since_dict['datetime'] = datetime.fromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
+                self.processes_scan_since_dict["timestamp"] = timestamp
+                self.processes_scan_since_dict["datetime"] = datetime.fromtimestamp(
+                    timestamp
+                ).strftime("%Y-%m-%d %H:%M:%S")
                 message = "Scan for processes started since %s%s"
                 if isinstance(processes_scan_since, str):
-                    submessage = 'last successful scan on '
+                    submessage = "last successful scan on "
                 else:
-                    submessage = '%s day%s ago on ' % (processes_scan_since, "s" if processes_scan_since > 1 else "")
-                logger.info(message, submessage, self.processes_scan_since_dict['datetime'])
+                    submessage = "%s day%s ago on " % (
+                        processes_scan_since,
+                        "s" if processes_scan_since > 1 else "",
+                    )
+                logger.info(
+                    message, submessage, self.processes_scan_since_dict["datetime"]
+                )
 
     def _parse_exclude_network_filesystem_mountpoints_option(self):
         """
@@ -576,233 +682,164 @@ class MalwareDetectionClient:
             return
 
         self.network_filesystem_mountpoints = []
-        if not self._get_config_option('exclude_network_filesystem_mountpoints'):
+        if not self._get_config_option("exclude_network_filesystem_mountpoints"):
             # We aren't excluding network filesystems, leave it as a blank list (ie nothing to exclude)
             return
 
-        network_filesystem_types = self._get_config_option('network_filesystem_types')
+        network_filesystem_types = self._get_config_option("network_filesystem_types")
         if not network_filesystem_types:
             logger.error("No value specified for 'network_filesystem_types' option")
             exit(constants.sig_kill_bad)
 
         if isinstance(network_filesystem_types, list):
-            network_filesystem_types = ','.join(network_filesystem_types)
-        cmd = ['findmnt', '-t', network_filesystem_types, '-n', '-o', 'TARGET']
-        logger.debug("Command to find mounted network filesystems: %s", ' '.join(cmd))
+            network_filesystem_types = ",".join(network_filesystem_types)
+        cmd = ["findmnt", "-t", network_filesystem_types, "-n", "-o", "TARGET"]
+        logger.debug("Command to find mounted network filesystems: %s", " ".join(cmd))
         try:
             output = call([cmd])
         except CalledProcessError as err:
-            logger.error("Unable to get network filesystem mountpoints: %s", err.output.strip())
+            logger.error(
+                "Unable to get network filesystem mountpoints: %s", err.output.strip()
+            )
             exit(constants.sig_kill_bad)
 
-        self.network_filesystem_mountpoints = str(output).strip().split('\n') if output else []
+        self.network_filesystem_mountpoints = (
+            str(output).strip().split("\n") if output else []
+        )
         if self.network_filesystem_mountpoints:
-            logger.info("Excluding network filesystem mountpoints: %s", self.network_filesystem_mountpoints)
+            logger.info(
+                "Excluding network filesystem mountpoints: %s",
+                self.network_filesystem_mountpoints,
+            )
         else:
             logger.debug("No mounted network filesystems found")
 
-    def _get_rules(self):
-        """
-        Obtain the rules used by yara for scanning from the rules_location option.
-        They can either be downloaded from the malware backend or obtained from a local file.
-        """
-        # The rules file that is downloaded from the backend should be automatically removed when the
-        # malware-detection client exits.
-        # However it can happen that the rules file isn't removed for some reason, so remove any existing
-        # rules files before beginning a new scan, otherwise they may show up as matches in the scan results.
-        old_rules_files = sum([glob(os.path.join(path, rules))
-                               for path in (RULE_DOWNLOAD_DIR, '/tmp', '/var/tmp', '/usr/tmp', gettempdir())
-                               for rules in ('malware-detection_yara_rules.*', '.tmpmdsigs*', 'tmp_malware-detection-client_rules.*')], [])
-        for old_rules_file in old_rules_files:
-            if os.path.exists(old_rules_file):
-                logger.debug("Removing old rules file %s", old_rules_file)
-                os.remove(old_rules_file)
-
-        self.rules_location = self._get_config_option('rules_location', '')
-
-        # If rules_location starts with a /, assume its a file rather than a URL
-        if self.rules_location.startswith('/'):
-            # Remove any extra slashes from the file name and from the start too (normpath doesn't remove those)
-            rules_file = os.path.normpath(self.rules_location).replace('//', '/')
-            if not os.path.isfile(rules_file):
-                logger.error("Couldn't find specified rules file: %s", rules_file)
-                exit(constants.sig_kill_bad)
-            logger.debug("Using specified rules file: %s", rules_file)
-            return rules_file
-
-        # If we are here, then we are downloading the rules from the malware backend
-        # Check if insights-config is defined first because we need to access its auth and network config
-        if not self.insights_config:
-            logger.error("Couldn't access the insights-client configuration")
-            exit(constants.sig_kill_bad)
-
-        signatures_file = 'signatures.yar'
-        signatures_file += '?yara_version=' + self.yara_version if hasattr(self, 'yara_version') else ''
-        if not self.rules_location:
-            self.rules_location = 'https://console.redhat.com/api/malware-detection/v1/' + signatures_file
-            if '/redhat_access/' in self.insights_config.base_url:
-                # Satellite URLs have '/redhat_access/' in the base_url config option
-                self.rules_location = self.insights_config.base_url + '/malware-detection/v1/' + signatures_file
-            elif any([url in self.insights_config.base_url for url in ['console.stage.', 'cloud.stage.']]):
-                # For downloading rules in the stage environment, use the URL of base_url (after finding it)
-                base_url = urlparse(self.insights_config.base_url)
-                self.rules_location = base_url.netloc or base_url.scheme or base_url.path.split('/')[0] or 'cert.console.stage.redhat.com'
-                self.rules_location += '/api/malware-detection/v1/' + signatures_file
-
-        # Make sure the rules_location starts with https://
-        if not re.match('^https?://', self.rules_location):
-            self.rules_location = 'https://' + self.rules_location
-
-        # If talking direct to C.R.C with cert auth or basic auth without a username/password, append 'cert.' to the url
-        if self.rules_location.startswith('https://console.redhat.com'):
-            authmethod = self.insights_config.authmethod if hasattr(self.insights_config, 'authmethod') else 'CERT'
-            username = self.insights_config.username if hasattr(self.insights_config, 'username') else ''
-            password = self.insights_config.password if hasattr(self.insights_config, 'password') else ''
-            if authmethod == 'CERT' or (authmethod == 'BASIC' and not (username or password)):
-                self.insights_config.authmethod = 'CERT'
-                parsed_url = urlparse(self.rules_location)
-                if not parsed_url.netloc.startswith('cert.'):
-                    self.rules_location = urlunparse(parsed_url._replace(netloc='cert.' + parsed_url.netloc))
-
-        # If doing a test scan, replace signatures.yar (or any other file suffix) with test-rule.yar
-        log_rule_contents = False
-        if self.test_scan:
-            self.rules_location = self._set_url_path(self.rules_location, 'test-rule.yar')
-            log_rule_contents = True
-
-        # Shouldn't need this, but left here for insurance: https://access.redhat.com/solutions/6997170
-        # If a custom CA cert is being used, eg on a Satellite, then SSL errors may occur when downloading the rules
-        # The CA cert needs to be added to a CA bundle (with update-ca-trust) and the bundle used for cert verification
-        ca_cert = None
-        ca_bundles = ['/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem', '/etc/pki/tls/certs/ca-bundle.crt']
-        for ca_bundle in ca_bundles:
-            if os.path.isfile(ca_bundle):
-                ca_cert = ca_bundle
-                break
-
-        logger.debug("Downloading rules from: %s", self.rules_location)
-        self.cert_verify = self.insights_config.cert_verify
-        if self.cert_verify is None or self.cert_verify == '':
-            self.cert_verify = True
-        elif self.cert_verify.lower() in ('true', 'false'):
-            self.cert_verify = self.cert_verify.lower() == 'true'
-        logger.debug("Using cert_verify value %s ...", self.cert_verify)
-        self.conn = InsightsConnection(self.insights_config)
-
-        for attempt in range(1, self.insights_config.retries + 1):
-            try:
-                response = self.conn.get(
-                    self.rules_location,
-                    log_response_text=log_rule_contents,
-                    verify=self.cert_verify,
-                    stream=True
-                )
-                if response.status_code != 200:
-                    raise Exception("%s %s: %s" % (response.status_code, response.reason, response.text))
-                break
-            except Exception as e:
-                if attempt < self.insights_config.retries:
-                    logger.debug("Unable to download rules from %s: %s", self.rules_location, str(e))
-                    logger.debug("Trying again in %d seconds ...", attempt)
-                    time.sleep(attempt)
-                else:
-                    logger.error("Unable to download rules from %s: %s", self.rules_location, str(e))
-                    exit(constants.sig_kill_bad)
-
-                if re.search('SSL.*verify.failed', str(e), re.IGNORECASE):
-                    # Kept as a fallback in case SSL errors still occur - add the custom CA cert to the trusted certs
-                    self.cert_verify = self._get_config_option('ca_cert', ca_cert)
-                    logger.debug("Trying cert_verify value %s ...", self.cert_verify)
-
-        self.temp_rules_file = NamedTemporaryFile(prefix='malware-detection_yara_rules.',
-                                                  mode='wb', delete=True, dir=RULE_DOWNLOAD_DIR)
-        self.temp_rules_file.write(response.content)
-        self.temp_rules_file.flush()
-        return self.temp_rules_file.name
-
-    def _get_disabled_rules(self):
-        """
-        Download the list of disabled rules, if any.
-        Doesn't apply if doing a test scan or if the rules are in a local file
-        Uses network connection information set via the _get_rules method, eg conn, rules_location & cert_verify
-        """
-        disabled_rules = []
-        if self.test_scan or self.rules_location.startswith('/'):
-            return disabled_rules
-
-        self.graphql_url = self._set_url_path(self.rules_location, 'graphql')
-        disabled_rules_query = "query { rulesList(condition: {isDisabled: true}) { name } }"
-        for attempt in range(1, self.insights_config.retries + 1):
-            try:
-                response = self.conn.post(
-                    self.graphql_url,
-                    json={'query': disabled_rules_query},
-                    headers={'Content-Type': 'application/json'},
-                    verify=self.cert_verify,
-                    stream=True
-                )
-                if response.status_code != 200:
-                    raise Exception("%s %s: %s" % (response.status_code, response.reason, response.text))
-
-                # Retrieved response from graphql endpoint, parse out the list of disabled rules
-                payload = response.json()
-                if payload.get('data', {}).get('rulesList', []):
-                    disabled_rules = list(map(lambda x: x['name'], payload['data']['rulesList']))
-                break
-            except Exception as e:
-                if attempt < self.insights_config.retries:
-                    logger.debug("Unable to get disabled rules list from %s: %s", self.graphql_url, str(e))
-                    logger.debug("Trying again in %d seconds ...", attempt)
-                    time.sleep(attempt)
-                else:
-                    logger.debug("Unable to get disabled rules list.  Skipping ...")
-
-        logger.debug("Disabled rules: %s", disabled_rules)
-        return sorted(map(lambda x: x.lower(), disabled_rules))
-
-    def _build_yara_command(self):
+    def _parse_rules_file(self):
         """
         Get all the switches for the yara command to be run, for example:
         - whether the rules file is compiled or not (-C)
         - the number of CPU threads to use (-p)
         - the nice command and its value to use (nice -n 'value')
         - scan timeouts (-a)
+        Returns:
+            - yara_cmd: the command for non-compiled rules files
+            - yara_compiled_cmd: a list of commands, one per compiled rules file due to yara limitation
         """
-        # Detect if the rules file is a text or binary (compiled) file (or otherwise)
-        output = call([['file', '-b', self.rules_file]])
-        rule_type = output.strip().lower()
-        if os.path.getsize(self.rules_file) == 0 or rule_type == 'empty':
-            logger.error("Rules file %s is empty", self.rules_file)
-            exit(constants.sig_kill_bad)
 
-        compiled_rules_flag = '-C' if rule_type.startswith('yara') or rule_type == 'data' else ''
-        logger.debug("Rules file type: '%s', Compiled rules: %s", rule_type, compiled_rules_flag == '-C')
+        for rules_file in self.rules_files:
+            output = call([["file", "-b", rules_file]])
+            rule_type = output.strip().lower()
+            if os.path.getsize(rules_file) == 0 or rule_type == "empty":
+                logger.error("Rules file %s is empty", rules_file)
+                exit(constants.sig_kill_bad)
 
-        # Quickly test the rules file to make sure it contains usable rules!
-        # Note, if the compiled_rules_flag is '' it must be removed from the list or it causes problems
-        cmd = list(filter(None, [self.yara_binary, '--fail-on-warnings', '-p', '1', '-f', compiled_rules_flag,
-                                 self.rules_file, '/dev/null']))
-        try:
-            call([cmd])
-        except CalledProcessError as err:
-            err_str = str(err.output.strip().decode())
-            logger.error("Unable to use rules file %s: %s", self.rules_file, err_str)
-            exit(constants.sig_kill_bad)
+            if rule_type.startswith("yara") or rule_type == "data":
+                self.compiled_files.append(rules_file)
+                self.compiled_rules_flags.append(
+                    "-C"
+                )  # Mark compiled rules for separate handling
+            else:
+                self.non_compiled_files.append(rules_file)
+                self.compiled_rules_flags.append("")  # Non-compiled files
+
+            logger.debug(
+                "Rules file %s type: '%s', Compiled rules: %s",
+                rules_file,
+                rule_type,
+                self.compiled_rules_flags[-1] == "-C",
+            )
+
+        # Quickly test each rules file to make sure it contains usable rules!
+        for rules_file, compiled_flag in zip(
+            self.rules_files, self.compiled_rules_flags
+        ):
+            cmd = list(
+                filter(
+                    None,
+                    [
+                        self.yara_binary,
+                        "--fail-on-warnings",
+                        "-p",
+                        "1",
+                        "-f",
+                        compiled_flag,
+                        rules_file,
+                        "/dev/null",
+                    ],
+                )
+            )
+            try:
+                call([cmd])
+            except CalledProcessError as err:
+                err_str = str(err.output.strip().decode())
+                logger.error("Unable to use rules file %s: %s", rules_file, err_str)
+                exit(constants.sig_kill_bad)
 
         # Limit the number of threads used by yara to limit the CPU load of the scans
-        # If system has 2 or fewer CPUs, then use just one thread
-        nproc = call('nproc').strip()
+        nproc = call("nproc").strip()
         if not nproc or int(nproc) <= 2:
             self.cpu_thread_limit = 1
         logger.debug("Using %s CPU thread(s) for scanning", self.cpu_thread_limit)
 
-        # Construct the (partial) yara command that will be used later for scanning files and processes
-        # The argument for the files and processes that will be scanned will be added later
-        yara_cmd = list(filter(None, ['nice', '-n', str(self.nice_value), self.yara_binary, '-s', '-N',
-                                      '-a', str(self.scan_timeout), '-p', str(self.cpu_thread_limit), '-r', '-f',
-                                      compiled_rules_flag, self.rules_file]))
-        logger.debug("Yara command: %s", yara_cmd)
+    def _build_yara_command(self):
+        # Build yara_cmd for non-compiled rules
+        yara_cmd = []
+        if self.non_compiled_files:
+            yara_cmd = list(
+                filter(
+                    None,
+                    [
+                        "nice",
+                        "-n",
+                        str(self.nice_value),
+                        self.yara_binary,
+                        "-s",
+                        "-N",
+                        "-a",
+                        str(self.scan_timeout),
+                        "-p",
+                        str(self.cpu_thread_limit),
+                        "-r",
+                        "-f",
+                    ]
+                    + self.non_compiled_files,
+                )
+            )
+
+        logger.debug("Yara command for non-compiled rules: %s", yara_cmd)
+
         return yara_cmd
+
+    def _build_compiled_yara_command(self):
+        # Build yara_compiled_cmd, one command per compiled file
+        yara_compiled_cmds = []
+        for compiled_file in self.compiled_files:
+            cmd = list(
+                filter(
+                    None,
+                    [
+                        "nice",
+                        "-n",
+                        str(self.nice_value),
+                        self.yara_binary,
+                        "-s",
+                        "-N",
+                        "-a",
+                        str(self.scan_timeout),
+                        "-p",
+                        str(self.cpu_thread_limit),
+                        "-r",
+                        "-f",
+                        "-C",
+                        compiled_file,
+                    ],
+                )
+            )
+            yara_compiled_cmds.append(cmd)
+
+        logger.debug("Yara commands for compiled rules: %s", yara_compiled_cmds)
+
+        return yara_compiled_cmds
 
     def scan_filesystem(self):
         """
@@ -810,31 +847,56 @@ class MalwareDetectionClient:
         If self.scan_fsobjects is set, then just scan its items, less any items in the exclude list
         scan_dict will contain all the toplevel directories to scan, and any particular files/subdirectories to scan
         """
+        logger.debug("-------filesystem scan with %s", self.yara_cmd)
         if not self.do_filesystem_scan:
             return False
 
-        # Exclude the rules file and insights-client log files, unless they are things we specifically want to scan
-        # Get a list of potential rules files locations,eg /tmp, /var/tmp, /usr/tmp and gettempdir()
-        # eg customers may have /tmp linked to /var/tmp so both must be checked for excluding the downloaded rules
-        rules_file_name = os.path.basename(self.rules_file)
-        potential_tmp_dirs = set([gettempdir(), '/tmp', '/var/tmp', '/usr/tmp'])
-        potential_rules_files = set(list(map(lambda d: os.path.join(d, rules_file_name), potential_tmp_dirs)) + [self.rules_file])
-        rules_files = list(filter(lambda f: os.path.isfile(f), potential_rules_files))
-        for rules_file in rules_files:
-            if rules_file not in self.scan_fsobjects:
-                self.filesystem_scan_exclude_list.append(rules_file)
-                logger.debug("Excluding rules file: %s", rules_file)
-        insights_log_files = glob(constants.default_log_file + '*')
-        self.filesystem_scan_exclude_list.extend(list(set(insights_log_files) - set(self.scan_fsobjects)))
+        # Exclude the rules files and insights-client log files, unless they are things we specifically want to scan
+        # Get a list of potential rules files locations, e.g., /tmp, /var/tmp, /usr/tmp, and gettempdir()
+        # For example, customers may have /tmp linked to /var/tmp, so both must be checked for excluding the downloaded rules
+        # Iterate over all rule files in the list `self.rules_files`
+        potential_tmp_dirs = set([gettempdir(), "/tmp", "/var/tmp", "/usr/tmp"])
 
-        scan_dict = process_include_exclude_items(include_items=self.scan_fsobjects,
-                                                  exclude_items=self.filesystem_scan_exclude_list,
-                                                  exclude_mountpoints=self.network_filesystem_mountpoints)
+        # Loop over each rules file to ensure they are excluded from the scan
+        for rule_file in self.rules_files:
+            rules_file_name = os.path.basename(rule_file)
+
+            # Generate potential locations where the rule files might be stored temporarily
+            potential_rules_files = set(
+                list(
+                    map(lambda d: os.path.join(d, rules_file_name), potential_tmp_dirs)
+                )
+                + [rule_file]
+            )
+
+            # Check if these files exist and add them to the exclusion list if not already included in scan_fsobjects
+            rules_files = list(
+                filter(lambda f: os.path.isfile(f), potential_rules_files)
+            )
+            for rules_file in rules_files:
+                if rules_file not in self.scan_fsobjects:
+                    self.filesystem_scan_exclude_list.append(rules_file)
+                    logger.debug("Excluding rules file: %s", rules_file)
+
+        # Exclude insights-client log files
+        insights_log_files = glob(constants.default_log_file + "*")
+        self.filesystem_scan_exclude_list.extend(
+            list(set(insights_log_files) - set(self.scan_fsobjects))
+        )
+
+        # Process the inclusion and exclusion lists
+        scan_dict = utils.process_include_exclude_items(
+            include_items=self.scan_fsobjects,
+            exclude_items=self.filesystem_scan_exclude_list,
+            exclude_mountpoints=self.network_filesystem_mountpoints,
+        )
         if not scan_dict:
             self.do_filesystem_scan = False
             return False
 
-        logger.debug("Filesystem objects to be scanned in: %s", sorted(scan_dict.keys()))
+        logger.debug(
+            "Filesystem objects to be scanned in: %s", sorted(scan_dict.keys())
+        )
 
         logger.info("Starting filesystem scan ...")
         fs_scan_start = time.time()
@@ -844,28 +906,50 @@ class MalwareDetectionClient:
             cmd = self.yara_cmd[:]
             dir_scan_start = time.time()
 
-            specified_log_txt = "specified " if 'include' in scan_dict[toplevel_dir] else ""
-            if self.filesystem_scan_since_dict['timestamp']:
-                logger.info("Scanning %sfiles in %s modified since %s ...", specified_log_txt, toplevel_dir,
-                            self.filesystem_scan_since_dict['datetime'])
+            specified_log_txt = (
+                "specified " if "include" in scan_dict[toplevel_dir] else ""
+            )
+            if self.filesystem_scan_since_dict["timestamp"]:
+                logger.info(
+                    "Scanning %sfiles in %s modified since %s ...",
+                    specified_log_txt,
+                    toplevel_dir,
+                    self.filesystem_scan_since_dict["datetime"],
+                )
                 # Find the recently modified files in the given top level directory
-                scan_list_file = NamedTemporaryFile(prefix='%s_scan_list.' % os.path.basename(toplevel_dir),
-                                                    mode='w', delete=True)
-                if 'include' in scan_dict[toplevel_dir]:
-                    find_modified_include_items(scan_dict[toplevel_dir]['include'], self.filesystem_scan_since_dict['timestamp'], scan_list_file)
+                scan_list_file = NamedTemporaryFile(
+                    prefix="%s_scan_list." % os.path.basename(toplevel_dir),
+                    mode="w",
+                    delete=True,
+                )
+                if "include" in scan_dict[toplevel_dir]:
+                    utils.find_modified_include_items(
+                        scan_dict[toplevel_dir]["include"],
+                        self.filesystem_scan_since_dict["timestamp"],
+                        scan_list_file,
+                    )
                 else:
-                    find_modified_in_directory(toplevel_dir, self.filesystem_scan_since_dict['timestamp'], scan_list_file)
+                    utils.find_modified_in_directory(
+                        toplevel_dir,
+                        self.filesystem_scan_since_dict["timestamp"],
+                        scan_list_file,
+                    )
 
                 scan_list_file.flush()
-                cmd.extend(['--scan-list', scan_list_file.name])
+                cmd.extend(["--scan-list", scan_list_file.name])
             else:
-                logger.info("Scanning %sfiles in %s ...", specified_log_txt, toplevel_dir)
-                if 'include' in scan_dict[toplevel_dir]:
-                    scan_list_file = NamedTemporaryFile(prefix='%s_scan_list.' % os.path.basename(toplevel_dir),
-                                                        mode='w', delete=True)
-                    scan_list_file.write('\n'.join(scan_dict[toplevel_dir]['include']))
+                logger.info(
+                    "Scanning %sfiles in %s ...", specified_log_txt, toplevel_dir
+                )
+                if "include" in scan_dict[toplevel_dir]:
+                    scan_list_file = NamedTemporaryFile(
+                        prefix="%s_scan_list." % os.path.basename(toplevel_dir),
+                        mode="w",
+                        delete=True,
+                    )
+                    scan_list_file.write("\n".join(scan_dict[toplevel_dir]["include"]))
                     scan_list_file.flush()
-                    cmd.extend(['--scan-list', scan_list_file.name])
+                    cmd.extend(["--scan-list", scan_list_file.name])
                 else:
                     cmd.append(toplevel_dir)
 
@@ -880,18 +964,32 @@ class MalwareDetectionClient:
                 self.parse_scan_output(output.strip())
             except Exception as e:
                 self.potential_matches += 1
-                logger.exception("Rule match(es) potentially found in %s but problems encountered parsing the results: %s.  Skipping ...",
-                                 toplevel_dir, str(e))
+                logger.exception(
+                    "Rule match(es) potentially found in %s but problems encountered parsing the results: %s.  Skipping ...",
+                    toplevel_dir,
+                    str(e),
+                )
 
             dir_scan_end = time.time()
-            logger.info("Scan time for %s: %d seconds", toplevel_dir, (dir_scan_end - dir_scan_start))
+            logger.info(
+                "Scan time for %s: %d seconds",
+                toplevel_dir,
+                (dir_scan_end - dir_scan_start),
+            )
             if dir_scan_end - dir_scan_start >= self.scan_timeout - 2:
-                logger.warning("Scan of %s timed-out after %d seconds and may not have been fully scanned.  "
-                               "Consider increasing the scan_timeout value in %s",
-                               toplevel_dir, self.scan_timeout, MALWARE_CONFIG_FILE)
+                logger.warning(
+                    "Scan of %s timed-out after %d seconds and may not have been fully scanned.  "
+                    "Consider increasing the scan_timeout value in %s",
+                    toplevel_dir,
+                    self.scan_timeout,
+                    config.MALWARE_CONFIG_FILE,
+                )
 
         fs_scan_end = time.time()
-        logger.info("Filesystem scan time: %s", time.strftime("%H:%M:%S", time.gmtime(fs_scan_end - fs_scan_start)))
+        logger.info(
+            "Filesystem scan time: %s",
+            time.strftime("%H:%M:%S", time.gmtime(fs_scan_end - fs_scan_start)),
+        )
         return True
 
     def scan_processes(self):
@@ -900,37 +998,60 @@ class MalwareDetectionClient:
 
         # Get a list of all PIDs to scan if none were specified with scan only option
         if not self.scan_pids:
-            self.scan_pids = [entry for entry in os.listdir('/proc') if entry.isdigit()]
+            self.scan_pids = [entry for entry in os.listdir("/proc") if entry.isdigit()]
 
         # Add this currently running process' PID to the list of processes to exclude (unless its a test_scan)
         # Then remove the excluded processes from the list of PIDs to scan
         if not self.test_scan:
-            self.processes_scan_exclude_list.append(str(os.getpid()))  # make sure to exclude our script's pid
-        self.scan_pids = sorted(list(set(self.scan_pids) - set(self.processes_scan_exclude_list)), key=lambda pid: int(pid))
+            self.processes_scan_exclude_list.append(
+                str(os.getpid())
+            )  # make sure to exclude our script's pid
+        self.scan_pids = sorted(
+            list(set(self.scan_pids) - set(self.processes_scan_exclude_list)),
+            key=lambda pid: int(pid),
+        )
 
         if not self.scan_pids:
-            logger.error("No processes to scan because the specified exclude items cancel them out")
+            logger.error(
+                "No processes to scan because the specified exclude items cancel them out"
+            )
             self.do_process_scan = False
             return False
 
         # If process_scan_since is specified, get a list of processes started since the specified date
-        if hasattr(self, 'processes_scan_since_dict') and self.processes_scan_since_dict['timestamp']:
+        if (
+            hasattr(self, "processes_scan_since_dict")
+            and self.processes_scan_since_dict["timestamp"]
+        ):
             # First get a list of all running processes and their start times
-            ps_output = call([['ps', '-eo', 'pid=', '-o', 'lstart=']]).splitlines()
-            all_proc_starts = list(map(lambda x: (str(x[0]), str(x[1])), map(lambda x: tuple(x.strip().split(' ', 1)), ps_output)))
+            ps_output = call([["ps", "-eo", "pid=", "-o", "lstart="]]).splitlines()
+            all_proc_starts = list(
+                map(
+                    lambda x: (str(x[0]), str(x[1])),
+                    map(lambda x: tuple(x.strip().split(" ", 1)), ps_output),
+                )
+            )
             scan_since_pids = []
             # Loop through all processes and if the process start time <= the specified scan_since time then
             # make note of the process
             for proc in all_proc_starts:
-                proc_start_secs = float(datetime.strptime(proc[1], '%a %b %d %H:%M:%S %Y').strftime('%s'))
-                if proc_start_secs >= self.processes_scan_since_dict['timestamp']:
+                proc_start_secs = float(
+                    datetime.strptime(proc[1], "%a %b %d %H:%M:%S %Y").strftime("%s")
+                )
+                if proc_start_secs >= self.processes_scan_since_dict["timestamp"]:
                     scan_since_pids.append(proc[0])
             # Finally, do a set intersection of the current list of scan_pids and the list of processes started
             # since processes_scan_since.  The resulting list is the list of processes to scan.
-            self.scan_pids = sorted(list(set(self.scan_pids) & set(scan_since_pids)), key=lambda pid: int(pid))
+            self.scan_pids = sorted(
+                list(set(self.scan_pids) & set(scan_since_pids)),
+                key=lambda pid: int(pid),
+            )
 
             if not self.scan_pids:
-                logger.error("No processes to scan because none were started since %s", self.processes_scan_since_dict['datetime'])
+                logger.error(
+                    "No processes to scan because none were started since %s",
+                    self.processes_scan_since_dict["datetime"],
+                )
                 self.do_process_scan = False
                 return False
 
@@ -945,25 +1066,41 @@ class MalwareDetectionClient:
             try:
                 output = call([cmd]).strip()
             except CalledProcessError as cpe:
-                logger.debug("Unable to scan process %s: %s", scan_pid, cpe.output.strip())
+                logger.debug(
+                    "Unable to scan process %s: %s", scan_pid, cpe.output.strip()
+                )
                 continue
 
             try:
                 self.parse_scan_output(output)
             except Exception as e:
                 self.potential_matches += 1
-                logger.exception("Rule match(es) potentially found in process %s but problems encountered parsing the results: %s.  Skipping ...",
-                                 scan_pid, str(e))
+                logger.exception(
+                    "Rule match(es) potentially found in process %s but problems encountered parsing the results: %s.  Skipping ...",
+                    scan_pid,
+                    str(e),
+                )
 
             pid_scan_end = time.time()
-            logger.info("Scan time for process %s: %d seconds", scan_pid, (pid_scan_end - pid_scan_start))
+            logger.info(
+                "Scan time for process %s: %d seconds",
+                scan_pid,
+                (pid_scan_end - pid_scan_start),
+            )
             if pid_scan_end - pid_scan_start >= self.scan_timeout - 2:
-                logger.warning("Scan of process %s timed-out after %d seconds and may not have been fully scanned.  "
-                               "Consider increasing the scan_timeout value in %s",
-                               scan_pid, self.scan_timeout, MALWARE_CONFIG_FILE)
+                logger.warning(
+                    "Scan of process %s timed-out after %d seconds and may not have been fully scanned.  "
+                    "Consider increasing the scan_timeout value in %s",
+                    scan_pid,
+                    self.scan_timeout,
+                    config.MALWARE_CONFIG_FILE,
+                )
 
         pids_scan_end = time.time()
-        logger.info("Processes scan time: %s", time.strftime("%H:%M:%S", time.gmtime(pids_scan_end - pids_scan_start)))
+        logger.info(
+            "Processes scan time: %s",
+            time.strftime("%H:%M:%S", time.gmtime(pids_scan_end - pids_scan_start)),
+        )
         return True
 
     def parse_scan_output(self, output):
@@ -982,12 +1119,12 @@ class MalwareDetectionClient:
 
         def skip_string_data_lines(string_data_lines):
             # Skip the 0x... lines containing string match data
-            while string_data_lines and string_data_lines[0].startswith('0x'):
+            while string_data_lines and string_data_lines[0].startswith("0x"):
                 string_data_lines.pop(0)
 
         output_lines = output.split("\n")
         while output_lines:
-            if 'error scanning ' in output_lines[0]:
+            if "error scanning " in output_lines[0]:
                 logger.debug("Skipping yara output line: %s", output_lines[0])
                 output_lines.pop(0)  # Skip the error scanning line
                 # Skip any string match lines after the error scanning line
@@ -998,7 +1135,9 @@ class MalwareDetectionClient:
                 rule_name, source = output_lines[0].rstrip().split(" ", 1)
             except ValueError as err:
                 # Hopefully shouldn't happen but log it and continue processing
-                logger.debug("Error parsing rule match '%s': %s", output_lines[0], str(err))
+                logger.debug(
+                    "Error parsing rule match '%s': %s", output_lines[0], str(err)
+                )
                 output_lines.pop(0)  # Skip the erroneous line
                 # Skip any string match lines afterwards until we get to the next rule match line
                 skip_string_data_lines(output_lines)
@@ -1010,7 +1149,7 @@ class MalwareDetectionClient:
             # Check if the rule name contains a ':' or doesn't start with a char/string
             # It shouldn't and its likely to be due to a malformed string_offset line
             # Skip any further scan matches until the next rule match
-            if ':' in rule_name or not re.match('^[a-zA-Z]+', rule_name):
+            if ":" in rule_name or not re.match("^[a-zA-Z]+", rule_name):
                 skip_string_data_lines(output_lines)
                 continue
 
@@ -1018,59 +1157,81 @@ class MalwareDetectionClient:
 
             # If the rule is disabled, then skip over its scan matches until the next rule match
             if rule_name.lower() in self.disabled_rules:
-                logger.debug("Skipping matches for disabled rule %s in %s %s", rule_name, source_type, source)
+                logger.debug(
+                    "Skipping matches for disabled rule %s in %s %s",
+                    rule_name,
+                    source_type,
+                    source,
+                )
                 skip_string_data_lines(output_lines)
                 continue
 
             # Parse the string match data for the remaining lines in the set
-            rule_match = {'rule_name': rule_name, 'matches': []}
+            rule_match = {"rule_name": rule_name, "matches": []}
             string_matches = 0
-            while output_lines and output_lines[0].startswith('0x'):
+            while output_lines and output_lines[0].startswith("0x"):
                 if string_matches < self.string_match_limit:
                     try:
-                        string_offset, string_identifier, string_data = output_lines[0].split(':', 2)
+                        string_offset, string_identifier, string_data = output_lines[
+                            0
+                        ].split(":", 2)
                         string_offset = int(string_offset, 0)
                     except ValueError as err:
-                        logger.debug("Error parsing string match '%s': %s", output_lines[0], err)
+                        logger.debug(
+                            "Error parsing string match '%s': %s", output_lines[0], err
+                        )
                         output_lines.pop(0)
                         continue
-                    rule_match_dict = {'source': source,
-                                       'string_data': string_data.strip(),
-                                       'string_identifier': string_identifier,
-                                       'string_offset': string_offset,
-                                       'metadata': {'source_type': source_type}}
-                    rule_match['matches'].extend([rule_match_dict])
+                    rule_match_dict = {
+                        "source": source,
+                        "string_data": string_data.strip(),
+                        "string_identifier": string_identifier,
+                        "string_offset": string_offset,
+                        "metadata": {"source_type": source_type},
+                    }
+                    rule_match["matches"].extend([rule_match_dict])
                 output_lines.pop(0)
                 string_matches += 1
 
             # If string_match_limit is 0 or there was no string data, there will be no rule_matches,
             # but still record the file/pid source that was matched
-            if not rule_match['matches']:
-                rule_match_dict = {'source': source,
-                                   'string_data': '',
-                                   'string_identifier': '',
-                                   'string_offset': -1,
-                                   'metadata': {'source_type': source_type}}
-                rule_match['matches'] = [rule_match_dict]
+            if not rule_match["matches"]:
+                rule_match_dict = {
+                    "source": source,
+                    "string_data": "",
+                    "string_identifier": "",
+                    "string_offset": -1,
+                    "metadata": {"source_type": source_type},
+                }
+                rule_match["matches"] = [rule_match_dict]
 
             if self.add_metadata:
                 try:
                     # Add extra data to each rule match, beyond what yara provides
                     # Eg, for files: line numbers & context, checksums; for processes: process name
                     # TODO: find more pythonic ways of doing this stuff instead of using system commands
-                    metadata_func = self._add_file_metadata if source_type == 'file' else self._add_process_metadata
-                    metadata_func(rule_match['matches'])
+                    metadata_func = (
+                        self._add_file_metadata
+                        if source_type == "file"
+                        else self._add_process_metadata
+                    )
+                    metadata_func(rule_match["matches"])
                 except Exception as e:
-                    logger.error("Error adding metadata to rule match %s in %s %s: %s.  Skipping ...",
-                                 rule_name, source_type, source, str(e))
+                    logger.error(
+                        "Error adding metadata to rule match %s in %s %s: %s.  Skipping ...",
+                        rule_name,
+                        source_type,
+                        source,
+                        str(e),
+                    )
 
             self.matches += 1
             logger.info("Matched rule %s in %s %s", rule_name, source_type, source)
             logger.debug(rule_match)
-            if self.host_scan.get(rule_match['rule_name']):
-                self.host_scan[rule_match['rule_name']].extend(rule_match['matches'])
+            if self.host_scan.get(rule_match["rule_name"]):
+                self.host_scan[rule_match["rule_name"]].extend(rule_match["matches"])
             else:
-                self.host_scan[rule_match['rule_name']] = rule_match['matches']
+                self.host_scan[rule_match["rule_name"]] = rule_match["matches"]
 
     def _add_process_metadata(self, rule_matches):
         """
@@ -1078,19 +1239,19 @@ class MalwareDetectionClient:
         """
         # All passed in rule_matches will have the same source PID
         # Check the process still exists before obtaining the metadata about it
-        source = rule_matches[0]['source']
-        if not os.path.exists('/proc/%s' % source):
+        source = rule_matches[0]["source"]
+        if not os.path.exists("/proc/%s" % source):
             return
 
         # Get name of process from ps command
         # -h: no output header, -q: only the specified process, -o args: just the process name and args
         try:
-            process_name = call([['ps', '-hq', source, '-o', 'args']]).strip()
+            process_name = call([["ps", "-hq", source, "-o", "args"]]).strip()
         except CalledProcessError:
-            process_name = 'unknown'
+            process_name = "unknown"
 
         for rule_match in rule_matches:
-            rule_match['metadata'].update({'process_name': process_name})
+            rule_match["metadata"].update({"process_name": process_name})
 
     def _add_file_metadata(self, rule_matches):
         """
@@ -1098,53 +1259,69 @@ class MalwareDetectionClient:
         - eg matching line numbers, line context, file checksum
         - Use grep to get the line numbers & sed to get the line
         """
+
         def get_line_from_file(file_name, line_number):
             # Extract the line at line_number from file_name
             line_length_limit = 120
             try:
-                line = call([['sed', '%dq;d' % line_number, file_name]]).strip()
+                line = call([["sed", "%dq;d" % line_number, file_name]]).strip()
             except CalledProcessError:
                 line = ""
             # Limit line length if necessary and urlencode it to minimize problems with GraphQL when uploading
-            return urlencode(line if len(line) < line_length_limit else line[:line_length_limit] + "...")
+            return urlencode(
+                line
+                if len(line) < line_length_limit
+                else line[:line_length_limit] + "..."
+            )
 
         # All passed in rule_matches will have the same source file
         # Check the file still exists before obtaining the metadata about it
-        source = rule_matches[0]['source']
+        source = rule_matches[0]["source"]
         if not os.path.exists(source):
             return
 
         # Get the file type, mime type and md5sum hash of the source file
         try:
-            file_type = call([['file', '-b', source]]).strip()
+            file_type = call([["file", "-b", source]]).strip()
         except Exception:
             file_type = ""
         try:
-            mime_type = call([['file', '-bi', source]]).strip()
+            mime_type = call([["file", "-bi", source]]).strip()
         except Exception:
             mime_type = ""
         try:
-            md5sum = call([['md5sum', source]]).strip().split()[0]
+            md5sum = call([["md5sum", source]]).strip().split()[0]
         except Exception:
             md5sum = ""
 
         grep_string_data_match_list = []
-        if mime_type and 'charset=binary' not in mime_type:
+        if mime_type and "charset=binary" not in mime_type:
             # Get the line numbers for each of yara's string_data matches in the source file, but not for binary files
             # Build a grep command that searches for each of the string_data patterns in the source file
             # For each string_data pattern that grep finds, the grep output will have the form...
             # line_number:offset_from_0:string_data_pattern
 
             # Get the set of patterns to grep for, eg ['pattern1', 'pattern2', etc], ie remove duplicate patterns
-            grep_string_data_pattern_set = set([match['string_data'] for match in rule_matches])
+            grep_string_data_pattern_set = set(
+                [match["string_data"] for match in rule_matches]
+            )
             if grep_string_data_pattern_set:
                 # Build an option list for grep, eg ['-e', 'pattern1', '-e', 'pattern2', ... etc]
                 # zip creates a list of tuples, eg [('-e', 'pattern'), ('-e', 'pattern2'), ...], then flatten the list
-                grep_string_data_patterns = [item for tup in list(zip(['-e'] * len(grep_string_data_pattern_set),
-                                                                      grep_string_data_pattern_set))
-                                             for item in tup]
+                grep_string_data_patterns = [
+                    item
+                    for tup in list(
+                        zip(
+                            ["-e"] * len(grep_string_data_pattern_set),
+                            grep_string_data_pattern_set,
+                        )
+                    )
+                    for item in tup
+                ]
                 # Create the grep command to execute.  -F means don't interpret regex special chars in the patterns
-                grep_command = ['/bin/grep', '-Fbon'] + grep_string_data_patterns + [source]
+                grep_command = (
+                    ["/bin/grep", "-Fbon"] + grep_string_data_patterns + [source]
+                )
                 logger.debug("grep command: %s", grep_command)
                 try:
                     grep_output = call([grep_command])
@@ -1153,37 +1330,50 @@ class MalwareDetectionClient:
 
                 # Now turn the grep output into a list of tuples for easier searching a little later, ie
                 # [(line_number, offset_from_0, string_data_pattern), (...), ]
-                if grep_output and not grep_output.lower().startswith('binary'):
-                    grep_string_data_match_list = list(map(lambda grep_output_line: tuple(grep_output_line.split(':', 3)),
-                                                           grep_output.splitlines()))
+                if grep_output and not grep_output.lower().startswith("binary"):
+                    grep_string_data_match_list = list(
+                        map(
+                            lambda grep_output_line: tuple(
+                                grep_output_line.split(":", 3)
+                            ),
+                            grep_output.splitlines(),
+                        )
+                    )
 
         for rule_match in rule_matches:
-            metadata = rule_match['metadata']
-            metadata.update({'file_type': file_type,
-                             'mime_type': mime_type,
-                             'md5sum': md5sum})
+            metadata = rule_match["metadata"]
+            metadata.update(
+                {"file_type": file_type, "mime_type": mime_type, "md5sum": md5sum}
+            )
             if grep_string_data_match_list:
                 # Now, for each offset_from_0 in the grep output, we want to match it with the corresponding
                 # string_offset value from the yara output so we can get the line number for that string_data match
                 # And while we are here, get the line from the source file at that line number
                 line_number = None
                 for grep_list_item in grep_string_data_match_list:
-                    if int(grep_list_item[1]) == rule_match['string_offset']:
+                    if int(grep_list_item[1]) == rule_match["string_offset"]:
                         line_number = int(grep_list_item[0])
                         break
                 if line_number:
-                    metadata.update({'line_number': line_number,
-                                     'line': get_line_from_file(source, line_number)})
+                    metadata.update(
+                        {
+                            "line_number": line_number,
+                            "line": get_line_from_file(source, line_number),
+                        }
+                    )
 
     def _create_host_scan_mutation(self):
         # Build the mutation text
-        mutation_header = """
-        mutation HostScan {
-          recordHostScan(
-            input: {
-              scannedhost: {
-                insightsId: "%s"
-                rulesScanned: [""" % generate_machine_id()
+        mutation_header = (
+            """
+            mutation HostScan {
+              recordHostScan(
+                input: {
+                  scannedhost: {
+                    insightsId: "%s"
+                    rulesScanned: ["""
+            % generate_machine_id()
+        )
 
         mutation_footer = """
                 ]
@@ -1196,9 +1386,12 @@ class MalwareDetectionClient:
 
         mutation = mutation_header
         for rule_name in self.host_scan.keys():
-            rule_scan = """{
-                ruleName: "%s"
-                stringsMatched: [""" % rule_name
+            rule_scan = (
+                """{
+                    ruleName: "%s"
+                    stringsMatched: ["""
+                % rule_name
+            )
             for match in self.host_scan[rule_name]:
                 rule_scan += """{
                     source: "%s"
@@ -1206,11 +1399,13 @@ class MalwareDetectionClient:
                     stringIdentifier: %s
                     stringOffset: "%s"
                     metadata: "%s"
-                }, """ % (match['source'],
-                          json.dumps(match['string_data']),
-                          json.dumps(match['string_identifier']),
-                          match['string_offset'],
-                          json.dumps(match['metadata']).replace('"', '\\"'))
+                }, """ % (
+                    match["source"],
+                    json.dumps(match["string_data"]),
+                    json.dumps(match["string_identifier"]),
+                    match["string_offset"],
+                    json.dumps(match["metadata"]).replace('"', '\\"'),
+                )
             rule_scan += "]}, "
             mutation += rule_scan
 
@@ -1223,44 +1418,12 @@ class MalwareDetectionClient:
         """
         value = os.getenv(option.upper())
         if value is not None:
-            return self._parse_env_var(option.upper(), value)
+            return config.parse_env_var(option.upper(), value)
         value = self.config.get(option)
         return value if value is not None else default_value
 
     @staticmethod
-    def _parse_env_var(env_var, value):
-        """
-        Parse specific environment variables to make sure they have appropriate values
-        """
-        logger.debug("Found environment variable: %s, value: %s", env_var, value)
-        # Parse these env vars as booleans
-        if env_var in ENV_VAR_TYPES['boolean']:
-            return value.lower() in ('true', 'yes', 't', 'y')
-
-        # Parse these as lists by splitting at the commas
-        if env_var in ENV_VAR_TYPES['list']:
-            if value:
-                return value.split(',') if ',' in value else [value]
-            else:
-                return []
-
-        # Parse *_scan_since, can be either an int or a string (ie 'last')
-        if env_var in ENV_VAR_TYPES['int_or_str']:
-            return int(value) if value.isdigit() else value
-
-        # Parse these as ints
-        if env_var in ENV_VAR_TYPES['integer']:
-            try:
-                return int(value)
-            except ValueError as e:
-                logger.error("Problem parsing environment variable %s: %s", env_var, str(e))
-                exit(constants.sig_kill_bad)
-
-        # env_var value doesn't require parsing, just return it as is (ie. as a string)
-        return value
-
-    @staticmethod
-    def _set_url_path(url, path='graphql'):
+    def _set_url_path(url, path="graphql"):
         """
         Change the last item in the 'url' to 'path'
         For example if url=http://localhost:3000/api/malware/signatures.yar and path=test-rule.yar
@@ -1271,365 +1434,9 @@ class MalwareDetectionClient:
         # Unconventional perhaps, but this seems to work ok with both URL and file paths
         return os.path.join(os.path.dirname(url), path)
 
-
-#
-# Utility functions
-# Mainly for including / excluding certain directories for scanning
-# And also for finding files that have been modified recently
-#
-def get_toplevel_dirs():
-    """
-    Returns a list of the top level directories directly under root (/),
-    """
-    toplevel_dirs = sorted(filter(lambda x: not os.path.islink(x), map(lambda x: "/" + x, os.listdir('/'))))
-    return toplevel_dirs
-
-
-def is_same_file_or_root(file1, file2):
-    # Catch possible permission denied error with fuse mounted filesystems. Yes, even for root!
-    try:
-        if os.path.samefile(file1, file2) or os.path.samefile(file1, '/'):
-            return True
-    except Exception as err:
-        logger.debug("Encountered exception running os.path.samefile('%s', '%s'): %s.  Trying string comparison ...",
-                     file1, file2, str(err))
-        if file1 == file2 or file1 == '/':
-            return True
-    return False
-
-
-def get_parent_dirs(item, parent_dir_list, base_case='/'):
-    """
-    Get a list of parent directories of a particular filesystem item, stopping at base_case (root by default)
-    Eg for get_parent_dirs('/path/to/some/item', parent_dir_list) ->
-        parent_dir_list = ['/path', '/path/to', '/path/to/some', '/path/to/some/item']
-    """
-    if is_same_file_or_root(item, base_case):
-        return
-    get_parent_dirs(os.path.dirname(item), parent_dir_list, base_case)
-    parent_dir_list.append(item)
-
-
-def process_include_items(include_items=[]):
-    """
-    Process the include items to a get list of directories to be scanned
-    If there are no entries then get the list of top level directories under root (/),
-    :return: a list of directories to be scanned.  It never returns an empty list.
-    """
-    default_values = get_toplevel_dirs()
-
-    logger.debug("Parsing include items ...")
-    parsed_list = []
-    for item in include_items:
-        item = item.strip()
-        if not item or item.startswith('#'):
-            continue
-        include_item = os.path.normpath(item).replace('//', '/')
-        if os.path.exists(include_item):
-            # ignore the include_item if its not a full directory path
-            if not include_item.startswith('/'):
-                logger.debug("Skipping partial directory path '%s' ...", include_item)
-                continue
-            elif os.path.islink(include_item):
-                logger.debug("Skipping link '%s' ...", include_item)
-                continue
-            elif include_item == '/':
-                # Found / in include item list.  No need to get the other items because / trumps all
-                logger.debug("Found root directory in list of items to scan.  Ignoring the other items ...")
-                parsed_list = default_values
-                break
-            else:
-                parsed_list.append(include_item)
-        else:
-            logger.debug("Skipping missing item '%s' ...", include_item)
-
-    if not parsed_list:
-        logger.debug("No items specified to be scanned.  Using default values %s ...", default_values)
-        parsed_list = default_values
-    else:
-        # Remove any duplicates and any children of parent directories before returning
-        parsed_list = remove_child_items(sorted(list(set(parsed_list))))
-
-    logger.debug("Include items: %s", parsed_list)
-    return parsed_list
-
-
-def process_exclude_items(exclude_items=[]):
-    """
-    Process the exclude items to get list of directories to NOT be scanned
-    :return: a list of directories to not be scanned if any, otherwise an empty list
-    """
-    logger.debug("Parsing exclude items ...")
-    parsed_list = []
-    for item in exclude_items:
-        item = item.strip()
-        if not item or item.startswith('#'):
-            continue
-        exclude_item = os.path.normpath(item).replace('//', '/')
-        if os.path.exists(exclude_item):
-            # ignore the exclude_item if its not a full directory path
-            if exclude_item == '/':
-                # Found / in exclude list.  No need to get the other items because / trumps all
-                logger.debug("Found root directory in the exclude list.  Expanding it to all toplevel directories ...")
-                parsed_list = get_toplevel_dirs()
-                break
-            elif not exclude_item.startswith('/'):
-                logger.debug("Skipping partial directory path '%s' ...", exclude_item)
-                continue
-            else:
-                parsed_list.append(exclude_item)
-        else:
-            logger.debug("Skipping missing item '%s' ...", exclude_item)
-
-    if not parsed_list:
-        logger.debug("No items specified to be excluded")
-    else:
-        # Remove any duplicates and any children of parent directories before returning
-        parsed_list = remove_child_items(sorted(list(set(parsed_list))))
-
-    logger.debug("Exclude items: %s", parsed_list)
-    return parsed_list
-
-
-def remove_child_items(item_list):
-    """
-    For a list of filesystem items, remove those items that are duplicates or children of other items
-    Eg, for remove_child_items['/path/to/some/item/child', '/path/to/another/item', '/path/to/some/item']
-        returns ['/path/to/another/item', '/path/to/some/item']
-    If one if the items is root, then it wins
-    Also, all items should be the full path starting at root (/).  Any that aren't are removed
-    """
-    if '/' in item_list:
-        return ['/']
-
-    # Remove duplicates and any non-full path items
-    item_list = sorted(list(set(filter(lambda x: x.startswith('/'), item_list))))
-    remove_items = set([])
-    for i, item1 in enumerate(item_list[:-1]):
-        for item2 in item_list[i + 1:]:
-            if item1 != item2 and item2.startswith(item1 + '/'):
-                remove_items.add(item2)
-    for remove_item in remove_items:
-        item_list.remove(remove_item)
-    return sorted(list(set(item_list)))
-
-
-def remove_included_excluded_items(included_items, excluded_items):
-    """
-    Go through the list of included items and remove any that are in the exclude list,
-        or are children of excluded items (no need to scan an included item if its parent is to be excluded)
-    """
-    # Clean up the lists, just in case this hasn't been done already
-    included_items = remove_child_items(included_items)
-    excluded_items = remove_child_items(excluded_items)
-
-    remove_items = set([])
-    for included_item in included_items:
-        for excluded_item in excluded_items:
-            if excluded_item == included_item or included_item.startswith(excluded_item + '/'):
-                remove_items.add(included_item)
-    for remove_item in remove_items:
-        included_items.remove(remove_item)
-    return included_items
-
-
-def process_include_exclude_items(include_items=[], exclude_items=[], exclude_mountpoints=[]):
-    """
-    Process the include and exclude items, where the exclude items are effectively subtracted from the include_items.
-    It builds a scan_dict dictionary of items to scan keyed by the filesystem top level directories.
-    Only the toplevel directories from items in the include_items list will be present in scan_dict.
-    scan_dict = {'/boot': {'include': ['/boot/include/me', ...], 'exclude: ['/boot/exclude/me', ...]},
-                 '/etc': {'include': ['/etc/include/me', ...], 'exclude: ['/etc/exclude/me', ...]},
-                 ...
-    :return: scan_dict
-    """
-    # Get a list of excluded items from the exclude file and network filesystem mountpoints
-    initial_exclude_list = process_exclude_items(exclude_items)
-    final_exclude_list = remove_child_items(list(set(exclude_mountpoints) | set(initial_exclude_list)))
-    logger.debug("Final exclude items: %s", final_exclude_list)
-
-    # Get a list of included items from the include file, minus the excluded items
-    initial_include_list = process_include_items(include_items)
-    if not initial_include_list:
-        logger.error("No filesystem items to scan because the include items doesn't contain any valid items")
-        return {}
-    final_include_list = remove_included_excluded_items(initial_include_list, final_exclude_list)
-    logger.debug("Final include items after removing exclude items: %s", final_include_list)
-    if not final_include_list:
-        logger.error("No filesystem items to scan because the specified exclude items cancel them out")
-        return {}
-
-    # This is the dictionary that will hold all the items to scan (after processing the include and exclude items)
-    # It will be keyed by each of the toplevel directories containing items to scan
-    # yara will scan each of the toplevel dir's 'include' keys (if present), or just the toplevel dir itself
-    scan_dict = {}
-
-    # Populate the scan_dict by creating keys for each toplevel directory of the items to include/scan
-    # Create an 'include' key for each toplevel directory containing items to include in that toplevel directory
-    logger.debug("Populating scan_dict's include items ...")
-    for include_item in final_include_list:
-        item_subpaths = []
-        get_parent_dirs(include_item, item_subpaths)
-        include_item_toplevel_dir = item_subpaths[0]
-        if include_item_toplevel_dir not in scan_dict:
-            # Create an 'include' key if the item to scan isn't just the toplevel directory itself
-            scan_dict[include_item_toplevel_dir] = {'include': set([include_item])}\
-                if include_item != include_item_toplevel_dir else {}
-        else:
-            scan_dict[include_item_toplevel_dir]['include'].add(include_item)
-
-    logger.debug("Scan dict after adding include items: %s", scan_dict)
-
-    # Populate an 'exclude' key for the toplevel dirs in the scan_dict that also have items to exclude
-    # Or remove the toplevel dirs from the scan dict where the toplevel dir itself is to be excluded
-    logger.debug("Populating scan_dict's exclude items ...")
-    for exclude_item in final_exclude_list:
-        item_subpaths = []
-        get_parent_dirs(exclude_item, item_subpaths)
-        exclude_item_toplevel_dir = item_subpaths[0]
-        if exclude_item_toplevel_dir not in scan_dict:
-            # This exclude_item's toplevel dir isn't in the scan dict, so skip it (since its not being included)
-            continue
-        if 'exclude' not in scan_dict[exclude_item_toplevel_dir]:
-            # Create the 'exclude' key if it doesn't already exist
-            scan_dict[exclude_item_toplevel_dir]['exclude'] = {'items': [], 'subpaths': set([])}
-
-        scan_dict[exclude_item_toplevel_dir]['exclude']['items'].append(exclude_item)
-
-        # Add the list of subpaths leading to this exclude item.
-        # The subpaths are needed later for listing the contents each subpath
-        scan_dict[exclude_item_toplevel_dir]['exclude']['subpaths'].update(item_subpaths)
-
-    logger.debug("Scan dict after adding exclude items: %s", scan_dict)
-
-    # For each toplevel dir with items to exclude, re-populate the include key with directory content listings
-    # of the subpaths, minus the items to exclude and only including items to include.  Yep, its complicated.
-    # These directory listings will be used with yara's --scan-list option
-    logger.debug("Re-populating scan_dict's include items with directory content listings to pass to yara ...")
-    for toplevel_dir in scan_dict:
-        if 'exclude' not in scan_dict[toplevel_dir]:
-            continue
-
-        # Get directory listings of each of the subpaths
-        if 'include' in scan_dict[toplevel_dir]:
-            scan_items = set(scan_dict[toplevel_dir]['include'])
-        else:
-            scan_items = set([])
-        toplevel_dir_exclude = scan_dict[toplevel_dir]['exclude']
-        for exclude_item in toplevel_dir_exclude['items']:
-            subpaths = []
-            get_parent_dirs(exclude_item, subpaths)
-            for i, subpath in enumerate(subpaths[:-1]):
-                dir_list = os.listdir(subpath)
-                dir_list = sorted(map(lambda x: subpath + '/' + x, dir_list))
-                dir_list.remove(subpaths[i + 1])
-                scan_items.update(dir_list)
-
-        # Go through the list of scan items and remove any exclude items or exclude item subpaths
-        for scan_item in list(scan_items):
-            for exclude_item in toplevel_dir_exclude['items']:
-                if scan_item == exclude_item or scan_item.startswith(exclude_item + '/'):
-                    scan_items.remove(scan_item)
-                    break
-            else:
-                for exclude_subpath in toplevel_dir_exclude['subpaths']:
-                    if scan_item == exclude_subpath:
-                        scan_items.remove(scan_item)
-
-        # If there is an include list, make sure the scan_items only include items in the include list
-        if 'include' in scan_dict[toplevel_dir]:
-            for maybe_include in list(scan_items):
-                if os.path.islink(maybe_include) or (not os.path.isfile(maybe_include) and not os.path.isdir(maybe_include)):
-                    scan_items.remove(maybe_include)
-                    continue
-                if any([maybe_include == definitely_include or maybe_include.startswith(definitely_include + '/')
-                        for definitely_include in scan_dict[toplevel_dir]['include']]):
-                    continue
-                else:
-                    scan_items.remove(maybe_include)
-
-        # Overwrite the existing include key list with the new list of scan_items
-        scan_dict[toplevel_dir]['include'] = sorted(list(scan_items))
-
-    logger.debug("Final scan_dict: %s", scan_dict)
-    return scan_dict
-
-
-def get_scan_since_timestamp(scan_since_option, since):
-    """
-    Return a unix timestamp corresponding to how long ago to scan for files or processes (depending on scan_since_option)
-    Valid values of 'since' are integers > 0 meaning the number of days back in time from now,
-                             or 'last' meaning get the timestamp of the last scan
-    If 'since' is not one of these valid values, then terminate
-    """
-    now = time.time()
-    timestamp_file = LAST_FILESYSTEM_SCAN_FILE if scan_since_option == 'filesystem_scan_since' else LAST_PROCESSES_SCAN_FILE
-
-    def get_lastscan_timestamp(scan_since_option, lastscan):
+    def _validate_option(self, option, value):
         try:
-            # Convert the datetime string into a unix timestamp
-            lastscan_seconds = float(datetime.strptime(lastscan, '%Y-%m-%dT%H:%M:%S.%f').strftime('%s'))
-            if lastscan_seconds > now:
-                raise RuntimeError("Last scan time is in the future.")
-        except Exception as err:
-            logger.error("Error getting time of last malware scan: %s.  Ignoring '%s: last' option ...", str(err), scan_since_option)
-            return None
-        return lastscan_seconds
-
-    if isinstance(since, str) and since.lower().startswith('l'):
-        # Get the timestamp of the last scan
-        if os.path.isfile(timestamp_file):
-            with open(timestamp_file) as f:
-                lastscan = f.readline().strip()
-            return get_lastscan_timestamp(scan_since_option, lastscan)
-        else:
-            logger.info("File %s doesn't exist for '%s: last' option.  Continuing ...", timestamp_file, scan_since_option)
-            return None
-    elif isinstance(since, str):
-        logger.error("Unknown value '%s' for %s option.  Valid values are integers >= 1 and 'last'", since, scan_since_option)
-        exit(constants.sig_kill_bad)
-
-    try:
-        since_int = int(since)
-        if since_int >= 1:
-            return now - (since_int * 86400)  # 86400 seconds in a day
-        else:
-            raise ValueError("Invalid %s value %s.  Valid values are integers >= 1 and 'last'" % (scan_since_option, since))
-    except ValueError as e:
-        logger.error(str(e))
-        exit(constants.sig_kill_bad)
-
-
-def is_recent_mtime(item, timestamp):
-    """
-    Return True if the given 'item' has a modification time that is newer than 'timestamp'
-    Return False otherwise, or if the the 'item' is a link or another non-file type (eg pipes)
-    """
-    if os.path.exists(item) and not os.path.islink(item) and os.path.isfile(item):
-        return os.path.getmtime(item) > timestamp
-    return False
-
-
-def find_modified_in_directory(directory, timestamp, output_file):
-    """
-    Find files in 'directory' that have been created/modified since 'timestamp'
-    and write their names to 'output_file'
-    """
-    for root, dirs, files in os.walk(directory):
-        for afile in files:
-            path = os.path.join(root, afile)
-            if is_recent_mtime(path, timestamp):
-                output_file.write(path + "\n")
-
-
-def find_modified_include_items(item_list, timestamp, output_file):
-    """
-    Find files in the given list of items (files/directories) that have been created/modified since 'timestamp'
-    and write their names to 'output_file'
-    """
-    for item in item_list:
-        if os.path.isdir(item):
-            find_modified_in_directory(item, timestamp, output_file)
-        else:
-            if is_recent_mtime(item, timestamp):
-                output_file.write(item + '\n')
+            return int(self._get_config_option(option, value))
+        except Exception as e:
+            logger.error("Problem setting configuration option %s: %s", option, str(e))
+            exit(constants.sig_kill_bad)

--- a/insights/specs/datasources/malware_detection/config.py
+++ b/insights/specs/datasources/malware_detection/config.py
@@ -1,0 +1,245 @@
+import os
+import logging
+import yaml
+from insights.util.subproc import call
+
+from insights.client.constants import InsightsConstants as constants
+from insights.client.utilities import write_data_to_file
+
+logger = logging.getLogger(__name__)
+
+MIN_YARA_VERSION = "4.1.0"
+MALWARE_APP_URL = "https://console.redhat.com/insights/malware"
+MALWARE_CONFIG_FILE = os.path.join(
+    constants.default_conf_dir, "malware-detection-config.yml"
+)
+LAST_FILESYSTEM_SCAN_FILE = os.path.join(
+    constants.default_conf_dir, ".last_malware-detection_filesystem_scan"
+)
+LAST_PROCESSES_SCAN_FILE = os.path.join(
+    constants.default_conf_dir, ".last_malware-detection_processes_scan"
+)
+RULE_DOWNLOAD_DIR = constants.insights_core_lib_dir
+DEFAULT_MALWARE_CONFIG = """
+# Configuration file for the Red Hat Insights Malware Detection Client app
+# File format is YAML
+---
+# Perform a simple test scan of the insights-client config directory and process to verify installation and scanning
+# are working correctly.  The results from this scan do not show up in the webUI.
+# Once verified, disable this option to perform actual malware scans.
+test_scan: true
+
+# Scan the filesystem?
+# When it is false, the filesystem isn't scanned and the filesystem_* options that follow are ignored
+scan_filesystem: true
+
+# filesystem_scan_only: a single or list of files/directories to be scanned and no others, for example:
+# filesystem_scan_only:
+# - /var/www
+# - /home
+# ... means only scan files in /var/www and /home.  May also be written as filesystem_scan_only: [/var/www, /home]
+# No value means scan all files and directories
+filesystem_scan_only:
+
+# filesystem_scan_exclude: a single or list of files/directories to be excluded from filesystem scanning
+# If an item appears in both filesystem_scan_only and filesystem_scan_exclude, filesystem_scan_exclude takes precedence
+# and the item will be excluded
+# filesystem_scan_exclude is pre-populated with a list of top level directories that are recommended to be excluded
+filesystem_scan_exclude:
+- /proc
+- /sys
+- /cgroup
+- /selinux
+- /net
+- /mnt
+- /media
+
+# filesystem_scan_since: scan files created or modified since X days ago or since the 'last' scan.
+# Valid values are integers >= 1 or the string 'last'.  For example:
+# filesystem_scan_since: 1
+# ... means scan files created/modified since 1 day ago
+# filesystem_scan_since: last
+# ... means scan files created/modified since the last successful scan
+# No value means scan all files regardless of created/modified date
+filesystem_scan_since:
+
+# Exclude mounted network/external filesystems mountpoints?
+# Scanning files within mounted network filesystems may be slow and cause extra network traffic.
+# They are excluded by default, meaning that files in network/externally mounted filesystems are not scanned.
+# Their mountpoints will be added to the scan_exclude list of directories to be excluded from scanning
+exclude_network_filesystem_mountpoints: true
+
+# List of network/external filesystem types to search for mountpoints on the system.
+# If any mountpoints are found for these filesystem types, the value of the exclude_network_filesystem_mountpoints
+# option will determine if files within the mountpoints are scanned or not.
+network_filesystem_types: [nfs, nfs4, cifs, smbfs, fuse.sshfs, ceph, glusterfs, gfs, gfs2]
+
+# Scan the running processes?
+# Scan_process is disabled by default to prevent an impact on system performance when scanning numerous or large processes.
+# When it is false, no processes are scanned and the processes_scan_* options that follow are ignored
+scan_processes: false
+
+# processes_scan_only: processes to be scanned and no others, for example:
+# processes_scan_only:
+# - 123
+# - 1..100
+# - 10000..
+# - docker
+# - chrome
+#... means only scan PID 123, PIDs from 1 to 100 inclusive, PIDs >= 10000 and process names containing the strings docker or chrome
+# No value means scan all processes
+processes_scan_only:
+
+# processes_scan_exclude: processes to be excluded from scanning.  Uses the same syntax as processes_scan_only.
+# If an item appears in both processes_scan_only and processes_scan_exclude, processes_scan_exclude takes precedence
+# and the item will be excluded
+# No value means don't exclude any processes
+processes_scan_exclude:
+
+# processes_scan_since: scan processes created since X days ago or since the 'last' scan.
+# Valid values are integers >= 1 or the string 'last'.  For example:
+# processes_scan_since: 1
+# ... means scan processes created since 1 day ago
+# processes_scan_since: last
+# ... means scan processes created since the last successful scan
+# No value means scan all processes regardless of created date
+processes_scan_since:
+
+# Add extra metadata about each scan match (if possible), eg file type & md5sum, matching line numbers, process name
+# The extra metadata will display in the webUI along with the scan matches
+add_metadata: true
+
+# Abort a particular scan if it takes longer than scan_timeout seconds.  Default is 3600 seconds (1 hour)
+scan_timeout: # 3600
+
+# Run the yara process with this nice priority value.  Default is 19 (lowest priority)
+nice_value: # 19
+
+# The max number of CPUs threads used by yara when scanning.  Autodetected, but default is 2
+cpu_thread_limit: # 2
+rules_location: /etc/insights-client/signatures
+use_remote_rules: true
+""".lstrip()
+
+# All the config options have corresponding environment variables
+# Env vars are initially strings and need to be parsed to their appropriate type to match the yaml types
+ENV_VAR_TYPES = {
+    "boolean": [
+        "SCAN_FILESYSTEM",
+        "SCAN_PROCESSES",
+        "TEST_SCAN",
+        "ADD_METADATA",
+        "EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS",
+        "USE_REMOTE_RULES",
+    ],
+    "list": [
+        "FILESYSTEM_SCAN_ONLY",
+        "FILESYSTEM_SCAN_EXCLUDE",
+        "PROCESSES_SCAN_ONLY",
+        "PROCESSES_SCAN_EXCLUDE",
+        "NETWORK_FILESYSTEM_TYPES",
+    ],
+    "integer": ["SCAN_TIMEOUT", "NICE_VALUE", "CPU_THREAD_LIMIT", "STRING_MATCH_LIMIT"],
+    "int_or_str": ["FILESYSTEM_SCAN_SINCE", "PROCESSES_SCAN_SINCE"],
+}
+
+
+def parse_env_var(env_var, value):
+    """
+    Parse specific environment variables to make sure they have appropriate values
+    """
+    logger.debug("Found environment variable: %s, value: %s", env_var, value)
+    # Parse these env vars as booleans
+    if env_var in ENV_VAR_TYPES["boolean"]:
+        return value.lower() in ("true", "yes", "t", "y")
+
+    # Parse these as lists by splitting at the commas
+    if env_var in ENV_VAR_TYPES["list"]:
+        if value:
+            return value.split(",") if "," in value else [value]
+        else:
+            return []
+
+    # Parse *_scan_since, can be either an int or a string (ie 'last')
+    if env_var in ENV_VAR_TYPES["int_or_str"]:
+        return int(value) if value.isdigit() else value
+
+    # Parse these as ints
+    if env_var in ENV_VAR_TYPES["integer"]:
+        try:
+            return int(value)
+        except ValueError as e:
+            logger.error("Problem parsing environment variable %s: %s", env_var, str(e))
+            exit(constants.sig_kill_bad)
+
+    # env_var value doesn't require parsing, just return it as is (ie. as a string)
+    return value
+
+
+def load_or_create_malware_config():
+    # Load the malware-detection config file.  Write out a default one first if it doesn't already exist
+    if not os.path.isfile(MALWARE_CONFIG_FILE):
+        logger.info(
+            "Writing the malware-detection app default configuration to %s",
+            MALWARE_CONFIG_FILE,
+        )
+        write_data_to_file(DEFAULT_MALWARE_CONFIG, MALWARE_CONFIG_FILE)
+        os.chmod(MALWARE_CONFIG_FILE, 0o644)
+
+    try:
+        with open(MALWARE_CONFIG_FILE) as m:
+            return yaml.safe_load(m)
+    except Exception as e:
+        logger.error(
+            "Error encountered loading the malware-detection app config file %s:\n%s",
+            MALWARE_CONFIG_FILE,
+            str(e),
+        )
+        exit(constants.sig_kill_bad)
+
+
+def find_yara():
+    """
+    Find the yara binary in particular locations on the local system.  Don't use 'which yara'
+    and rely on the system path in case it finds a malicious yara.
+    Also, don't let the user specify where yara is, again in case it is a malicious version of yara
+    If found, check it's version >= MIN_YARA_VERSION
+    """
+
+    def yara_version_ok(yara):
+        # Check the installed yara version >= MIN_YARA_VERSION
+        yara_version = call([[yara, "--version"]]).strip()
+        try:
+            # Check the installed yara X.Y version > the minimal recommended yara version
+            if float(".".join(yara_version.split(".")[:2])) < float(
+                    MIN_YARA_VERSION[:3]
+            ):
+                raise RuntimeError(
+                    "Found %s with version %s, but malware-detection requires version >= %s\n"
+                    "Please install a later version of yara."
+                    % (yara, yara_version, MIN_YARA_VERSION)
+                )
+        except RuntimeError as e:
+            logger.error(str(e))
+            exit(constants.sig_kill_bad)
+        except Exception as e:
+            logger.error(
+                "Error getting the version of the specified yara binary %s: %s",
+                yara,
+                str(e),
+            )
+            exit(constants.sig_kill_bad)
+        # If we are here then the version of yara was ok
+        return yara_version
+
+    # Try to find yara in only these usual locations.
+    # /bin/yara and /usr/bin/yara will exist if yara is installed via rpm
+    # /usr/local/bin/yara will (likely) exist if the user has compiled and installed yara manually
+    for yara in ["/bin/yara", "/usr/bin/yara"]:
+        if os.path.exists(yara):
+            yara_version = yara_version_ok(yara)
+            if yara_version:
+                logger.debug("Using yara binary: %s", yara)
+                return yara, yara_version
+
+    return None, None

--- a/insights/specs/datasources/malware_detection/malware_detection_ds.py
+++ b/insights/specs/datasources/malware_detection/malware_detection_ds.py
@@ -10,15 +10,20 @@ collected. To collect other specs within the collection of malware-detection,
 add them to the "persist" section in the "malware_detection_manifest"
 pre-defined in the :py:mod:`insights.specs.datasources.manifests`
 """
+
 import json
 import logging
 
+from insights.client.constants import InsightsConstants as constants
 from insights.core.context import HostContext
 from insights.core.exceptions import SkipComponent
 from insights.core.plugins import datasource
 from insights.core.spec_factory import DatasourceProvider
 from insights.specs.datasources.malware_detection import MalwareDetectionClient
-
+from insights.specs.datasources.malware_detection.config import (
+    find_yara,
+    load_or_create_malware_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,18 +37,59 @@ def malware_detection(broker):
     """
     try:
         # Only run malware-detection if it was passed as an option to insights-client
-        insights_config = broker.get('client_config')
-        if not (insights_config and hasattr(insights_config, 'app') and insights_config.app == 'malware-detection'):
-            raise SkipComponent("Only run malware-detection app when specifically requested via --collector option")
+        insights_config = broker.get("client_config")
+        if not (
+            insights_config
+            and hasattr(insights_config, "app")
+            and insights_config.app == "malware-detection"
+        ):
+            raise SkipComponent(
+                "Only run malware-detection app when specifically requested via --collector option"
+            )
+
+        # Load or create malware-detection config
+        malware_detection_config = load_or_create_malware_config()
+
+        # Find the yara binary location and version or exit
+        yara_binary_location, yara_version = find_yara()
+        if not yara_binary_location:
+            logger.error("Couldn't find yara. Please ensure the yara package is installed")
+            exit(constants.sig_kill_bad)
 
         # Manifest of malware-detection is wrapped in the 'insights_config'
         # and was set in the `insights.client.config.InsightsConfig._imply_options`
-        mdc = MalwareDetectionClient(insights_config)
+        mdc = MalwareDetectionClient(
+            insights_config,
+            malware_detection_config,
+            yara_binary_location,
+            yara_version,
+        )
+
+        # Sets up the scan options for a malware detection client run
+        mdc.parse_scan_options()
+
+        # Loads the compiled and uncompiled yara rules from local and remote locations
+        # and inserts them to client attribute rules_files
+        mdc.load_rules()
+
+        # Loads rules that are disabled into malware client attribute disabled rules
+        # These rules will be excluded from the run
+        mdc.load_disabled_rules()
+
+        # Builds the yara commands that client will run against system and return results for
+        mdc.build_yara_commands()
+
         scan_results = mdc.run()
         if scan_results:
             return [
-                DatasourceProvider(content=scan_results[0], relative_path="malware-detection-results.json"),
-                DatasourceProvider(content=json.dumps(scan_results[1]), relative_path="malware-detection-results-raw.json")
+                DatasourceProvider(
+                    content=scan_results[0],
+                    relative_path="malware-detection-results.json",
+                ),
+                DatasourceProvider(
+                    content=json.dumps(scan_results[1]),
+                    relative_path="malware-detection-results-raw.json",
+                ),
             ]
         else:
             raise SkipComponent("No scan results were produced")
@@ -51,6 +97,7 @@ def malware_detection(broker):
         raise SkipComponent("Skipping malware-detection app: {0}".format(str(msg)))
     except Exception as err:
         from traceback import format_exc
+
         err_msg = "Unexpected exception in malware-detection app: {0}".format(str(err))
         logger.error(err_msg)
         logger.debug(format_exc())

--- a/insights/specs/datasources/malware_detection/rules.py
+++ b/insights/specs/datasources/malware_detection/rules.py
@@ -1,0 +1,255 @@
+import os
+import logging
+from glob import glob
+from tempfile import gettempdir
+from insights.client.constants import InsightsConstants as constants
+import re
+import time
+
+try:
+    # python 2
+    from urlparse import urlparse, urlunparse
+except ImportError:
+    # python 3
+    from urllib.parse import urlparse, urlunparse
+
+logger = logging.getLogger(__name__)
+
+
+RULE_DOWNLOAD_DIR = constants.insights_core_lib_dir
+
+
+def remove_old_rules_files():
+    """
+    The rules file that is downloaded from the backend should be automatically removed when the
+    malware-detection client exits.
+    However, it can happen that the rules file isn't removed for some reason, so remove any existing
+    rules files before beginning a new scan, otherwise they may show up as matches in the scan results.
+    """
+    old_rules_files = sum(
+        [
+            glob(os.path.join(path, rules))
+            for path in (
+                RULE_DOWNLOAD_DIR,
+                "/tmp",
+                "/var/tmp",
+                "/usr/tmp",
+                gettempdir(),
+            )
+            for rules in (
+                "malware-detection_yara_rules.*",
+                ".tmpmdsigs*",
+                "tmp_malware-detection-client_rules.*",
+            )
+        ],
+        [],
+    )
+    for old_rules_file in old_rules_files:
+        if os.path.exists(old_rules_file):
+            logger.debug("Removing old rules file %s", old_rules_file)
+            os.remove(old_rules_file)
+
+
+def find_rules_in_directory(rules_dir):
+    """
+    Find all rule files within the specified directory.
+    If directory path is provided by `self.rules_dir_location`,
+    it is assumed client wants to include local rules kept on a disk for the scan.
+    """
+    # Look for files that match the pattern for YARA rules files (.yar and .yc)
+    # Define the patterns you want to match
+    patterns = ["*.yar", "*.yc", "*.yara"]
+
+    # Use list comprehension to concatenate the results of all glob calls
+    rule_files = sum(
+        [glob(os.path.join(rules_dir, pattern)) for pattern in patterns], []
+    )
+
+    if not rule_files:
+        logger.warning("No rule files found in directory: %s", rules_dir)
+    else:
+        logger.debug("Found rule files: %s", rule_files)
+
+    return rule_files
+
+
+def is_local_file(location):
+    """
+    If rules_location starts with a /, assume its a file rather than a URL
+    """
+    return location.startswith("/")
+
+
+def use_local_rules(rules_location):
+    """
+    Remove any extra slashes from the file name and from the start too (normpath doesn't remove those)
+    """
+    rules_file = os.path.normpath(rules_location).replace("//", "/")
+    if os.path.isdir(rules_file):
+        logger.debug("Using rules directory: %s", rules_file)
+        # It is a directory with rules
+        return find_rules_in_directory(rules_file)
+    else:
+        if not os.path.isfile(rules_file):
+            logger.error("Couldn't find specified rules file: %s", rules_file)
+            exit(constants.sig_kill_bad)
+        logger.debug("Using specified rules file: %s", rules_file)
+        # It is single rules file
+        return [rules_file]
+
+
+def set_remote_rules_location(
+    insights_config, remote_rules_location="", yara_version=""
+):
+    """
+    If we are here, then we are downloading the rules from the malware backend
+    """
+    signatures_file = "signatures.yar"
+    signatures_file += "?yara_version=" + yara_version
+
+    if not remote_rules_location:
+        remote_rules_location = (
+            "https://console.redhat.com/api/malware-detection/v1/" + signatures_file
+        )
+        if "/redhat_access/" in insights_config.base_url:
+            # Satellite URLs have '/redhat_access/' in the base_url config option
+            remote_rules_location = (
+                insights_config.base_url + "/malware-detection/v1/" + signatures_file
+            )
+        elif any(
+            [
+                url in insights_config.base_url
+                for url in ["console.stage.", "cloud.stage."]
+            ]
+        ):
+            # For downloading rules in the stage environment, use the URL of base_url (after finding it)
+            base_url = urlparse(insights_config.base_url)
+            remote_rules_location = (
+                base_url.netloc
+                or base_url.scheme
+                or base_url.path.split("/")[0]
+                or "cert.console.stage.redhat.com"
+            )
+            remote_rules_location += "/api/malware-detection/v1/" + signatures_file
+    return remote_rules_location
+
+
+def validate_rules_location(insights_config, remote_rules_location):
+    """
+    Make sure the rules_location starts with https://
+    """
+    if not re.match("^https?://", remote_rules_location):
+        remote_rules_location = "https://" + remote_rules_location
+
+    # If talking direct to C.R.C with cert auth or basic auth without a username/password, append 'cert.' to the url
+    if remote_rules_location.startswith("https://console.redhat.com"):
+        authmethod = (
+            insights_config.authmethod
+            if hasattr(insights_config, "authmethod")
+            else "CERT"
+        )
+        username = (
+            insights_config.username if hasattr(insights_config, "username") else ""
+        )
+        password = (
+            insights_config.password if hasattr(insights_config, "password") else ""
+        )
+        if authmethod == "CERT" or (
+            authmethod == "BASIC" and not (username or password)
+        ):
+            parsed_url = urlparse(remote_rules_location)
+            if not parsed_url.netloc.startswith("cert."):
+                remote_rules_location = urlunparse(
+                    parsed_url._replace(netloc="cert." + parsed_url.netloc)
+                )
+        return remote_rules_location, authmethod
+    return remote_rules_location, ""
+
+
+def set_url_path(url, path="graphql"):
+    """
+    Change the last item in the 'url' to 'path'
+    For example if url=http://localhost:3000/api/malware/signatures.yar and path=test-rule.yar
+    The returned url would be http://localhost:3000/api/malware/test-rule.yar
+    """
+    if url.endswith(path):
+        return url
+    # Unconventional perhaps, but this seems to work ok with both URL and file paths
+    return os.path.join(os.path.dirname(url), path)
+
+
+def handle_test_scan(test_scan, remote_rules_location):
+    if test_scan:
+        remote_rules_location = set_url_path(remote_rules_location, "test-rule.yar")
+    return test_scan, remote_rules_location
+
+
+def get_ca_certificate():
+    """
+    Shouldn't need this, but left here for insurance: https://access.redhat.com/solutions/6997170
+    If a custom CA cert is being used, eg on a Satellite, then SSL errors may occur when downloading the rules
+    The CA cert needs to be added to a CA bundle (with update-ca-trust) and the bundle used for cert verification
+    """
+    ca_bundles = [
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+        "/etc/pki/tls/certs/ca-bundle.crt",
+    ]
+    for ca_bundle in ca_bundles:
+        if os.path.isfile(ca_bundle):
+            return ca_bundle
+    return None
+
+
+def get_cert_verify_value(insights_config):
+    cert_verify = insights_config.cert_verify
+    if cert_verify is None or cert_verify == "":
+        cert_verify = True
+    elif cert_verify.lower() in ("true", "false"):
+        cert_verify = cert_verify.lower() == "true"
+    return cert_verify
+
+
+def download_rules(
+    conn,
+    insights_config,
+    log_rule_contents,
+    remote_rules_location,
+    cert_verify,
+    custom_cert,
+):
+
+    for attempt in range(1, insights_config.retries + 1):
+        try:
+            response = conn.get(
+                remote_rules_location,
+                log_response_text=log_rule_contents,
+                verify=cert_verify,
+                stream=True,
+            )
+            if response.status_code != 200:
+                raise Exception(
+                    "%s %s: %s" % (response.status_code, response.reason, response.text)
+                )
+            break
+        except Exception as e:
+            if attempt < insights_config.retries:
+                logger.debug(
+                    "Unable to download rules from %s: %s",
+                    remote_rules_location,
+                    str(e),
+                )
+                logger.debug("Trying again in %d seconds ...", attempt)
+                time.sleep(attempt)
+            else:
+                logger.error(
+                    "Unable to download rules from %s: %s",
+                    remote_rules_location,
+                    str(e),
+                )
+                exit(constants.sig_kill_bad)
+
+            if re.search("SSL.*verify.failed", str(e), re.IGNORECASE):
+                # Kept as a fallback in case SSL errors still occur - add the custom CA cert to the trusted certs
+                cert_verify = custom_cert
+                logger.debug("Trying cert_verify value %s ...", custom_cert)
+    return response

--- a/insights/specs/datasources/malware_detection/utils.py
+++ b/insights/specs/datasources/malware_detection/utils.py
@@ -1,0 +1,443 @@
+import os
+import logging
+import time
+from datetime import datetime
+
+from insights.client.constants import InsightsConstants as constants
+from insights.specs.datasources.malware_detection.config import (
+    LAST_FILESYSTEM_SCAN_FILE,
+    LAST_PROCESSES_SCAN_FILE,
+)
+
+logger = logging.getLogger(__name__)
+
+
+#
+# Utility functions
+# Mainly for including / excluding certain directories for scanning
+# And also for finding files that have been modified recently
+#
+def get_toplevel_dirs():
+    """
+    Returns a list of the top level directories directly under root (/),
+    """
+    toplevel_dirs = sorted(
+        filter(lambda x: not os.path.islink(x), map(lambda x: "/" + x, os.listdir("/")))
+    )
+    return toplevel_dirs
+
+
+def is_same_file_or_root(file1, file2):
+    # Catch possible permission denied error with fuse mounted filesystems. Yes, even for root!
+    try:
+        if os.path.samefile(file1, file2) or os.path.samefile(file1, "/"):
+            return True
+    except Exception as err:
+        logger.debug(
+            "Encountered exception running os.path.samefile('%s', '%s'): %s.  Trying string comparison ...",
+            file1,
+            file2,
+            str(err),
+        )
+        if file1 == file2 or file1 == "/":
+            return True
+    return False
+
+
+def get_parent_dirs(item, parent_dir_list, base_case="/"):
+    """
+    Get a list of parent directories of a particular filesystem item, stopping at base_case (root by default)
+    Eg for get_parent_dirs('/path/to/some/item', parent_dir_list) ->
+        parent_dir_list = ['/path', '/path/to', '/path/to/some', '/path/to/some/item']
+    """
+    if is_same_file_or_root(item, base_case):
+        return
+    get_parent_dirs(os.path.dirname(item), parent_dir_list, base_case)
+    parent_dir_list.append(item)
+
+
+def process_include_items(include_items=[]):
+    """
+    Process the include items to a get list of directories to be scanned
+    If there are no entries then get the list of top level directories under root (/),
+    :return: a list of directories to be scanned.  It never returns an empty list.
+    """
+    default_values = get_toplevel_dirs()
+
+    logger.debug("Parsing include items ...")
+    parsed_list = []
+    for item in include_items:
+        item = item.strip()
+        if not item or item.startswith("#"):
+            continue
+        include_item = os.path.normpath(item).replace("//", "/")
+        if os.path.exists(include_item):
+            # ignore the include_item if its not a full directory path
+            if not include_item.startswith("/"):
+                logger.debug("Skipping partial directory path '%s' ...", include_item)
+                continue
+            elif os.path.islink(include_item):
+                logger.debug("Skipping link '%s' ...", include_item)
+                continue
+            elif include_item == "/":
+                # Found / in include item list.  No need to get the other items because / trumps all
+                logger.debug(
+                    "Found root directory in list of items to scan.  Ignoring the other items ..."
+                )
+                parsed_list = default_values
+                break
+            else:
+                parsed_list.append(include_item)
+        else:
+            logger.debug("Skipping missing item '%s' ...", include_item)
+
+    if not parsed_list:
+        logger.debug(
+            "No items specified to be scanned.  Using default values %s ...",
+            default_values,
+        )
+        parsed_list = default_values
+    else:
+        # Remove any duplicates and any children of parent directories before returning
+        parsed_list = remove_child_items(sorted(list(set(parsed_list))))
+
+    logger.debug("Include items: %s", parsed_list)
+    return parsed_list
+
+
+def process_exclude_items(exclude_items=[]):
+    """
+    Process the exclude items to get list of directories to NOT be scanned
+    :return: a list of directories to not be scanned if any, otherwise an empty list
+    """
+    logger.debug("Parsing exclude items ...")
+    parsed_list = []
+    for item in exclude_items:
+        item = item.strip()
+        if not item or item.startswith("#"):
+            continue
+        exclude_item = os.path.normpath(item).replace("//", "/")
+        if os.path.exists(exclude_item):
+            # ignore the exclude_item if its not a full directory path
+            if exclude_item == "/":
+                # Found / in exclude list.  No need to get the other items because / trumps all
+                logger.debug(
+                    "Found root directory in the exclude list.  Expanding it to all toplevel directories ..."
+                )
+                parsed_list = get_toplevel_dirs()
+                break
+            elif not exclude_item.startswith("/"):
+                logger.debug("Skipping partial directory path '%s' ...", exclude_item)
+                continue
+            else:
+                parsed_list.append(exclude_item)
+        else:
+            logger.debug("Skipping missing item '%s' ...", exclude_item)
+
+    if not parsed_list:
+        logger.debug("No items specified to be excluded")
+    else:
+        # Remove any duplicates and any children of parent directories before returning
+        parsed_list = remove_child_items(sorted(list(set(parsed_list))))
+
+    logger.debug("Exclude items: %s", parsed_list)
+    return parsed_list
+
+
+def remove_child_items(item_list):
+    """
+    For a list of filesystem items, remove those items that are duplicates or children of other items
+    Eg, for remove_child_items['/path/to/some/item/child', '/path/to/another/item', '/path/to/some/item']
+        returns ['/path/to/another/item', '/path/to/some/item']
+    If one if the items is root, then it wins
+    Also, all items should be the full path starting at root (/).  Any that aren't are removed
+    """
+    if "/" in item_list:
+        return ["/"]
+
+    # Remove duplicates and any non-full path items
+    item_list = sorted(list(set(filter(lambda x: x.startswith("/"), item_list))))
+    remove_items = set([])
+    for i, item1 in enumerate(item_list[:-1]):
+        for item2 in item_list[i + 1 :]:
+            if item1 != item2 and item2.startswith(item1 + "/"):
+                remove_items.add(item2)
+    for remove_item in remove_items:
+        item_list.remove(remove_item)
+    return sorted(list(set(item_list)))
+
+
+def remove_included_excluded_items(included_items, excluded_items):
+    """
+    Go through the list of included items and remove any that are in the exclude list,
+        or are children of excluded items (no need to scan an included item if its parent is to be excluded)
+    """
+    # Clean up the lists, just in case this hasn't been done already
+    included_items = remove_child_items(included_items)
+    excluded_items = remove_child_items(excluded_items)
+
+    remove_items = set([])
+    for included_item in included_items:
+        for excluded_item in excluded_items:
+            if excluded_item == included_item or included_item.startswith(
+                excluded_item + "/"
+            ):
+                remove_items.add(included_item)
+    for remove_item in remove_items:
+        included_items.remove(remove_item)
+    return included_items
+
+
+def process_include_exclude_items(
+    include_items=[], exclude_items=[], exclude_mountpoints=[]
+):
+    """
+    Process the include and exclude items, where the exclude items are effectively subtracted from the include_items.
+    It builds a scan_dict dictionary of items to scan keyed by the filesystem top level directories.
+    Only the toplevel directories from items in the include_items list will be present in scan_dict.
+    scan_dict = {'/boot': {'include': ['/boot/include/me', ...], 'exclude: ['/boot/exclude/me', ...]},
+                 '/etc': {'include': ['/etc/include/me', ...], 'exclude: ['/etc/exclude/me', ...]},
+                 ...
+    :return: scan_dict
+    """
+    # Get a list of excluded items from the exclude file and network filesystem mountpoints
+    initial_exclude_list = process_exclude_items(exclude_items)
+    final_exclude_list = remove_child_items(
+        list(set(exclude_mountpoints) | set(initial_exclude_list))
+    )
+    logger.debug("Final exclude items: %s", final_exclude_list)
+
+    # Get a list of included items from the include file, minus the excluded items
+    initial_include_list = process_include_items(include_items)
+    if not initial_include_list:
+        logger.error(
+            "No filesystem items to scan because the include items doesn't contain any valid items"
+        )
+        return {}
+    final_include_list = remove_included_excluded_items(
+        initial_include_list, final_exclude_list
+    )
+    logger.debug(
+        "Final include items after removing exclude items: %s", final_include_list
+    )
+    if not final_include_list:
+        logger.error(
+            "No filesystem items to scan because the specified exclude items cancel them out"
+        )
+        return {}
+
+    # This is the dictionary that will hold all the items to scan (after processing the include and exclude items)
+    # It will be keyed by each of the toplevel directories containing items to scan
+    # yara will scan each of the toplevel dir's 'include' keys (if present), or just the toplevel dir itself
+    scan_dict = {}
+
+    # Populate the scan_dict by creating keys for each toplevel directory of the items to include/scan
+    # Create an 'include' key for each toplevel directory containing items to include in that toplevel directory
+    logger.debug("Populating scan_dict's include items ...")
+    for include_item in final_include_list:
+        item_subpaths = []
+        get_parent_dirs(include_item, item_subpaths)
+        include_item_toplevel_dir = item_subpaths[0]
+        if include_item_toplevel_dir not in scan_dict:
+            # Create an 'include' key if the item to scan isn't just the toplevel directory itself
+            scan_dict[include_item_toplevel_dir] = (
+                {"include": set([include_item])}
+                if include_item != include_item_toplevel_dir
+                else {}
+            )
+        else:
+            scan_dict[include_item_toplevel_dir]["include"].add(include_item)
+
+    logger.debug("Scan dict after adding include items: %s", scan_dict)
+
+    # Populate an 'exclude' key for the toplevel dirs in the scan_dict that also have items to exclude
+    # Or remove the toplevel dirs from the scan dict where the toplevel dir itself is to be excluded
+    logger.debug("Populating scan_dict's exclude items ...")
+    for exclude_item in final_exclude_list:
+        item_subpaths = []
+        get_parent_dirs(exclude_item, item_subpaths)
+        exclude_item_toplevel_dir = item_subpaths[0]
+        if exclude_item_toplevel_dir not in scan_dict:
+            # This exclude_item's toplevel dir isn't in the scan dict, so skip it (since its not being included)
+            continue
+        if "exclude" not in scan_dict[exclude_item_toplevel_dir]:
+            # Create the 'exclude' key if it doesn't already exist
+            scan_dict[exclude_item_toplevel_dir]["exclude"] = {
+                "items": [],
+                "subpaths": set([]),
+            }
+
+        scan_dict[exclude_item_toplevel_dir]["exclude"]["items"].append(exclude_item)
+
+        # Add the list of subpaths leading to this exclude item.
+        # The subpaths are needed later for listing the contents each subpath
+        scan_dict[exclude_item_toplevel_dir]["exclude"]["subpaths"].update(
+            item_subpaths
+        )
+
+    logger.debug("Scan dict after adding exclude items: %s", scan_dict)
+
+    # For each toplevel dir with items to exclude, re-populate the include key with directory content listings
+    # of the subpaths, minus the items to exclude and only including items to include.  Yep, its complicated.
+    # These directory listings will be used with yara's --scan-list option
+    logger.debug(
+        "Re-populating scan_dict's include items with directory content listings to pass to yara ..."
+    )
+    for toplevel_dir in scan_dict:
+        if "exclude" not in scan_dict[toplevel_dir]:
+            continue
+
+        # Get directory listings of each of the subpaths
+        if "include" in scan_dict[toplevel_dir]:
+            scan_items = set(scan_dict[toplevel_dir]["include"])
+        else:
+            scan_items = set([])
+        toplevel_dir_exclude = scan_dict[toplevel_dir]["exclude"]
+        for exclude_item in toplevel_dir_exclude["items"]:
+            subpaths = []
+            get_parent_dirs(exclude_item, subpaths)
+            for i, subpath in enumerate(subpaths[:-1]):
+                dir_list = os.listdir(subpath)
+                dir_list = sorted(map(lambda x: subpath + "/" + x, dir_list))
+                dir_list.remove(subpaths[i + 1])
+                scan_items.update(dir_list)
+
+        # Go through the list of scan items and remove any exclude items or exclude item subpaths
+        for scan_item in list(scan_items):
+            for exclude_item in toplevel_dir_exclude["items"]:
+                if scan_item == exclude_item or scan_item.startswith(
+                    exclude_item + "/"
+                ):
+                    scan_items.remove(scan_item)
+                    break
+            else:
+                for exclude_subpath in toplevel_dir_exclude["subpaths"]:
+                    if scan_item == exclude_subpath:
+                        scan_items.remove(scan_item)
+
+        # If there is an include list, make sure the scan_items only include items in the include list
+        if "include" in scan_dict[toplevel_dir]:
+            for maybe_include in list(scan_items):
+                if os.path.islink(maybe_include) or (
+                    not os.path.isfile(maybe_include)
+                    and not os.path.isdir(maybe_include)
+                ):
+                    scan_items.remove(maybe_include)
+                    continue
+                if any(
+                    [
+                        maybe_include == definitely_include
+                        or maybe_include.startswith(definitely_include + "/")
+                        for definitely_include in scan_dict[toplevel_dir]["include"]
+                    ]
+                ):
+                    continue
+                else:
+                    scan_items.remove(maybe_include)
+
+        # Overwrite the existing include key list with the new list of scan_items
+        scan_dict[toplevel_dir]["include"] = sorted(list(scan_items))
+
+    logger.debug("Final scan_dict: %s", scan_dict)
+    return scan_dict
+
+
+def get_scan_since_timestamp(scan_since_option, since):
+    """
+    Return a unix timestamp corresponding to how long ago to scan for files or processes (depending on scan_since_option)
+    Valid values of 'since' are integers > 0 meaning the number of days back in time from now,
+                             or 'last' meaning get the timestamp of the last scan
+    If 'since' is not one of these valid values, then terminate
+    """
+    now = time.time()
+    timestamp_file = (
+        LAST_FILESYSTEM_SCAN_FILE
+        if scan_since_option == "filesystem_scan_since"
+        else LAST_PROCESSES_SCAN_FILE
+    )
+
+    def get_lastscan_timestamp(scan_since_option, lastscan):
+        try:
+            # Convert the datetime string into a unix timestamp
+            lastscan_seconds = float(
+                datetime.strptime(lastscan, "%Y-%m-%dT%H:%M:%S.%f").strftime("%s")
+            )
+            if lastscan_seconds > now:
+                raise RuntimeError("Last scan time is in the future.")
+        except Exception as err:
+            logger.error(
+                "Error getting time of last malware scan: %s.  Ignoring '%s: last' option ...",
+                str(err),
+                scan_since_option,
+            )
+            return None
+        return lastscan_seconds
+
+    if isinstance(since, str) and since.lower().startswith("l"):
+        # Get the timestamp of the last scan
+        if os.path.isfile(timestamp_file):
+            with open(timestamp_file) as f:
+                lastscan = f.readline().strip()
+            return get_lastscan_timestamp(scan_since_option, lastscan)
+        else:
+            logger.info(
+                "File %s doesn't exist for '%s: last' option.  Continuing ...",
+                timestamp_file,
+                scan_since_option,
+            )
+            return None
+    elif isinstance(since, str):
+        logger.error(
+            "Unknown value '%s' for %s option.  Valid values are integers >= 1 and 'last'",
+            since,
+            scan_since_option,
+        )
+        exit(constants.sig_kill_bad)
+
+    try:
+        since_int = int(since)
+        if since_int >= 1:
+            return now - (since_int * 86400)  # 86400 seconds in a day
+        else:
+            raise ValueError(
+                "Invalid %s value %s.  Valid values are integers >= 1 and 'last'"
+                % (scan_since_option, since)
+            )
+    except ValueError as e:
+        logger.error(str(e))
+        exit(constants.sig_kill_bad)
+
+
+def is_recent_mtime(item, timestamp):
+    """
+    Return True if the given 'item' has a modification time that is newer than 'timestamp'
+    Return False otherwise, or if the the 'item' is a link or another non-file type (eg pipes)
+    """
+    if os.path.exists(item) and not os.path.islink(item) and os.path.isfile(item):
+        return os.path.getmtime(item) > timestamp
+    return False
+
+
+def find_modified_in_directory(directory, timestamp, output_file):
+    """
+    Find files in 'directory' that have been created/modified since 'timestamp'
+    and write their names to 'output_file'
+    """
+    for root, dirs, files in os.walk(directory):
+        for afile in files:
+            path = os.path.join(root, afile)
+            if is_recent_mtime(path, timestamp):
+                output_file.write(path + "\n")
+
+
+def find_modified_include_items(item_list, timestamp, output_file):
+    """
+    Find files in the given list of items (files/directories) that have been created/modified since 'timestamp'
+    and write their names to 'output_file'
+    """
+    for item in item_list:
+        if os.path.isdir(item):
+            find_modified_in_directory(item, timestamp, output_file)
+        else:
+            if is_recent_mtime(item, timestamp):
+                output_file.write(item + "\n")

--- a/insights/tests/datasources/malware_detection/test_malware_detection.py
+++ b/insights/tests/datasources/malware_detection/test_malware_detection.py
@@ -19,76 +19,127 @@ except ImportError:
     from urllib.parse import quote as urlencode  # python 3
 
 from insights.client.config import InsightsConfig
-from insights.client.constants import InsightsConstants as constants
+from insights.client.utilities import write_data_to_file
 from insights.core.exceptions import CalledProcessError
 from insights.specs.manifests import manifests, content_types
 from insights.tests.helpers import getenv_bool
 from insights.util.subproc import call
 
 from insights.specs.datasources.malware_detection import (
-    DEFAULT_MALWARE_CONFIG,
     MalwareDetectionClient,
     InsightsConnection,
-    get_toplevel_dirs,
-    get_parent_dirs,
-    remove_child_items,
-    remove_included_excluded_items,
-    process_include_items,
-    process_exclude_items,
-    process_include_exclude_items,
     logger,
-    MIN_YARA_VERSION,
+)
+from insights.specs.datasources.malware_detection.config import (
+    DEFAULT_MALWARE_CONFIG,
+    load_or_create_malware_config,
+    find_yara,
+)
+from insights.specs.datasources.malware_detection.utils import (
+    process_include_exclude_items,
+    process_exclude_items,
+    process_include_items,
+    remove_child_items,
+    get_parent_dirs,
+    remove_included_excluded_items,
+    get_toplevel_dirs,
 )
 
 # Temporary directory for testing stuff in
-RANDOM_STRING = ''.join(random.choice(string.ascii_lowercase) for _ in range(5))
+RANDOM_STRING = "".join(random.choice(string.ascii_lowercase) for _ in range(5))
 TEMP_TEST_DIR = "/tmp/malware-detection_test_dir_%s" % RANDOM_STRING
 
-FAKE_YARA = '/bin/yara'  # Need to fake yara for a number of tests
-RULES_FILE = os.path.join(TEMP_TEST_DIR, 'malware-detection_yara_rules.yar')
-TEST_RULE_FILE = os.path.join(TEMP_TEST_DIR, 'test-rule.yar')
-TEST_RULE_SCRIPT = os.path.join(TEMP_TEST_DIR, 'test-rule_process_match.sh')
-MATCHING_ENTITY_FILE = os.path.join(TEMP_TEST_DIR, 'matching_entity')
-ANOTHER_MATCHING_ENTITY_FILE = os.path.join(TEMP_TEST_DIR, 'another matching_entity')
+FAKE_YARA = "/bin/yara"  # Need to fake yara for a number of tests
+FAKE_YARA_VERSION = "4.5.2"
+
+RULES_FILE = os.path.join(TEMP_TEST_DIR, "malware-detection_yara_rules.yar")
+TEST_RULE_FILE = os.path.join(TEMP_TEST_DIR, "test-rule.yar")
+TEST_REMOTE_RULE_LOCATION = (
+    "https://console.redhat.com/api/malware-detection/v1/test-rule.yar"
+)
+
+TEST_RULE_SCRIPT = os.path.join(TEMP_TEST_DIR, "test-rule_process_match.sh")
+MATCHING_ENTITY_FILE = os.path.join(TEMP_TEST_DIR, "matching_entity")
+ANOTHER_MATCHING_ENTITY_FILE = os.path.join(TEMP_TEST_DIR, "another matching_entity")
 CONFIG = yaml.safe_load(DEFAULT_MALWARE_CONFIG)  # Config 'returned' from _load_config
-TEMP_CONFIG_FILE = os.path.join(TEMP_TEST_DIR, 'malware-detection-config.yml')
+MALWARE_CONFIG = yaml.safe_load(
+    DEFAULT_MALWARE_CONFIG
+)  # Config 'returned' from load_or_create_malware_config
+
+TEST_RULE_LOCATION = "/tmp/signatures"
+# Important: containers can't write to /etc/insights-client/signatures so substitute it
+if not os.path.isdir(TEST_RULE_LOCATION):
+    os.mkdir(TEST_RULE_LOCATION)
+MALWARE_CONFIG["rules_location"] = TEST_RULE_LOCATION
+CONFIG["rules_location"] = TEST_RULE_LOCATION
+
+TEMP_CONFIG_FILE = os.path.join(TEMP_TEST_DIR, "malware-detection-config.yml")
 TEST_PID = str(os.getpid())  # This running processes ID
 
+REMOTE_RULES_FILE = os.path.join(TEMP_TEST_DIR, "test-rule.yar")
+THIRD_PARTY_RULES_FILE = os.path.join(TEMP_TEST_DIR, "third-party.yar")
+
 # Get the number of CPU threads to run yara
-CPUS = 1 if int(call('nproc').strip()) <= 2 else 2
+CPUS = 1 if int(call("nproc").strip()) <= 2 else 2
 
 # Some of the toplevel directories that will be included/excluded by default when listing root (/)
-TLDS = ['/boot', '/dev', '/etc', '/home', '/opt', '/proc', '/root', '/sys', '/tmp', '/usr', '/var']
+TLDS = [
+    "/boot",
+    "/dev",
+    "/etc",
+    "/home",
+    "/opt",
+    "/proc",
+    "/root",
+    "/sys",
+    "/tmp",
+    "/usr",
+    "/var",
+]
 INCLUDED_TLDS = [
-    '/boot',
-    '/dev',
-    '/etc',
-    '/home',
-    '/opt',
-    '/root',
-    '/tmp',
-    '/usr',
-    '/var',
+    "/boot",
+    "/dev",
+    "/etc",
+    "/home",
+    "/opt",
+    "/root",
+    "/tmp",
+    "/usr",
+    "/var",
 ]  # after removing exclude items
-DEFAULT_SCAN_EXCLUDE = ['/cgroup', '/media', '/mnt', '/net', '/proc', '/selinux', '/sys']
+DEFAULT_SCAN_EXCLUDE = [
+    "/cgroup",
+    "/media",
+    "/mnt",
+    "/net",
+    "/proc",
+    "/selinux",
+    "/sys",
+]
 
 # Various patch targets
 LOGGER_TARGET = "insights.specs.datasources.malware_detection.logger"
+CONFIG_LOGGER_TARGET = "insights.specs.datasources.malware_detection.config.logger"
+UTILS_LOGGER_TARGET = "insights.specs.datasources.malware_detection.utils.logger"
+RULES_LOGGER_TARGET = "insights.specs.datasources.malware_detection.rules.logger"
+
 LOAD_CONFIG_TARGET = (
-    "insights.specs.datasources.malware_detection.MalwareDetectionClient._load_config"
+    "insights.specs.datasources.malware_detection.config.load_or_create_malware_config"
 )
-FIND_YARA_TARGET = "insights.specs.datasources.malware_detection.MalwareDetectionClient._find_yara"
-GET_RULES_TARGET = "insights.specs.datasources.malware_detection.MalwareDetectionClient._get_rules"
-DISABLED_RULES_TARGET = (
-    "insights.specs.datasources.malware_detection.MalwareDetectionClient._get_disabled_rules"
-)
-BUILD_YARA_COMMAND_TARGET = (
-    "insights.specs.datasources.malware_detection.MalwareDetectionClient._build_yara_command"
-)
+
 FINDMNT_TARGET = "insights.specs.datasources.malware_detection.MalwareDetectionClient._parse_exclude_network_filesystem_mountpoints_option"
+
 CALL_TARGET = "insights.specs.datasources.malware_detection.call"
-CONFIG_FILE_TARGET = "insights.specs.datasources.malware_detection.MALWARE_CONFIG_FILE"
-NAMEDTMPFILE_TARGET = "insights.specs.datasources.malware_detection.NamedTemporaryFile"
+CONFIG_CALL_TARGET = "insights.specs.datasources.malware_detection.config.call"
+
+CONFIG_FILE_TARGET = (
+    "insights.specs.datasources.malware_detection.config.MALWARE_CONFIG_FILE"
+)
+
+NAMEDTMPFILE_TARGET = (
+    "insights.specs.datasources.malware_detection.rules.NamedTemporaryFile"
+)
+
 
 # Run these slowish tests?
 TEST_PROCESSES_SCAN_SINCE = getenv_bool("TEST_PROCESSES_SCAN_SINCE", False)
@@ -98,16 +149,75 @@ TEST_ALL = getenv_bool("TEST_ALL", False)
 
 # Are we running on RHEL6? (well actually, with python 2.6)
 IS_RHEL6 = sys.version_info < (2, 7)
-SKIP_IF_RHEL6_REASON = "The malware-detection client isn't supported on RHEL6 / python 2.6"
+SKIP_IF_RHEL6_REASON = (
+    "The malware-detection client isn't supported on RHEL6 / python 2.6"
+)
 # Is the best way to determine if we are running in a container?
 IS_CONTAINER = (
     os.path.exists("/.dockerenv")
     or os.path.exists("/run/.containerenv")
-    or '1' not in call('pidof init systemd').strip().split()
+    or "1" not in call("pidof init systemd").strip().split()
 )
+
 SKIP_IF_CONTAINER_REASON = (
     "This test uses running process that may not exist when run in a container"
 )
+
+
+class InsightsClientConfig:
+    def __init__(self):
+        self.loglevel = "INFO"
+        self.auto_config = "True"
+        self.authmethod = "BASIC"
+        self.username = "your_username"
+        self.password = "your_password"
+        self.base_url = "https://cert-api.access.redhat.com:443/r/insights"
+        self.cert_verify = "/etc/insights-client/cert-api.access.redhat.com.pem"
+        self.proxy = "http://proxy.example.com:8080"
+        self.cmd_timeout = "120"
+        self.http_timeout = "120"
+        self.auto_update = "True"
+        self.obfuscate = "False"
+        self.obfuscate_hostname = "False"
+        self.legacy_upload = "True"
+        self.upload_url = "https://upload.insights.redhat.com/api"
+        self.branch_info_url = "https://branch-info.redhat.com"
+        self.systemid = "default_system_id"
+        self.no_proxy = False
+        self.retries = 3
+
+
+THIRD_PARTY_RULE_CONTENTS = """
+rule golang_file
+{
+    meta:
+        description = "Detects a Go (Golang) compiled binary"
+        author = "Your Name"
+        date = "2024-10-15"
+        version = "1.0"
+    strings:
+        // Strings that are typical in Go binaries
+        $go_pclntab = { 5f 63 67 6f 5f 6d 75 6e  6d 61 70 00 5f 63 67 6f }
+    condition:
+        // Check if any of the Go-specific strings and the section signature are present
+        any of ($go_pclntab)
+}
+"""
+
+THIRD_PARTY_RULE = "third-party.yara"
+SECOND_THIRD_PARTY_RULE = "third-party2.yara"
+# todo use os join
+THIRD_PARTY_RULE_LOCATION = TEST_RULE_LOCATION + "/" + THIRD_PARTY_RULE
+SECOND_THIRD_PARTY_RULE_LOCATION = TEST_RULE_LOCATION + "/" + SECOND_THIRD_PARTY_RULE
+
+
+@pytest.fixture
+def add_3rd_party_rules():
+    write_data_to_file(THIRD_PARTY_RULE_CONTENTS, THIRD_PARTY_RULE_LOCATION)
+    write_data_to_file(THIRD_PARTY_RULE_CONTENTS, SECOND_THIRD_PARTY_RULE_LOCATION)
+    yield
+    os.system("rm %s" % THIRD_PARTY_RULE_LOCATION)
+    os.system("rm %s" % SECOND_THIRD_PARTY_RULE_LOCATION)
 
 
 @pytest.fixture
@@ -115,7 +225,9 @@ def create_test_files_fake_yara():
     # Write the test files to the temp directory
     if not os.path.exists(TEMP_TEST_DIR):
         os.mkdir(TEMP_TEST_DIR)
-    with open(TEMP_CONFIG_FILE, 'w') as tcf:
+    # if not os.path.exists(TEMP_THIRD_PARTY_TEST_DIR):
+    #     os.mkdir(TEMP_THIRD_PARTY_TEST_DIR)
+    with open(TEMP_CONFIG_FILE, "w") as tcf:
         tcf.write(DEFAULT_MALWARE_CONFIG)
     test_files = [
         (MATCHING_ENTITY_FILE, MATCHING_ENTITY_FILE_CONTENTS),
@@ -125,20 +237,23 @@ def create_test_files_fake_yara():
     ]
     for test_file, contents in test_files:
         if not os.path.exists(test_file):
-            with open(test_file, 'w') as f:
+            with open(test_file, "w") as f:
                 f.write(contents)
     os.chmod(TEST_RULE_SCRIPT, 0o755)
     yield
-    os.system('rm -rf %s' % TEMP_TEST_DIR)
+    os.system("rm -rf %s" % TEMP_TEST_DIR)
 
 
 @pytest.fixture
 def extract_tmp_files():
     if not os.path.exists(TEMP_TEST_DIR):
         os.mkdir(TEMP_TEST_DIR)
-    os.system("echo '%s' | base64 -d - | tar -C %s -zxf -" % (SCAN_FILES_BASE64, TEMP_TEST_DIR))
+    os.system(
+        "echo '%s' | base64 -d - | tar -C %s -zxf -"
+        % (SCAN_FILES_BASE64, TEMP_TEST_DIR)
+    )
     yield
-    os.system('rm -rf %s' % TEMP_TEST_DIR)
+    os.system("rm -rf %s" % TEMP_TEST_DIR)
 
 
 #######################################################################
@@ -149,42 +264,52 @@ class TestsNotUtilizingYara:
 
     def test_default_spec(self):
         # Read in the default malware spec and check its values
-        manifest = yaml.safe_load(manifests['malware-detection'])
-        content_type = content_types['malware-detection']
+        manifest = yaml.safe_load(manifests["malware-detection"])
+        content_type = content_types["malware-detection"]
         assert content_type == "application/vnd.redhat.malware-detection.results+tgz"
-        specs = manifest['plugins']['configs']
+        specs = manifest["plugins"]["configs"]
         for spec in [
-            'mac_addresses',
-            'etc_machine_id',
-            'hostname',
-            'dmidecode',
-            'machine_id',
-            'ip_addresses',
-            'subscription_manager_id',
+            "mac_addresses",
+            "etc_machine_id",
+            "hostname",
+            "dmidecode",
+            "machine_id",
+            "ip_addresses",
+            "subscription_manager_id",
         ]:
             assert {
-                'enabled': True,
-                'name': 'insights.specs.default.DefaultSpecs.%s' % spec,
+                "enabled": True,
+                "name": "insights.specs.default.DefaultSpecs.%s" % spec,
             } in specs
-            assert {'enabled': True, 'name': 'insights.specs.Specs.%s' % spec} in specs
+            assert {"enabled": True, "name": "insights.specs.Specs.%s" % spec} in specs
 
     def test_default_options(self):
         # Read in the default malware_detection_config options and check their values
-        assert CONFIG['test_scan'] is True
-        assert CONFIG['scan_filesystem'] is True
-        assert CONFIG['scan_processes'] is False
-        assert CONFIG['filesystem_scan_only'] is None
-        assert CONFIG['processes_scan_only'] is None
-        assert CONFIG['filesystem_scan_since'] is None
-        assert CONFIG['processes_scan_since'] is None
+        assert CONFIG["test_scan"] is True
+        assert CONFIG["scan_filesystem"] is True
+        assert CONFIG["scan_processes"] is False
+        assert CONFIG["filesystem_scan_only"] is None
+        assert CONFIG["processes_scan_only"] is None
+        assert CONFIG["filesystem_scan_since"] is None
+        assert CONFIG["processes_scan_since"] is None
         assert all(
             [
-                x in CONFIG['filesystem_scan_exclude']
-                for x in ['/proc', '/sys', '/cgroup', '/selinux', '/net', '/mnt', '/media']
+                x in CONFIG["filesystem_scan_exclude"]
+                for x in [
+                    "/proc",
+                    "/sys",
+                    "/cgroup",
+                    "/selinux",
+                    "/net",
+                    "/mnt",
+                    "/media",
+                ]
             ]
         )
-        assert CONFIG['processes_scan_exclude'] is None
-        assert CONFIG['exclude_network_filesystem_mountpoints'] is True
+        assert CONFIG["processes_scan_exclude"] is None
+        assert CONFIG["exclude_network_filesystem_mountpoints"] is True
+        assert CONFIG["rules_location"] == TEST_RULE_LOCATION
+        assert CONFIG["use_remote_rules"] is True
 
     def test_toplevel_dirs(self):
         tlds = get_toplevel_dirs()
@@ -193,97 +318,115 @@ class TestsNotUtilizingYara:
 
     def test_get_parent_dirs(self):
         parent_dir_list = []
-        get_parent_dirs('/usr/lib/systemd/user/basic.target', parent_dir_list)
+        get_parent_dirs("/usr/lib/systemd/user/basic.target", parent_dir_list)
         assert sorted(parent_dir_list) == [
-            '/usr',
-            '/usr/lib',
-            '/usr/lib/systemd',
-            '/usr/lib/systemd/user',
-            '/usr/lib/systemd/user/basic.target',
+            "/usr",
+            "/usr/lib",
+            "/usr/lib/systemd",
+            "/usr/lib/systemd/user",
+            "/usr/lib/systemd/user/basic.target",
         ]
 
         parent_dir_list = []
-        get_parent_dirs('/usr/lib/systemd/user/basic.target', parent_dir_list, '/usr/lib')
+        get_parent_dirs(
+            "/usr/lib/systemd/user/basic.target", parent_dir_list, "/usr/lib"
+        )
         assert sorted(parent_dir_list) == [
-            '/usr/lib/systemd',
-            '/usr/lib/systemd/user',
-            '/usr/lib/systemd/user/basic.target',
+            "/usr/lib/systemd",
+            "/usr/lib/systemd/user",
+            "/usr/lib/systemd/user/basic.target",
         ]
 
         parent_dir_list = []
-        get_parent_dirs('/usr/lib/systemd/user/basic.target', parent_dir_list, '/var')
+        get_parent_dirs("/usr/lib/systemd/user/basic.target", parent_dir_list, "/var")
         assert sorted(parent_dir_list) == [
-            '/usr',
-            '/usr/lib',
-            '/usr/lib/systemd',
-            '/usr/lib/systemd/user',
-            '/usr/lib/systemd/user/basic.target',
+            "/usr",
+            "/usr/lib",
+            "/usr/lib/systemd",
+            "/usr/lib/systemd/user",
+            "/usr/lib/systemd/user/basic.target",
         ]
 
     def test_remove_child_items(self):
         # Simple example from the function docstring
-        items = ['/path/to/some/item/child', '/path/to/another/item', '/path/to/some/item']
-        assert remove_child_items(items) == ['/path/to/another/item', '/path/to/some/item']
+        items = [
+            "/path/to/some/item/child",
+            "/path/to/another/item",
+            "/path/to/some/item",
+        ]
+        assert remove_child_items(items) == [
+            "/path/to/another/item",
+            "/path/to/some/item",
+        ]
 
         # More complex test with duplicate items and items whose names start with another's name
         # (rather than start with the same path) and names with spaces in them
         items = [
-            '/var/lib64',
-            '/home/bob',
-            '/var/lib/docker',
-            '/home/bob',
-            '/var/lib',
-            '/home/bobby-droptables',
-            r'/home/bob/this\ is\ bobs/child',
-            '/var/lib63/im ok',
-            '/var/lib64/im not',
+            "/var/lib64",
+            "/home/bob",
+            "/var/lib/docker",
+            "/home/bob",
+            "/var/lib",
+            "/home/bobby-droptables",
+            r"/home/bob/this\ is\ bobs/child",
+            "/var/lib63/im ok",
+            "/var/lib64/im not",
         ]
         assert remove_child_items(items) == [
-            '/home/bob',
-            '/home/bobby-droptables',
-            '/var/lib',
-            '/var/lib63/im ok',
-            '/var/lib64',
+            "/home/bob",
+            "/home/bobby-droptables",
+            "/var/lib",
+            "/var/lib63/im ok",
+            "/var/lib64",
         ]
 
         # /path is common to both so that will be all that is returned
-        items = ['/path/to/another/item', '/path/to/some/item', '/path']
-        assert remove_child_items(items) == ['/path']
+        items = ["/path/to/another/item", "/path/to/some/item", "/path"]
+        assert remove_child_items(items) == ["/path"]
 
         # The root directory will always win
-        items = ['/path/to/another/item', '/path/to/some/item', '/']
-        assert remove_child_items(items) == ['/']
+        items = ["/path/to/another/item", "/path/to/some/item", "/"]
+        assert remove_child_items(items) == ["/"]
 
         # Any non-full path items (doesn't start with /) are removed from the list
-        items = ['/path/to/another/item', '', '/path/to/some/item']
-        assert remove_child_items(items) == ['/path/to/another/item', '/path/to/some/item']
+        items = ["/path/to/another/item", "", "/path/to/some/item"]
+        assert remove_child_items(items) == [
+            "/path/to/another/item",
+            "/path/to/some/item",
+        ]
 
     def test_remove_included_excluded_items(self):
-        include_items = ['/home/bob', '/tmp', '/var/www/html']
-        exclude_items = ['/home/bo', '/home/bob/exclude', '/home/bobby', '/temp', '/var/www']
+        include_items = ["/home/bob", "/tmp", "/var/www/html"]
+        exclude_items = [
+            "/home/bo",
+            "/home/bob/exclude",
+            "/home/bobby",
+            "/temp",
+            "/var/www",
+        ]
         include_items = remove_included_excluded_items(include_items, exclude_items)
-        assert include_items == ['/home/bob', '/tmp']
+        assert include_items == ["/home/bob", "/tmp"]
 
         # Some fairly random lists similar to before
         include_items = [
-            '/var/lib64/docker',
-            r'/home/bob/this\ is\ bobs/child',
-            '/var/lib/docker',
-            '/home/bob',
-            '/var/lib',
-            '/usr',
+            "/var/lib64/docker",
+            r"/home/bob/this\ is\ bobs/child",
+            "/var/lib/docker",
+            "/home/bob",
+            "/var/lib",
+            "/usr",
         ]
         exclude_items = [
-            '/var/lib/docker2',
-            '/home/bob',
-            '/home/bobby-droptables',
-            r'/home/bob/this\ is\ bobs/child',
-            '/var/lib63/im ok',
-            '/var/lib64/im not',
-            '/boot',
+            "/var/lib/docker2",
+            "/home/bob",
+            "/home/bobby-droptables",
+            r"/home/bob/this\ is\ bobs/child",
+            "/var/lib63/im ok",
+            "/var/lib64/im not",
+            "/boot",
         ]
         include_items = remove_included_excluded_items(include_items, exclude_items)
-        assert include_items == ['/usr', '/var/lib', '/var/lib64/docker']
+        assert include_items == ["/usr", "/var/lib", "/var/lib64/docker"]
 
     def test_default_include_items(self):
         # Call process_include_items with an empty list.
@@ -299,41 +442,41 @@ class TestsNotUtilizingYara:
 
     def test_process_include_items(self, caplog):
         # Call process_include_items with variously populated lists
-        logger.setLevel('DEBUG')
+        logger.setLevel("DEBUG")
 
         # Add some valid entries to include_items list, esp subdirectories
-        include_items = ['/etc/pam.d', '/tmp', '/var/log/']
+        include_items = ["/etc/pam.d", "/tmp", "/var/log/"]
         processed_items = process_include_items(include_items)
-        assert processed_items == ['/etc/pam.d', '/tmp', '/var/log']
+        assert processed_items == ["/etc/pam.d", "/tmp", "/var/log"]
 
         # Add some more subdirectories
-        include_items.extend(['/etc/alternatives', '/tmp', '/var/lib/'])
+        include_items.extend(["/etc/alternatives", "/tmp", "/var/lib/"])
         processed_items = process_include_items(include_items)
         assert processed_items == [
-            '/etc/alternatives',
-            '/etc/pam.d',
-            '/tmp',
-            '/var/lib',
-            '/var/log',
+            "/etc/alternatives",
+            "/etc/pam.d",
+            "/tmp",
+            "/var/lib",
+            "/var/log",
         ]
 
         # Add some top level directories to override the subdirectories
-        include_items.extend(['/etc', '/var'])
+        include_items.extend(["/etc", "/var"])
         processed_items = process_include_items(include_items)
-        assert processed_items == ['/etc', '/tmp', '/var']
+        assert processed_items == ["/etc", "/tmp", "/var"]
 
         # Add some invalid entries that will get ignored
         caplog.clear()
-        include_items.extend(['..', '/var/run', '/missing'])
+        include_items.extend(["..", "/var/run", "/missing"])
         processed_items = process_include_items(include_items)
         assert "Skipping partial directory path '..' ..." in caplog.text
         assert "Skipping link '/var/run' ..." in caplog.text
         assert "Skipping missing item '/missing' ..." in caplog.text
-        assert processed_items == ['/etc', '/tmp', '/var']
+        assert processed_items == ["/etc", "/tmp", "/var"]
 
         # Add the root directory (/) which will override all the other entries
         caplog.clear()
-        include_items.append('/')
+        include_items.append("/")
         processed_items = process_include_items(include_items)
         assert (
             "Found root directory in list of items to scan.  Ignoring the other items ..."
@@ -344,7 +487,7 @@ class TestsNotUtilizingYara:
 
     def test_process_exclude_items(self, caplog):
         # Call process_exclude_items with variously populated lists
-        logger.setLevel('DEBUG')
+        logger.setLevel("DEBUG")
 
         # Remove the default entries from the exclude file
         processed_items = process_exclude_items()
@@ -352,31 +495,37 @@ class TestsNotUtilizingYara:
         assert processed_items == []
 
         # Add some valid entries to exclude items (links are ok in the exclude list ... why?)
-        exclude_items = ['/etc/ssh', '/tmp', '/var/run/']
+        exclude_items = ["/etc/ssh", "/tmp", "/var/run/"]
         processed_items = process_exclude_items(exclude_items)
-        assert processed_items == ['/etc/ssh', '/tmp', '/var/run']
+        assert processed_items == ["/etc/ssh", "/tmp", "/var/run"]
 
         # Add some more subdirectories
-        exclude_items.extend(['/etc/alternatives', '/tmp', '/var/lock/'])
+        exclude_items.extend(["/etc/alternatives", "/tmp", "/var/lock/"])
         processed_items = process_exclude_items(exclude_items)
-        assert processed_items == ['/etc/alternatives', '/etc/ssh', '/tmp', '/var/lock', '/var/run']
+        assert processed_items == [
+            "/etc/alternatives",
+            "/etc/ssh",
+            "/tmp",
+            "/var/lock",
+            "/var/run",
+        ]
 
         # Add some top level directories to override the subdirectories
-        exclude_items.extend(['/etc', '/var'])
+        exclude_items.extend(["/etc", "/var"])
         processed_items = process_exclude_items(exclude_items)
-        assert processed_items == ['/etc', '/tmp', '/var']
+        assert processed_items == ["/etc", "/tmp", "/var"]
 
         # Add some invalid entries to exclude items
         caplog.clear()
-        exclude_items.extend(['..', '/missing'])
+        exclude_items.extend(["..", "/missing"])
         processed_items = process_exclude_items(exclude_items)
         assert "Skipping partial directory path '..' ..." in caplog.text
         assert "Skipping missing item '/missing' ..." in caplog.text
-        assert processed_items == ['/etc', '/tmp', '/var']
+        assert processed_items == ["/etc", "/tmp", "/var"]
 
         # Add the root directory
         caplog.clear()
-        exclude_items.append('/')
+        exclude_items.append("/")
         processed_items = process_exclude_items(exclude_items)
         assert (
             "Found root directory in the exclude list.  Expanding it to all toplevel directories ..."
@@ -389,33 +538,35 @@ class TestsNotUtilizingYara:
         # Specifically tests excluding link files (good or broken) and pipe files (as well as explicit exclude items)
 
         include_items = list(
-            map(lambda x: os.path.join(TEMP_TEST_DIR, x), ['scan_me', 'scan_me_too'])
+            map(lambda x: os.path.join(TEMP_TEST_DIR, x), ["scan_me", "scan_me_too"])
         )
         exclude_items = list(
             map(
                 lambda x: os.path.join(TEMP_TEST_DIR, x),
-                ['scan_me_not', 'scan_me/dont_scan_me', 'scan_me_too/dont_scan_me_too'],
+                ["scan_me_not", "scan_me/dont_scan_me", "scan_me_too/dont_scan_me_too"],
             )
         )
         scan_dict = process_include_exclude_items(
             include_items=include_items, exclude_items=exclude_items
         )
-        assert list(scan_dict.keys()) == ['/tmp']
-        assert sorted(list(scan_dict['/tmp']['exclude']['items'])) == sorted(exclude_items)
+        assert list(scan_dict.keys()) == ["/tmp"]
+        assert sorted(list(scan_dict["/tmp"]["exclude"]["items"])) == sorted(
+            exclude_items
+        )
 
         include_files = sorted(
             list(
                 map(
                     lambda x: os.path.join(TEMP_TEST_DIR, x),
                     [
-                        'scan_me/new_file',
-                        'scan_me/old_file',
-                        'scan_me/scan_me',
-                        'scan_me/scan_me_file',
-                        'scan_me_too/new_file',
-                        'scan_me_too/old_file',
-                        'scan_me_too/scan_me_too',
-                        'scan_me_too/scan_me_too_file',
+                        "scan_me/new_file",
+                        "scan_me/old_file",
+                        "scan_me/scan_me",
+                        "scan_me/scan_me_file",
+                        "scan_me_too/new_file",
+                        "scan_me_too/old_file",
+                        "scan_me_too/scan_me_too",
+                        "scan_me_too/scan_me_too_file",
                     ],
                 )
             )
@@ -425,42 +576,50 @@ class TestsNotUtilizingYara:
                 map(
                     lambda x: os.path.join(TEMP_TEST_DIR, x),
                     [
-                        'scan_me/link_file',
-                        'scan_me/pipe_file',
-                        'scan_me/broken_link',
-                        'scan_me/dont_scan_me',
-                        'scan_me_too/link_file',
-                        'scan_me_too/pipe_file',
-                        'scan_me_too/broken_link',
-                        'scan_me_too/dont_scan_me_too',
+                        "scan_me/link_file",
+                        "scan_me/pipe_file",
+                        "scan_me/broken_link",
+                        "scan_me/dont_scan_me",
+                        "scan_me_too/link_file",
+                        "scan_me_too/pipe_file",
+                        "scan_me_too/broken_link",
+                        "scan_me_too/dont_scan_me_too",
                     ],
                 )
             )
         )
-        assert sorted(scan_dict['/tmp']['include']) == include_files
-        assert all([x not in scan_dict['/tmp']['include'] for x in dont_include_files])
+        assert sorted(scan_dict["/tmp"]["include"]) == include_files
+        assert all([x not in scan_dict["/tmp"]["include"] for x in dont_include_files])
 
         # Another test to assert a bug I found is fixed ... due to only having scan_items = set([])
         # Basically include_files should = ['scan_me/scan_me'] but the bug made include_files = []
-        include_items = list(map(lambda x: os.path.join(TEMP_TEST_DIR, x), ['scan_me/scan_me']))
-        exclude_items = list(map(lambda x: os.path.join(TEMP_TEST_DIR, x), ['scan_me_not']))
+        include_items = list(
+            map(lambda x: os.path.join(TEMP_TEST_DIR, x), ["scan_me/scan_me"])
+        )
+        exclude_items = list(
+            map(lambda x: os.path.join(TEMP_TEST_DIR, x), ["scan_me_not"])
+        )
         scan_dict = process_include_exclude_items(
             include_items=include_items, exclude_items=exclude_items
         )
 
         include_files = sorted(
-            list(map(lambda x: os.path.join(TEMP_TEST_DIR, x), ['scan_me/scan_me']))
+            list(map(lambda x: os.path.join(TEMP_TEST_DIR, x), ["scan_me/scan_me"]))
         )
-        assert sorted(scan_dict['/tmp']['include']) == include_files
+        assert sorted(scan_dict["/tmp"]["include"]) == include_files
         dont_include_files = sorted(
             list(
                 map(
                     lambda x: os.path.join(TEMP_TEST_DIR, x),
-                    ['scan_me/scan_me_file', 'scan_me/dont_scan_me', 'scan_me/scan_me/here_i_am'],
+                    [
+                        "scan_me/scan_me_file",
+                        "scan_me/dont_scan_me",
+                        "scan_me/scan_me/here_i_am",
+                    ],
                 )
             )
         )
-        assert all([x not in scan_dict['/tmp']['include'] for x in dont_include_files])
+        assert all([x not in scan_dict["/tmp"]["include"] for x in dont_include_files])
 
 
 ###################################################################################################
@@ -469,16 +628,53 @@ class TestsNotUtilizingYara:
 @pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
 class TestsUtilizingFakeYara:
 
-    @patch(BUILD_YARA_COMMAND_TARGET)
-    @patch(GET_RULES_TARGET, return_value=TEST_RULE_FILE)
-    @patch(DISABLED_RULES_TARGET, return_value=[])
-    @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
     @patch(LOGGER_TARGET)
     class TestDefaultValues:
 
-        @patch('insights.client.utilities.write_to_disk', Mock())
+        @patch("insights.client.utilities.write_to_disk", Mock())
+        def test_default_options(
+            self,
+            log_mock,
+        ):
+            # Try running malware-detection with the default options
+            # With the default options, test_scan is true, so some of the option values will be changed for that and
+            # will be different from those in the default config file.
+            # For example, do_filesystem_scan AND do_process_scan are both True when doing a test scan
+            # Use a real config file so scan_fsobjects will be populated properly
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+            )
+            assert mdc.yara_binary == FAKE_YARA
+            assert mdc.yara_version == FAKE_YARA_VERSION
+            assert mdc.test_scan is True
+            assert mdc.rules_files == []
+            assert mdc.remote_rules_location == ""
+            assert mdc.use_remote_rules is True
+            assert mdc.disabled_rules == []
+            assert mdc.do_filesystem_scan is True
+            assert mdc.do_process_scan is False
+            assert mdc.scan_fsobjects == []
+            assert mdc.scan_pids == []
+            assert mdc.filesystem_scan_since_dict == {}
+            assert mdc.filesystem_scan_exclude_list == [TEST_RULE_LOCATION]
+            assert mdc.processes_scan_exclude_list == []
+            assert mdc.processes_scan_since_dict == {}
+            assert mdc.network_filesystem_mountpoints == []
+            assert mdc.scan_timeout == 3600
+            assert mdc.nice_value == 19
+
+        @patch(
+            "insights.specs.datasources.malware_detection.MalwareDetectionClient.load_rules",
+            return_value=TEST_RULE_FILE,
+        )
+        @patch("insights.specs.datasources.malware_detection.rules.download_rules")
+        @patch("insights.client.utilities.write_to_disk", Mock())
         def test_running_default_options(
-            self, log_mock, yara, disabled, rules, cmd, create_test_files_fake_yara
+            self,
+            rule_location,
+            download_rules,
+            log_mock,
+            create_test_files_fake_yara,
         ):
             # Try running malware-detection with the default options
             # With the default options, test_scan is true, so some of the option values will be changed for that and
@@ -486,18 +682,31 @@ class TestsUtilizingFakeYara:
             # For example, do_filesystem_scan AND do_process_scan are both True when doing a test scan
             # Use a real config file so scan_fsobjects will be populated properly
             with patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE):
-                mdc = MalwareDetectionClient(None)
+                mdc = MalwareDetectionClient(
+                    InsightsClientConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+                )
+                # parse options of a test scan
+                mdc.parse_scan_options()
+                # manually adding rules file
+                mdc.rules_files.append(mdc.load_rules())
+
             assert mdc.yara_binary == FAKE_YARA
-            assert mdc.rules_file == TEST_RULE_FILE
+            assert mdc.yara_version == FAKE_YARA_VERSION
+            assert mdc.rules_files == [TEST_RULE_FILE]
+            assert mdc.rules_location == TEST_RULE_LOCATION
+            assert mdc.remote_rules_location == TEST_REMOTE_RULE_LOCATION
+            assert mdc.use_remote_rules is True
             assert mdc.disabled_rules == []
             assert mdc.do_filesystem_scan is True
             assert mdc.do_process_scan is True
             assert mdc.scan_fsobjects == [TEMP_CONFIG_FILE]
             assert mdc.scan_pids == [TEST_PID]
-            assert mdc.filesystem_scan_since_dict == {'timestamp': None}
+            # todo is this timestamp none needed to be set in test scan?
+            assert mdc.filesystem_scan_since_dict == {"timestamp": None}
             assert mdc.filesystem_scan_exclude_list == []
             assert mdc.processes_scan_exclude_list == []
-            assert mdc.processes_scan_since_dict == {'timestamp': None}
+            # todo is this timestamp none needed to be set in test scan?
+            assert mdc.processes_scan_since_dict == {"timestamp": None}
             assert mdc.network_filesystem_mountpoints == []
             assert mdc.scan_timeout == 3600
             assert mdc.nice_value == 19
@@ -518,115 +727,151 @@ class TestsUtilizingFakeYara:
                     % TEST_PID,
                     "python insights_client/run.py --collector malware-detection",
                 ]
+                # have to manually set yara_cmd
+                mdc.yara_cmd = ["manually_set_yara"]
                 mutation = mdc.run()
             log_mock.info.assert_any_call("Found %d rule match%s.", 2, "es")
             # Test scan results in mutation format
             assert 'ruleName: "TEST_RedHatInsightsMalwareDetection"' in mutation[0]
             assert 'source: "%s"' % TEST_RULE_FILE in mutation[0]
             assert 'source: "%s"' % TEST_PID in mutation[0]
-            assert re.search('metadata:.*line_number', mutation[0])
-            assert re.search('metadata:.*process_name', mutation[0])
+            assert re.search("metadata:.*line_number", mutation[0])
+            assert re.search("metadata:.*process_name", mutation[0])
             # Test scan results in JSON format
-            rule = 'TEST_RedHatInsightsMalwareDetection'
+            rule = "TEST_RedHatInsightsMalwareDetection"
             assert len(mutation[1][rule]) == 2
-            assert mutation[1][rule][0]['source'] == TEST_RULE_FILE
-            assert mutation[1][rule][1]['source'] == TEST_PID
-            assert mutation[1][rule][0]['string_data'] == 'Malware Detection Client'
-            assert mutation[1][rule][1]['string_data'] == 'Malware Detection Client'
-            assert mutation[1][rule][0]['metadata']['source_type'] == 'file'
+            assert mutation[1][rule][0]["source"] == TEST_RULE_FILE
+            assert mutation[1][rule][1]["source"] == TEST_PID
+            assert mutation[1][rule][0]["string_data"] == "Malware Detection Client"
+            assert mutation[1][rule][1]["string_data"] == "Malware Detection Client"
+            assert mutation[1][rule][0]["metadata"]["source_type"] == "file"
             assert (
-                mutation[1][rule][0]['metadata']['line']
-                == '//%20Verifies%20the%20Red%20Hat%20Insights%20Malware%20Detection%20Client%20app%20is%20present%20on%20the%20system'
+                mutation[1][rule][0]["metadata"]["line"]
+                == "//%20Verifies%20the%20Red%20Hat%20Insights%20Malware%20Detection%20Client%20app%20is%20present%20on%20the%20system"
             )
-            assert mutation[1][rule][1]['metadata']['source_type'] == 'process'
+            assert mutation[1][rule][1]["metadata"]["source_type"] == "process"
             assert (
-                mutation[1][rule][1]['metadata']['process_name']
-                == 'python insights_client/run.py --collector malware-detection'
+                mutation[1][rule][1]["metadata"]["process_name"]
+                == "python insights_client/run.py --collector malware-detection"
             )
 
     @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
-    @patch(BUILD_YARA_COMMAND_TARGET)
-    @patch(GET_RULES_TARGET, return_value=RULES_FILE)
-    @patch(DISABLED_RULES_TARGET, return_value=[])
-    @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
     @patch.dict(
-        os.environ, {'TEST_SCAN': 'false', 'EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS': 'false'}
+        os.environ,
+        {"TEST_SCAN": "false", "EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS": "false"},
     )
     class TestMalwareDetectionOptions:
 
-        @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
-        def test_running_modified_options(self, conf, yara, disabled, rules, cmd):
+        def test_running_modified_options(self):
             # Disable test_scan and the mdc attribute values should mostly match what's in the config file
-            mdc = MalwareDetectionClient(None)
-            assert mdc.rules_file == RULES_FILE
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+            )
+            # parse the malware options
+            mdc.parse_scan_options()
+
+            assert mdc.rules_files == []
             assert mdc.disabled_rules == []
             assert mdc.yara_binary == FAKE_YARA
             assert mdc.do_filesystem_scan is True
             assert mdc.do_process_scan is False
             assert mdc.scan_fsobjects == []
             assert mdc.scan_pids == []
-            assert mdc.filesystem_scan_since_dict == {'timestamp': None, 'datetime': None}
-            assert all(
-                [d in mdc.filesystem_scan_exclude_list for d in ['/proc', '/sys', '/mnt', '/media']]
-            )
-            # filesystem_scan_* attributes will exist whereas processes_scan_* will not
+            assert mdc.filesystem_scan_since_dict == {
+                "timestamp": None,
+                "datetime": None,
+            }
             assert all(
                 [
-                    hasattr(mdc, 'filesystem_scan_' + attr) is True
-                    and hasattr(mdc, 'processes_scan_' + attr) is False
-                    for attr in ('exclude_list', 'since_dict')
+                    d in mdc.filesystem_scan_exclude_list
+                    for d in ["/proc", "/sys", "/mnt", "/media"]
                 ]
             )
+            # filesystem_scan_* attributes will exist whereas
+            # processes_scan_* will be set to false
+            assert mdc.filesystem_scan_since_dict
+            assert mdc.filesystem_scan_exclude_list
+            assert mdc.processes_scan_since_dict == {}
+            assert mdc.processes_scan_exclude_list == []
 
-        @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
         @patch(LOGGER_TARGET)
-        def test_scan_only_options(self, log_mock, conf, yara, disabled, rules, cmd):
+        def test_scan_only_options(self, log_mock):
             # Test various combinations of filesystem_scan_only, process_scan_only, scan_filesystem & scan_processes
             # Firstly, test the default option values
-            mdc = MalwareDetectionClient(None)
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+            )
             assert mdc.do_filesystem_scan is True
             assert mdc.scan_fsobjects == []
             assert mdc.do_process_scan is False
             assert mdc.scan_pids == []
 
             # Add some directories
-            os.environ['FILESYSTEM_SCAN_ONLY'] = '/tmp,/var'
-            mdc = MalwareDetectionClient(None)
-            assert mdc.scan_fsobjects == ['/tmp', '/var']
+            os.environ["FILESYSTEM_SCAN_ONLY"] = "/tmp,/var"
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+            )
+            # parse malware options
+            mdc.parse_scan_options()
+            assert mdc.scan_fsobjects == ["/tmp", "/var"]
 
             # Disable filesystem scanning and only expect the process to be scanned
-            os.environ['SCAN_FILESYSTEM'] = 'false'
+            os.environ["SCAN_FILESYSTEM"] = "false"
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
+                MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                ).parse_scan_options()
+
             log_mock.error.assert_called_with(
                 "Both scan_filesystem and scan_processes are disabled.  Nothing to scan."
             )
 
             # Add scan_only for a process
-            os.environ['PROCESSES_SCAN_ONLY'] = '1'
+            os.environ["PROCESSES_SCAN_ONLY"] = "1"
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
+                MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                ).parse_scan_options()
             log_mock.error.assert_called_with(
                 "Both scan_filesystem and scan_processes are disabled.  Nothing to scan."
             )
 
             # Enable process scanning and now the scan_only value should be used
-            os.environ['SCAN_PROCESSES'] = 'true'
-            mdc = MalwareDetectionClient(None)
+            os.environ["SCAN_PROCESSES"] = "true"
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+            )
+            # parse malware options
+            mdc.parse_scan_options()
             assert mdc.do_filesystem_scan is False
             assert mdc.do_process_scan is True
-            assert mdc.scan_pids == ['1']
+            assert mdc.scan_pids == ["1"]
 
         @patch(LOGGER_TARGET)
         @patch.dict(os.environ)
         def test_removed_config_values(
-            self, log_mock, yara, disabled, rules, cmd, create_test_files_fake_yara
+            self,
+            log_mock,
+            create_test_files_fake_yara,
         ):
             # If the user uses old config items, eg scan_only and scan_exclude, then notify them
-            with open(TEMP_CONFIG_FILE, 'a') as f:
-                f.write('scan_only: /tmp\nscan_exclude: /home\n')
+            with open(TEMP_CONFIG_FILE, "a") as f:
+                f.write("scan_only: /tmp\nscan_exclude: /home\n")
+
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
+                altered_malware_config = load_or_create_malware_config()
+                MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                ).parse_scan_options()
             log_mock.error.assert_any_call(
                 "The 'scan_only' option has been replaced with the 'filesystem_scan_only' and 'processes_scan_only' options in "
                 + TEMP_CONFIG_FILE
@@ -640,42 +885,75 @@ class TestsUtilizingFakeYara:
                 line = "#scan_only: /tmp" if line.startswith("scan_only: ") else line
                 print(line)
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
+                altered_malware_config = load_or_create_malware_config()
+                MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                ).parse_scan_options()
             log_mock.error.assert_any_call(
                 "The 'scan_exclude' option has been replaced with the 'filesystem_scan_exclude' and 'processes_scan_exclude' options in "
                 + TEMP_CONFIG_FILE
             )
 
-            os.environ['SCAN_ONLY'] = '/tmp'
+            os.environ["SCAN_ONLY"] = "/tmp"
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                line = "#scan_exclude: /home" if line.startswith("scan_exclude: ") else line
+                line = (
+                    "#scan_exclude: /home"
+                    if line.startswith("scan_exclude: ")
+                    else line
+                )
                 print(line)
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
+                altered_malware_config = load_or_create_malware_config()
+                MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                ).parse_scan_options()
             log_mock.error.assert_any_call(
                 "The 'scan_only' option has been replaced with the 'filesystem_scan_only' and 'processes_scan_only' options in "
                 + TEMP_CONFIG_FILE
             )
 
-            del os.environ['SCAN_ONLY']
-            os.environ['FILESYSTEM_SCAN_ONLY'] = '/tmp'
-            os.environ['SCAN_EXCLUDE'] = '/home'
+            del os.environ["SCAN_ONLY"]
+            os.environ["FILESYSTEM_SCAN_ONLY"] = "/tmp"
+            os.environ["SCAN_EXCLUDE"] = "/home"
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
+                altered_malware_config = load_or_create_malware_config()
+                MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                ).parse_scan_options()
             log_mock.error.assert_any_call(
                 "The 'scan_exclude' option has been replaced with the 'filesystem_scan_exclude' and 'processes_scan_exclude' options in "
                 + TEMP_CONFIG_FILE
             )
 
-            del os.environ['SCAN_EXCLUDE']
-            os.environ['FILESYSTEM_SCAN_EXCLUDE'] = '/home'
-            mdc = MalwareDetectionClient(None)
-            assert mdc.scan_fsobjects == ['/tmp']
-            assert mdc.filesystem_scan_exclude_list == ['/home']
+            del os.environ["SCAN_EXCLUDE"]
+            os.environ["FILESYSTEM_SCAN_EXCLUDE"] = "/home"
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            assert mdc.scan_fsobjects == ["/tmp"]
+            assert mdc.filesystem_scan_exclude_list == ["/home"]
 
         @patch(LOGGER_TARGET)
+        @patch(CONFIG_LOGGER_TARGET)
         def test_invalid_config_values(
-            self, log_mock, yara, disabled, rules, cmd, create_test_files_fake_yara
+            self,
+            config_log_mock,
+            log_mock,
+            create_test_files_fake_yara,
         ):
             # Check the malware client app behaves in a predictable way if the user specifies invalid option values
             # in the config file.  Some of these will fail yaml parsing, others will fail type checking
@@ -685,11 +963,16 @@ class TestsUtilizingFakeYara:
                 line = "nice_value: nineteen" if line.startswith("nice_value") else line
                 print(line)
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
+                altered_malware_config = load_or_create_malware_config()
+                MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                ).parse_scan_options()
             log_mock.error.assert_called_with(
                 "Problem setting configuration option %s: %s", "nice_value", ANY
             )
-            yara.assert_called_once()  # It failed after the _find_yara method
 
             # Missing colon for nice_value option - fails yaml parsing
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
@@ -697,13 +980,13 @@ class TestsUtilizingFakeYara:
                 line = "nice_value 19\n" if line.startswith("nice_value") else line
                 print(line)
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
-            log_mock.error.assert_called_with(
+                load_or_create_malware_config()
+
+            config_log_mock.error.assert_called_with(
                 "Error encountered loading the malware-detection app config file %s:\n%s",
                 TEMP_CONFIG_FILE,
                 ANY,
             )
-            yara.assert_called_once()  # It failed before the _find_yara method because it was invalid yaml
 
             # Bad list items for scan_only, mixing single item and list items - fails yaml parsing
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
@@ -715,89 +998,103 @@ class TestsUtilizingFakeYara:
                 )
                 print(line)
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
-            log_mock.error.assert_called_with(
+                load_or_create_malware_config()
+            config_log_mock.error.assert_called_with(
                 "Error encountered loading the malware-detection app config file %s:\n%s",
                 TEMP_CONFIG_FILE,
                 ANY,
             )
-            yara.assert_called_once()  # It failed before the _find_yara method because it was invalid yaml
 
             # Bad list items for scan_only, not a list item -  fails yaml parsing
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                line = "filesystem_scan_only:" if line.startswith("filesystem_scan_only:") else line
+                line = (
+                    "filesystem_scan_only:"
+                    if line.startswith("filesystem_scan_only:")
+                    else line
+                )
                 line = "/bad" if line.startswith("- /bad") else line
                 print(line)
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
-            log_mock.error.assert_called_with(
+                load_or_create_malware_config()
+            config_log_mock.error.assert_called_with(
                 "Error encountered loading the malware-detection app config file %s:\n%s",
                 TEMP_CONFIG_FILE,
                 ANY,
             )
-            yara.assert_called_once()  # It failed before the _find_yara method because it was invalid yaml
 
             # Bad list items for scan_only, not enough spaces -  fails yaml parsing
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "-/bad" if line.startswith("/bad") else line
                 print(line)
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
-            log_mock.error.assert_called_with(
+                load_or_create_malware_config()
+            config_log_mock.error.assert_called_with(
                 "Error encountered loading the malware-detection app config file %s:\n%s",
                 TEMP_CONFIG_FILE,
                 ANY,
             )
-            yara.assert_called_once()  # It failed before the _find_yara method because it was invalid yaml
 
             # Bad list items for scan_only, using tabs instead of spaces -  fails yaml parsing
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "\t- /bad" if line.startswith("-/bad") else line
                 print(line)
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
-            log_mock.error.assert_called_with(
+                load_or_create_malware_config()
+            config_log_mock.error.assert_called_with(
                 "Error encountered loading the malware-detection app config file %s:\n%s",
                 TEMP_CONFIG_FILE,
                 ANY,
             )
-            yara.assert_called_once()  # It failed before the _find_yara method because it was invalid yaml
 
         # Patch the os.environ dict so all the changes are only temporary
-        @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
         @patch.dict(os.environ)
-        def test_using_env_vars(self, conf, yara, disabled, rules, cmd):
+        def test_using_env_vars(self, create_test_files_fake_yara):
             # Set certain option values via environment variables
             env_var_list = [
-                ('RULES_LOCATION', RULES_FILE),
-                ('TEST_SCAN', 'hello'),  # will be interpreted as false
-                ('SCAN_FILESYSTEM', 'YES'),
-                ('SCAN_PROCESSES', 'T'),
-                ('FILESYSTEM_SCAN_ONLY', '/tmp'),
-                ('FILESYSTEM_SCAN_EXCLUDE', '/tmp'),
-                ('PROCESSES_SCAN_ONLY', '1,2'),
-                ('PROCESSES_SCAN_EXCLUDE', '2,1'),
-                ('FILESYSTEM_SCAN_SINCE', '2'),
-                ('PROCESSES_SCAN_SINCE', '10'),
-                ('SCAN_TIMEOUT', '1800'),
-                ('CPU_THREAD_LIMIT', '1'),
+                ("RULES_LOCATION", TEMP_TEST_DIR),
+                ("USE_REMOTE_RULES", "false"),
+                ("TEST_SCAN", "hello"),  # will be interpreted as false
+                ("SCAN_FILESYSTEM", "YES"),
+                ("SCAN_PROCESSES", "T"),
+                ("FILESYSTEM_SCAN_ONLY", "/tmp"),
+                ("FILESYSTEM_SCAN_EXCLUDE", "/tmp"),
+                ("PROCESSES_SCAN_ONLY", "1,2"),
+                ("PROCESSES_SCAN_EXCLUDE", "2,1"),
+                ("FILESYSTEM_SCAN_SINCE", "2"),
+                ("PROCESSES_SCAN_SINCE", "10"),
+                ("SCAN_TIMEOUT", "1800"),
+                ("CPU_THREAD_LIMIT", "1"),
             ]
             for key, value in env_var_list:
                 os.environ[key] = value
 
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+
             assert mdc.yara_binary == FAKE_YARA
-            assert mdc.rules_file == RULES_FILE
+            assert mdc.yara_version == FAKE_YARA_VERSION
+            assert mdc.rules_files == [TEST_RULE_FILE]
             assert mdc.test_scan is False
             assert mdc.do_filesystem_scan is True
             assert mdc.do_process_scan is True
-            assert mdc.scan_fsobjects == ['/tmp']
-            assert mdc.filesystem_scan_exclude_list == ['/tmp']
+            assert mdc.scan_fsobjects == ["/tmp"]
+            assert mdc.filesystem_scan_exclude_list == ["/tmp"]
             if not IS_CONTAINER:
-                assert mdc.scan_pids == ['1', '2']
-                assert mdc.processes_scan_exclude_list == ['1', '2']
-            assert mdc.filesystem_scan_since_dict['timestamp'] < time.time() - (2 * 86400)
-            assert mdc.processes_scan_since_dict['timestamp'] < time.time() - (10 * 86400)
+                assert mdc.scan_pids == ["1", "2"]
+                assert mdc.processes_scan_exclude_list == ["1", "2"]
+            assert mdc.filesystem_scan_since_dict["timestamp"] < time.time() - (
+                2 * 86400
+            )
+            assert mdc.processes_scan_since_dict["timestamp"] < time.time() - (
+                10 * 86400
+            )
             assert mdc.scan_timeout == 1800
             # Not env vars, but just checking they have the expected values
             assert mdc.nice_value == 19
@@ -814,97 +1111,166 @@ class TestsUtilizingFakeYara:
             # Test when SCAN_ONLY and SCAN_EXCLUDE values are comma separated
             # No items will be scanned because '/' is to be excluded
             for key, value in [
-                ('FILESYSTEM_SCAN_ONLY', '/tmp,/,/var/tmp'),
-                ('FILESYSTEM_SCAN_EXCLUDE', '/home,/,/fred,barney'),
+                ("FILESYSTEM_SCAN_ONLY", "/tmp,/,/var/tmp"),
+                ("FILESYSTEM_SCAN_EXCLUDE", "/home,/,/fred,barney"),
             ]:
                 os.environ[key] = value
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
             assert mdc.do_filesystem_scan is True
-            assert mdc.scan_fsobjects == ['/tmp', '/', '/var/tmp']
-            assert mdc.filesystem_scan_exclude_list == ['/home', '/']
+            assert mdc.scan_fsobjects == ["/tmp", "/", "/var/tmp"]
+            assert mdc.filesystem_scan_exclude_list == ["/home", "/"]
             mdc.scan_filesystem()
             assert mdc.do_filesystem_scan is False
 
             # Test when FILESYSTEM_SCAN_ONLY is empty, so no items will be scanned because '/' is to be excluded
-            os.environ['FILESYSTEM_SCAN_ONLY'] = ''
-            mdc = MalwareDetectionClient(None)
+            os.environ["FILESYSTEM_SCAN_ONLY"] = ""
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
             assert mdc.do_filesystem_scan is True
             assert mdc.scan_fsobjects == []
-            assert mdc.filesystem_scan_exclude_list == ['/home', '/']
+            assert mdc.filesystem_scan_exclude_list == ["/home", "/"]
             mdc.scan_filesystem()
             assert mdc.do_filesystem_scan is False
 
             # Test when FILESYSTEM_SCAN_EXCLUDE is empty
-            os.environ['FILESYSTEM_SCAN_EXCLUDE'] = ''
-            mdc = MalwareDetectionClient(None)
+            os.environ["FILESYSTEM_SCAN_EXCLUDE"] = ""
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
             assert mdc.scan_fsobjects == []
             assert mdc.filesystem_scan_exclude_list == []
 
             if not IS_CONTAINER:
                 # Test when FILESYSTEM_SCAN_EXCLUDE is empty
-                os.environ['PROCESSES_SCAN_ONLY'] = 'systemd,2,3..10'
-                os.environ['PROCESSES_SCAN_EXCLUDE'] = '3..100,systemd,2'
-                mdc = MalwareDetectionClient(None)
-                assert all([pid in mdc.scan_pids for pid in ['1', '2', '3']])
-                assert all([pid in mdc.processes_scan_exclude_list for pid in ['1', '2', '3']])
+                os.environ["PROCESSES_SCAN_ONLY"] = "systemd,2,3..10"
+                os.environ["PROCESSES_SCAN_EXCLUDE"] = "3..100,systemd,2"
+                altered_malware_config = load_or_create_malware_config()
+                mdc = MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
+                assert all([pid in mdc.scan_pids for pid in ["1", "2", "3"]])
+                assert all(
+                    [pid in mdc.processes_scan_exclude_list for pid in ["1", "2", "3"]]
+                )
 
             # Further testing of list type env vars
-            os.environ['NETWORK_FILESYSTEM_TYPES'] = ''
-            assert mdc._get_config_option('network_filesystem_types') == []
-            os.environ['NETWORK_FILESYSTEM_TYPES'] = 'nfs'
-            assert mdc._get_config_option('network_filesystem_types') == ['nfs']
-            os.environ['NETWORK_FILESYSTEM_TYPES'] = 'nfs,nfs4'
-            assert mdc._get_config_option('network_filesystem_types') == ['nfs', 'nfs4']
+            os.environ["NETWORK_FILESYSTEM_TYPES"] = ""
+            assert mdc._get_config_option("network_filesystem_types") == []
+            os.environ["NETWORK_FILESYSTEM_TYPES"] = "nfs"
+            assert mdc._get_config_option("network_filesystem_types") == ["nfs"]
+            os.environ["NETWORK_FILESYSTEM_TYPES"] = "nfs,nfs4"
+            assert mdc._get_config_option("network_filesystem_types") == [
+                "nfs",
+                "nfs4",
+            ]
 
-        @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
         @patch(LOGGER_TARGET)
+        @patch(CONFIG_LOGGER_TARGET)
+        @patch(UTILS_LOGGER_TARGET)
         @patch.dict(
             os.environ,
-            {'TEST_SCAN': 'false', 'NICE_VALUE': 'nineteen', 'FILESYSTEM_SCAN_SINCE': 'blast'},
+            {
+                "TEST_SCAN": "false",
+                "NICE_VALUE": "nineteen",
+                "FILESYSTEM_SCAN_SINCE": "blast",
+            },
         )
-        def test_invalid_env_vars(self, log_mock, conf, yara, disabled, rules, cmd):
+        def test_invalid_env_vars(self, utils_log_mock, config_log_mock, log_mock):
             # NICE_VALUE and FILESYSTEM_SCAN_SINCE have invalid values
             # First time through the NICE_VALUE should generate an error
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
-            log_mock.error.assert_called_with(
+                altered_malware_config = load_or_create_malware_config()
+                MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+            config_log_mock.error.assert_called_with(
                 "Problem parsing environment variable %s: %s", "NICE_VALUE", ANY
             )
 
             # Set NICE_VALUE to proper value to avoid it giving an error this time.
             # Only FILESYSTEM_SCAN_SINCE should generate an error
-            os.environ['NICE_VALUE'] = '19'
+            os.environ["NICE_VALUE"] = "19"
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
-            log_mock.error.assert_called_with(
-                "Unknown value '%s' for %s option.  " "Valid values are integers >= 1 and 'last'",
+                altered_malware_config = load_or_create_malware_config()
+                MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                ).parse_scan_options()
+            utils_log_mock.error.assert_called_with(
+                "Unknown value '%s' for %s option.  "
+                "Valid values are integers >= 1 and 'last'",
                 "blast",
                 "filesystem_scan_since",
             )
 
             # Fix FILESYSTEM_SCAN_SINCE to proper value to avoid it giving an error this time.
             # Give an invalid value for PROCESSES_SCAN_SINCE, but need to enable SCAN_PROCESSES too
-            os.environ['FILESYSTEM_SCAN_SINCE'] = 'last'
-            os.environ['SCAN_PROCESSES'] = 'true'
-            os.environ['PROCESSES_SCAN_SINCE'] = '0'
+            os.environ["FILESYSTEM_SCAN_SINCE"] = "last"
+            os.environ["SCAN_PROCESSES"] = "true"
+            os.environ["PROCESSES_SCAN_SINCE"] = "0"
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
-            log_mock.error.assert_called_with(
+                altered_malware_config = load_or_create_malware_config()
+                MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                ).parse_scan_options()
+            utils_log_mock.error.assert_called_with(
                 "Invalid processes_scan_since value 0.  Valid values are integers >= 1 and 'last'"
             )
 
             # Disable SCAN_PROCESSES and the invalid PROCESSES_SCAN_SINCE doesn't raise an error anymore
             # because it isn't even parsed
-            os.environ['SCAN_PROCESSES'] = 'false'
-            mdc = MalwareDetectionClient(None)
-            assert hasattr(mdc, 'processes_scan_since_dict') is False
+            os.environ["SCAN_PROCESSES"] = "false"
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            assert mdc.processes_scan_since_dict == {}
 
         def test_filesystem_scan_only_root(
-            self, yara, disabled, rules, cmd, create_test_files_fake_yara
+            self,
+            create_test_files_fake_yara,
         ):
             # Nothing special about root when parsing the filesystem_scan_only option
             # There is no parsing of root to individual toplevel directories until running scan_filesystem
-            filesystem_scan_only = '/'
+            filesystem_scan_only = "/"
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "test_scan: false" if line.startswith("test_scan:") else line
                 line = (
@@ -913,17 +1279,25 @@ class TestsUtilizingFakeYara:
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
             assert mdc.scan_fsobjects == [filesystem_scan_only]
             # This is called by scan_filesystem to convert '/' into its top level subdirectories
             scan_dict = process_include_exclude_items(
-                include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
+                include_items=mdc.scan_fsobjects,
+                exclude_items=mdc.filesystem_scan_exclude_list,
             )
             assert all([x in list(scan_dict.keys()) for x in INCLUDED_TLDS])
-            assert '/' not in list(scan_dict.keys())
+            assert "/" not in list(scan_dict.keys())
 
             # Multiple directories aren't consolidated until later
-            filesystem_scan_only = ['/', '/tmp', '/home']
+            filesystem_scan_only = ["/", "/tmp", "/home"]
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = (
                     "filesystem_scan_only: %s" % filesystem_scan_only
@@ -931,39 +1305,63 @@ class TestsUtilizingFakeYara:
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
             assert mdc.scan_fsobjects == filesystem_scan_only
             scan_dict = process_include_exclude_items(
-                include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
+                include_items=mdc.scan_fsobjects,
+                exclude_items=mdc.filesystem_scan_exclude_list,
             )
             assert all([x in list(scan_dict.keys()) for x in INCLUDED_TLDS])
-            assert '/' not in list(scan_dict.keys())
+            assert "/" not in list(scan_dict.keys())
 
-        @patch(LOGGER_TARGET)
+        @patch(UTILS_LOGGER_TARGET)
         def test_filesystem_scan_exclude_root(
-            self, log_mock, yara, disabled, rules, cmd, create_test_files_fake_yara
+            self,
+            utils_log_mock,
+            create_test_files_fake_yara,
         ):
             # Nothing special about root when parsing the filesystem_scan_exclude option
             # There is no parsing of root to individual toplevel directories until running scan_filesystem
             # Add '/' to the list of filesystem_scan_exclude items.  Add it directly after the filesystem_scan_exclude: line
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "test_scan: false" if line.startswith("test_scan:") else line
-                line = line + "\n- /" if line.startswith("filesystem_scan_exclude:") else line
+                line = (
+                    line + "\n- /"
+                    if line.startswith("filesystem_scan_exclude:")
+                    else line
+                )
                 print(line)
-            mdc = MalwareDetectionClient(None)
-            assert '/' in mdc.filesystem_scan_exclude_list
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            assert "/" in mdc.filesystem_scan_exclude_list
             # When scan_filesystem is run, '/' will be expanded into toplevel directories that cancel out everything
             scan_dict = process_include_exclude_items(
-                include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
+                include_items=mdc.scan_fsobjects,
+                exclude_items=mdc.filesystem_scan_exclude_list,
             )
             assert scan_dict == {}
-            log_mock.error.assert_called_with(
+            utils_log_mock.error.assert_called_with(
                 "No filesystem items to scan because the specified exclude items cancel them out"
             )
 
-        @patch(LOGGER_TARGET)
+        @patch(UTILS_LOGGER_TARGET)
         def test_filesystem_scan_only_exclude_nullify(
-            self, log_mock, yara, disabled, rules, cmd, create_test_files_fake_yara
+            self,
+            utils_log_mock,
+            create_test_files_fake_yara,
         ):
             # Testing filesystem scan_only and scan_exclude items such that the exclude items nullify the scan_only items
             # In which case there will be nothing to scan
@@ -980,59 +1378,88 @@ class TestsUtilizingFakeYara:
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
-            assert mdc.scan_fsobjects == ['/var/log', '/usr/lib/systemd', '/tmp']
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            assert mdc.scan_fsobjects == ["/var/log", "/usr/lib/systemd", "/tmp"]
             assert all(
-                [x in mdc.filesystem_scan_exclude_list for x in ['/tmp', '/usr/lib', '/var/log']]
+                [
+                    x in mdc.filesystem_scan_exclude_list
+                    for x in ["/tmp", "/usr/lib", "/var/log"]
+                ]
             )
             # The exclude list covers all the items to be scanned, thus there is nothing to scan
             mdc.scan_filesystem()
             assert mdc.do_filesystem_scan is False
-            log_mock.error.assert_called_with(
+            utils_log_mock.error.assert_called_with(
                 "No filesystem items to scan because the specified exclude items cancel them out"
             )
 
             # Both filesystem scan_only and scan_exclude contain root
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                line = line + "\n- /" if line.startswith("filesystem_scan_only:") else line
-                line = line + "\n- /" if line.startswith("filesystem_scan_exclude:") else line
+                line = (
+                    line + "\n- /" if line.startswith("filesystem_scan_only:") else line
+                )
+                line = (
+                    line + "\n- /"
+                    if line.startswith("filesystem_scan_exclude:")
+                    else line
+                )
                 print(line)
-            mdc = MalwareDetectionClient(None)
-            assert mdc.scan_fsobjects == ['/', '/var/log', '/usr/lib/systemd', '/tmp']
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            assert mdc.scan_fsobjects == [
+                "/",
+                "/var/log",
+                "/usr/lib/systemd",
+                "/tmp",
+            ]
             assert all(
                 [
                     x in mdc.filesystem_scan_exclude_list
-                    for x in ['/', '/tmp', '/usr/lib', '/var/log']
+                    for x in ["/", "/tmp", "/usr/lib", "/var/log"]
                 ]
             )
             # Because both lists contain /, they will cancel each other out and there is nothing to scan
             mdc.scan_filesystem()
             assert mdc.do_filesystem_scan is False
-            log_mock.error.assert_called_with(
+            utils_log_mock.error.assert_called_with(
                 "No filesystem items to scan because the specified exclude items cancel them out"
             )
 
-        @patch(CALL_TARGET)
         @patch(LOGGER_TARGET)
-        @patch.dict(os.environ, {'TEST_SCAN': 'false'})
+        @patch.dict(os.environ, {"TEST_SCAN": "false"})
         def test_filesystem_scan_only_exclude_symlinks(
             self,
             log_mock,
-            call_mock,
-            disabled,
-            yara,
-            rules,
-            cmd,
             extract_tmp_files,
             create_test_files_fake_yara,
         ):
             # Testing using symlinks for filesystem scan_only and scan_exclude items
             # Symlinks will be skipped, whereas broken symlinks are treated like missing files
-            symlink = os.path.join(TEMP_TEST_DIR, 'scan_me/link_file')
-            broken_symlink = os.path.join(TEMP_TEST_DIR, 'scan_me/broken_link')
-            os.environ['FILESYSTEM_SCAN_ONLY'] = "%s,%s" % (symlink, broken_symlink)
+            symlink = os.path.join(TEMP_TEST_DIR, "scan_me/link_file")
+            broken_symlink = os.path.join(TEMP_TEST_DIR, "scan_me/broken_link")
+            os.environ["FILESYSTEM_SCAN_ONLY"] = "%s,%s" % (symlink, broken_symlink)
             with pytest.raises(SystemExit):
-                mdc = MalwareDetectionClient(None)
+                altered_malware_config = load_or_create_malware_config()
+                mdc = MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
                 assert mdc.scan_fsobjects == []
             log_mock.info.assert_any_call(
                 "Skipping symlink filesystem_scan_only item: '%s'.  Please use non-symlink items",
@@ -1045,10 +1472,20 @@ class TestsUtilizingFakeYara:
                 "Nothing to scan with filesystem_scan_only option and scan_processes is disabled"
             )
 
-            scan_only = os.path.join(TEMP_TEST_DIR, 'scan_me')
-            os.environ['FILESYSTEM_SCAN_ONLY'] = scan_only
-            os.environ['FILESYSTEM_SCAN_EXCLUDE'] = "%s,%s" % (symlink, broken_symlink)
-            mdc = MalwareDetectionClient(None)
+            scan_only = os.path.join(TEMP_TEST_DIR, "scan_me")
+            os.environ["FILESYSTEM_SCAN_ONLY"] = scan_only
+            os.environ["FILESYSTEM_SCAN_EXCLUDE"] = "%s,%s" % (
+                symlink,
+                broken_symlink,
+            )
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
             assert mdc.filesystem_scan_exclude_list == []
             assert mdc.scan_fsobjects == [scan_only]
             log_mock.info.assert_any_call(
@@ -1056,7 +1493,8 @@ class TestsUtilizingFakeYara:
                 symlink,
             )
             log_mock.info.assert_any_call(
-                "Skipping missing filesystem_scan_exclude item: '%s'", broken_symlink
+                "Skipping missing filesystem_scan_exclude item: '%s'",
+                broken_symlink,
             )
             log_mock.info.assert_any_call(
                 "Unable to find the items specified for the filesystem_scan_exclude option.  Not excluding any filesystem items"
@@ -1064,31 +1502,29 @@ class TestsUtilizingFakeYara:
 
         @patch(CALL_TARGET)
         @patch(LOGGER_TARGET)
+        @patch(UTILS_LOGGER_TARGET)
         def test_network_filesystem_mountpoints(
             self,
+            utils_log_mock,
             log_mock,
             call_mock,
-            yara,
-            disabled,
-            rules,
-            cmd,
             extract_tmp_files,
             create_test_files_fake_yara,
         ):
             # Test the exclude_network_filesystem_mountpoints option by 'creating' various mountpoints to exclude
-            os.environ['EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'] = (
-                'true'  # Override the default setting for this test class
+            os.environ["EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS"] = (
+                "true"  # Override the default setting for this test class
             )
-            scan_me_scan_me = os.path.join(TEMP_TEST_DIR, 'scan_me/scan_me')
-            scan_me_too = os.path.join(TEMP_TEST_DIR, 'scan_me_too')
-            scan_me_not_mnt = os.path.join(TEMP_TEST_DIR, 'scan_me_not')
-            dont_scan_me_mnt = os.path.join(TEMP_TEST_DIR, 'scan_me/dont_scan_me')
+            scan_me_scan_me = os.path.join(TEMP_TEST_DIR, "scan_me/scan_me")
+            scan_me_too = os.path.join(TEMP_TEST_DIR, "scan_me_too")
+            scan_me_not_mnt = os.path.join(TEMP_TEST_DIR, "scan_me_not")
+            dont_scan_me_mnt = os.path.join(TEMP_TEST_DIR, "scan_me/dont_scan_me")
 
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "test_scan: false" if line.startswith("test_scan:") else line
                 line = (
                     line + "rules_location: %s\n" % TEST_RULE_FILE
-                    if line.startswith('---')
+                    if line.startswith("---")
                     else line
                 )
                 line = (
@@ -1099,27 +1535,54 @@ class TestsUtilizingFakeYara:
                 print(line)
 
             # This is the mocked output returned from the findmnt command
-            call_mock.return_value = '%s\n%s\n' % (scan_me_not_mnt, dont_scan_me_mnt)
+            call_mock.return_value = "%s\n%s\n" % (
+                scan_me_not_mnt,
+                dont_scan_me_mnt,
+            )
 
             # Setting exclude_network_filesystem_mountpoints to false means we don't care about excluding mountpoints
-            os.environ['EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'] = 'false'
-            os.environ['NETWORK_FILESYSTEM_TYPES'] = ''
-            mdc = MalwareDetectionClient(None)
+            os.environ["EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS"] = "false"
+            os.environ["NETWORK_FILESYSTEM_TYPES"] = ""
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
             assert mdc.network_filesystem_mountpoints == []
 
             # Removing the env var (it'll be true from the config file) but still not having any
             # network_filesystem_types value will generate an error
-            del os.environ['EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS']
+            del os.environ["EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS"]
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
+                altered_malware_config = load_or_create_malware_config()
+                mdc = MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
             log_mock.error.assert_called_with(
                 "No value specified for 'network_filesystem_types' option"
             )
 
             # Ok, now with exclude mountpoints true and a value for types we will produce a list of mountpoints
-            os.environ['NETWORK_FILESYSTEM_TYPES'] = 'nfs'
-            mdc = MalwareDetectionClient(None)
-            assert mdc.network_filesystem_mountpoints == [scan_me_not_mnt, dont_scan_me_mnt]
+            os.environ["NETWORK_FILESYSTEM_TYPES"] = "nfs"
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            assert mdc.network_filesystem_mountpoints == [
+                scan_me_not_mnt,
+                dont_scan_me_mnt,
+            ]
 
             # Now we can process all the include and exclude items to build the scan_dict of things to scan
             scan_dict = process_include_exclude_items(
@@ -1129,17 +1592,32 @@ class TestsUtilizingFakeYara:
             )
 
             # The exclude_mountpoints will be added to the list of items to exclude
-            assert list(scan_dict.keys()) == ['/tmp']
-            assert sorted(list(scan_dict['/tmp']['exclude']['items'])) == sorted(
+            assert list(scan_dict.keys()) == ["/tmp"]
+            assert sorted(list(scan_dict["/tmp"]["exclude"]["items"])) == sorted(
                 [scan_me_not_mnt, dont_scan_me_mnt]
             )
-            assert all([x in scan_dict['/tmp']['include'] for x in [scan_me_scan_me, scan_me_too]])
+            assert all(
+                [
+                    x in scan_dict["/tmp"]["include"]
+                    for x in [scan_me_scan_me, scan_me_too]
+                ]
+            )
             # scan_me dir won't be in the list of include items because it has a sub-item to be excluded
-            assert os.path.join(TEMP_TEST_DIR, 'scan_me') not in scan_dict['/tmp']['include']
+            assert (
+                os.path.join(TEMP_TEST_DIR, "scan_me")
+                not in scan_dict["/tmp"]["include"]
+            )
 
             # Now make TEMP_TEST_DIR a mountpoint and it will cancel out TEMP_TEST_DIR for scan_only
-            call_mock.return_value = '%s\n' % TEMP_TEST_DIR
-            mdc = MalwareDetectionClient(None)
+            call_mock.return_value = "%s\n" % TEMP_TEST_DIR
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
             assert mdc.network_filesystem_mountpoints == [TEMP_TEST_DIR]
             scan_dict = process_include_exclude_items(
                 include_items=mdc.scan_fsobjects,
@@ -1147,20 +1625,20 @@ class TestsUtilizingFakeYara:
                 exclude_mountpoints=mdc.network_filesystem_mountpoints,
             )
             assert scan_dict == {}
-            log_mock.error.assert_called_with(
+            utils_log_mock.error.assert_called_with(
                 "No filesystem items to scan because the specified exclude items cancel them out"
             )
 
         @patch(CALL_TARGET)
-        @patch('os.path.samefile', side_effect=OSError(13, "Permission denied"))
+        @patch("os.path.samefile", side_effect=OSError(13, "Permission denied"))
         @patch(LOGGER_TARGET)
         @patch.dict(
             os.environ,
             {
-                'EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS': 'true',
-                'TEST_SCAN': 'false',
-                'RULES_LOCATION': TEST_RULE_FILE,
-                'FILESYSTEM_SCAN_ONLY': TEMP_TEST_DIR,
+                "EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS": "true",
+                "TEST_SCAN": "false",
+                "RULES_LOCATION": TEST_RULE_FILE,
+                "FILESYSTEM_SCAN_ONLY": TEMP_TEST_DIR,
             },
         )
         def test_network_filesystem_permission_denied(
@@ -1168,24 +1646,33 @@ class TestsUtilizingFakeYara:
             log_mock,
             samefile_mock,
             call_mock,
-            yara,
-            disabled,
-            rules,
-            cmd,
             extract_tmp_files,
             create_test_files_fake_yara,
         ):
             # Test accessing network filesystem mountpoints that result in permission denied errors
             # Yes, even root can get permission denied trying to access fuse filesystems
             # Should produce the same results as the corresponding test in test_network_filesystem_mountpoints
-            scan_me_not_mnt = os.path.join(TEMP_TEST_DIR, 'scan_me_not')
-            dont_scan_me_mnt = os.path.join(TEMP_TEST_DIR, 'scan_me/dont_scan_me')
+            scan_me_not_mnt = os.path.join(TEMP_TEST_DIR, "scan_me_not")
+            dont_scan_me_mnt = os.path.join(TEMP_TEST_DIR, "scan_me/dont_scan_me")
             # This is the mocked output returned from the findmnt command
-            call_mock.return_value = '%s\n%s\n' % (scan_me_not_mnt, dont_scan_me_mnt)
+            call_mock.return_value = "%s\n%s\n" % (
+                scan_me_not_mnt,
+                dont_scan_me_mnt,
+            )
 
             with patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE):
-                mdc = MalwareDetectionClient(None)
-            assert mdc.network_filesystem_mountpoints == [scan_me_not_mnt, dont_scan_me_mnt]
+                altered_malware_config = load_or_create_malware_config()
+                mdc = MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
+            assert mdc.network_filesystem_mountpoints == [
+                scan_me_not_mnt,
+                dont_scan_me_mnt,
+            ]
 
             # process_include_exclude_items uses os.path.samefile, but should gracefully handle the permission denied errors
             scan_dict = process_include_exclude_items(
@@ -1193,21 +1680,32 @@ class TestsUtilizingFakeYara:
                 exclude_items=mdc.filesystem_scan_exclude_list,
                 exclude_mountpoints=mdc.network_filesystem_mountpoints,
             )
-            assert sorted(list(scan_dict['/tmp']['exclude']['items'])) == sorted(
+            assert sorted(list(scan_dict["/tmp"]["exclude"]["items"])) == sorted(
                 [scan_me_not_mnt, dont_scan_me_mnt]
             )
 
         @pytest.mark.skipif(IS_CONTAINER, reason=SKIP_IF_CONTAINER_REASON)
         def test_processes_scan_options(
-            self, yara, disabled, rules, cmd, create_test_files_fake_yara
+            self,
+            create_test_files_fake_yara,
         ):
             # Test the processes scan options
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "test_scan: false" if line.startswith("test_scan:") else line
-                line = "scan_filesystem: false" if line.startswith("scan_filesystem:") else line
-                line = "scan_processes: true" if line.startswith("scan_processes:") else line
                 line = (
-                    "processes_scan_only: 1\n" if line.startswith("processes_scan_only:") else line
+                    "scan_filesystem: false"
+                    if line.startswith("scan_filesystem:")
+                    else line
+                )
+                line = (
+                    "scan_processes: true"
+                    if line.startswith("scan_processes:")
+                    else line
+                )
+                line = (
+                    "processes_scan_only: 1\n"
+                    if line.startswith("processes_scan_only:")
+                    else line
                 )
                 line = (
                     "processes_scan_exclude: 1\n"
@@ -1215,9 +1713,16 @@ class TestsUtilizingFakeYara:
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
-            assert mdc.scan_pids == ['1']
-            assert mdc.processes_scan_exclude_list == ['1']
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            assert mdc.scan_pids == ["1"]
+            assert mdc.processes_scan_exclude_list == ["1"]
 
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = (
@@ -1231,11 +1736,18 @@ class TestsUtilizingFakeYara:
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
             assert len(mdc.scan_pids) > 1
-            assert all([pid in mdc.scan_pids for pid in ['1', '2']])
+            assert all([pid in mdc.scan_pids for pid in ["1", "2"]])
             assert len(mdc.processes_scan_exclude_list) > 1
-            assert all([pid in mdc.processes_scan_exclude_list for pid in ['1', '2']])
+            assert all([pid in mdc.processes_scan_exclude_list for pid in ["1", "2"]])
 
             # Test an open ended range, but really just saves typing '1' - scan all processes from 1 to 10
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
@@ -1250,7 +1762,14 @@ class TestsUtilizingFakeYara:
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
             assert len(mdc.scan_pids) > 1
             assert all([int(pid) <= 10 for pid in mdc.scan_pids])
             assert len(mdc.processes_scan_exclude_list) > 1
@@ -1269,7 +1788,14 @@ class TestsUtilizingFakeYara:
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
             assert len(mdc.scan_pids) > 1
             assert all([int(pid) > 100 for pid in mdc.scan_pids])
             assert len(mdc.processes_scan_exclude_list) > 1
@@ -1288,7 +1814,14 @@ class TestsUtilizingFakeYara:
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
             assert len(mdc.scan_pids) > 1
             assert all([int(pid) <= 10 for pid in mdc.scan_pids])
             assert len(mdc.processes_scan_exclude_list) > 1
@@ -1306,11 +1839,18 @@ class TestsUtilizingFakeYara:
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
             assert len(mdc.scan_pids) > 1
-            assert '1' in mdc.scan_pids
+            assert "1" in mdc.scan_pids
             assert len(mdc.processes_scan_exclude_list) > 1
-            assert '1' in mdc.processes_scan_exclude_list
+            assert "1" in mdc.processes_scan_exclude_list
 
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = (
@@ -1324,21 +1864,40 @@ class TestsUtilizingFakeYara:
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
             assert len(mdc.scan_pids) > 1
-            assert all([pid in mdc.scan_pids for pid in ['1', '2', '3']])
+            assert all([pid in mdc.scan_pids for pid in ["1", "2", "3"]])
             assert len(mdc.processes_scan_exclude_list) > 1
-            assert all([pid in mdc.processes_scan_exclude_list for pid in ['1', '2', '3']])
+            assert all(
+                [pid in mdc.processes_scan_exclude_list for pid in ["1", "2", "3"]]
+            )
 
         @patch(LOGGER_TARGET)
         def test_processes_scan_options_invalid_or_missing_values(
-            self, log_mock, yara, disabled, rules, cmd, create_test_files_fake_yara
+            self,
+            log_mock,
+            create_test_files_fake_yara,
         ):
             # Test the processes scan options
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "test_scan: false" if line.startswith("test_scan:") else line
-                line = "scan_filesystem: false" if line.startswith("scan_filesystem:") else line
-                line = "scan_processes: true" if line.startswith("scan_processes:") else line
+                line = (
+                    "scan_filesystem: false"
+                    if line.startswith("scan_filesystem:")
+                    else line
+                )
+                line = (
+                    "scan_processes: true"
+                    if line.startswith("scan_processes:")
+                    else line
+                )
                 line = (
                     line + "\n- pid2\n- three..10\n- 20.50\n- notsystemd"
                     if line.startswith("processes_scan_only:")
@@ -1346,9 +1905,16 @@ class TestsUtilizingFakeYara:
                 )
                 print(line)
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
+                altered_malware_config = load_or_create_malware_config()
+                mdc = MalwareDetectionClient(
+                    InsightsClientConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
             log_mock.error.assert_any_call(
-                "Unable to parse '%s' in to a range of PIDs: %s", 'three..10', ANY
+                "Unable to parse '%s' in to a range of PIDs: %s", "three..10", ANY
             )
             log_mock.error.assert_any_call(
                 "Unable to find the items specified for the processes_scan_only option.  Skipping ..."
@@ -1358,140 +1924,186 @@ class TestsUtilizingFakeYara:
             )
 
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                line = line + "\n- 1" if line.startswith("processes_scan_only:") else line
+                line = (
+                    line + "\n- 1" if line.startswith("processes_scan_only:") else line
+                )
                 line = (
                     line + "\n- -1\n- 3..ten\n- 123 systemd"
                     if line.startswith("processes_scan_exclude:")
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
-            assert mdc.scan_pids == ['1']
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsClientConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            assert mdc.scan_pids == ["1"]
             assert mdc.processes_scan_exclude_list == []
             log_mock.error.assert_any_call(
-                "Unable to parse '%s' in to a range of PIDs: %s", '3..ten', ANY
+                "Unable to parse '%s' in to a range of PIDs: %s", "3..ten", ANY
             )
             log_mock.error.assert_any_call(
                 "Unable to find the items specified for the processes_scan_exclude option.  Not excluding any processes."
             )
 
-    @patch(BUILD_YARA_COMMAND_TARGET)
-    @patch(GET_RULES_TARGET, return_value=RULES_FILE)
-    @patch(DISABLED_RULES_TARGET)
-    @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
     @patch(LOGGER_TARGET)
+    @patch.dict(
+        os.environ,
+        {"USE_REMOTE_RULES": "false", "TEST_SCAN": "false"},
+    )
     class TestFindYara:
 
-        def test_find_yara_binary(self, log_mock, conf, disabled, rules, cmd):
+        def test_find_yara_binary(self, log_mock):
             # Testing finding yara with correct version
-            with patch('os.path.exists', return_value=True):
-                with patch(CALL_TARGET, return_value='4.1'):
-                    mdc = MalwareDetectionClient(None)
-            assert mdc.yara_binary == '/bin/yara'
-            assert mdc.yara_version == '4.1'
-            cmd.assert_called()
+            with patch("os.path.exists", return_value=True):
+                with patch(CONFIG_CALL_TARGET, return_value="4.1"):
+                    yara, yara_version = find_yara()
+                    mdc = MalwareDetectionClient(
+                        InsightsConfig(),
+                        MALWARE_CONFIG,
+                        yara,
+                        yara_version,
+                    )
+            assert mdc.yara_binary == "/bin/yara"
+            assert mdc.yara_version == "4.1"
 
             # 'Find' yara in /usr/bin/yara (fails to 'find' /bin/yara)
-            with patch('os.path.exists', side_effect=[False, True]):
-                with patch(CALL_TARGET, return_value='4.1'):
-                    mdc = MalwareDetectionClient(None)
-            assert mdc.yara_binary == '/usr/bin/yara'
-            assert mdc.yara_version == '4.1'
-            cmd.assert_called()
+            with patch("os.path.exists", side_effect=[False, True]):
+                with patch(CONFIG_CALL_TARGET, return_value="4.1"):
+                    yara, yara_version = find_yara()
+                    mdc = MalwareDetectionClient(
+                        InsightsClientConfig(),
+                        MALWARE_CONFIG,
+                        yara,
+                        yara_version,
+                    )
+            assert mdc.yara_binary == "/usr/bin/yara"
+            assert mdc.yara_version == "4.1"
 
-        def test_find_unsupported_yara(self, log_mock, conf, disabled, rules, cmd):
+        @patch(CONFIG_LOGGER_TARGET)
+        def test_find_unsupported_yara(self, config_log_mock, log_mock):
             # Test finding unsupported yara version
-            with patch('os.path.exists', return_value=True):
-                with patch(CALL_TARGET, return_value='3.10'):
+            with patch("os.path.exists", return_value=True):
+                with patch(CONFIG_CALL_TARGET, return_value="3.10"):
                     with pytest.raises(SystemExit):
-                        mdc = MalwareDetectionClient(None)
-                        assert mdc.yara_version == '3.10'
-            log_mock.error.assert_called_with(
+                        find_yara()
+
+            config_log_mock.error.assert_called_with(
                 "Found /bin/yara with version 3.10, but malware-detection requires version >= 4.1.0\n"
                 "Please install a later version of yara."
             )
-            cmd.assert_not_called()
 
-        def test_find_invalid_yara(self, log_mock, conf, disabled, rules, cmd):
+        @patch(CONFIG_LOGGER_TARGET)
+        def test_find_invalid_yara(self, config_log_mock, log_mock):
             # Test finding a binary called yara, but its not yara
-            with patch('os.path.exists', return_value=True):
-                with patch(CALL_TARGET, return_value='not yara 1.2.3'):
+            with patch("os.path.exists", return_value=True):
+                with patch(CONFIG_CALL_TARGET, return_value="not yara 1.2.3"):
                     with pytest.raises(SystemExit):
-                        MalwareDetectionClient(None)
-            log_mock.error.assert_called_with(
-                "Error getting the version of the specified yara binary %s: %s", "/bin/yara", ANY
+                        find_yara()
+            config_log_mock.error.assert_called_with(
+                "Error getting the version of the specified yara binary %s: %s",
+                "/bin/yara",
+                ANY,
             )
-            cmd.assert_not_called()
 
-        def test_cant_find_yara(self, log_mock, conf, disabled, rules, cmd):
+        @patch(CONFIG_LOGGER_TARGET)
+        def test_cant_find_yara(self, config_log_mock, log_mock):
             # Test can't find yara on the system
-            with patch('os.path.exists', return_value=False):
+            with patch("os.path.exists", return_value=False):
                 with pytest.raises(SystemExit):
-                    MalwareDetectionClient(None)
-            log_mock.error.assert_called_with(
+                    find_yara()
+            config_log_mock.error.assert_called_with(
                 "Couldn't find yara.  Please ensure the yara package is installed"
             )
-            cmd.assert_not_called()
 
         @patch("os.path.exists", return_value=True)
-        @patch(CALL_TARGET)  # mock call to 'yara --version'
+        @patch(CONFIG_CALL_TARGET)  # mock call to 'yara --version'
+        @patch(CONFIG_LOGGER_TARGET)
         def test_yara_versions(
-            self, version_mock, exists_mock, log_mock, conf, disabled, rules, cmd
+            self,
+            config_log_mock,
+            version_mock,
+            exists_mock,
+            log_mock,
         ):
             # Test checking the version of yara
             # Invalid versions of yara
-            for version in ['4.0.99', '4']:
+            for version in ["4.0.99", "4"]:
                 version_mock.return_value = version
                 with pytest.raises(SystemExit):
-                    MalwareDetectionClient(None)
-            cmd.assert_not_called()  # We won't get to the build_yara_cmd method because we exit before its called
+                    find_yara()
 
             # Valid versions of yara
-            for version in ['4.1', '4.10.10', '10.100.1000.0', '5']:
+            for version in ["4.1", "4.10.10", "10.100.1000.0", "5"]:
                 version_mock.return_value = version
-                mdc = MalwareDetectionClient(None)
-                assert mdc.yara_binary == '/bin/yara'
-                assert mdc.yara_version in ['4.1', '4.10.10', '10.100.1000.0', '5']
-            cmd.assert_called()
+                yara_binary, yara_version = find_yara()
+                assert yara_binary == "/bin/yara"
+                assert yara_version in ["4.1", "4.10.10", "10.100.1000.0", "5"]
 
     # Use patch.object, just because I wanted to try using patch.object instead of using patch all the time :shrug:
     @patch(
         NAMEDTMPFILE_TARGET
     )  # Mock NamedTemporaryFile so it doesn't try to create the temporary file
-    @patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
-    @patch.object(MalwareDetectionClient, '_parse_exclude_network_filesystem_mountpoints_option')
+    @patch(
+        "os.remove"
+    )  # Mock os.remove so it doesn't actually try to remove any existing files
     @patch.object(
-        InsightsConnection, 'get', return_value=Mock(status_code=200, content=b"Rule Content")
+        MalwareDetectionClient,
+        "_parse_exclude_network_filesystem_mountpoints_option",
     )
-    @patch.object(InsightsConnection, 'get_proxies')
-    @patch.object(InsightsConnection, '_init_session', return_value=Mock())
-    @patch.object(MalwareDetectionClient, '_get_disabled_rules', return_value=[])
-    @patch.object(MalwareDetectionClient, '_build_yara_command')
-    @patch.object(MalwareDetectionClient, '_load_config', return_value=CONFIG)
+    @patch.object(
+        InsightsConnection,
+        "get",
+        return_value=Mock(status_code=200, content=b"Rule Content"),
+    )
+    @patch.object(InsightsConnection, "get_proxies")
+    @patch.object(InsightsConnection, "_init_session", return_value=Mock())
     # NOTE: Downloading the malware rules file happens within the malware client code so it's possible to test it here
     # However uploading the results archive is done outside the malware client code so it's not possible to test here
     class TestGetRules:
         """Testing the _get_rules method"""
 
-        @patch.dict(os.environ, {'TEST_SCAN': 'true'})
-        @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
+        @patch.dict(os.environ, {"TEST_SCAN": "true"})
         def test_download_rules_cert_auth(
-            self, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile
+            self,
+            session,
+            proxies,
+            get,
+            findmnt,
+            remove,
+            tmpfile,
         ):
             # Test the standard rules_location urls, but will result in cert auth being used to download the rules
             # Test with insights-config None, expect an error when trying to use the insights-config object
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(None)
-            session.assert_not_called()
 
+                mdc = MalwareDetectionClient(
+                    None, MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
+            session.assert_not_called()
             # With default insights config and test scan true ...
             # Expect to use cert auth because no username or password specified and expect to download test-rule.yar
-            mdc = MalwareDetectionClient(InsightsConfig())
+            mdc = MalwareDetectionClient(
+                InsightsConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+
+            assert mdc.rules_location == TEST_RULE_LOCATION
             assert (
-                mdc.rules_location
+                mdc.remote_rules_location
                 == "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
             )
-            assert mdc.rules_file.startswith('/tmp')  # rules will be saved into a temp file
+            # rules_file a list now? probably need to update this
+            assert mdc.rules_files[0].startswith(
+                "/tmp"
+            )  # rules will be saved into a temp file
             get.assert_called_with(
                 "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar",
                 log_response_text=True,
@@ -1500,9 +2112,17 @@ class TestsUtilizingFakeYara:
             )
 
             # With authmethod=CERT, expect 'cert.' to be prefixed to the url
-            mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
+            mdc = MalwareDetectionClient(
+                InsightsConfig(authmethod="CERT"),
+                MALWARE_CONFIG,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+            assert mdc.rules_location == TEST_RULE_LOCATION
             assert (
-                mdc.rules_location
+                mdc.remote_rules_location
                 == "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
             )
             get.assert_called_with(
@@ -1514,41 +2134,56 @@ class TestsUtilizingFakeYara:
 
             # With authmethod=BASIC and test scan false ...
             # Expect to still use cert auth because no username or password specified
-            os.environ['TEST_SCAN'] = 'false'
-            mdc = MalwareDetectionClient(InsightsConfig(authmethod='BASIC'))
+            os.environ["TEST_SCAN"] = "false"
+            mdc = MalwareDetectionClient(
+                InsightsConfig(authmethod="BASIC"),
+                MALWARE_CONFIG,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+            assert mdc.rules_location == TEST_RULE_LOCATION
             assert (
-                mdc.rules_location
-                == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
+                mdc.remote_rules_location
+                == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar?yara_version="
+                + FAKE_YARA_VERSION
             )
             get.assert_called_with(
-                "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar",
+                "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar?yara_version="
+                + FAKE_YARA_VERSION,
                 log_response_text=False,
                 verify=True,
                 stream=True,
             )
 
-            mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
+            mdc = MalwareDetectionClient(
+                InsightsConfig(authmethod="CERT"),
+                MALWARE_CONFIG,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+            assert mdc.rules_location == TEST_RULE_LOCATION
             assert (
-                mdc.rules_location
-                == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
+                mdc.remote_rules_location
+                == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar?yara_version="
+                + FAKE_YARA_VERSION
             )
             get.assert_called_with(
-                "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar",
+                "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar?yara_version="
+                + FAKE_YARA_VERSION,
                 log_response_text=False,
                 verify=True,
                 stream=True,
             )
 
-        @patch.dict(os.environ, {'TEST_SCAN': 'true'})
-        @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
-        @patch(LOGGER_TARGET)
+        @patch.dict(os.environ, {"TEST_SCAN": "true"})
+        @patch(RULES_LOGGER_TARGET)
         def test_download_rules_basic_auth(
             self,
-            log_mock,
-            yara,
-            conf,
-            cmd,
-            disabled,
+            rules_log_mock,
             session,
             proxies,
             get,
@@ -1559,16 +2194,27 @@ class TestsUtilizingFakeYara:
             # Test the standard rules_location urls, with basic auth attempting to be used to download the rules
             # Basic auth is used by default, but needs to have a valid username and password for it to work
             # Without a username and password, then cert auth will be used
-            expected_rules_url = "https://console.redhat.com/api/malware-detection/v1/test-rule.yar"
+            expected_rules_url = (
+                "https://console.redhat.com/api/malware-detection/v1/test-rule.yar"
+            )
 
             # Test with just a username specified - expect basic auth to be used but fails
-            get.return_value = Mock(status_code=401, reason="Unauthorized", text="No can do")
+            get.return_value = Mock(
+                status_code=401, reason="Unauthorized", text="No can do"
+            )
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(InsightsConfig(username='user'))
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(username="user"),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
             get.assert_called_with(
                 expected_rules_url, log_response_text=True, verify=True, stream=True
             )
-            log_mock.error.assert_called_with(
+            rules_log_mock.error.assert_called_with(
                 "Unable to download rules from %s: %s",
                 expected_rules_url,
                 "401 Unauthorized: No can do",
@@ -1576,11 +2222,18 @@ class TestsUtilizingFakeYara:
 
             # Test with just a password specified - expect basic auth to be used but fails
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(InsightsConfig(password='pass'))
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(password="pass"),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
             get.assert_called_with(
                 expected_rules_url, log_response_text=True, verify=True, stream=True
             )
-            log_mock.error.assert_called_with(
+            rules_log_mock.error.assert_called_with(
                 "Unable to download rules from %s: %s",
                 expected_rules_url,
                 "401 Unauthorized: No can do",
@@ -1588,11 +2241,19 @@ class TestsUtilizingFakeYara:
 
             # Test with 'incorrect' username and/or password - expect basic auth failure
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(InsightsConfig(username='user', password='badpass'))
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(username="user", password="badpass"),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
+
             get.assert_called_with(
                 expected_rules_url, log_response_text=True, verify=True, stream=True
             )
-            log_mock.error.assert_called_with(
+            rules_log_mock.error.assert_called_with(
                 "Unable to download rules from %s: %s",
                 expected_rules_url,
                 "401 Unauthorized: No can do",
@@ -1600,22 +2261,32 @@ class TestsUtilizingFakeYara:
 
             # Test with 'correct' username and password - expect basic auth success
             get.return_value = Mock(status_code=200, content=b"Rule Content")
-            mdc = MalwareDetectionClient(InsightsConfig(username='user', password='goodpass'))
-            assert mdc.rules_location == expected_rules_url
+
+            mdc = MalwareDetectionClient(
+                InsightsConfig(username="user", password="goodpass"),
+                MALWARE_CONFIG,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
                 expected_rules_url, log_response_text=True, verify=True, stream=True
             )
 
-        @patch.dict(os.environ, {'TEST_SCAN': 'false'})
-        @patch("os.path.exists", return_value=True)  # mock call to os.path.exists in _find_yara
-        @patch(CALL_TARGET, return_value='4.2.1')  # mock call to 'yara --version'
+        @patch.dict(os.environ, {"TEST_SCAN": "false"})
+        @patch(
+            "os.path.exists", return_value=True
+        )  # mock call to os.path.exists in _find_yara
+        @patch(
+            CONFIG_CALL_TARGET, return_value="4.2.1"
+        )  # mock call to 'yara --version'
         def test_download_rules_versioned_files(
             self,
             version_mock,
             exists_mock,
-            conf,
-            cmd,
-            disabled,
             session,
             proxies,
             get,
@@ -1624,12 +2295,17 @@ class TestsUtilizingFakeYara:
             tmpfile,
         ):
             # Test downloading different signatures files depending on the yara version found on the system
-            expected_rules_url = (
-                "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
+            expected_rules_url = "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
+            yara, yara_version = find_yara()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(), MALWARE_CONFIG, yara, yara_version
             )
-            mdc = MalwareDetectionClient(InsightsConfig())
-            assert mdc.yara_version == '4.2.1'
-            assert mdc.rules_location == expected_rules_url + "?yara_version=4.2.1"
+            mdc.parse_scan_options()
+            mdc.load_rules()
+            assert mdc.yara_version == "4.2.1"
+            assert (
+                mdc.remote_rules_location == expected_rules_url + "?yara_version=4.2.1"
+            )
             get.assert_called_with(
                 expected_rules_url + "?yara_version=4.2.1",
                 log_response_text=False,
@@ -1637,9 +2313,16 @@ class TestsUtilizingFakeYara:
                 stream=True,
             )
 
-            version_mock.return_value = '4.1.0'
-            mdc = MalwareDetectionClient(InsightsConfig())
-            assert mdc.rules_location == expected_rules_url + "?yara_version=4.1.0"
+            version_mock.return_value = "4.1.0"
+            yara, yara_version = find_yara()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(), MALWARE_CONFIG, yara, yara_version
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+            assert (
+                mdc.remote_rules_location == expected_rules_url + "?yara_version=4.1.0"
+            )
             get.assert_called_with(
                 expected_rules_url + "?yara_version=4.1.0",
                 log_response_text=False,
@@ -1647,9 +2330,16 @@ class TestsUtilizingFakeYara:
                 stream=True,
             )
 
-            version_mock.return_value = '10.100'
-            mdc = MalwareDetectionClient(InsightsConfig())
-            assert mdc.rules_location == expected_rules_url + "?yara_version=10.100"
+            version_mock.return_value = "10.100"
+            yara, yara_version = find_yara()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(), MALWARE_CONFIG, yara, yara_version
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+            assert (
+                mdc.remote_rules_location == expected_rules_url + "?yara_version=10.100"
+            )
             get.assert_called_with(
                 expected_rules_url + "?yara_version=10.100",
                 log_response_text=False,
@@ -1657,25 +2347,17 @@ class TestsUtilizingFakeYara:
                 stream=True,
             )
 
-            # Bypass the _find_yara method so self.yara_version isn't set
-            with patch(FIND_YARA_TARGET, return_value=FAKE_YARA):
-                mdc = MalwareDetectionClient(InsightsConfig())
-            assert not hasattr(mdc, 'yara_version')
-            assert mdc.rules_location == expected_rules_url
-            get.assert_called_with(
-                expected_rules_url, log_response_text=False, verify=True, stream=True
-            )
-
-        @patch.dict(os.environ, {'TEST_SCAN': 'false'})
-        @patch("os.path.exists", return_value=True)  # mock call to os.path.exists in _find_yara
-        @patch(CALL_TARGET, return_value='4.2.0')  # mock call to 'yara --version'
+        @patch.dict(os.environ, {"TEST_SCAN": "false"})
+        @patch(
+            "os.path.exists", return_value=True
+        )  # mock call to os.path.exists in _find_yara
+        @patch(
+            CONFIG_CALL_TARGET, return_value="4.2.0"
+        )  # mock call to 'yara --version'
         def test_download_rules_from_stage(
             self,
             version_mock,
             exists_mock,
-            conf,
-            cmd,
-            disabled,
             session,
             proxies,
             get,
@@ -1688,83 +2370,164 @@ class TestsUtilizingFakeYara:
 
             base_url = "cert.console.stage.example.com:443/r/insights"
             expected_rules_url = "https://cert.console.stage.example.com/api/malware-detection/v1/signatures.yar?yara_version=4.2.0"
-            mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url, cert_verify='False'))
-            assert mdc.yara_version == '4.2.0'
-            assert mdc.rules_location == expected_rules_url
+
+            yara, yara_version = find_yara()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(base_url=base_url, cert_verify="False"),
+                MALWARE_CONFIG,
+                yara,
+                yara_version,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+
+            assert mdc.yara_version == "4.2.0"
+            assert mdc.rules_location == TEST_RULE_LOCATION
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
-                expected_rules_url, log_response_text=False, verify=False, stream=True
+                expected_rules_url,
+                log_response_text=False,
+                verify=False,
+                stream=True,
             )
 
             for base_url in (
-                'cert.console.stage.example.com/r/insights',
-                'cert.console.stage.example.com',
+                "cert.console.stage.example.com/r/insights",
+                "cert.console.stage.example.com",
             ):
-                mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url, cert_verify='false'))
-                assert mdc.rules_location == expected_rules_url
+
+                yara, yara_version = find_yara()
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(base_url=base_url, cert_verify="false"),
+                    MALWARE_CONFIG,
+                    yara,
+                    yara_version,
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
+
+                assert mdc.rules_location == TEST_RULE_LOCATION
+                assert mdc.remote_rules_location == expected_rules_url
                 get.assert_called_with(
-                    expected_rules_url, log_response_text=False, verify=False, stream=True
+                    expected_rules_url,
+                    log_response_text=False,
+                    verify=False,
+                    stream=True,
                 )
 
             base_url = "https://cert.console.stage.example.com:443/r/insights"
             expected_rules_url = "https://cert.console.stage.example.com:443/api/malware-detection/v1/signatures.yar?yara_version=4.2.0"
-            mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url, cert_verify='True'))
-            assert mdc.rules_location == expected_rules_url
+
+            yara, yara_version = find_yara()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(base_url=base_url, cert_verify="True"),
+                MALWARE_CONFIG,
+                yara,
+                yara_version,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+
+            assert mdc.rules_location == TEST_RULE_LOCATION
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
-                expected_rules_url, log_response_text=False, verify=True, stream=True
+                expected_rules_url,
+                log_response_text=False,
+                verify=True,
+                stream=True,
             )
 
-            os.environ['TEST_SCAN'] = 'true'
+            os.environ["TEST_SCAN"] = "true"
             base_url = "cloud.stage.example.com"
             expected_rules_url = (
                 "https://cloud.stage.example.com/api/malware-detection/v1/test-rule.yar"
             )
-            mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url, cert_verify=''))
-            assert mdc.rules_location == expected_rules_url
+
+            yara, yara_version = find_yara()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(base_url=base_url, cert_verify=""),
+                MALWARE_CONFIG,
+                yara,
+                yara_version,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+
+            assert mdc.rules_location == TEST_RULE_LOCATION
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
                 expected_rules_url, log_response_text=True, verify=True, stream=True
             )
 
         @patch.dict(
-            os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': 'console.redhat.com/rules.yar'}
+            os.environ,
+            {
+                "TEST_SCAN": "true",
+                "REMOTE_RULES_LOCATION": "console.redhat.com/api/malware-detection/v1/rules.yar",
+            },
         )
-        @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
         def test_get_rules_missing_protocol(
-            self, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile
+            self,
+            session,
+            proxies,
+            get,
+            findmnt,
+            remove,
+            tmpfile,
         ):
             # Non-standard rules URLS - without https:// at the start and not signatures.yar
             # test-scan true and BASIC auth by default expect test-rule.yar and no 'cert.' in URL
-            mdc = MalwareDetectionClient(InsightsConfig(username='user', password='pass'))
-            assert mdc.rules_location == "https://console.redhat.com/test-rule.yar"
+            mdc = MalwareDetectionClient(
+                InsightsConfig(username="user", password="pass"),
+                MALWARE_CONFIG,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+            assert (
+                mdc.remote_rules_location
+                == "https://console.redhat.com/api/malware-detection/v1/test-rule.yar"
+            )
             get.assert_called_with(
-                "https://console.redhat.com/test-rule.yar",
+                "https://console.redhat.com/api/malware-detection/v1/test-rule.yar",
                 log_response_text=True,
                 verify=True,
                 stream=True,
             )
 
             # test-scan false and CERT auth - expect 'cert.' prefixed to the URL and not test-rule.yar
-            os.environ['TEST_SCAN'] = 'false'
-            mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
-            assert mdc.rules_location == "https://cert.console.redhat.com/rules.yar"
+            os.environ["TEST_SCAN"] = "false"
+            mdc = MalwareDetectionClient(
+                InsightsConfig(authmethod="CERT"),
+                MALWARE_CONFIG,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+            assert (
+                mdc.remote_rules_location
+                == "https://cert.console.redhat.com/api/malware-detection/v1/rules.yar"
+            )
             get.assert_called_with(
-                "https://cert.console.redhat.com/rules.yar",
+                "https://cert.console.redhat.com/api/malware-detection/v1/rules.yar",
                 log_response_text=False,
                 verify=True,
                 stream=True,
             )
 
         @patch.dict(
-            os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'http://localhost/rules.yar'}
+            os.environ,
+            {
+                "TEST_SCAN": "false",
+                "REMOTE_RULES_LOCATION": "http://localhost/rules.yar",
+            },
         )
-        @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
-        @patch(LOGGER_TARGET)
+        @patch(RULES_LOGGER_TARGET)
         def test_download_failures(
             self,
-            log_mock,
-            yara,
-            conf,
-            cmd,
-            disabled,
+            rules_log_mock,
             session,
             proxies,
             get,
@@ -1775,55 +2538,80 @@ class TestsUtilizingFakeYara:
             from requests.exceptions import ConnectionError, Timeout
 
             # Test various problems downloading rules
-            expected_rules_url = os.environ['RULES_LOCATION']
+            expected_rules_url = os.environ["REMOTE_RULES_LOCATION"]
 
             # 404 error - unlikely to occur unless an incorrect rules_location was manually specified
             get.return_value = Mock(status_code=404, reason="Not found", text="Nup")
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(InsightsConfig())
-            log_mock.error.assert_called_with(
-                "Unable to download rules from %s: %s", expected_rules_url, "404 Not found: Nup"
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
+            rules_log_mock.error.assert_called_with(
+                "Unable to download rules from %s: %s",
+                expected_rules_url,
+                "404 Not found: Nup",
             )
             assert get.call_count == 1
 
             # Test other errors downloading rules from the backend - these are more likely to occur
             # Firstly handling an error like connection refused (Couldn't connect)
-            get.side_effect = [ConnectionError("Couldn't connect"), Timeout("Timeout")]
+            get.side_effect = [
+                ConnectionError("Couldn't connect"),
+                Timeout("Timeout"),
+            ]
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(InsightsConfig(username='user', password='pass'))
-            log_mock.error.assert_called_with(
-                "Unable to download rules from %s: %s", expected_rules_url, "Couldn't connect"
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(username="user", password="pass"),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
+            rules_log_mock.error.assert_called_with(
+                "Unable to download rules from %s: %s",
+                expected_rules_url,
+                "Couldn't connect",
             )
             assert get.call_count == 2
 
             # Then handling a Timeout error
             # Note, because we aren't downloading from console.redhat.com, there won't be 'cert.*' appended to the URL
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(InsightsConfig())
-            log_mock.error.assert_called_with(
-                "Unable to download rules from %s: %s", expected_rules_url, "Timeout"
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
+            rules_log_mock.error.assert_called_with(
+                "Unable to download rules from %s: %s",
+                expected_rules_url,
+                "Timeout",
             )
             assert get.call_count == 3
 
         @pytest.mark.skipif(
             not (TEST_DOWNLOAD_FAILURE_RETRIES or TEST_ALL),
-            reason='test_download_failure_retries is slow due to the inherent delay in the retry logic. '
-            'Use TEST_DOWNLOAD_FAILURE_RETRIES=True to enable test',
+            reason="test_download_failure_retries is slow due to the inherent delay in the retry logic. "
+            "Use TEST_DOWNLOAD_FAILURE_RETRIES=True to enable test",
         )
         @patch.dict(
-            os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'http://localhost/rules.yar'}
+            os.environ,
+            {
+                "TEST_SCAN": "false",
+                "REMOTE_RULES_LOCATION": "http://localhost/rules.yar",
+            },
         )
-        @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
         @patch("os.path.isfile", return_value=True)
         @patch(LOGGER_TARGET)
+        @patch(RULES_LOGGER_TARGET)
         def test_download_failure_retries(
             self,
+            rules_log_mock,
             log_mock,
             isfile,
-            yara,
-            conf,
-            cmd,
-            disabled,
             session,
             proxies,
             get,
@@ -1834,102 +2622,184 @@ class TestsUtilizingFakeYara:
             from requests.exceptions import ConnectionError, SSLError
 
             # Testing the download failure retry logic
-            expected_rules_url = os.environ['RULES_LOCATION']
+            expected_rules_url = os.environ["REMOTE_RULES_LOCATION"]
 
             # Status code != 200 will trigger a retry, but only if retries > 1
             get.return_value = Mock(status_code=404, reason="Not found", text="Nup")
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(InsightsConfig(retries=1))
-            log_mock.error.assert_called_with(
-                "Unable to download rules from %s: %s", expected_rules_url, "404 Not found: Nup"
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(retries=1),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
+            rules_log_mock.error.assert_called_with(
+                "Unable to download rules from %s: %s",
+                expected_rules_url,
+                "404 Not found: Nup",
             )
             # Last call to logger.debug will be about downloading rules, not about retrying, which shows retrying wasn't invoked
             log_mock.debug.assert_called_with("Using cert_verify value %s ...", True)
-            log_mock.debug.assert_any_call("Downloading rules from: %s", expected_rules_url)
+            log_mock.debug.assert_any_call(
+                "Downloading rules from: %s", expected_rules_url
+            )
 
             # Set retries > 1 and now retrying happens
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(InsightsConfig(retries=2))
-            log_mock.error.assert_called_with(
-                "Unable to download rules from %s: %s", expected_rules_url, "404 Not found: Nup"
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(retries=2),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
+            rules_log_mock.error.assert_called_with(
+                "Unable to download rules from %s: %s",
+                expected_rules_url,
+                "404 Not found: Nup",
             )
             # This time, the last call to logger.debug will be about retrying the download
-            log_mock.debug.assert_called_with("Trying again in %d seconds ...", 1)
+            rules_log_mock.debug.assert_called_with("Trying again in %d seconds ...", 1)
 
             # Other network errors that raise an exception will trigger a retry
             get.side_effect = ConnectionError("Couldn't connect")
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(InsightsConfig(retries=3))
-            log_mock.error.assert_called_with(
-                "Unable to download rules from %s: %s", expected_rules_url, "Couldn't connect"
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(retries=3),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
+            rules_log_mock.error.assert_called_with(
+                "Unable to download rules from %s: %s",
+                expected_rules_url,
+                "Couldn't connect",
             )
             # Because we've set retries to 3, the last attempted retry will wait 2 seconds
-            log_mock.debug.assert_called_with("Trying again in %d seconds ...", 2)
+            rules_log_mock.debug.assert_called_with("Trying again in %d seconds ...", 2)
 
             # Certificate verify failed SSL Errors will cause a different CA certificate bundle to be tried
-            ca_cert = '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'  # default ca cert bundle file to try
+            ca_cert = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"  # default ca cert bundle file to try
             ssl_error = "SSL Error: certificate verify failed"
             get.side_effect = SSLError(ssl_error)
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(InsightsConfig(retries=2))
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(retries=2),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
             get.assert_called_with(
-                expected_rules_url, log_response_text=False, verify=ca_cert, stream=True
+                expected_rules_url,
+                log_response_text=False,
+                verify=ca_cert,
+                stream=True,
             )
-            log_mock.debug.assert_called_with("Trying cert_verify value %s ...", ca_cert)
-            log_mock.error.assert_called_with(
-                "Unable to download rules from %s: %s", expected_rules_url, ssl_error
+            rules_log_mock.debug.assert_called_with(
+                "Trying cert_verify value %s ...", ca_cert
+            )
+            rules_log_mock.error.assert_called_with(
+                "Unable to download rules from %s: %s",
+                expected_rules_url,
+                ssl_error,
             )
 
             # CA certificate bundles can be specified in the config file or via env vars too
-            ca_cert = '/some/cert/file.crt'
-            os.environ['CA_CERT'] = (
+            ca_cert = "/some/cert/file.crt"
+            os.environ["CA_CERT"] = (
                 ca_cert  # customers can specify their own ca bundle file via config/env vars
             )
             ssl_error = "SslError CERTIFICATE_VERIFY_FAILED"
             get.side_effect = SSLError(ssl_error)
             with pytest.raises(SystemExit):
-                MalwareDetectionClient(InsightsConfig(retries=2))
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(retries=2),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
+                mdc.load_rules()
             get.assert_called_with(
-                expected_rules_url, log_response_text=False, verify=ca_cert, stream=True
+                expected_rules_url,
+                log_response_text=False,
+                verify=ca_cert,
+                stream=True,
             )
-            log_mock.debug.assert_called_with("Trying cert_verify value %s ...", ca_cert)
-            log_mock.error.assert_called_with(
-                "Unable to download rules from %s: %s", expected_rules_url, ssl_error
+            rules_log_mock.debug.assert_called_with(
+                "Trying cert_verify value %s ...", ca_cert
+            )
+            rules_log_mock.error.assert_called_with(
+                "Unable to download rules from %s: %s",
+                expected_rules_url,
+                ssl_error,
             )
 
-        @patch.dict(
-            os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': '//console.redhat.com/rules.yar'}
-        )
-        @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
-        @patch("os.path.isfile", return_value=True)
-        def test_get_rules_location_as_file(
-            self, isfile, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile
-        ):
-            # Test using files for rules_location, esp irregular file names
-            # rules_location that starts with a '/' is assumed to be a file, even if its a double '//'
-            # Re-writing the rule to be test-rule.yar doesn't apply to local files
-            mdc = MalwareDetectionClient(None)
-            assert mdc.rules_location == "//console.redhat.com/rules.yar"
-            assert mdc.rules_file == "/console.redhat.com/rules.yar"
-            get.assert_not_called()
+        # todo think this test is no longer necessary since rule_location should be local
+        # @patch.dict(
+        #     os.environ,
+        #     {
+        #         "TEST_SCAN": "true",
+        #         "RULES_LOCATION": "//api/malware-detection/v1/rules.yar",
+        #         "USE_REMOTE_RULES": "FALSE",
+        #     },
+        # )
+        # @patch("os.path.isfile", return_value=True)
+        # def test_get_rules_location_as_file(
+        #     self,
+        #     isfile,
+        #     session,
+        #     proxies,
+        #     get,
+        #     findmnt,
+        #     remove,
+        #     tmpfile,
+        # ):
+        #     # Test using files for rules_location, esp irregular file names
+        #     # rules_location that starts with a '/' is assumed to be a file, even if its a double '//'
+        #     # Re-writing the rule to be test-rule.yar doesn't apply to local files
+        #     mdc = MalwareDetectionClient(
+        #         InsightsConfig(), MALWARE_CONFIG,
+        #         FAKE_YARA, FAKE_YARA_VERSION)
+        #     mdc.parse_scan_options()
+        #     mdc.load_rules()
+        #     assert mdc.rules_location == "//api/malware-detection/v1/rules.yar"
+        #     assert mdc.rules_files == ['/api/malware-detection/v1/rules.yar']
+        #     get.assert_not_called()
+        #
+        #     # Just to confirm the filename stays the same for regardless of test_rule value
+        #     os.environ["TEST_SCAN"] = "false"
+        #     mdc = MalwareDetectionClient(InsightsConfig())
+        #     assert mdc.rules_location == "//api/malware-detection/v1/rules.yar"
+        #     assert mdc.rules_file == ['/api/malware-detection/v1/rules.yar']
+        #     get.assert_not_called()
 
-            # Just to confirm the filename stays the same for regardless of test_rule value
-            os.environ['TEST_SCAN'] = 'false'
-            mdc = MalwareDetectionClient(None)
-            assert mdc.rules_location == "//console.redhat.com/rules.yar"
-            assert mdc.rules_file == "/console.redhat.com/rules.yar"
-            get.assert_not_called()
-
-        @patch.dict(os.environ, {'TEST_SCAN': 'true'})
+        @patch.dict(os.environ, {"TEST_SCAN": "true"})
         @patch(LOGGER_TARGET)
         def test_download_rules_via_satellite(
-            self, log_mock, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile
+            self,
+            log_mock,
+            session,
+            proxies,
+            get,
+            findmnt,
+            remove,
+            tmpfile,
         ):
             # Test recognizing and handling of Satellite URLs.
             # Satellite URLs have '/redhat_access/' in their path (so Satellite knows to redirect the query to C.R.C)
             # For malware-detection requests through a Satellite we append the malware-detection path and add https://
-            satellite_url = 'satellite.example.com:443/redhat_access/r/insights/platform'
-            satellite_cert = '/etc/rhsm/ca/katello-server-ca.pem'
+            satellite_url = (
+                "satellite.example.com:443/redhat_access/r/insights/platform"
+            )
+            satellite_cert = "/etc/rhsm/ca/katello-server-ca.pem"
             expected_rules_url_prefix = "https://satellite.example.com:443/redhat_access/r/insights/platform/malware-detection/v1/"
             insights_config = InsightsConfig(
                 base_url=satellite_url, verbose=True, cert_verify=satellite_cert
@@ -1937,202 +2807,334 @@ class TestsUtilizingFakeYara:
 
             # Firstly try with test-rule
             expected_rules_url = expected_rules_url_prefix + "test-rule.yar"
-            with patch(FIND_YARA_TARGET, return_value=FAKE_YARA):
-                mdc = MalwareDetectionClient(insights_config)
-            assert mdc.rules_location == expected_rules_url
-            get.assert_called_with(
-                expected_rules_url, log_response_text=True, verify=satellite_cert, stream=True
+            mdc = MalwareDetectionClient(
+                insights_config, MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
             )
-            log_mock.debug.assert_called_with("Using cert_verify value %s ...", satellite_cert)
-            log_mock.debug.assert_any_call("Downloading rules from: %s", expected_rules_url)
+            mdc.parse_scan_options()
+            mdc.load_rules()
+
+            assert mdc.remote_rules_location == expected_rules_url
+            get.assert_called_with(
+                expected_rules_url,
+                log_response_text=True,
+                verify=satellite_cert,
+                stream=True,
+            )
+            log_mock.debug.assert_called_with(
+                "Using cert_verify value %s ...", satellite_cert
+            )
+            log_mock.debug.assert_any_call(
+                "Downloading rules from: %s", expected_rules_url
+            )
 
             # Then with the actual rules file
-            os.environ['TEST_SCAN'] = 'false'
+            os.environ["TEST_SCAN"] = "false"
             expected_rules_url = expected_rules_url_prefix + "signatures.yar"
-            with patch(FIND_YARA_TARGET, return_value=FAKE_YARA):
-                mdc = MalwareDetectionClient(insights_config)
-            assert mdc.rules_location == expected_rules_url
-            get.assert_called_with(
-                expected_rules_url, log_response_text=False, verify=satellite_cert, stream=True
+            default_expected_rules_url = (
+                expected_rules_url + "?yara_version=" + FAKE_YARA_VERSION
             )
-            log_mock.debug.assert_called_with("Using cert_verify value %s ...", satellite_cert)
-            log_mock.debug.assert_any_call("Downloading rules from: %s", expected_rules_url)
 
-            expected_rules_url += '?yara_version=4.1'
-            with patch('os.path.exists', return_value=True):
-                with patch(CALL_TARGET, return_value='4.1'):
-                    mdc = MalwareDetectionClient(insights_config)
-            assert mdc.rules_location == expected_rules_url
-            get.assert_called_with(
-                expected_rules_url, log_response_text=False, verify=satellite_cert, stream=True
+            mdc = MalwareDetectionClient(
+                insights_config, MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
             )
-            log_mock.debug.assert_called_with("Using cert_verify value %s ...", satellite_cert)
-            log_mock.debug.assert_any_call("Downloading rules from: %s", expected_rules_url)
+            mdc.parse_scan_options()
+            mdc.load_rules()
+
+            assert mdc.remote_rules_location == default_expected_rules_url
+            get.assert_called_with(
+                default_expected_rules_url,
+                log_response_text=False,
+                verify=satellite_cert,
+                stream=True,
+            )
+            log_mock.debug.assert_called_with(
+                "Using cert_verify value %s ...", satellite_cert
+            )
+            log_mock.debug.assert_any_call(
+                "Downloading rules from: %s", default_expected_rules_url
+            )
+
+            expected_rules_url += "?yara_version=4.1"
+            with patch("os.path.exists", return_value=True):
+                with patch(CONFIG_CALL_TARGET, return_value="4.1"):
+                    yara, yara_version = find_yara()
+                    mdc = MalwareDetectionClient(
+                        insights_config, MALWARE_CONFIG, yara, yara_version
+                    )
+                    mdc.parse_scan_options()
+                    mdc.load_rules()
+            assert mdc.remote_rules_location == expected_rules_url
+            get.assert_called_with(
+                expected_rules_url,
+                log_response_text=False,
+                verify=satellite_cert,
+                stream=True,
+            )
+            log_mock.debug.assert_called_with(
+                "Using cert_verify value %s ...", satellite_cert
+            )
+            log_mock.debug.assert_any_call(
+                "Downloading rules from: %s", expected_rules_url
+            )
 
             # Test a Satellite URL with 'cloud.stage.' in its name - expect to still download from Satellite
             # Also test using cert_verify=None in the InsightsConfig and check it changes to cert_verify=True
-            satellite_url = (
-                'satellite.cloud.stage.example.com:443/redhat_access/r/insights/platform'
-            )
+            satellite_url = "satellite.cloud.stage.example.com:443/redhat_access/r/insights/platform"
             expected_rules_url = "https://satellite.cloud.stage.example.com:443/redhat_access/r/insights/platform/malware-detection/v1/"
-            expected_rules_url += 'signatures.yar?yara_version=4.1'
-            with patch('os.path.exists', return_value=True):
-                with patch(CALL_TARGET, return_value='4.1'):
+            expected_rules_url += "signatures.yar?yara_version=4.1"
+            with patch("os.path.exists", return_value=True):
+                with patch(CONFIG_CALL_TARGET, return_value="4.1"):
+                    yara, yara_version = find_yara()
                     mdc = MalwareDetectionClient(
-                        InsightsConfig(base_url=satellite_url, verbose=True, cert_verify=None)
+                        InsightsConfig(
+                            base_url=satellite_url, verbose=True, cert_verify=None
+                        ),
+                        MALWARE_CONFIG,
+                        yara,
+                        yara_version,
                     )
-            assert mdc.rules_location == expected_rules_url
+                    mdc.parse_scan_options()
+                    mdc.load_rules()
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
-                expected_rules_url, log_response_text=False, verify=True, stream=True
+                expected_rules_url,
+                log_response_text=False,
+                verify=True,
+                stream=True,
             )
             log_mock.debug.assert_called_with("Using cert_verify value %s ...", True)
-            log_mock.debug.assert_any_call("Downloading rules from: %s", expected_rules_url)
+            log_mock.debug.assert_any_call(
+                "Downloading rules from: %s", expected_rules_url
+            )
 
     @patch(
         NAMEDTMPFILE_TARGET
     )  # Mock NamedTemporaryFile so it doesn't try to create the temporary file
-    @patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
-    @patch(FINDMNT_TARGET)  # Don't run the command
-    @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
-    @patch(BUILD_YARA_COMMAND_TARGET)
-    @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
+    @patch(
+        "os.remove"
+    )  # Mock os.remove so it doesn't actually try to remove any existing files
+    @patch(FINDMNT_TARGET)
     class TestDisabledRules:
         """Testing the _get_disabled_rules method"""
 
         @patch.dict(os.environ)
-        def test_skip_getting_disabled_rules(self, conf, cmd, yara, findmnt, remove, tmpfile):
+        def test_skip_getting_disabled_rules(self, findmnt, remove, tmpfile):
             # Skip getting disabled rules if doing a test scan
-            os.environ['TEST_SCAN'] = 'true'
-            with patch(GET_RULES_TARGET, return_value=RULES_FILE):
-                mdc = MalwareDetectionClient(None)
+            os.environ["TEST_SCAN"] = "true"
+            mdc = MalwareDetectionClient(
+                InsightsConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+            )
+            mdc.parse_scan_options()
+            mdc.load_disabled_rules()
             assert mdc.disabled_rules == []
 
             # Skip getting disabled rules if the rules are coming from a file (which is really only for testing anyway)
-            os.environ['TEST_SCAN'] = 'false'
-            os.environ['RULES_LOCATION'] = '/local/rules/file.yar'
-            with patch("os.path.isfile", return_value=True):
-                mdc = MalwareDetectionClient(None)
+            os.environ["TEST_SCAN"] = "false"
+            os.environ["RULES_LOCATION"] = ""
+            os.environ["USE_REMOTE_RULES"] = "false"  # sets use_remote_rules to False
+            mdc = MalwareDetectionClient(
+                InsightsConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+            )
+            mdc.parse_scan_options()
+            mdc.load_disabled_rules()
             assert mdc.disabled_rules == []
 
-        @patch.object(InsightsConnection, 'post')
+        @patch.object(InsightsConnection, "post")
         @patch.object(
-            InsightsConnection, 'get', return_value=Mock(status_code=200, content=b"Rule Content")
+            InsightsConnection,
+            "get",
+            return_value=Mock(status_code=200, content=b"Rule Content"),
         )
-        @patch.object(InsightsConnection, 'get_proxies')
-        @patch.object(InsightsConnection, '_init_session', return_value=Mock())
-        @patch.dict(os.environ, {'TEST_SCAN': 'false'})
+        @patch.object(InsightsConnection, "get_proxies")
+        @patch.object(InsightsConnection, "_init_session", return_value=Mock())
+        @patch.dict(os.environ, {"TEST_SCAN": "false"})
         def test_get_disabled_rules(
-            self, session, proxies, get, post, conf, cmd, yara, findmnt, remove, tmpfile
+            self,
+            session,
+            proxies,
+            get,
+            post,
+            findmnt,
+            remove,
+            tmpfile,
         ):
             # Test with no disabled rules
-            rules_location = (
-                "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
-            )
+            rules_location = "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
             expected_graphql_url = (
                 "https://cert.console.redhat.com/api/malware-detection/v1/graphql"
             )
             post.return_value = Mock(
-                status_code=200, json=Mock(return_value={'data': {'rulesList': []}})
+                status_code=200, json=Mock(return_value={"data": {"rulesList": []}})
             )
-            mdc = MalwareDetectionClient(InsightsConfig())
-            assert mdc.rules_location == rules_location
-            assert mdc.graphql_url == expected_graphql_url
-            assert post.called_with(expected_graphql_url, ANY, ANY, verify=True, stream=True)
+
+            mdc = MalwareDetectionClient(
+                InsightsConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+            mdc.load_disabled_rules()
+
+            assert (
+                mdc.remote_rules_location
+                == rules_location + "?yara_version=" + FAKE_YARA_VERSION
+            )
+            post.assert_called_with(
+                expected_graphql_url,
+                json=ANY,
+                headers=ANY,
+                verify=True,
+                stream=True,
+            )
             assert mdc.disabled_rules == []
 
             # Test with one disabled rule
             post.return_value = Mock(
                 status_code=200,
-                json=Mock(return_value={'data': {'rulesList': [{'name': 'Rule1'}]}}),
+                json=Mock(return_value={"data": {"rulesList": [{"name": "Rule1"}]}}),
             )
-            mdc = MalwareDetectionClient(InsightsConfig())
-            assert mdc.disabled_rules == ['rule1']
+
+            mdc = MalwareDetectionClient(
+                InsightsConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+            )
+            mdc.parse_scan_options()
+            mdc.load_disabled_rules()
+
+            assert mdc.disabled_rules == ["rule1"]
 
             # Test with multiple disabled rules and a different rules_location
             rules_location = "http://localhost/rules.yar"
-            os.environ['RULES_LOCATION'] = rules_location
+            os.environ["REMOTE_RULES_LOCATION"] = rules_location
             expected_graphql_url = "http://localhost/graphql"
             post.return_value = Mock(
                 status_code=200,
                 json=Mock(
                     return_value={
-                        'data': {
-                            'rulesList': [
-                                {'name': 'Rule2'},
-                                {'name': 'Rule1'},
-                                {'name': 'XYZ'},
-                                {'name': 'abc'},
+                        "data": {
+                            "rulesList": [
+                                {"name": "Rule2"},
+                                {"name": "Rule1"},
+                                {"name": "XYZ"},
+                                {"name": "abc"},
                             ]
                         }
                     }
                 ),
             )
-            mdc = MalwareDetectionClient(InsightsConfig())
-            assert mdc.rules_location == rules_location
-            assert mdc.graphql_url == expected_graphql_url
-            assert post.called_with(expected_graphql_url, ANY, ANY, verify=True, stream=True)
-            assert mdc.disabled_rules == ['abc', 'rule1', 'rule2', 'xyz']
+
+            mdc = MalwareDetectionClient(
+                InsightsConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+            )
+            mdc.parse_scan_options()
+            mdc.load_disabled_rules()
+
+            assert mdc.remote_rules_location == rules_location
+            post.assert_called_with(
+                expected_graphql_url,
+                json=ANY,
+                headers=ANY,
+                verify=True,
+                stream=True,
+            )
+            assert mdc.disabled_rules == ["abc", "rule1", "rule2", "xyz"]
 
         @pytest.mark.skipif(
             not (TEST_GET_DISABLED_RULES_FAILURE or TEST_ALL),
-            reason='test_get_disabled_rules_failure_retries is slow due to the inherent delay in the retry logic. '
-            'Use TEST_GET_DISABLED_RULES_FAILURE=True to enable test',
+            reason="test_get_disabled_rules_failure_retries is slow due to the inherent delay in the retry logic. "
+            "Use TEST_GET_DISABLED_RULES_FAILURE=True to enable test",
         )
-        @patch.object(InsightsConnection, 'post')
+        @patch.object(InsightsConnection, "post")
         @patch.object(
-            InsightsConnection, 'get', return_value=Mock(status_code=200, content=b"Rule Content")
+            InsightsConnection,
+            "get",
+            return_value=Mock(status_code=200, content=b"Rule Content"),
         )
-        @patch.object(InsightsConnection, 'get_proxies')
-        @patch.object(InsightsConnection, '_init_session', return_value=Mock())
-        @patch.dict(os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'localhost/rules.yar'})
+        @patch.object(InsightsConnection, "get_proxies")
+        @patch.object(InsightsConnection, "_init_session", return_value=Mock())
+        @patch.dict(
+            os.environ,
+            {"TEST_SCAN": "false", "REMOTE_RULES_LOCATION": "localhost/rules.yar"},
+        )
         @patch(LOGGER_TARGET)
         def test_get_disabled_rules_failure(
-            self, log, session, proxies, get, post, conf, cmd, yara, findmnt, remove, tmpfile
+            self,
+            log,
+            session,
+            proxies,
+            get,
+            post,
+            findmnt,
+            remove,
+            tmpfile,
         ):
             from requests.exceptions import ConnectionError, Timeout
 
-            expected_graphql_url = 'https://localhost/graphql'
+            expected_graphql_url = "https://localhost/graphql"
 
             # 404 error - unlikely to occur unless an incorrect rules_location was manually specified
             post.return_value = Mock(status_code=404, reason="Not found", text="Nup")
-            mdc = MalwareDetectionClient(InsightsConfig(retries=2))
+            mdc = MalwareDetectionClient(
+                InsightsConfig(retries=2),
+                MALWARE_CONFIG,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+            mdc.load_disabled_rules()
             log.debug.assert_any_call(
                 "Unable to get disabled rules list from %s: %s",
                 expected_graphql_url,
                 "404 Not found: Nup",
             )
-            log.debug.assert_any_call("Unable to get disabled rules list.  Skipping ...")
+            log.debug.assert_any_call(
+                "Unable to get disabled rules list.  Skipping ..."
+            )
             log.debug.assert_called_with("Disabled rules: %s", [])
-            assert post.called_with(expected_graphql_url, ANY, ANY, verify=True, stream=True)
+            assert post.called_with(
+                expected_graphql_url, ANY, ANY, verify=True, stream=True
+            )
             assert post.call_count == 2
             assert mdc.disabled_rules == []
 
             # Test other errors downloading rules from the backend - these are more likely to occur
             post.reset_mock()
-            post.side_effect = [ConnectionError("Couldn't connect"), Timeout("Timeout")]
-            mdc = MalwareDetectionClient(InsightsConfig(retries=3))
+            post.side_effect = [
+                ConnectionError("Couldn't connect"),
+                Timeout("Timeout"),
+            ]
+            mdc = MalwareDetectionClient(
+                InsightsConfig(retries=3),
+                MALWARE_CONFIG,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            mdc.load_rules()
+            mdc.load_disabled_rules()
             log.debug.assert_any_call(
                 "Unable to get disabled rules list from %s: %s",
                 expected_graphql_url,
                 "Couldn't connect",
             )
             log.debug.assert_any_call(
-                "Unable to get disabled rules list from %s: %s", expected_graphql_url, "Timeout"
+                "Unable to get disabled rules list from %s: %s",
+                expected_graphql_url,
+                "Timeout",
             )
-            log.debug.assert_any_call("Unable to get disabled rules list.  Skipping ...")
+            log.debug.assert_any_call(
+                "Unable to get disabled rules list.  Skipping ..."
+            )
             log.debug.assert_called_with("Disabled rules: %s", [])
-            assert post.called_with(expected_graphql_url, ANY, ANY, verify=True, stream=True)
+            assert post.called_with(
+                expected_graphql_url, ANY, ANY, verify=True, stream=True
+            )
             assert post.call_count == 3
             assert mdc.disabled_rules == []
 
-    @patch(GET_RULES_TARGET, return_value=RULES_FILE)
-    @patch(DISABLED_RULES_TARGET)
-    @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
-    @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
     class TestBuildYaraCmd:
 
-        @patch('os.path.getsize')
-        def test_build_yara_command_success(self, size, conf, yara, disabled, rules):
+        @patch("os.path.getsize")
+        def test_build_yara_command_success(self, size):
             expected_yara_cmd = "nice -n 19 {0} -s -N -a 3600 -p 1 -r -f%s {1}".format(
                 FAKE_YARA, RULES_FILE
             )
@@ -2140,74 +3142,287 @@ class TestsUtilizingFakeYara:
             # Use side_effect with 3 'call' values because build_yara_command calls 'call' 3 times ...
             # 1 to get the type of the rules file; 2 to see if the rules files contains valid rules; 3 to call nproc
             # Test with text rules file - file type is 'ascii'
-            with patch(CALL_TARGET, side_effect=['ascii', 'ok', '2']) as call_mock:
-                mdc = MalwareDetectionClient(None)
+            with patch(CALL_TARGET, side_effect=["ascii", "ok", "2"]) as call_mock:
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+                )
+                # manually set rules
+                mdc.rules_files = [RULES_FILE]
+                mdc.parse_scan_options()
+                mdc.build_yara_commands()
+
                 assert call_mock.call_count == 3
-            assert ' '.join(mdc.yara_cmd) == expected_yara_cmd % ''
+            assert " ".join(mdc.yara_cmd) == expected_yara_cmd % ""
 
             # Test with 'compiled' rules file - file type is 'Yara 3.x'
-            with patch(CALL_TARGET, side_effect=['Yara 3.X', 'ok', '2']) as call_mock:
-                mdc = MalwareDetectionClient(None)
+            with patch(CALL_TARGET, side_effect=["Yara 3.X", "ok", "2"]) as call_mock:
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+                )
+                # manually set rules
+                mdc.rules_files = [RULES_FILE]
+                mdc.parse_scan_options()
+                mdc.build_yara_commands()
                 assert call_mock.call_count == 3
-            assert ' '.join(mdc.yara_cmd) == expected_yara_cmd % ' -C'
+            assert " ".join(mdc.yara_compiled_cmds[0]) == expected_yara_cmd % " -C"
 
             # Another test with compiled rules file - file type is 'data'
-            with patch(CALL_TARGET, side_effect=['data', 'ok', '2']) as call_mock:
-                mdc = MalwareDetectionClient(None)
+            with patch(CALL_TARGET, side_effect=["data", "ok", "2"]) as call_mock:
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+                )
+                # manually set rules
+                mdc.rules_files = [RULES_FILE]
+                mdc.parse_scan_options()
+                mdc.build_yara_commands()
                 assert call_mock.call_count == 3
-            assert ' '.join(mdc.yara_cmd) == expected_yara_cmd % ' -C'
+            assert " ".join(mdc.yara_compiled_cmds[0]) == expected_yara_cmd % " -C"
+
+        @patch("os.path.getsize")
+        @patch.dict(
+            os.environ,
+            {"TEST_SCAN": "false", "USE_REMOTE_RULES": "false"},
+        )
+        @patch(FINDMNT_TARGET)
+        def test_build_yara_multiple_success(self, findmnt, size, add_3rd_party_rules):
+            expected_yara_cmd1 = (
+                "nice -n 19 {0} -s -N -a 3600 -p 1 -r -f -C%s {1}".format(
+                    FAKE_YARA, SECOND_THIRD_PARTY_RULE_LOCATION
+                )
+            )
+            expected_yara_cmd2 = (
+                "nice -n 19 {0} -s -N -a 3600 -p 1 -r -f -C%s {1}".format(
+                    FAKE_YARA, THIRD_PARTY_RULE_LOCATION
+                )
+            )
+            expected_yara_cmd3 = (
+                "nice -n 19 {0} -s -N -a 3600 -p 1 -r -f -C%s {1}".format(
+                    FAKE_YARA, TEST_RULE_FILE
+                )
+            )
+            expected_uncompiled_yara_cmd1 = (
+                "nice -n 19 {0} -s -N -a 3600 -p 1 -r -f%s {1}".format(
+                    FAKE_YARA, TEST_RULE_FILE
+                )
+            )
+            expected_uncompiled_multiple_yara_cmd2 = (
+                "nice -n 19 {0} -s -N -a 3600 -p 1 -r -f%s {1} {2}".format(
+                    FAKE_YARA, SECOND_THIRD_PARTY_RULE_LOCATION, TEST_RULE_FILE
+                )
+            )
+            expected_uncompiled_multiple_yara_cmd3 = (
+                "nice -n 19 {0} -s -N -a 3600 -p 1 -r -f%s {1} {2} {3}".format(
+                    FAKE_YARA,
+                    SECOND_THIRD_PARTY_RULE_LOCATION,
+                    THIRD_PARTY_RULE_LOCATION,
+                    TEST_RULE_FILE,
+                )
+            )
+            size.return_value = 1
+            # Use side_effect with 3 'call' values because build_yara_command calls 'call' 3 times ...
+            # 1 to get the type of the rules file; 2 to see if the rules files contains valid rules; 3 to call nproc
+            # Test with text rules file - file type is 'ascii'
+            # do this 3 times
+            with patch(
+                CALL_TARGET,
+                side_effect=["data", "data", "data", "ok", "oc", "ok", "2"],
+            ) as call_mock:
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+                )
+                mdc.load_rules()
+                # manually add test rule
+                mdc.rules_files.append(TEST_RULE_FILE)
+                mdc.parse_scan_options()
+                mdc.build_yara_commands()
+
+                assert call_mock.call_count == 7
+            assert not mdc.yara_cmd
+            assert " ".join(mdc.yara_compiled_cmds[0]) == expected_yara_cmd1 % ""
+            assert " ".join(mdc.yara_compiled_cmds[1]) == expected_yara_cmd2 % ""
+            assert " ".join(mdc.yara_compiled_cmds[2]) == expected_yara_cmd3 % ""
+
+            # Test with 'compiled' rules file - file type is 'Yara 3.x'
+            with patch(
+                CALL_TARGET,
+                side_effect=[
+                    "Yara 3.X",
+                    "Yara 3.X",
+                    "Yara 3.X",
+                    "ok",
+                    "ok",
+                    "ok",
+                    "2",
+                ],
+            ) as call_mock:
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(), MALWARE_CONFIG, FAKE_YARA, FAKE_YARA_VERSION
+                )
+                mdc.load_rules()
+                # manually add test rule
+                mdc.rules_files.append(TEST_RULE_FILE)
+                mdc.parse_scan_options()
+                mdc.build_yara_commands()
+                assert call_mock.call_count == 7
+            assert not mdc.yara_cmd
+            assert " ".join(mdc.yara_compiled_cmds[0]) == expected_yara_cmd1 % ""
+            assert " ".join(mdc.yara_compiled_cmds[1]) == expected_yara_cmd2 % ""
+            assert " ".join(mdc.yara_compiled_cmds[2]) == expected_yara_cmd3 % ""
+
+            # Test both compiled and uncompiled rules
+            with patch(
+                CALL_TARGET,
+                side_effect=["data", "Yara 3.X", "ascii", "ok", "ok", "ok", "2"],
+            ) as call_mock:
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(retries=2),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.load_rules()
+                # manually add test rule
+                mdc.rules_files.append(TEST_RULE_FILE)
+                mdc.parse_scan_options()
+                mdc.build_yara_commands()
+                assert call_mock.call_count == 7
+            assert " ".join(mdc.yara_cmd) == expected_uncompiled_yara_cmd1 % ""
+            assert " ".join(mdc.yara_compiled_cmds[0]) == expected_yara_cmd1 % ""
+            assert " ".join(mdc.yara_compiled_cmds[1]) == expected_yara_cmd2 % ""
+
+            # Test both compiled and uncompiled rules
+            with patch(
+                CALL_TARGET,
+                side_effect=["ascii", "Yara 3.X", "ascii", "ok", "ok", "ok", "2"],
+            ) as call_mock:
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(retries=2),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.load_rules()
+                # manually add test rule
+                mdc.rules_files.append(TEST_RULE_FILE)
+                mdc.parse_scan_options()
+                mdc.build_yara_commands()
+                assert call_mock.call_count == 7
+            assert " ".join(mdc.yara_cmd) == expected_uncompiled_multiple_yara_cmd2 % ""
+            assert " ".join(mdc.yara_compiled_cmds[0]) == expected_yara_cmd2 % ""
+
+            # Test both compiled and uncompiled rules
+            with patch(
+                CALL_TARGET,
+                side_effect=["ascii", "ascii", "ascii", "ok", "ok", "ok", "2"],
+            ) as call_mock:
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(retries=2),
+                    MALWARE_CONFIG,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.load_rules()
+                # manually add test rule
+                mdc.rules_files.append(TEST_RULE_FILE)
+                mdc.parse_scan_options()
+                mdc.build_yara_commands()
+                assert call_mock.call_count == 7
+            assert " ".join(mdc.yara_cmd) == expected_uncompiled_multiple_yara_cmd3 % ""
 
         @patch(LOGGER_TARGET)
-        @patch('os.path.getsize')
-        def test_build_yara_command_fail(self, size_mock, log_mock, conf, yara, disabled, rules):
+        @patch("os.path.getsize")
+        def test_build_yara_command_fail(self, size_mock, log_mock):
             # Test with empty rules file, ie file size is 0
             size_mock.return_value = 0
-            with patch(CALL_TARGET, side_effect=['wtf?', 'yikes', '2']) as call_mock:
+            with patch(CALL_TARGET, side_effect=["wtf?", "yikes", "2"]) as call_mock:
                 with pytest.raises(SystemExit):
-                    MalwareDetectionClient(None)
+                    mdc = MalwareDetectionClient(
+                        InsightsConfig(),
+                        MALWARE_CONFIG,
+                        FAKE_YARA,
+                        FAKE_YARA_VERSION,
+                    )
+                    # manually set rule
+                    mdc.rules_files = [RULES_FILE]
+                    mdc.parse_scan_options()
+                    mdc.build_yara_commands()
                 call_mock.assert_called_once()  # Only 1 call to 'call' before we exit
             log_mock.error.assert_called_with("Rules file %s is empty", RULES_FILE)
 
             # Test with empty rules files, ie the file type is 'empty'
             size_mock.return_value = 1
-            with patch(CALL_TARGET, side_effect=['empty', 'yikes', '2']) as call_mock:
+            with patch(CALL_TARGET, side_effect=["empty", "yikes", "2"]) as call_mock:
                 with pytest.raises(SystemExit):
-                    MalwareDetectionClient(None)
+                    mdc = MalwareDetectionClient(
+                        InsightsConfig(),
+                        MALWARE_CONFIG,
+                        FAKE_YARA,
+                        FAKE_YARA_VERSION,
+                    )
+                    # manually set rule
+                    mdc.rules_files = [RULES_FILE]
+                    mdc.parse_scan_options()
+                    mdc.build_yara_commands()
                 call_mock.assert_called_once()  # Only 1 call to 'call' before we exit
             log_mock.error.assert_called_with("Rules file %s is empty", RULES_FILE)
 
             # Test with 'invalid' rules file - raise CalledProcessError when running command
             with patch(CALL_TARGET) as call_mock:
-                call_mock.side_effect = ['yara', CalledProcessError(1, 'cmd', b'invalid\n'), '2']
+                call_mock.side_effect = [
+                    "yara",
+                    CalledProcessError(1, "cmd", b"invalid\n"),
+                    "2",
+                ]
                 with pytest.raises(SystemExit):
-                    MalwareDetectionClient(None)
+                    mdc = MalwareDetectionClient(
+                        InsightsConfig(),
+                        MALWARE_CONFIG,
+                        FAKE_YARA,
+                        FAKE_YARA_VERSION,
+                    )
+                    # manually set rule
+                    mdc.rules_files = [RULES_FILE]
+                    mdc.parse_scan_options()
+                    mdc.build_yara_commands()
                 assert call_mock.call_count == 2  # 2 calls to 'call' before we exit
             log_mock.error.assert_called_with(
                 "Unable to use rules file %s: %s", RULES_FILE, "invalid"
             )
 
-    @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
-    @patch(BUILD_YARA_COMMAND_TARGET)
-    @patch(GET_RULES_TARGET, return_value=TEST_RULE_FILE)
-    @patch(DISABLED_RULES_TARGET)
-    @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
     @patch(LOGGER_TARGET)
+    @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
     @patch.dict(os.environ)
     class TestProcessScanning:
 
         @pytest.mark.skipif(IS_CONTAINER, reason=SKIP_IF_CONTAINER_REASON)
         def test_scan_processes(
-            self, log_mock, yara, disabled, rules, cmd, create_test_files_fake_yara
+            self,
+            log_mock,
+            create_test_files_fake_yara,
         ):
             # Test scanning processes to test which processes are going to be scanned
-            os.environ['EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'] = 'false'
+            os.environ["EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS"] = "false"
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "test_scan: false" if line.startswith("test_scan:") else line
-                line = "scan_processes: true" if line.startswith("scan_processes:") else line
-                line = "add_metadata: false" if line.startswith("add_metadata:") else line
+                line = (
+                    "scan_processes: true"
+                    if line.startswith("scan_processes:")
+                    else line
+                )
+                line = (
+                    "add_metadata: false" if line.startswith("add_metadata:") else line
+                )
                 print(line)
-            mdc = MalwareDetectionClient(None)
-            assert mdc.rules_file == TEST_RULE_FILE
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            # manually set rule
+            mdc.rules_files = [TEST_RULE_FILE]
+            mdc.parse_scan_options()
             assert mdc.do_filesystem_scan is True
             assert mdc.do_process_scan is True
             assert mdc.scan_pids == []
@@ -2218,7 +3433,7 @@ class TestsUtilizingFakeYara:
                 mdc.scan_processes()
             assert mdc.processes_scan_exclude_list == [TEST_PID]
             assert len(mdc.scan_pids) > 1
-            assert '1' in mdc.scan_pids
+            assert "1" in mdc.scan_pids
             assert TEST_PID not in mdc.scan_pids
 
             # Exclude some processes via the config file
@@ -2229,54 +3444,88 @@ class TestsUtilizingFakeYara:
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
-            assert mdc.processes_scan_exclude_list == ['1']
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            # manually set rule
+            mdc.parse_scan_options()
+            assert mdc.processes_scan_exclude_list == ["1"]
             # Patch the calls to yara so it doesn't actually try to scan any processes
             with patch(CALL_TARGET, return_value=""):
                 mdc.scan_processes()
-            assert mdc.processes_scan_exclude_list == ['1', TEST_PID]
+            assert mdc.processes_scan_exclude_list == ["1", TEST_PID]
             assert len(mdc.scan_pids) > 1
-            assert all([x not in mdc.scan_pids for x in ['1', TEST_PID]])
+            assert all([x not in mdc.scan_pids for x in ["1", TEST_PID]])
 
             # Exclude some processes via env vars
-            os.environ['PROCESSES_SCAN_EXCLUDE'] = 'systemd,3..10'
-            mdc = MalwareDetectionClient(None)
-            assert all([pid in mdc.processes_scan_exclude_list for pid in ['1', '3']])
-            assert '2' not in mdc.processes_scan_exclude_list
+            os.environ["PROCESSES_SCAN_EXCLUDE"] = "systemd,3..10"
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
+            assert all([pid in mdc.processes_scan_exclude_list for pid in ["1", "3"]])
+            assert "2" not in mdc.processes_scan_exclude_list
             # Patch the calls to yara so it doesn't actually try to scan any processes
             with patch(CALL_TARGET, return_value=""):
                 mdc.scan_processes()
-            assert all([pid in mdc.processes_scan_exclude_list for pid in ['1', '3', TEST_PID]])
+            assert all(
+                [pid in mdc.processes_scan_exclude_list for pid in ["1", "3", TEST_PID]]
+            )
             assert len(mdc.scan_pids) > 1
-            assert all([x not in mdc.scan_pids for x in ['1', '3', TEST_PID]])
-            assert '2' in mdc.scan_pids
+            assert all([x not in mdc.scan_pids for x in ["1", "3", TEST_PID]])
+            assert "2" in mdc.scan_pids
 
         @pytest.mark.skipif(
             not (TEST_PROCESSES_SCAN_SINCE or TEST_ALL),
-            reason='test_processes_scan_since is slowish and could potentially fail. '
-            'Use TEST_PROCESSES_SCAN_SINCE=True to enable test',
+            reason="test_processes_scan_since is slowish and could potentially fail. "
+            "Use TEST_PROCESSES_SCAN_SINCE=True to enable test",
         )
-        def test_processes_scan_since(
-            self, log_mock, yara, disabled, rules, cmd, create_test_files_fake_yara
-        ):
+        def test_processes_scan_since(self, log_mock, create_test_files_fake_yara):
             # Firstly, start the TEST_RULE_SCRIPT process then scan_only that process
             # Expect that we'll find it
             os.system(TEST_RULE_SCRIPT + " &")  # Run the script in the background
-            ps_call_output = call([['ps', '-eo', 'pid=', '-o', 'lstart=']])
-            os.environ['EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'] = 'false'
+            ps_call_output = call([["ps", "-eo", "pid=", "-o", "lstart="]])
+            os.environ["EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS"] = "false"
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "test_scan: false" if line.startswith("test_scan:") else line
-                line = "scan_filesystem: false" if line.startswith("scan_filesystem:") else line
-                line = "scan_processes: true" if line.startswith("scan_processes:") else line
+                line = (
+                    "scan_filesystem: false"
+                    if line.startswith("scan_filesystem:")
+                    else line
+                )
+                line = (
+                    "scan_processes: true"
+                    if line.startswith("scan_processes:")
+                    else line
+                )
                 line = (
                     "processes_scan_only: test-rule"
                     if line.startswith("processes_scan_only:")
                     else line
                 )
-                line = "add_metadata: false" if line.startswith("add_metadata:") else line
+                line = (
+                    "add_metadata: false" if line.startswith("add_metadata:") else line
+                )
                 print(line)
-            mdc = MalwareDetectionClient(None)
-            assert mdc.rules_file == TEST_RULE_FILE
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            # manually set rule
+            mdc.rules_files = [TEST_RULE_FILE]
+            mdc.parse_scan_options()
+
             assert mdc.do_filesystem_scan is False
             assert mdc.do_process_scan is True
             # Match TEST_RULE_SCRIPT process from processes_scan_only
@@ -2285,7 +3534,9 @@ class TestsUtilizingFakeYara:
             # Now find processes started since the last scan, specifically the TEST_RULE_SCRIPT process
             # However expect to not find it because it wasn't started since the last_scan date
             last_scan = time.time()
-            last_scan_fmt = datetime.fromtimestamp(last_scan).strftime('%Y-%m-%d %H:%M:%S')
+            last_scan_fmt = datetime.fromtimestamp(last_scan).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = (
                     "processes_scan_since: last"
@@ -2294,12 +3545,19 @@ class TestsUtilizingFakeYara:
                 )
                 print(line)
             with patch(
-                "insights.specs.datasources.malware_detection.get_scan_since_timestamp",
+                "insights.specs.datasources.malware_detection.utils.get_scan_since_timestamp",
                 return_value=last_scan,
             ):
-                mdc = MalwareDetectionClient(None)
-            assert mdc.processes_scan_since_dict['timestamp'] == last_scan
-            assert mdc.processes_scan_since_dict['datetime'] == last_scan_fmt
+                altered_malware_config = load_or_create_malware_config()
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
+            assert mdc.processes_scan_since_dict["timestamp"] == last_scan
+            assert mdc.processes_scan_since_dict["datetime"] == last_scan_fmt
             # Still match the TEST_RULE_SCRIPT process from processes_scan_only
             assert len(mdc.scan_pids) == 1
             # But when we run scan_processes() it won't be found because it wasn't started since the last scan
@@ -2315,10 +3573,19 @@ class TestsUtilizingFakeYara:
             # Expect to find it this time it was started since a day ago
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = (
-                    "processes_scan_since: 1" if line.startswith("processes_scan_since:") else line
+                    "processes_scan_since: 1"
+                    if line.startswith("processes_scan_since:")
+                    else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.parse_scan_options()
             # Still match the TEST_RULE_SCRIPT process from processes_scan_only
             assert len(mdc.scan_pids) == 1
             with patch(CALL_TARGET) as call_mock:
@@ -2335,12 +3602,19 @@ class TestsUtilizingFakeYara:
                 2
             )  # Wait a second to ensure the last_scan time is greater than the process start time
             os.system(TEST_RULE_SCRIPT + " &")  # Run the script in the background
-            ps_call_output = call([['ps', '-eo', 'pid=', '-o', 'lstart=']])
+            ps_call_output = call([["ps", "-eo", "pid=", "-o", "lstart="]])
             with patch(
-                "insights.specs.datasources.malware_detection.get_scan_since_timestamp",
+                "insights.specs.datasources.malware_detection.utils.get_scan_since_timestamp",
                 return_value=last_scan,
             ):
-                mdc = MalwareDetectionClient(None)
+                altered_malware_config = load_or_create_malware_config()
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.parse_scan_options()
             # Match 2 TEST_RULE_SCRIPT processes from processes_scan_only
             assert len(mdc.scan_pids) == 2
             # But when we run scan_processes() only the latest one will be found
@@ -2351,14 +3625,24 @@ class TestsUtilizingFakeYara:
             assert len(mdc.scan_pids) == 1
 
     @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
-    @patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
-    @patch(BUILD_YARA_COMMAND_TARGET)
-    @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
+    @patch(
+        "os.remove"
+    )  # Mock os.remove so it doesn't actually try to remove any existing files
+    @patch("insights.specs.datasources.malware_detection.rules.download_rules")
+    @patch(
+        "insights.specs.datasources.malware_detection.rules.save_rules_to_temp_file",
+        return_value=RULES_FILE,
+    )
     @patch(LOGGER_TARGET)
     class TestFilesystemScanning:
 
         def test_scan_rules_file_with_extra_slashes(
-            self, log_mock, yara, cmd, remove, create_test_files_fake_yara
+            self,
+            log_mock,
+            save,
+            download,
+            remove,
+            create_test_files_fake_yara,
         ):
             # Test scanning RULES_FILE with an extra slash only in the rules_location one
             # Even with the extra slashes in the rules_location there will be rules matched
@@ -2366,8 +3650,8 @@ class TestsUtilizingFakeYara:
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "test_scan: false" if line.startswith("test_scan:") else line
                 line = (
-                    line + "rules_location: %s\n" % TEST_RULE_FILE.replace('/', '//')
-                    if line.startswith('---')
+                    line + "rules_location: %s\n" % TEST_RULE_FILE.replace("/", "//")
+                    if line.startswith("rules_location:")
                     else line
                 )
                 line = (
@@ -2375,16 +3659,26 @@ class TestsUtilizingFakeYara:
                     if line.startswith("filesystem_scan_only:")
                     else line
                 )
-                line = "add_metadata: false" if line.startswith("add_metadata:") else line
+                line = (
+                    "add_metadata: false" if line.startswith("add_metadata:") else line
+                )
                 line = (
                     "exclude_network_filesystem_mountpoints: false"
                     if line.startswith("exclude_network_filesystem_mountpoints:")
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
-            assert mdc.rules_location == TEST_RULE_FILE.replace('/', '//')
-            assert mdc.rules_file == TEST_RULE_FILE
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.load_rules()
+            mdc.parse_scan_options()
+            assert mdc.rules_location == TEST_RULE_FILE.replace("/", "//")
+            assert mdc.rules_files == [TEST_RULE_FILE, RULES_FILE]
             assert mdc.scan_fsobjects == [TEST_RULE_FILE]
             with patch(CALL_TARGET) as call_mock:
                 # Mock the scan match data from yara
@@ -2393,11 +3687,11 @@ class TestsUtilizingFakeYara:
                     % TEST_RULE_FILE
                 )
                 mdc.scan_filesystem()
-            rule_match = mdc.host_scan['TEST_RedHatInsightsMalwareDetection']
-            assert rule_match[0]['source'] == TEST_RULE_FILE
-            assert rule_match[0]['string_data'] == "Malware Detection Client"
-            assert rule_match[0]['string_identifier'] == '$re1'
-            assert rule_match[0]['string_offset'] == 74
+            rule_match = mdc.host_scan["TEST_RedHatInsightsMalwareDetection"]
+            assert rule_match[0]["source"] == TEST_RULE_FILE
+            assert rule_match[0]["string_data"] == "Malware Detection Client"
+            assert rule_match[0]["string_identifier"] == "$re1"
+            assert rule_match[0]["string_offset"] == 74
             log_mock.info.assert_any_call(
                 "Matched rule %s in %s %s",
                 "TEST_RedHatInsightsMalwareDetection",
@@ -2405,63 +3699,94 @@ class TestsUtilizingFakeYara:
                 TEST_RULE_FILE,
             )
 
+        @patch(UTILS_LOGGER_TARGET)
         def test_scan_root_with_extra_slashes(
-            self, log_mock, yara, cmd, remove, create_test_files_fake_yara
+            self,
+            util_log_mock,
+            log_mock,
+            save,
+            download,
+            remove,
+            create_test_files_fake_yara,
         ):
             # Testing we handle the situation where items in filesystem_scan_only & scan_exclude contain multiple slashes
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "test_scan: false" if line.startswith("test_scan:") else line
                 line = (
                     line + "rules_location: %s\n" % TEST_RULE_FILE
-                    if line.startswith('---')
+                    if line.startswith("rules_location:")
                     else line
                 )
-                line = line + "- //\n" if line.startswith("filesystem_scan_only:") else line
-                line = line + "- //\n" if line.startswith("filesystem_scan_exclude:") else line
+                line = (
+                    line + "- //\n"
+                    if line.startswith("filesystem_scan_only:")
+                    else line
+                )
+                line = (
+                    line + "- //\n"
+                    if line.startswith("filesystem_scan_exclude:")
+                    else line
+                )
                 line = (
                     "exclude_network_filesystem_mountpoints: false"
                     if line.startswith("exclude_network_filesystem_mountpoints:")
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
-            assert mdc.scan_fsobjects == ['/']
-            assert '/' in mdc.filesystem_scan_exclude_list
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.load_rules()
+            mdc.parse_scan_options()
+            assert mdc.scan_fsobjects == ["/"]
+            assert "/" in mdc.filesystem_scan_exclude_list
             # Chaos monkey - modify scan_fsobjects and filesystem_scan_exclude_list AFTER they have been verified
             # Assert that they still work and cancel each other out
-            mdc.scan_fsobjects = ['//']
-            mdc.filesystem_scan_exclude_list = ['//']
+            mdc.scan_fsobjects = ["//"]
+            mdc.filesystem_scan_exclude_list = ["//"]
             mdc.scan_filesystem()
             assert mdc.do_filesystem_scan is False
-            log_mock.error.assert_called_with(
+            util_log_mock.error.assert_called_with(
                 "No filesystem items to scan because the specified exclude items cancel them out"
             )
 
-        @patch('insights.specs.datasources.malware_detection.NamedTemporaryFile')
+        @patch("insights.specs.datasources.malware_detection.NamedTemporaryFile")
         @patch(CALL_TARGET, return_value="")
         def test_filesystem_scan_since_tmp_files(
             self,
             call_mock,
             tmp_file_mock,
             log_mock,
-            yara,
-            cmd,
+            save,
+            download,
             remove,
             extract_tmp_files,
             create_test_files_fake_yara,
         ):
             # Set filesystem_scan_only, filesystem_scan_exclude options to some of the tmp files and then 'scan' them
             # Then touch files to test the filesystem_scan_since option and make sure that only the touched files will be scanned
-            yara_file_list = os.path.join(TEMP_TEST_DIR, 'yara_file_list')
-            scan_me_file = os.path.join(TEMP_TEST_DIR, 'scan_me/scan_me_file')
-            scan_me_too_file = os.path.join(TEMP_TEST_DIR, 'scan_me_too/scan_me_too_file')
+            yara_file_list = os.path.join(TEMP_TEST_DIR, "yara_file_list")
+            scan_me_file = os.path.join(TEMP_TEST_DIR, "scan_me/scan_me_file")
+            scan_me_too_file = os.path.join(
+                TEMP_TEST_DIR, "scan_me_too/scan_me_too_file"
+            )
             filesystem_scan_only = tuple(
-                map(lambda x: os.path.join(TEMP_TEST_DIR, x), ['scan_me', 'scan_me_too'])
+                map(
+                    lambda x: os.path.join(TEMP_TEST_DIR, x), ["scan_me", "scan_me_too"]
+                )
             )
             filesystem_scan_exclude = tuple(
                 map(
                     lambda x: os.path.join(TEMP_TEST_DIR, x),
-                    ['scan_me_not', 'scan_me/dont_scan_me', 'scan_me_too/dont_scan_me_too'],
+                    [
+                        "scan_me_not",
+                        "scan_me/dont_scan_me",
+                        "scan_me_too/dont_scan_me_too",
+                    ],
                 )
             )
 
@@ -2469,11 +3794,11 @@ class TestsUtilizingFakeYara:
                 line = "test_scan: false" if line.startswith("test_scan:") else line
                 line = (
                     line + "rules_location: %s\n" % TEST_RULE_FILE
-                    if line.startswith('---')
+                    if line.startswith("rules_location:")
                     else line
                 )
                 line = (
-                    line + '- %s\n- %s' % filesystem_scan_only
+                    line + "- %s\n- %s" % filesystem_scan_only
                     if line.startswith("filesystem_scan_only:")
                     else line
                 )
@@ -2488,22 +3813,31 @@ class TestsUtilizingFakeYara:
                     else line
                 )
                 print(line)
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.load_rules()
+            mdc.parse_scan_options()
             scan_dict = process_include_exclude_items(
-                include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
+                include_items=mdc.scan_fsobjects,
+                exclude_items=mdc.filesystem_scan_exclude_list,
             )
             # Ensure the correct scan include and exclude values are set
-            assert list(scan_dict.keys()) == ['/tmp']
-            assert sorted(list(scan_dict['/tmp']['exclude']['items'])) == sorted(
+            assert list(scan_dict.keys()) == ["/tmp"]
+            assert sorted(list(scan_dict["/tmp"]["exclude"]["items"])) == sorted(
                 filesystem_scan_exclude
             )
 
             # Run scan_filesystem, but mock out NamedTemporaryFile so we can use our own file and inspect its contents after
             # Also mock out the call to yara but we don't return anything since we aren't testing it
-            with open(yara_file_list, 'w') as f:
+            with open(yara_file_list, "w") as f:
                 tmp_file_mock.return_value = f
                 mdc.scan_filesystem()
-            with open(yara_file_list, 'r') as f:
+            with open(yara_file_list, "r") as f:
                 contents = f.read().splitlines()
             # Ensure that a number of files are in the list of files passed to yara to scan
             assert len(contents) > 2
@@ -2512,7 +3846,9 @@ class TestsUtilizingFakeYara:
             # With the same filesystem scan_only and scan_exclude values, add filesystem_scan_since: last into the mix and set
             # the last scan time to now.  There should be no matches because no files have been modified since now
             last_scan = time.time()
-            last_scan_fmt = datetime.fromtimestamp(last_scan).strftime('%Y-%m-%d %H:%M:%S')
+            last_scan_fmt = datetime.fromtimestamp(last_scan).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = (
                     "filesystem_scan_since: last"
@@ -2521,37 +3857,55 @@ class TestsUtilizingFakeYara:
                 )
                 print(line)
             with patch(
-                "insights.specs.datasources.malware_detection.get_scan_since_timestamp",
+                "insights.specs.datasources.malware_detection.utils.get_scan_since_timestamp",
                 return_value=last_scan,
             ):
-                mdc = MalwareDetectionClient(None)
-            assert mdc.filesystem_scan_since_dict['timestamp'] == last_scan
-            assert mdc.filesystem_scan_since_dict['datetime'] == last_scan_fmt
-            log_mock.info.assert_called_with("Scan for files created/modified since %s%s", ANY, ANY)
+                altered_malware_config = load_or_create_malware_config()
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.load_rules()
+                mdc.parse_scan_options()
+            assert mdc.filesystem_scan_since_dict["timestamp"] == last_scan
+            assert mdc.filesystem_scan_since_dict["datetime"] == last_scan_fmt
+            log_mock.info.assert_called_with(
+                "Scan for files created/modified since %s%s", ANY, ANY
+            )
 
             # Run scan_filesystem, but mock out NamedTemporaryFile so we can use our own file and inspect its contents after
             # Also mock out the call to yara, but we don't return anything since we aren't testing it
-            with open(yara_file_list, 'w') as f:
+            with open(yara_file_list, "w") as f:
                 tmp_file_mock.return_value = f
                 mdc.scan_filesystem()
-            with open(yara_file_list, 'r') as f:
+            with open(yara_file_list, "r") as f:
                 contents = f.read().splitlines()
             # Ensure no files were passed to yara to scan because none were modified since 'last_scan'
             assert not contents
 
             # Try again, keeping the same last_scan time, but this time touch 2 files
             # Confirm that only these 2 files appear in the list of files to be passed to yara
-            os.system('touch %s %s' % (scan_me_file, scan_me_too_file))
+            os.system("touch %s %s" % (scan_me_file, scan_me_too_file))
             with patch(
-                "insights.specs.datasources.malware_detection.get_scan_since_timestamp",
+                "insights.specs.datasources.malware_detection.utils.get_scan_since_timestamp",
                 return_value=last_scan,
             ):
-                mdc = MalwareDetectionClient(None)
+                altered_malware_config = load_or_create_malware_config()
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.load_rules()
+                mdc.parse_scan_options()
 
-            with open(yara_file_list, 'w') as f:
+            with open(yara_file_list, "w") as f:
                 tmp_file_mock.return_value = f
                 mdc.scan_filesystem()
-            with open(yara_file_list, 'r') as f:
+            with open(yara_file_list, "r") as f:
                 contents = f.read().splitlines()
             # Ensure the scan_me_file was passed to yara to scan because it was 'modified' since 'last_scan'
             assert len(contents) == 2
@@ -2560,169 +3914,229 @@ class TestsUtilizingFakeYara:
             # Touch some files that are excluded from scanning so even though they have been modified, they won't be
             # in the list of files to scan that is passed to yara
             os.system(
-                'touch %s %s %s'
+                "touch %s %s %s"
                 % (
-                    os.path.join(TEMP_TEST_DIR, 'scan_me/dont_scan_me/matching_entity'),
-                    os.path.join(TEMP_TEST_DIR, 'scan_me_not/matching_entity'),
+                    os.path.join(TEMP_TEST_DIR, "scan_me/dont_scan_me/matching_entity"),
+                    os.path.join(TEMP_TEST_DIR, "scan_me_not/matching_entity"),
                     os.path.join(
-                        TEMP_TEST_DIR, "scan_me_too/dont_scan_me_too/'another matching_entity'"
+                        TEMP_TEST_DIR,
+                        "scan_me_too/dont_scan_me_too/'another matching_entity'",
                     ),
                 )
             )
             with patch(
-                "insights.specs.datasources.malware_detection.get_scan_since_timestamp",
+                "insights.specs.datasources.malware_detection.utils.get_scan_since_timestamp",
                 return_value=last_scan,
             ):
-                mdc = MalwareDetectionClient(None)
+                altered_malware_config = load_or_create_malware_config()
+                mdc = MalwareDetectionClient(
+                    InsightsConfig(),
+                    altered_malware_config,
+                    FAKE_YARA,
+                    FAKE_YARA_VERSION,
+                )
+                mdc.load_rules()
+                mdc.parse_scan_options()
 
-            with open(yara_file_list, 'w') as f:
+            with open(yara_file_list, "w") as f:
                 tmp_file_mock.return_value = f
                 mdc.scan_filesystem()
-            with open(yara_file_list, 'r') as f:
+            with open(yara_file_list, "r") as f:
                 contents = f.read().splitlines()
             # Ensure both scan_me_file and scan_me_too_file were passed to yara because both were modified since last_scan
             assert len(contents) == 2
             assert contents == [scan_me_file, scan_me_too_file]
 
-        @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
+        @patch(LOAD_CONFIG_TARGET, return_value=MALWARE_CONFIG)
         @patch.dict(os.environ)
         def test_rule_n_glob_files_excluded(
-            self, conf, log_mock, yara, cmd, remove, extract_tmp_files, create_test_files_fake_yara
+            self,
+            conf,
+            log_mock,
+            save,
+            download,
+            remove,
+            extract_tmp_files,
+            create_test_files_fake_yara,
         ):
             # Fake a scan but make sure we are excluding the rules file and globbed files (they are supposed to be
             # insights log files, but that's hard to mock).
             # Also test we are not excluding ones we actually want to scan
             glob_files = [
-                os.path.join(TEMP_TEST_DIR, 'scan_me', f) for f in ['new_file', 'old_file']
+                os.path.join(TEMP_TEST_DIR, "scan_me", f)
+                for f in ["new_file", "old_file"]
             ]
-            os.environ['TEST_SCAN'] = 'false'
-            os.environ['EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'] = 'false'
-            os.environ['RULES_LOCATION'] = TEST_RULE_FILE
-            os.environ['FILESYSTEM_SCAN_ONLY'] = "%s,%s" % (
+            os.environ["TEST_SCAN"] = "false"
+            os.environ["USE_REMOTE_RULES"] = "false"
+            os.environ["EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS"] = "false"
+            os.environ["RULES_LOCATION"] = TEST_RULE_FILE
+            os.environ["FILESYSTEM_SCAN_ONLY"] = "%s,%s" % (
                 TEMP_TEST_DIR,
                 glob_files[1],
             )  # we actually want to scan glob_files[1]
-            mdc = MalwareDetectionClient(None)
-            assert mdc.rules_file == TEST_RULE_FILE
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.load_rules()
+            mdc.parse_scan_options()
+
+            assert mdc.rules_files == [TEST_RULE_FILE]
             assert mdc.scan_fsobjects == [TEMP_TEST_DIR, glob_files[1]]
 
             # Patch the call to glob so it returns a specific list of files
             # Patch the calls for running yara and have it return no matches
             with patch(
-                "insights.specs.datasources.malware_detection.glob", return_value=glob_files
+                "insights.specs.datasources.malware_detection.glob",
+                return_value=glob_files,
             ):
                 with patch(CALL_TARGET, return_value=""):
                     mdc.scan_filesystem()
-            assert mdc.rules_file in mdc.filesystem_scan_exclude_list
+            for r in mdc.rules_files:
+                assert r in mdc.filesystem_scan_exclude_list
             assert glob_files[0] in mdc.filesystem_scan_exclude_list
             # Make sure glob_files[1] isn't excluded because we actually want to scan that file
             assert glob_files[1] not in mdc.filesystem_scan_exclude_list
 
             # This time patch glob so it returns an empty list, ie simulating no extra files to exclude
-            mdc = MalwareDetectionClient(None)
-            with patch("insights.specs.datasources.malware_detection.glob", return_value=[]):
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            mdc.load_rules()
+            mdc.parse_scan_options()
+            with patch(
+                "insights.specs.datasources.malware_detection.glob", return_value=[]
+            ):
                 with patch(CALL_TARGET, return_value=""):
                     mdc.scan_filesystem()
-            assert mdc.rules_file in mdc.filesystem_scan_exclude_list
+            for r in mdc.rules_files:
+                assert r in mdc.filesystem_scan_exclude_list
             # None of the glob files should be excluded this time
             assert all([f not in mdc.filesystem_scan_exclude_list for f in glob_files])
 
+    @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
     @patch(FINDMNT_TARGET)
-    @patch(BUILD_YARA_COMMAND_TARGET)
-    @patch(GET_RULES_TARGET, return_value=RULES_FILE)
-    @patch(DISABLED_RULES_TARGET)
-    @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
-    @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
-    @patch.dict(os.environ, {'TEST_SCAN': 'false'})
+    @patch.dict(os.environ, {"TEST_SCAN": "false"})
     class TestFilesystemIncludeExcludeProcessing:
 
-        def test_process_include_exclude_items_simple(
-            self, conf, yara, disabled, rules, cmd, findmnt
-        ):
+        def test_process_include_exclude_items_simple(self, findmnt):
             # Test the process_include_exclude_items function with simple modified include and exclude items
             # Simple in that the include and exclude files are modified in such a way that
             # directory listings aren't required get the list of included files
             # Add a single toplevel directory to the include file - expect only a single directory to scan
-            mdc = MalwareDetectionClient(None)
-            mdc.scan_fsobjects = ['/etc']
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            # manually set rules
+            mdc.rules_files = [RULES_FILE]
+            mdc.parse_scan_options()
+
+            mdc.scan_fsobjects = ["/etc"]
             mdc.filesystem_scan_exclude_list = []
             scan_dict = process_include_exclude_items(
-                include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
+                include_items=mdc.scan_fsobjects,
+                exclude_items=mdc.filesystem_scan_exclude_list,
             )
-            assert list(scan_dict.keys()) == ['/etc']
-            assert 'include' not in scan_dict['/etc']
-            assert 'exclude' not in scan_dict['/etc']
+            assert list(scan_dict.keys()) == ["/etc"]
+            assert "include" not in scan_dict["/etc"]
+            assert "exclude" not in scan_dict["/etc"]
 
             # Add some extra subdirectories to scan
-            mdc.scan_fsobjects.extend(['/var/lib', '/var/log'])
+            mdc.scan_fsobjects.extend(["/var/lib", "/var/log"])
             scan_dict = process_include_exclude_items(
-                include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
+                include_items=mdc.scan_fsobjects,
+                exclude_items=mdc.filesystem_scan_exclude_list,
             )
-            assert sorted(scan_dict.keys()) == ['/etc', '/var']
-            assert sorted(list(scan_dict['/var']['include'])) == ['/var/lib', '/var/log']
-            assert 'exclude' not in scan_dict['/var']
+            assert sorted(scan_dict.keys()) == ["/etc", "/var"]
+            assert sorted(list(scan_dict["/var"]["include"])) == [
+                "/var/lib",
+                "/var/log",
+            ]
+            assert "exclude" not in scan_dict["/var"]
 
             # Add some extra directories to exclude that won't impact the already included directories
-            mdc.filesystem_scan_exclude_list.extend(['/tmp', '/var/run'])
+            mdc.filesystem_scan_exclude_list.extend(["/tmp", "/var/run"])
             scan_dict = process_include_exclude_items(
-                include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
+                include_items=mdc.scan_fsobjects,
+                exclude_items=mdc.filesystem_scan_exclude_list,
             )
-            assert sorted(scan_dict.keys()) == ['/etc', '/var']
-            assert sorted(scan_dict['/var']['include']) == ['/var/lib', '/var/log']
-            assert scan_dict['/var']['exclude']['items'] == ['/var/run']
+            assert sorted(scan_dict.keys()) == ["/etc", "/var"]
+            assert sorted(scan_dict["/var"]["include"]) == ["/var/lib", "/var/log"]
+            assert scan_dict["/var"]["exclude"]["items"] == ["/var/run"]
 
             # Exclude /var which will remove it from the list of directories to scan
-            mdc.filesystem_scan_exclude_list.append('/var')
+            mdc.filesystem_scan_exclude_list.append("/var")
             scan_dict = process_include_exclude_items(
-                include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
+                include_items=mdc.scan_fsobjects,
+                exclude_items=mdc.filesystem_scan_exclude_list,
             )
-            assert list(scan_dict.keys()) == ['/etc']
+            assert list(scan_dict.keys()) == ["/etc"]
 
             # Exclude /etc which means there will be no directories to scan
-            mdc.filesystem_scan_exclude_list.append('/etc')
+            mdc.filesystem_scan_exclude_list.append("/etc")
             scan_dict = process_include_exclude_items(
-                include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
+                include_items=mdc.scan_fsobjects,
+                exclude_items=mdc.filesystem_scan_exclude_list,
             )
             assert scan_dict == {}
 
-        def test_process_include_exclude_items_complex(
-            self, conf, yara, disabled, rules, cmd, findmnt
-        ):
+        def test_process_include_exclude_items_complex(self, findmnt):
             # Test the process function with modified include and exclude files that will require more complex
             # processing to generate the list of items to be scanned
             # Because we are including items in /var/lib, we only need to list the contents of the /var/lib directory
             # We don't need to list the contents of the /var directory
-            mdc = MalwareDetectionClient(None)
-            mdc.scan_fsobjects = ['/var/lib', '/var/log']
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            # manually set rules
+            mdc.rules_files = [RULES_FILE]
+            mdc.parse_scan_options()
+
+            mdc.scan_fsobjects = ["/var/lib", "/var/log"]
             mdc.filesystem_scan_exclude_list = [
-                '/var/lib/systemd',
-                '/var/lib/misc/',
-                '/var/log/wtmp',
+                "/var/lib/systemd",
+                "/var/lib/misc/",
+                "/var/log/wtmp",
             ]
 
             scan_dict = process_include_exclude_items(
-                include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
+                include_items=mdc.scan_fsobjects,
+                exclude_items=mdc.filesystem_scan_exclude_list,
             )
-            assert list(scan_dict.keys()) == ['/var']
-            assert sorted(scan_dict['/var']['exclude']['items']) == [
-                '/var/lib/misc',
-                '/var/lib/systemd',
-                '/var/log/wtmp',
+            assert list(scan_dict.keys()) == ["/var"]
+            assert sorted(scan_dict["/var"]["exclude"]["items"]) == [
+                "/var/lib/misc",
+                "/var/lib/systemd",
+                "/var/log/wtmp",
             ]
             # The exclude items shouldn't be in the include items
             # Nor should other items that aren't in the explicitly included items
             assert all(
                 [
-                    x not in scan_dict['/var']['include']
+                    x not in scan_dict["/var"]["include"]
                     for x in [
-                        '/var/lib/misc',
-                        '/var/lib/systemd',
-                        '/var/log/wtmp',
-                        '/var/cache',
-                        '/var/lib',
-                        '/var/log',
-                        '/var/tmp',
-                        '/tmp',
+                        "/var/lib/misc",
+                        "/var/lib/systemd",
+                        "/var/log/wtmp",
+                        "/var/cache",
+                        "/var/lib",
+                        "/var/log",
+                        "/var/tmp",
+                        "/tmp",
                     ]
                 ]
             )
@@ -2732,34 +4146,40 @@ class TestsUtilizingFakeYara:
             maybe_dirs = list(
                 filter(
                     lambda path: os.path.exists(path),
-                    ['/var/lib/dbus', '/var/lib/pam', '/var/lib/rpm', '/var/log/lastlog'],
+                    [
+                        "/var/lib/dbus",
+                        "/var/lib/pam",
+                        "/var/lib/rpm",
+                        "/var/log/lastlog",
+                    ],
                 )
             )
-            assert all([x in scan_dict['/var']['include'] for x in maybe_dirs])
+            assert all([x in scan_dict["/var"]["include"] for x in maybe_dirs])
 
             # Change the include directory to /var
             # Now immediate child directories of /var will be in the include list, eg /var/cache and /var/tmp
             # Because now we have to list the contents of the /var and /var/lib directories
-            mdc.scan_fsobjects.append('/var')
+            mdc.scan_fsobjects.append("/var")
             scan_dict = process_include_exclude_items(
-                include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
+                include_items=mdc.scan_fsobjects,
+                exclude_items=mdc.filesystem_scan_exclude_list,
             )
-            assert list(scan_dict.keys()) == ['/var']
-            assert sorted(scan_dict['/var']['exclude']['items']) == [
-                '/var/lib/misc',
-                '/var/lib/systemd',
-                '/var/log/wtmp',
+            assert list(scan_dict.keys()) == ["/var"]
+            assert sorted(scan_dict["/var"]["exclude"]["items"]) == [
+                "/var/lib/misc",
+                "/var/lib/systemd",
+                "/var/log/wtmp",
             ]
             assert all(
                 [
-                    x not in scan_dict['/var']['include']
+                    x not in scan_dict["/var"]["include"]
                     for x in [
-                        '/var/lib/misc',
-                        '/var/lib/systemd',
-                        '/var/log/wtmp',
-                        '/var/lib',
-                        '/var/log',
-                        '/tmp',
+                        "/var/lib/misc",
+                        "/var/lib/systemd",
+                        "/var/log/wtmp",
+                        "/var/lib",
+                        "/var/log",
+                        "/tmp",
                     ]
                 ]
             )
@@ -2768,29 +4188,34 @@ class TestsUtilizingFakeYara:
                 filter(
                     lambda path: os.path.exists(path),
                     [
-                        '/var/cache',
-                        '/var/tmp',
-                        '/var/lib/dbus',
-                        '/var/lib/pam',
-                        '/var/lib/rpm',
-                        '/var/log/lastlog',
+                        "/var/cache",
+                        "/var/tmp",
+                        "/var/lib/dbus",
+                        "/var/lib/pam",
+                        "/var/lib/rpm",
+                        "/var/log/lastlog",
                     ],
                 )
             )
-            assert all([x in scan_dict['/var']['include'] for x in maybe_dirs])
+            assert all([x in scan_dict["/var"]["include"] for x in maybe_dirs])
 
+    @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
     @patch(FINDMNT_TARGET)
-    @patch(BUILD_YARA_COMMAND_TARGET)
-    @patch(GET_RULES_TARGET, return_value=RULES_FILE)
-    @patch(DISABLED_RULES_TARGET, return_value=[])
-    @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
-    @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
-    @patch.dict(os.environ, {'TEST_SCAN': 'false'})
+    @patch.dict(os.environ, {"TEST_SCAN": "false"})
     class TestParseScanOutput:
 
-        def test_contrived_scan_output(self, conf, yara, disabled, rules, cmd, findmnt):
+        def test_contrived_scan_output(self, findmnt):
             # Parse the CONTRIVED_SCAN_OUTPUT to find actual rule matches amongst malformed output lines
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            # manually set rules
+            mdc.rules_files = [RULES_FILE]
+            mdc.parse_scan_options()
             assert mdc.disabled_rules == []
             mdc.add_metadata = False
             mdc.parse_scan_output(CONTRIVED_SCAN_OUTPUT)
@@ -2802,2534 +4227,484 @@ class TestsUtilizingFakeYara:
             assert mdc.matches == 8  # 8 sources/files matched across the 5 rules
 
             # 1 matching source/file and 1 matching string for rule 'this'
-            rule_match = mdc.host_scan['this']
-            rule_sources = set(map(lambda x: x['source'], rule_match))
+            rule_match = mdc.host_scan["this"]
+            rule_sources = set(map(lambda x: x["source"], rule_match))
             assert len(rule_sources) == 1
             assert len(rule_match) == 1
-            assert 'e-r-r-o-r s-c-a-n-n-i-n-g' in rule_match[0]['source']
-            assert rule_match[0]['string_data'] == "matches 'this' rule"
-            assert rule_match[0]['string_identifier'] == '$match'
-            assert rule_match[0]['string_offset'] == 291
+            assert "e-r-r-o-r s-c-a-n-n-i-n-g" in rule_match[0]["source"]
+            assert rule_match[0]["string_data"] == "matches 'this' rule"
+            assert rule_match[0]["string_identifier"] == "$match"
+            assert rule_match[0]["string_offset"] == 291
 
             # 3 source/file matches and 14 matching strings across those sources for rule 'Rule'
-            rule_match = mdc.host_scan['Rule']
-            rule_sources = set(map(lambda x: x['source'], rule_match))
+            rule_match = mdc.host_scan["Rule"]
+            rule_sources = set(map(lambda x: x["source"], rule_match))
             assert len(rule_sources) == 3
             assert len(rule_match) == 14
-            assert rule_match[0]['source'] == MATCHING_ENTITY_FILE
-            assert rule_match[0]['string_data'] == 'string match in the file "matching_entity"'
-            assert rule_match[0]['string_identifier'] == '$match0'
-            assert rule_match[0]['string_offset'] == 21
-            assert rule_match[1]['source'] == MATCHING_ENTITY_FILE
-            assert rule_match[1]['string_data'] == "another string match in matching_entity"
-            assert rule_match[1]['string_identifier'] == '$match1'
-            assert rule_match[1]['string_offset'] == 83
-            assert rule_match[2]['source'] == MATCHING_ENTITY_FILE
+            assert rule_match[0]["source"] == MATCHING_ENTITY_FILE
             assert (
-                rule_match[2]['string_data']
-                == 'string with different types of quotes \'here\' and "here"'
+                rule_match[0]["string_data"]
+                == 'string match in the file "matching_entity"'
             )
-            assert rule_match[2]['string_identifier'] == '$match2'
-            assert rule_match[2]['string_offset'] == 230
+            assert rule_match[0]["string_identifier"] == "$match0"
+            assert rule_match[0]["string_offset"] == 21
+            assert rule_match[1]["source"] == MATCHING_ENTITY_FILE
+            assert (
+                rule_match[1]["string_data"]
+                == "another string match in matching_entity"
+            )
+            assert rule_match[1]["string_identifier"] == "$match1"
+            assert rule_match[1]["string_offset"] == 83
+            assert rule_match[2]["source"] == MATCHING_ENTITY_FILE
+            assert (
+                rule_match[2]["string_data"]
+                == "string with different types of quotes 'here' and \"here\""
+            )
+            assert rule_match[2]["string_identifier"] == "$match2"
+            assert rule_match[2]["string_offset"] == 230
 
             # Rule matches for ANOTHER_MATCHING_ENTITY_FILE (which has a space in the filename)
-            assert rule_match[3]['source'] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[3]["source"] == ANOTHER_MATCHING_ENTITY_FILE
             assert (
-                rule_match[3]['string_data']
+                rule_match[3]["string_data"]
                 == "string match containing error scanning but it's ok because its not in a rule line"
             )
-            assert rule_match[3]['string_identifier'] == '$match3'
-            assert rule_match[3]['string_offset'] == 2
-            assert rule_match[4]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[4]['string_data'] == "contains ="
-            assert rule_match[4]['string_identifier'] == '$grep1'
-            assert rule_match[4]['string_offset'] == 97
-            assert rule_match[6]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[6]['string_data'] == "contains .+"
-            assert rule_match[6]['string_identifier'] == '$grep2'
-            assert rule_match[6]['string_offset'] == 153
-            assert rule_match[8]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[8]['string_data'] == 'contains "'
-            assert rule_match[8]['string_identifier'] == '$grep3'
-            assert rule_match[8]['string_offset'] == 213
-            assert rule_match[9]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[9]['string_data'] == "contains '"
-            assert rule_match[9]['string_identifier'] == '$grep4'
-            assert rule_match[9]['string_offset'] == 241
-            assert rule_match[10]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[10]['string_data'] == 'contains ()[]'
-            assert rule_match[10]['string_identifier'] == '$grep5'
-            assert rule_match[10]['string_offset'] == 269
-            assert rule_match[11]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[11]['string_data'] == 'contains {'
-            assert rule_match[11]['string_identifier'] == '$grep6'
-            assert rule_match[11]['string_offset'] == 299
-            assert rule_match[12]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[12]['string_data'] == 'contains ^$'
-            assert rule_match[12]['string_identifier'] == '$grep7'
-            assert rule_match[12]['string_offset'] == 327
+            assert rule_match[3]["string_identifier"] == "$match3"
+            assert rule_match[3]["string_offset"] == 2
+            assert rule_match[4]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[4]["string_data"] == "contains ="
+            assert rule_match[4]["string_identifier"] == "$grep1"
+            assert rule_match[4]["string_offset"] == 97
+            assert rule_match[6]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[6]["string_data"] == "contains .+"
+            assert rule_match[6]["string_identifier"] == "$grep2"
+            assert rule_match[6]["string_offset"] == 153
+            assert rule_match[8]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[8]["string_data"] == 'contains "'
+            assert rule_match[8]["string_identifier"] == "$grep3"
+            assert rule_match[8]["string_offset"] == 213
+            assert rule_match[9]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[9]["string_data"] == "contains '"
+            assert rule_match[9]["string_identifier"] == "$grep4"
+            assert rule_match[9]["string_offset"] == 241
+            assert rule_match[10]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[10]["string_data"] == "contains ()[]"
+            assert rule_match[10]["string_identifier"] == "$grep5"
+            assert rule_match[10]["string_offset"] == 269
+            assert rule_match[11]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[11]["string_data"] == "contains {"
+            assert rule_match[11]["string_identifier"] == "$grep6"
+            assert rule_match[11]["string_offset"] == 299
+            assert rule_match[12]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[12]["string_data"] == "contains ^$"
+            assert rule_match[12]["string_identifier"] == "$grep7"
+            assert rule_match[12]["string_offset"] == 327
 
-            assert rule_match[13]['source'].startswith('matching_entity_3')
-            assert rule_match[13]['string_data'] == ''
-            assert rule_match[13]['string_identifier'] == ''
-            assert rule_match[13]['string_offset'] == -1
+            assert rule_match[13]["source"].startswith("matching_entity_3")
+            assert rule_match[13]["string_data"] == ""
+            assert rule_match[13]["string_identifier"] == ""
+            assert rule_match[13]["string_offset"] == -1
 
             # 2 source matches and 4 matching strings for 'another_matching_rule'
-            rule_match = mdc.host_scan['another_matching_rule']
-            rule_sources = set(map(lambda x: x['source'], rule_match))
+            rule_match = mdc.host_scan["another_matching_rule"]
+            rule_sources = set(map(lambda x: x["source"], rule_match))
             assert len(rule_sources) == 2
             assert len(rule_match) == 4
-            assert rule_match[2]['source'].endswith(
-                'snap/signal-desktop/350/opt/Signal/resources/app.asar'
+            assert rule_match[2]["source"].endswith(
+                "snap/signal-desktop/350/opt/Signal/resources/app.asar"
             )
-            assert rule_match[2]['string_data'] == '#!/bin/sh'
-            assert rule_match[2]['string_identifier'] == '$s0'
-            assert rule_match[2]['string_offset'] == 60783814
-            assert rule_match[3]['source'] == '1234567'
-            assert rule_match[3]['string_data'] == '#!/bin/sh'
-            assert rule_match[3]['string_identifier'] == '$s0'
-            assert rule_match[3]['string_offset'] == 0
+            assert rule_match[2]["string_data"] == "#!/bin/sh"
+            assert rule_match[2]["string_identifier"] == "$s0"
+            assert rule_match[2]["string_offset"] == 60783814
+            assert rule_match[3]["source"] == "1234567"
+            assert rule_match[3]["string_data"] == "#!/bin/sh"
+            assert rule_match[3]["string_identifier"] == "$s0"
+            assert rule_match[3]["string_offset"] == 0
 
             # 1 matching source and 1 matching string for 'Iyamtho'
-            rule_match = mdc.host_scan['Iyamtho']
+            rule_match = mdc.host_scan["Iyamtho"]
             assert len(rule_match) == 1
-            assert rule_match[0]['source'] == " yep"
-            assert rule_match[0]['string_data'] == ''
-            assert rule_match[0]['string_identifier'] == ''
-            assert rule_match[0]['string_offset'] == -1
+            assert rule_match[0]["source"] == " yep"
+            assert rule_match[0]["string_data"] == ""
+            assert rule_match[0]["string_identifier"] == ""
+            assert rule_match[0]["string_offset"] == -1
 
             # 1 matching source and 1 matching string for 'n_m3_t00'
-            rule_match = mdc.host_scan['n_m3_t00']
+            rule_match = mdc.host_scan["n_m3_t00"]
             assert len(rule_match) == 1
-            assert rule_match[0]['source'] == "damn   straight"
-            assert rule_match[0]['string_data'] == ''
-            assert rule_match[0]['string_identifier'] == ''
-            assert rule_match[0]['string_offset'] == -1
+            assert rule_match[0]["source"] == "damn   straight"
+            assert rule_match[0]["string_data"] == ""
+            assert rule_match[0]["string_identifier"] == ""
+            assert rule_match[0]["string_offset"] == -1
 
         def test_contrived_scan_output_metadata(
-            self, conf, yara, disabled, rules, cmd, findmnt, create_test_files_fake_yara
+            self,
+            findmnt,
+            create_test_files_fake_yara,
         ):
             # Again, parse the CONTRIVED_SCAN_OUTPUT to find actual rule matches amongst malformed output lines,
             # but this time check the expected metadata values too
 
             # Again, need to populate rules_file_location with any rule, but its not relevant for the tests
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            # manually set rules
+            mdc.rules_files = [RULES_FILE]
+            mdc.parse_scan_options()
+
             mdc.parse_scan_output(CONTRIVED_SCAN_OUTPUT)
 
             # Matches and metadata for MATCHING_ENTITY_FILE
-            rule_match = mdc.host_scan['Rule']
-            assert rule_match[0]['source'] == MATCHING_ENTITY_FILE
-            assert rule_match[0]['string_offset'] == 21
-            metadata = rule_match[0]['metadata']
-            assert metadata['source_type'] == 'file'
-            assert metadata['file_type'] == 'ASCII text'
-            assert metadata['mime_type'] == 'text/plain; charset=us-ascii'
-            assert metadata['md5sum'] == '9dd5c5e00d28520dc9da3c509c0db2a0'
-            assert metadata['line_number'] == 1
-            assert metadata['line'] == urlencode(
+            rule_match = mdc.host_scan["Rule"]
+            assert rule_match[0]["source"] == MATCHING_ENTITY_FILE
+            assert rule_match[0]["string_offset"] == 21
+            metadata = rule_match[0]["metadata"]
+            assert metadata["source_type"] == "file"
+            assert metadata["file_type"] == "ASCII text"
+            assert metadata["mime_type"] == "text/plain; charset=us-ascii"
+            assert metadata["md5sum"] == "9dd5c5e00d28520dc9da3c509c0db2a0"
+            assert metadata["line_number"] == 1
+            assert metadata["line"] == urlencode(
                 'This line contains a string match in the file "matching_entity"'
             )
 
             # Testing displaying long lines
-            assert rule_match[1]['source'] == MATCHING_ENTITY_FILE
-            assert rule_match[1]['string_offset'] == 83
-            metadata = rule_match[1]['metadata']
-            assert metadata['source_type'] == 'file'
-            assert metadata['file_type'] == 'ASCII text'
-            assert metadata['mime_type'] == 'text/plain; charset=us-ascii'
-            assert metadata['md5sum'] == '9dd5c5e00d28520dc9da3c509c0db2a0'
-            assert metadata['line_number'] == 2
-            assert metadata['line'] == urlencode(
-                'This line contains another string match in matching_entity and it is very long for testing the ellipses that are added o...'
+            assert rule_match[1]["source"] == MATCHING_ENTITY_FILE
+            assert rule_match[1]["string_offset"] == 83
+            metadata = rule_match[1]["metadata"]
+            assert metadata["source_type"] == "file"
+            assert metadata["file_type"] == "ASCII text"
+            assert metadata["mime_type"] == "text/plain; charset=us-ascii"
+            assert metadata["md5sum"] == "9dd5c5e00d28520dc9da3c509c0db2a0"
+            assert metadata["line_number"] == 2
+            assert metadata["line"] == urlencode(
+                "This line contains another string match in matching_entity and it is very long for testing the ellipses that are added o..."
             )
 
             # Testing matching/displaying a mixture of quote types in the string_data
-            assert rule_match[2]['source'] == MATCHING_ENTITY_FILE
-            assert rule_match[2]['string_offset'] == 230
-            metadata = rule_match[2]['metadata']
-            assert metadata['source_type'] == 'file'
-            assert metadata['file_type'] == 'ASCII text'
-            assert metadata['mime_type'] == 'text/plain; charset=us-ascii'
-            assert metadata['md5sum'] == '9dd5c5e00d28520dc9da3c509c0db2a0'
-            assert metadata['line_number'] == 4
-            assert metadata['line'] == urlencode(
+            assert rule_match[2]["source"] == MATCHING_ENTITY_FILE
+            assert rule_match[2]["string_offset"] == 230
+            metadata = rule_match[2]["metadata"]
+            assert metadata["source_type"] == "file"
+            assert metadata["file_type"] == "ASCII text"
+            assert metadata["mime_type"] == "text/plain; charset=us-ascii"
+            assert metadata["md5sum"] == "9dd5c5e00d28520dc9da3c509c0db2a0"
+            assert metadata["line_number"] == 4
+            assert metadata["line"] == urlencode(
                 """And this line contains a string with different types of quotes 'here' and "here" and its long too but not long enough"""
             )
 
             # Rule match metadata for ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[3]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[3]['string_offset'] == 2
-            metadata = rule_match[3]['metadata']
-            assert metadata['source_type'] == 'file'
-            assert metadata['file_type'] == 'ASCII text'
-            assert metadata['mime_type'] == 'text/plain; charset=us-ascii'
-            assert metadata['md5sum'] == '64764d295e92ffeec36d3fcd646a3af4'
-            assert metadata['line_number'] == 3
-            assert metadata['line'] == urlencode(
+            assert rule_match[3]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[3]["string_offset"] == 2
+            metadata = rule_match[3]["metadata"]
+            assert metadata["source_type"] == "file"
+            assert metadata["file_type"] == "ASCII text"
+            assert metadata["mime_type"] == "text/plain; charset=us-ascii"
+            assert metadata["md5sum"] == "64764d295e92ffeec36d3fcd646a3af4"
+            assert metadata["line_number"] == 3
+            assert metadata["line"] == urlencode(
                 "string match containing error scanning but it's ok because its not in a rule line"
             )
 
-            assert rule_match[4]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[4]['string_offset'] == 97
-            metadata = rule_match[4]['metadata']
-            assert metadata['md5sum'] == '64764d295e92ffeec36d3fcd646a3af4'
-            assert metadata['line_number'] == 7
-            assert metadata['line'] == urlencode("This line contains = char")
+            assert rule_match[4]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[4]["string_offset"] == 97
+            metadata = rule_match[4]["metadata"]
+            assert metadata["md5sum"] == "64764d295e92ffeec36d3fcd646a3af4"
+            assert metadata["line_number"] == 7
+            assert metadata["line"] == urlencode("This line contains = char")
 
-            assert rule_match[5]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[5]['string_offset'] == 123
-            metadata = rule_match[5]['metadata']
-            assert metadata['line_number'] == 8
-            assert metadata['line'] == urlencode("This line contains = char too")
+            assert rule_match[5]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[5]["string_offset"] == 123
+            metadata = rule_match[5]["metadata"]
+            assert metadata["line_number"] == 8
+            assert metadata["line"] == urlencode("This line contains = char too")
 
-            assert rule_match[6]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[6]['string_offset'] == 153
-            metadata = rule_match[6]['metadata']
-            assert metadata['line_number'] == 9
-            assert metadata['line'] == urlencode("This line contains .+ chars")
+            assert rule_match[6]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[6]["string_offset"] == 153
+            metadata = rule_match[6]["metadata"]
+            assert metadata["line_number"] == 9
+            assert metadata["line"] == urlencode("This line contains .+ chars")
 
-            assert rule_match[8]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[8]['string_offset'] == 213
-            metadata = rule_match[8]['metadata']
-            assert metadata['line_number'] == 11
-            assert metadata['line'] == urlencode('This line contains "" chars')
+            assert rule_match[8]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[8]["string_offset"] == 213
+            metadata = rule_match[8]["metadata"]
+            assert metadata["line_number"] == 11
+            assert metadata["line"] == urlencode('This line contains "" chars')
 
-            assert rule_match[9]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[9]['string_offset'] == 241
-            metadata = rule_match[9]['metadata']
-            assert metadata['line_number'] == 12
-            assert metadata['line'] == urlencode("This line contains '' chars")
+            assert rule_match[9]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[9]["string_offset"] == 241
+            metadata = rule_match[9]["metadata"]
+            assert metadata["line_number"] == 12
+            assert metadata["line"] == urlencode("This line contains '' chars")
 
-            assert rule_match[10]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[10]['string_offset'] == 269
-            metadata = rule_match[10]['metadata']
-            assert metadata['line_number'] == 13
-            assert metadata['line'] == urlencode("This line contains ()[] chars")
+            assert rule_match[10]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[10]["string_offset"] == 269
+            metadata = rule_match[10]["metadata"]
+            assert metadata["line_number"] == 13
+            assert metadata["line"] == urlencode("This line contains ()[] chars")
 
-            assert rule_match[11]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[11]['string_offset'] == 299
-            metadata = rule_match[11]['metadata']
-            assert metadata['line_number'] == 14
-            assert metadata['line'] == urlencode("This line contains {} chars")
+            assert rule_match[11]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[11]["string_offset"] == 299
+            metadata = rule_match[11]["metadata"]
+            assert metadata["line_number"] == 14
+            assert metadata["line"] == urlencode("This line contains {} chars")
 
-            assert rule_match[12]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-            assert rule_match[12]['string_offset'] == 327
-            metadata = rule_match[12]['metadata']
-            assert metadata['line_number'] == 15
-            assert metadata['line'] == urlencode("This line contains ^$ chars")
+            assert rule_match[12]["source"] == ANOTHER_MATCHING_ENTITY_FILE
+            assert rule_match[12]["string_offset"] == 327
+            metadata = rule_match[12]["metadata"]
+            assert metadata["line_number"] == 15
+            assert metadata["line"] == urlencode("This line contains ^$ chars")
 
             # Testing a missing file - expect minimal metadata because we can't know the other values
             assert (
-                rule_match[13]['source']
+                rule_match[13]["source"]
                 == "matching_entity_3, but without any string matches - yes that's ok"
             )
-            metadata = rule_match[13]['metadata']
-            assert metadata['source_type'] == 'file'
+            metadata = rule_match[13]["metadata"]
+            assert metadata["source_type"] == "file"
             assert all(
-                [key not in ['file_type', 'md5sum', 'line_number'] for key in metadata.keys()]
+                [
+                    key not in ["file_type", "md5sum", "line_number"]
+                    for key in metadata.keys()
+                ]
             )
 
             # Testing a missing file for another rule - again, expect minimal metadata because we can't find out more info
-            rule_match = mdc.host_scan['another_matching_rule']
-            assert rule_match[2]['source'].endswith(
-                'snap/signal-desktop/350/opt/Signal/resources/app.asar'
+            rule_match = mdc.host_scan["another_matching_rule"]
+            assert rule_match[2]["source"].endswith(
+                "snap/signal-desktop/350/opt/Signal/resources/app.asar"
             )
-            metadata = rule_match[2]['metadata']
-            assert metadata['source_type'] == 'file'
+            metadata = rule_match[2]["metadata"]
+            assert metadata["source_type"] == "file"
             assert all(
-                [key not in ['file_type', 'md5sum', 'line_number'] for key in metadata.keys()]
+                [
+                    key not in ["file_type", "md5sum", "line_number"]
+                    for key in metadata.keys()
+                ]
             )
 
             # Testing a missing process - again, expect minimal metadata because we can't find out more info
-            assert rule_match[3]['source'] == '1234567'
-            metadata = rule_match[3]['metadata']
-            assert metadata['source_type'] == 'process'
+            assert rule_match[3]["source"] == "1234567"
+            metadata = rule_match[3]["metadata"]
+            assert metadata["source_type"] == "process"
             assert all(
                 [
-                    key not in ['process_name', 'file_type', 'md5sum', 'line_number']
+                    key not in ["process_name", "file_type", "md5sum", "line_number"]
                     for key in metadata.keys()
                 ]
             )
 
         @patch(LOGGER_TARGET)
         def test_contrived_scan_output_with_disabled_rules(
-            self, log_mock, conf, yara, disabled, rules, cmd, findmnt
+            self,
+            log_mock,
+            findmnt,
         ):
             # Parse the CONTRIVED_SCAN_OUTPUT but with a number of disabled rules
             # Disable 3 of the rules in CONTRIVED_SCAN_OUTPUT, expect 2 matching rules
-            disabled.return_value = ['this', 'rule', 'another_matching_rule']
-            mdc = MalwareDetectionClient(None)
-            assert mdc.disabled_rules == ['this', 'rule', 'another_matching_rule']
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            # manually set rules
+            mdc.rules_files = [RULES_FILE]
+            # manually set disabled rules
+            mdc.disabled_rules = ["this", "rule", "another_matching_rule"]
+            mdc.parse_scan_options()
+
             mdc.parse_scan_output(CONTRIVED_SCAN_OUTPUT)
             assert mdc.matches == 2
             assert all(
                 list(
-                    map(lambda x: x not in ['this', 'Rule', 'another_matching_rule'], mdc.host_scan)
+                    map(
+                        lambda x: x not in ["this", "Rule", "another_matching_rule"],
+                        mdc.host_scan,
+                    )
                 )
             )
-            assert all(list(map(lambda x: x in ['Iyamtho', 'n_m3_t00'], mdc.host_scan)))
+            assert all(list(map(lambda x: x in ["Iyamtho", "n_m3_t00"], mdc.host_scan)))
             log_mock.debug.assert_any_call(
-                'Skipping matches for disabled rule %s in %s %s', 'this', 'file', ANY
+                "Skipping matches for disabled rule %s in %s %s", "this", "file", ANY
             )
             log_mock.debug.assert_any_call(
-                'Skipping matches for disabled rule %s in %s %s', 'Rule', 'file', ANY
+                "Skipping matches for disabled rule %s in %s %s", "Rule", "file", ANY
             )
-            log_mock.info.assert_any_call('Matched rule %s in %s %s', 'Iyamtho', 'file', ANY)
-            log_mock.info.assert_any_call('Matched rule %s in %s %s', 'n_m3_t00', 'file', ANY)
+            log_mock.info.assert_any_call(
+                "Matched rule %s in %s %s", "Iyamtho", "file", ANY
+            )
+            log_mock.info.assert_any_call(
+                "Matched rule %s in %s %s", "n_m3_t00", "file", ANY
+            )
 
             # disable all rules except 'Rule', because it isn't excluded
             log_mock.debug.reset_mock()
             log_mock.info.reset_mock()
-            disabled.return_value = ['this', 'rool', 'another_matching_rule', 'iyamtho', 'n_m3_t00']
-            mdc = MalwareDetectionClient(None)
+
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            # manually set rules
+            mdc.rules_files = [RULES_FILE]
+            # manually set disabled rules
+            mdc.disabled_rules = [
+                "this",
+                "rool",
+                "another_matching_rule",
+                "iyamtho",
+                "n_m3_t00",
+            ]
+            mdc.parse_scan_options()
+
             mdc.parse_scan_output(CONTRIVED_SCAN_OUTPUT)
-            assert list(mdc.host_scan) == ['Rule']
+            assert list(mdc.host_scan) == ["Rule"]
             assert mdc.matches == 3
-            sources = set(map(lambda x: x['source'], mdc.host_scan['Rule']))
+            sources = set(map(lambda x: x["source"], mdc.host_scan["Rule"]))
             assert len(sources) == 3
             log_mock.debug.assert_any_call(
-                'Skipping matches for disabled rule %s in %s %s', 'Iyamtho', 'file', ANY
+                "Skipping matches for disabled rule %s in %s %s", "Iyamtho", "file", ANY
             )
-            log_mock.info.assert_any_call('Matched rule %s in %s %s', 'Rule', 'file', ANY)
+            log_mock.info.assert_any_call(
+                "Matched rule %s in %s %s", "Rule", "file", ANY
+            )
 
-        def test_random_output(self, conf, yara, disabled, rules, cmd, findmnt):
-            mdc = MalwareDetectionClient(None)
+        def test_random_output(self, findmnt):
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            # manually set rules
+            mdc.rules_files = [RULES_FILE]
+            mdc.parse_scan_options()
+
             assert mdc.disabled_rules == []
             mdc.parse_scan_output(RANDOM_OUTPUT)
             assert mdc.matches == 2
-            rule_match = mdc.host_scan['Lorem']
-            assert rule_match[0]['source'].startswith('ipsum dolor')
-            assert rule_match[0]['string_data'] == ''
-            assert rule_match[0]['string_identifier'] == ''
-            assert rule_match[0]['string_offset'] == -1
-            rule_match = mdc.host_scan['Dictum']
-            assert rule_match[0]['source'].startswith('at tempor')
-            assert rule_match[0]['string_data'] == ''
-            assert rule_match[0]['string_identifier'] == ''
-            assert rule_match[0]['string_offset'] == -1
+            rule_match = mdc.host_scan["Lorem"]
+            assert rule_match[0]["source"].startswith("ipsum dolor")
+            assert rule_match[0]["string_data"] == ""
+            assert rule_match[0]["string_identifier"] == ""
+            assert rule_match[0]["string_offset"] == -1
+            rule_match = mdc.host_scan["Dictum"]
+            assert rule_match[0]["source"].startswith("at tempor")
+            assert rule_match[0]["string_data"] == ""
+            assert rule_match[0]["string_identifier"] == ""
+            assert rule_match[0]["string_offset"] == -1
 
         @patch(LOGGER_TARGET)
         def test_random_output_with_disabled_rules(
-            self, log_mock, conf, yara, disabled, rules, cmd, findmnt
+            self,
+            log_mock,
+            findmnt,
         ):
             # Test various disabled rules with parsing RANDOM_OUTPUT
             # Disable 'Lorem' rule (and others) and expect just to match the 'Dictum' rule
-            disabled.return_value = ['random', 'rules', 'and', 'lorem']
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            # manually set rules
+            mdc.rules_files = [RULES_FILE]
+            # manually set disabled rules
+            mdc.disabled_rules = ["random", "rules", "and", "lorem"]
+            mdc.parse_scan_options()
+
             mdc.parse_scan_output(RANDOM_OUTPUT)
             assert mdc.matches == 1
-            assert list(mdc.host_scan) == ['Dictum']
+            assert list(mdc.host_scan) == ["Dictum"]
             log_mock.debug.assert_any_call(
-                'Skipping matches for disabled rule %s in %s %s', 'Lorem', 'file', ANY
+                "Skipping matches for disabled rule %s in %s %s", "Lorem", "file", ANY
             )
 
             # Disable both 'Lorem' and 'Dictum' rules and expect to have no matches
             log_mock.debug.reset_mock()
-            disabled.return_value = ['dictum', 'lorem']
-            mdc = MalwareDetectionClient(None)
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            # manually set rules
+            mdc.rules_files = [RULES_FILE]
+            # manually set disabled rules
+            mdc.disabled_rules = ["dictum", "lorem"]
+            mdc.parse_scan_options()
+
             mdc.parse_scan_output(RANDOM_OUTPUT)
             assert mdc.matches == 0
             assert mdc.host_scan == {}
             log_mock.debug.assert_any_call(
-                'Skipping matches for disabled rule %s in %s %s', 'Dictum', 'file', ANY
+                "Skipping matches for disabled rule %s in %s %s", "Dictum", "file", ANY
             )
             log_mock.debug.assert_any_call(
-                'Skipping matches for disabled rule %s in %s %s', 'Lorem', 'file', ANY
+                "Skipping matches for disabled rule %s in %s %s", "Lorem", "file", ANY
             )
 
             # Disable rules other than 'Lorem' and 'Dictum' and expect match both those rules
-            disabled.return_value = ['dictumm', 'lore', 'and', 'other', 'rules']
-            mdc = MalwareDetectionClient(None)
+            altered_malware_config = load_or_create_malware_config()
+            mdc = MalwareDetectionClient(
+                InsightsConfig(),
+                altered_malware_config,
+                FAKE_YARA,
+                FAKE_YARA_VERSION,
+            )
+            # manually set rules
+            mdc.rules_files = [RULES_FILE]
+            # manually set disabled rules
+            mdc.disabled_rules = ["dictumm", "lore", "and", "other", "rules"]
+            mdc.parse_scan_options()
+
             mdc.parse_scan_output(RANDOM_OUTPUT)
             assert mdc.matches == 2
-            assert sorted(mdc.host_scan) == ['Dictum', 'Lorem']
-            log_mock.info.assert_any_call('Matched rule %s in %s %s', 'Dictum', 'file', ANY)
-            log_mock.info.assert_any_call('Matched rule %s in %s %s', 'Lorem', 'file', ANY)
-
-
-################################################################################################################
-# The following section involves tests that are run only if yara is installed on the system
-# They are included to ensure future versions of yara maintain the same behaviour expected by malware-detection
-################################################################################################################
-REAL_YARA = None
-try:
-    REAL_YARA = '/bin/yara' if os.path.isfile('/bin/yara') else str(call('which yara')).strip()
-except CalledProcessError:
-    # Double check its not in /usr/local/bin/yara
-    REAL_YARA = '/usr/local/bin/yara' if os.path.isfile('/usr/local/bin/yara') else None
-
-if REAL_YARA:
-    REAL_YARA_VERSION = str(call('%s --version' % REAL_YARA)).strip()
-
-    def find_test_item(item_name):
-        for path, dirs, files in os.walk(os.getcwd()):
-            if item_name in dirs or item_name in files:
-                return os.path.join(path, item_name)
-        return ""
-
-    def tld(path):
-        """
-        Return the top level directory for 'path' argument
-        """
-        full_path = os.path.abspath(path)
-        if os.path.samefile(full_path, '/'):
-            return full_path
-        parent_dirs = []
-        get_parent_dirs(full_path, parent_dirs)
-        return parent_dirs[0]
-
-    # Location of this test file (might be a better way of determining this!)
-    MALWARE_TEST_FILE = find_test_item('test_malware_detection.py')
-    # Miscellaneous rules files and other text files used in the tests
-    COMPILED_RULES_FILE = os.path.join(TEMP_TEST_DIR, 'compiled_rules.%s.yar' % REAL_YARA_VERSION)
-    RULE_RULE_FILE = os.path.join(TEMP_TEST_DIR, 'rule rule.yar')
-    RULE_METADATA_TEST_FILE = os.path.join(TEMP_TEST_DIR, 'rule_metadata_test.yar')
-    TEST_RULE_SCRIPT = os.path.join(TEMP_TEST_DIR, 'test-rule_process_match.sh')
-
-    @pytest.fixture
-    def create_test_files_real_yara():
-        # Write the test files to the temp directory
-        if not os.path.exists(TEMP_TEST_DIR):
-            os.mkdir(TEMP_TEST_DIR)
-        with open(TEMP_CONFIG_FILE, 'w') as tcf:
-            tcf.write(DEFAULT_MALWARE_CONFIG)
-        test_files = [
-            (MATCHING_ENTITY_FILE, MATCHING_ENTITY_FILE_CONTENTS),
-            (ANOTHER_MATCHING_ENTITY_FILE, ANOTHER_MATCHING_ENTITY_FILE_CONTENTS),
-            (TEST_RULE_FILE, TEST_RULE_FILE_CONTENTS),
-            (TEST_RULE_SCRIPT, TEST_RULE_SCRIPT_CONTENTS),
-            (RULE_RULE_FILE, RULE_RULE_FILE_CONTENTS),
-            (RULE_METADATA_TEST_FILE, RULE_METADATA_TEST_FILE_CONTENTS),
-        ]
-        for test_file, contents in test_files:
-            if not os.path.exists(test_file):
-                with open(test_file, 'w') as f:
-                    f.write(contents)
-        os.chmod(TEST_RULE_SCRIPT, 0o755)
-        if REAL_YARA:
-            with open(COMPILED_RULES_FILE, 'wb') as crf:
-                crf.write(TEST_RULE1)
-                crf.write(TEST_RULE2)
-            os.system("cat {0} | yarac - {0}".format(COMPILED_RULES_FILE))
-        yield
-        os.system('rm -rf %s' % TEMP_TEST_DIR)
-
-    @pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
-    class TestsUtilizingRealYara:
-
-        @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
-        class TestMalwareDetectionOptions:
-
-            @patch(GET_RULES_TARGET, return_value=TEST_RULE_FILE)
-            @patch(DISABLED_RULES_TARGET, return_value=[])
-            def test_running_default_options(
-                self, disabled, rules, create_test_files_real_yara, caplog
-            ):
-                # However, with the default malware options, test_scan is true, so some of the options values
-                # will be different from those of the default options.
-                # For example, do_filesystem_scan AND do_process_scan are both True when doing a test scan
-                logger.setLevel('DEBUG')
-                test_pid = str(os.getpid())
-
-                mdc = MalwareDetectionClient(None)
-                assert mdc.yara_binary == REAL_YARA
-                assert mdc.rules_file == TEST_RULE_FILE
-                assert mdc.disabled_rules == []
-                assert mdc.do_process_scan is True
-                if os.path.isfile(TEMP_CONFIG_FILE):
-                    assert mdc.scan_fsobjects == [TEMP_CONFIG_FILE]
-                    assert mdc.do_filesystem_scan is True
-                else:
-                    assert mdc.do_filesystem_scan is False
-                assert mdc.scan_pids == [test_pid]
-                assert mdc.filesystem_scan_since_dict == {'timestamp': None}
-                assert mdc.filesystem_scan_exclude_list == []
-                assert mdc.network_filesystem_mountpoints == []
-                assert mdc.scan_timeout == 3600
-                assert mdc.nice_value == 19
-                yara_cmd = ' '.join(mdc.yara_cmd)
-                assert yara_cmd == "nice -n 19 %s -s -N -a 3600 -p %s -r -f %s" % (
-                    REAL_YARA,
-                    CPUS,
-                    mdc.rules_file,
-                )
-                if os.path.isfile(TEMP_CONFIG_FILE):
-                    assert (
-                        "Performing a test scan of %s and the current process (PID %s)"
-                        % (TEMP_CONFIG_FILE, test_pid)
-                        in caplog.text
-                    )
-                else:
-                    assert (
-                        "Performing a test scan of the current process (PID %s)" % test_pid
-                        in caplog.text
-                    )
-                assert "Using yara binary: %s" % REAL_YARA in caplog.text
-
-                # Remainder of test may not work in QE Jenkins environment because config file may not exist and
-                # can't scan the pytest process
-                if os.path.exists(TEMP_CONFIG_FILE):
-                    mdc.scan_filesystem()
-                    assert (
-                        "Scanning specified files in %s ..." % tld(TEMP_CONFIG_FILE) in caplog.text
-                    )
-                    assert (
-                        "Matched rule TEST_RedHatInsightsMalwareDetection in file %s"
-                        % TEMP_CONFIG_FILE
-                        in caplog.text
-                    )
-
-                mdc.scan_processes()
-                assert "Scanning process %s ..." % test_pid in caplog.text
-                assert (
-                    "Matched rule TEST_RedHatInsightsMalwareDetection in process %s" % test_pid
-                    in caplog.text
-                )
-
-            @patch(GET_RULES_TARGET, return_value=COMPILED_RULES_FILE)
-            @patch(DISABLED_RULES_TARGET, return_value=[])
-            def test_running_modified_options(self, disabled, rules, create_test_files_real_yara):
-                # Disable test_scan and the malware options should mostly be same as what's in the mdc object
-                logger.setLevel('DEBUG')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    print(line)
-
-                mdc = MalwareDetectionClient(None)
-                assert mdc.rules_file == COMPILED_RULES_FILE
-                assert mdc.disabled_rules == []
-                assert mdc.yara_binary == REAL_YARA
-                assert mdc.do_filesystem_scan is True
-                assert mdc.do_process_scan is False
-                assert mdc.scan_fsobjects == []
-                assert mdc.scan_pids == []
-                assert mdc.filesystem_scan_since_dict == {'timestamp': None, 'datetime': None}
-                assert all(
-                    [
-                        d in mdc.filesystem_scan_exclude_list
-                        for d in ['/proc', '/sys', '/mnt', '/media']
-                    ]
-                )
-
-            def test_scan_only_option(self, create_test_files_real_yara, caplog):
-                # Test various combinations of scan_only and the scan_filesystem and scan_processes options
-                # Firstly, test the default option values
-                logger.setLevel('INFO')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = (
-                        line + "rules_location: %s\n" % COMPILED_RULES_FILE
-                        if line.startswith('---')
-                        else line
-                    )
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert mdc.do_filesystem_scan is True
-                assert mdc.do_process_scan is False
-                assert mdc.scan_fsobjects == []
-                assert mdc.scan_pids == []
-
-                # Add scan_only for a process - expect to exit because we can't scan processes because do_process_scan is false
-                caplog.clear()
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = (
-                        "processes_scan_only: 1"
-                        if line.startswith("processes_scan_only:")
-                        else line
-                    )
-                    print(line)
-                MalwareDetectionClient(None)
-                assert (
-                    "Skipping processes_scan_only option because scan_processes is false"
-                    in caplog.text
-                )
-
-                # Enable process scanning and now the scan_only value should be used
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "scan_processes: true" if line.startswith("scan_processes:") else line
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert mdc.scan_pids == ['1']
-
-                # Add directories and processes and expect all to be scanned
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = (
-                        "filesystem_scan_only:\n- /tmp"
-                        if line.startswith("filesystem_scan_only:")
-                        else line
-                    )
-                    line = (
-                        "processes_scan_only:\n- 1"
-                        if line.startswith("processes_scan_only:")
-                        else line
-                    )
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert mdc.scan_fsobjects == ['/tmp']
-                assert mdc.scan_pids == ['1']
-
-                # Disable filesystem scanning and only expect the process to be scanned
-                caplog.clear()
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "scan_filesystem: false" if line.startswith("scan_filesystem:") else line
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert (
-                    "Skipping filesystem_scan_only option because scan_filesystem is false"
-                    in caplog.text
-                )
-                assert mdc.scan_pids == ['1']
-
-                # Disable both filesystem and process scanning and expect an error as there is nothing to scan
-                caplog.clear()
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "scan_processes: false" if line.startswith("scan_processes:") else line
-                    print(line)
-                with pytest.raises(SystemExit) as exc_info:
-                    MalwareDetectionClient(None)
-                assert (
-                    "Both scan_filesystem and scan_processes are disabled.  Nothing to scan."
-                    in caplog.text
-                )
-                assert exc_info.value.code == constants.sig_kill_bad
-
-            def test_invalid_option_values(self, create_test_files_real_yara, caplog):
-                # Check the malware client app behaves in a predictable way if the user specifies invalid option values
-                # Invalid value for nice - should be an integer
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    line = "nice_value: nineteen" if line.startswith("nice_value") else line
-                    print(line)
-                with pytest.raises(SystemExit) as exc_info:
-                    MalwareDetectionClient(None)
-                assert (
-                    "Problem setting configuration option nice_value: invalid literal"
-                    in caplog.text
-                )
-                assert exc_info.value.code == constants.sig_kill_bad
-
-                # Missing colon for nice_value option
-                caplog.clear()
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "nice_value 19\n" if line.startswith("nice_value") else line
-                    print(line)
-                with pytest.raises(SystemExit) as exc_info:
-                    MalwareDetectionClient(None)
-                assert (
-                    "Error encountered loading the malware-detection app config file" in caplog.text
-                )
-                assert exc_info.value.code == constants.sig_kill_bad
-
-                # Bad list items for scan_only, mixing single item and list items
-                caplog.clear()
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "nice_value: 19\n" if line.startswith("nice_value") else line
-                    line = (
-                        "filesystem_scan_only: /bad\n- /bad"
-                        if line.startswith("filesystem_scan_only:")
-                        else line
-                    )
-                    print(line)
-                with pytest.raises(SystemExit) as exc_info:
-                    MalwareDetectionClient(None)
-                assert (
-                    "Error encountered loading the malware-detection app config file" in caplog.text
-                )
-                assert exc_info.value.code == constants.sig_kill_bad
-
-                # Bad list items for scan_only, not a list item
-                caplog.clear()
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = (
-                        "filesystem_scan_only:"
-                        if line.startswith("filesystem_scan_only:")
-                        else line
-                    )
-                    line = "/bad" if line.startswith("- /bad") else line
-                    print(line)
-                with pytest.raises(SystemExit) as exc_info:
-                    MalwareDetectionClient(None)
-                assert (
-                    "Error encountered loading the malware-detection app config file" in caplog.text
-                )
-                assert exc_info.value.code == constants.sig_kill_bad
-
-                # Bad list items for scan_only, not enough spaces
-                caplog.clear()
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "-/bad" if line.startswith("/bad") else line
-                    print(line)
-                with pytest.raises(SystemExit) as exc_info:
-                    MalwareDetectionClient(None)
-                assert (
-                    "Error encountered loading the malware-detection app config file" in caplog.text
-                )
-                assert exc_info.value.code == constants.sig_kill_bad
-
-                # Bad list items for scan_only, using tabs instead of spaces
-                caplog.clear()
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "\t- /bad" if line.startswith("-/bad") else line
-                    print(line)
-                with pytest.raises(SystemExit) as exc_info:
-                    MalwareDetectionClient(None)
-                assert (
-                    "Error encountered loading the malware-detection app config file" in caplog.text
-                )
-                assert exc_info.value.code == constants.sig_kill_bad
-
-            @patch.dict(os.environ)
-            def test_using_env_vars(self, create_test_files_real_yara, caplog):
-                # Set certain option values via environment variables
-                env_var_list = [
-                    ('RULES_LOCATION', COMPILED_RULES_FILE),
-                    ('TEST_SCAN', 'false'),
-                    ('SCAN_FILESYSTEM', 'YES'),
-                    ('SCAN_PROCESSES', 'hello'),  # will be interpreted as false
-                    ('FILESYSTEM_SCAN_ONLY', '/tmp'),
-                    ('FILESYSTEM_SCAN_EXCLUDE', '/tmp'),
-                    ('FILESYSTEM_SCAN_SINCE', '2'),
-                    ('SCAN_TIMEOUT', '1800'),
-                ]
-                for key, value in env_var_list:
-                    os.environ[key] = value
-
-                logger.setLevel('INFO')
-                mdc = MalwareDetectionClient(None)
-                assert mdc.yara_binary == REAL_YARA
-                assert mdc.rules_file == COMPILED_RULES_FILE
-                assert mdc.test_scan is False
-                assert mdc.do_filesystem_scan is True
-                assert mdc.do_process_scan is False
-                assert mdc.scan_fsobjects == ['/tmp']
-                assert mdc.filesystem_scan_exclude_list == ['/tmp']
-                assert mdc.filesystem_scan_since_dict['timestamp'] < time.time() - (2 * 86400)
-                assert mdc.scan_timeout == 1800
-                # Not env vars, but just checking they have the expected values
-                assert mdc.nice_value == 19
-                assert mdc.cpu_thread_limit == CPUS
-
-                # Start a filesystem scan and expect scan_only and scan_exclude to cancel each other out
-                result = mdc.scan_filesystem()
-                assert (
-                    "No filesystem items to scan because the specified exclude items cancel them out"
-                    in caplog.text
-                )
-                assert result is False
-
-                # Test when SCAN_ONLY and SCAN_EXCLUDE values are comma separated
-                for key, value in [
-                    ('FILESYSTEM_SCAN_ONLY', '/tmp,/,/var/tmp'),
-                    ('FILESYSTEM_SCAN_EXCLUDE', '/home,/,/fred,barney'),
-                ]:
-                    os.environ[key] = value
-                mdc = MalwareDetectionClient(None)
-                assert mdc.scan_fsobjects == ['/tmp', '/', '/var/tmp']
-                assert mdc.filesystem_scan_exclude_list == ['/home', '/']
-                assert mdc.test_scan is False
-
-            @patch(GET_RULES_TARGET, return_value=COMPILED_RULES_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            @patch.dict(os.environ)
-            def test_invalid_env_vars(self, disabled, rules, caplog):
-                # Set options to invalid values
-                logger.setLevel('INFO')
-                os.environ['TEST_SCAN'] = 'false'
-                os.environ['NICE_VALUE'] = 'nineteen'
-                with pytest.raises(SystemExit) as exc_info:
-                    MalwareDetectionClient(None)
-                assert (
-                    "Problem parsing environment variable NICE_VALUE: invalid literal"
-                    in caplog.text
-                )
-                assert exc_info.value.code == constants.sig_kill_bad
-
-                caplog.clear()
-                os.environ['NICE_VALUE'] = '19'
-                os.environ['FILESYSTEM_SCAN_SINCE'] = 'blast'
-                with pytest.raises(SystemExit) as exc_info:
-                    MalwareDetectionClient(None)
-                assert "Unknown value 'blast' for filesystem_scan_since option" in caplog.text
-                assert exc_info.value.code == constants.sig_kill_bad
-
-            @patch(GET_RULES_TARGET, return_value=TEST_RULE_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            def test_successful_find_yara_binary(
-                self, disabled, rules, create_test_files_real_yara, caplog
-            ):
-                logger.setLevel('DEBUG')
-                # Find yara using the system search path
-                # If its already on the system, then malware will find that one, otherwise the test yara will be found
-                mdc = MalwareDetectionClient(None)
-                assert mdc.yara_binary == REAL_YARA
-                assert "Using yara binary: %s" % REAL_YARA in caplog.text
-
-                # Finding yara binary by using the yara_binary option
-                # NOTE: this option has been removed from the config file, so specifying it has no effect
-                caplog.clear()
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = (
-                        "yara_binary: %s" % REAL_YARA if line.startswith("yara_binary:") else line
-                    )
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert mdc.yara_binary == REAL_YARA
-                assert "Using yara binary: %s" % REAL_YARA in caplog.text
-
-            def test_failing_find_yara_binary(self, create_test_files_real_yara, caplog):
-                # Testing failing to find yara
-
-                # Test with no yara found on system.  If yara is present on the system, then skip this test
-                if not REAL_YARA:
-                    with pytest.raises(SystemExit) as exc_info:
-                        MalwareDetectionClient(None)
-                    assert (
-                        "Couldn't find yara.  Please ensure the yara package is installed"
-                        in caplog.text
-                    )
-                    assert exc_info.value.code == constants.sig_kill_bad
-
-                caplog.clear()
-                with patch('os.path.exists', return_value=False):
-                    with pytest.raises(SystemExit) as exc_info:
-                        MalwareDetectionClient(None)
-                assert (
-                    "Couldn't find yara.  Please ensure the yara package is installed"
-                    in caplog.text
-                )
-                assert exc_info.value.code == constants.sig_kill_bad
-
-            @patch(GET_RULES_TARGET, return_value=TEST_RULE_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            @patch(CALL_TARGET)
-            def test_find_yara_version(self, call, disabled, rules, caplog):
-                # Test checking the version of yara
-
-                # Invalid versions of yara
-                for version in ['4.0.99', '4']:
-                    call.return_value = version
-                    with pytest.raises(SystemExit) as exc_info:
-                        MalwareDetectionClient(None)
-                    assert (
-                        "Found %s with version %s, but malware-detection requires version >= %s\n"
-                        % (REAL_YARA, version, MIN_YARA_VERSION)
-                        in caplog.text
-                    )
-                    assert exc_info.value.code == constants.sig_kill_bad
-                    caplog.clear()
-
-                # Valid versions of yara
-                for version in ['4.1', '10.0.0']:
-                    call.return_value = version
-                    with patch(BUILD_YARA_COMMAND_TARGET, return_value="yara"):
-                        mdc = MalwareDetectionClient(None)
-                    assert mdc.yara_binary
-
-            @patch(GET_RULES_TARGET, return_value=COMPILED_RULES_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            def test_scanning_compiled_rules_file(
-                self, disabled, rules, create_test_files_real_yara, caplog
-            ):
-                # Scan the compiled rules file ... with the compiled rules file
-                logger.setLevel('INFO')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    line = (
-                        "filesystem_scan_only: %s" % COMPILED_RULES_FILE
-                        if line.startswith("filesystem_scan_only:")
-                        else line
-                    )
-                    print(line)
-
-                mdc = MalwareDetectionClient(None)
-                assert mdc.scan_fsobjects == [COMPILED_RULES_FILE]
-                mdc.scan_filesystem()
-                assert (
-                    "Scan only the specified filesystem item: ['%s']" % COMPILED_RULES_FILE
-                    in caplog.text
-                )
-                assert (
-                    "Scanning specified files in %s ..." % tld(COMPILED_RULES_FILE) in caplog.text
-                )
-                assert (
-                    "Matched rule MalwareDetectionClientRule in file %s" % COMPILED_RULES_FILE
-                    in caplog.text
-                )
-                assert (
-                    "Matched rule MiscellaneousStringsRule in file %s" % COMPILED_RULES_FILE
-                    in caplog.text
-                )
-                # Matched 2 rules
-                assert mdc.matches == 2
-                # Matched rule strings 3 times
-                string_matches = sum([len(mdc.host_scan[x]) for x in mdc.host_scan])
-                assert string_matches == 3
-
-                rule_match = mdc.host_scan['MalwareDetectionClientRule']
-                assert rule_match[0]['source'] == COMPILED_RULES_FILE
-                assert rule_match[0]['string_data'] == 'MalwareDetectionClient'
-                assert rule_match[0]['string_identifier'] == '$text1'
-                assert rule_match[0]['string_offset'] <= 544
-
-                rule_match = mdc.host_scan['MiscellaneousStringsRule']
-                assert rule_match[0]['source'] == COMPILED_RULES_FILE
-                assert rule_match[0]['string_data'] == 'sent"'
-                assert rule_match[0]['string_identifier'] == '$string1'
-                assert rule_match[0]['string_offset'] == 601
-                assert rule_match[1]['source'] == COMPILED_RULES_FILE
-                assert (
-                    rule_match[1]['string_data'] == r'ata_sff\\x00bioset\\x00bond0\\x00cifsd\\x00'
-                )
-                assert rule_match[1]['string_identifier'] == '$string2'
-                assert rule_match[1]['string_offset'] == 616
-                assert mdc.scan_processes() is False
-
-            @patch(GET_RULES_TARGET, return_value=COMPILED_RULES_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            def test_scanning_malware_test_file(self, disabled, rules, create_test_files_real_yara):
-                # Scan this test_malware_detection.py file
-                # Expect to match both rules in COMPILED_RULES_FILE, but only 1 string match per rule, due to using
-                #   yara -f/fast scan option which stops searching for a matching string after finding it once
-                logger.setLevel('INFO')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    line = (
-                        "filesystem_scan_only: %s" % MALWARE_TEST_FILE
-                        if line.startswith("filesystem_scan_only:")
-                        else line
-                    )
-                    print(line)
-
-                mdc = MalwareDetectionClient(None)
-                assert mdc.scan_fsobjects == [MALWARE_TEST_FILE]
-                assert mdc.string_match_limit == 10
-
-                mdc.scan_filesystem()
-                assert mdc.matches == 2  # Matches the two rules
-                rule_match = mdc.host_scan['MalwareDetectionClientRule']
-                assert len(rule_match) == 1  # But only 1 string match per rule
-                assert rule_match[0]['source'] == MALWARE_TEST_FILE
-                assert rule_match[0]['string_data'] == 'MalwareDetectionClient'
-                assert rule_match[0]['string_identifier'] == '$text1'
-                # First match is near the start of the file
-                assert rule_match[0]['string_offset'] < 1000
-
-                # Increase string_match_limit and scan again.
-                # Expect to find just one string match per rule again because of the yara fast scan option
-                # (Should we still bother using string_match_limit now that we use fast scan option?)
-                mdc = MalwareDetectionClient(None)
-                assert mdc.scan_fsobjects == [MALWARE_TEST_FILE]
-                mdc.string_match_limit = 100
-                mdc.scan_filesystem()
-                rule_match = mdc.host_scan['MalwareDetectionClientRule']
-                assert len(rule_match) == 1
-
-            @patch(GET_RULES_TARGET, return_value=COMPILED_RULES_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            def test_scan_only_root(self, disabled, rules, create_test_files_real_yara, caplog):
-                # Nothing special about root when parsing the scan_only option
-                # There is no parsing of root to individual toplevel directories until running scan_filesystem
-                logger.setLevel('DEBUG')
-                scan_only = '/'
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    line = (
-                        "filesystem_scan_only: %s" % scan_only
-                        if line.startswith("filesystem_scan_only:")
-                        else line
-                    )
-                    print(line)
-
-                mdc = MalwareDetectionClient(None)
-                assert mdc.scan_fsobjects == [scan_only]
-                assert "Scan only the specified filesystem item: ['%s']" % scan_only in caplog.text
-
-                # This is called by scan_filesystem to convert '/' into its top level subdirectories
-                scan_dict = process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert (
-                    "Found root directory in list of items to scan.  Ignoring the other items ..."
-                    in caplog.text
-                )
-                assert all([x in list(scan_dict.keys()) for x in INCLUDED_TLDS])
-                assert '/' not in list(scan_dict.keys())
-
-                # Multiple directories aren't consolidated until later
-                caplog.clear()
-                scan_only = ['/', '/tmp', '/home']
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = (
-                        "filesystem_scan_only: %s" % scan_only
-                        if line.startswith("filesystem_scan_only:")
-                        else line
-                    )
-                    print(line)
-
-                mdc = MalwareDetectionClient(None)
-                assert mdc.scan_fsobjects == scan_only
-                assert "Scan only the specified filesystem items: %s" % scan_only in caplog.text
-                scan_dict = process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert (
-                    "Found root directory in list of items to scan.  Ignoring the other items ..."
-                    in caplog.text
-                )
-                assert all([x in list(scan_dict.keys()) for x in INCLUDED_TLDS])
-                assert '/' not in list(scan_dict.keys())
-
-            @patch(GET_RULES_TARGET, return_value=COMPILED_RULES_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            def test_scan_exclude_root(self, disabled, rules, create_test_files_real_yara, caplog):
-                # Nothing special about root when parsing the scan_exclude option
-                # There is no parsing of root to individual toplevel directories until running scan_filesystem
-                logger.setLevel('DEBUG')
-                # Add '/' to the list of scan_exclude items.  Add it directly after the scan_exclude: line
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    line = line + "\n- /" if line.startswith("filesystem_scan_exclude:") else line
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert '/' in mdc.filesystem_scan_exclude_list
-
-                # When scan_filesystem is run, '/' will be expanded into toplevel directories that cancel out everything
-                process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert (
-                    "Found root directory in the exclude list.  Expanding it to all toplevel directories ..."
-                    in caplog.text
-                )
-                assert (
-                    "No filesystem items to scan because the specified exclude items cancel them out"
-                    in caplog.text
-                )
-
-            @patch(GET_RULES_TARGET, return_value=COMPILED_RULES_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            def test_scan_only_scan_exclude_nullify(
-                self, disabled, rules, create_test_files_real_yara, caplog
-            ):
-                # Testing scan_only and scan_exclude items such that the exclude items nullify all the scan_only items
-                # In which case there will be nothing to scan
-                logger.setLevel('INFO')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    line = (
-                        line + "\n- /var/log\n- /usr/lib/systemd\n- /tmp"
-                        if line.startswith("filesystem_scan_only:")
-                        else line
-                    )
-                    line = (
-                        line + "\n- /tmp/\n- /usr/lib/\n- /var/log"
-                        if line.startswith("filesystem_scan_exclude:")
-                        else line
-                    )
-                    print(line)
-
-                mdc = MalwareDetectionClient(None)
-                assert mdc.scan_fsobjects == ['/var/log', '/usr/lib/systemd', '/tmp']
-                assert all(
-                    [
-                        x in mdc.filesystem_scan_exclude_list
-                        for x in ['/tmp', '/usr/lib', '/var/log']
-                    ]
-                )
-                result = mdc.scan_filesystem()
-                assert (
-                    "No filesystem items to scan because the specified exclude items cancel them out"
-                    in caplog.text
-                )
-                assert result is False
-
-                # Both scan_only and scan_exclude contain root
-                caplog.clear()
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = line + "\n- /" if line.startswith("filesystem_scan_only:") else line
-                    line = line + "\n- /" if line.startswith("filesystem_scan_exclude:") else line
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert mdc.scan_fsobjects == ['/', '/var/log', '/usr/lib/systemd', '/tmp']
-                assert all(
-                    [
-                        x in mdc.filesystem_scan_exclude_list
-                        for x in ['/', '/tmp', '/usr/lib', '/var/log']
-                    ]
-                )
-                result = mdc.scan_filesystem()
-                assert (
-                    "No filesystem items to scan because the specified exclude items cancel them out"
-                    in caplog.text
-                )
-                assert result is False
-
-            @patch.dict(os.environ, {'TEST_SCAN': 'false'})
-            @patch(GET_RULES_TARGET)
-            @patch(DISABLED_RULES_TARGET)
-            def test_rules_file_types(self, disabled, rules, create_test_files_real_yara, caplog):
-                # Testing if the rules file is compiled or not
-                logger.setLevel('DEBUG')
-                rules.return_value = TEST_RULE_FILE
-                mdc = MalwareDetectionClient(None)
-                assert '-C' not in mdc.yara_cmd
-                assert 'Compiled rules: False' in caplog.text
-
-                caplog.clear()
-                rules.return_value = COMPILED_RULES_FILE
-                mdc = MalwareDetectionClient(None)
-                assert '-C' in mdc.yara_cmd
-                assert 'Compiled rules: True' in caplog.text
-
-            def test_bad_rules_files(self, create_test_files_real_yara, caplog):
-                # Tests with non-rules/problematic files
-                with open(TEMP_CONFIG_FILE, 'a') as tcf:
-                    # Append rules_location: and test_rule: to the bottom of the config file
-                    tcf.write("rules_location: %s\ntest_scan: false\n" % REAL_YARA)
-                with pytest.raises(SystemExit) as exc_info:
-                    MalwareDetectionClient(None)
-                assert "Unable to use rules file %s" % REAL_YARA in caplog.text
-                assert exc_info.value.code == constants.sig_kill_bad
-
-                # Missing rules file
-                caplog.clear()
-                missing_file = os.path.join(TEMP_TEST_DIR, 'missing')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = (
-                        "rules_location: %s" % missing_file
-                        if line.startswith("rules_location:")
-                        else line
-                    )
-                    print(line)
-                with pytest.raises(SystemExit) as exc_info:
-                    MalwareDetectionClient(None)
-                assert "Couldn't find specified rules file: %s" % missing_file in caplog.text
-                assert exc_info.value.code == constants.sig_kill_bad
-
-                # Specify directory instead of a file
-                caplog.clear()
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = (
-                        "rules_location: %s" % TEMP_TEST_DIR
-                        if line.startswith("rules_location:")
-                        else line
-                    )
-                    print(line)
-                with pytest.raises(SystemExit) as exc_info:
-                    MalwareDetectionClient(None)
-                assert "Couldn't find specified rules file: %s" % TEMP_TEST_DIR in caplog.text
-                assert exc_info.value.code == constants.sig_kill_bad
-
-            def test_files_with_extra_slashes_1(self, create_test_files_real_yara, caplog):
-                # Test behaviour when rules_location file and scan_only files have extra slashes in them
-                logger.setLevel('INFO')
-                # Test scanning COMPILED_RULES_FILE with an extra slash only in the rules_location one
-                # Even with the extra slashes in the rules_location there will be rules matched
-                # because */rules_compiled.yar and *//rules_compiled.yar are the same file
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    line = (
-                        line + "rules_location: %s\n" % COMPILED_RULES_FILE.replace('/', '//')
-                        if line.startswith('---')
-                        else line
-                    )
-                    line = (
-                        "filesystem_scan_only: %s" % COMPILED_RULES_FILE
-                        if line.startswith("filesystem_scan_only:")
-                        else line
-                    )
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert mdc.rules_location == COMPILED_RULES_FILE.replace('/', '//')
-                assert mdc.rules_file == COMPILED_RULES_FILE
-                assert mdc.scan_fsobjects == [COMPILED_RULES_FILE]
-                mdc.scan_filesystem()
-                rule_match = mdc.host_scan['MalwareDetectionClientRule']
-                assert rule_match[0]['source'] == COMPILED_RULES_FILE
-                # Will match the rules file because it is the same file
-                assert (
-                    "Matched rule MalwareDetectionClientRule in file %s" % COMPILED_RULES_FILE
-                    in caplog.text
-                )
-                assert (
-                    "Matched rule MiscellaneousStringsRule in file %s" % COMPILED_RULES_FILE
-                    in caplog.text
-                )
-
-            def test_files_with_extra_slashes_2(self, create_test_files_real_yara, caplog):
-                # Test behaviour when rules_location file and scan_only files have extra slashes in them
-                # Replace slashes in both rules_location and scan_only with double slashes
-                logger.setLevel('INFO')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    if line.startswith('---'):
-                        line = line + "rules_location: %s\n" % COMPILED_RULES_FILE.replace(
-                            '/', '//'
-                        )
-                    if line.startswith("filesystem_scan_only:"):
-                        line = line + "- %s\n- %s" % (
-                            TEMP_TEST_DIR.replace('/', '//'),
-                            MALWARE_TEST_FILE.replace('/', '//'),
-                        )
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert mdc.rules_location == COMPILED_RULES_FILE.replace('/', '//')
-                assert mdc.rules_file == COMPILED_RULES_FILE
-                assert mdc.scan_fsobjects == [TEMP_TEST_DIR, MALWARE_TEST_FILE]
-                mdc.scan_filesystem()
-                rule_match = mdc.host_scan['MalwareDetectionClientRule']
-                assert len(rule_match) == 1
-                assert rule_match[0]['source'] == MALWARE_TEST_FILE
-                assert (
-                    "Matched rule MalwareDetectionClientRule in file %s" % MALWARE_TEST_FILE
-                    in caplog.text
-                )
-                assert (
-                    "Matched rule MiscellaneousStringsRule in file %s" % MALWARE_TEST_FILE
-                    in caplog.text
-                )
-                # Won't match anything in the rules file because we are not specifically scanning that
-                assert (
-                    "Matched rule MalwareDetectionClientRule in file %s" % COMPILED_RULES_FILE
-                    not in caplog.text
-                )
-                assert (
-                    "Matched rule MiscellaneousStringsRule in file %s" % COMPILED_RULES_FILE
-                    not in caplog.text
-                )
-
-            def test_files_with_extra_slashes_3(self, create_test_files_real_yara, caplog):
-                # Test behaviour when rules_location file and scan_only files have extra slashes in them
-                # For completeness (silliness?), try with even more slashes in the file names
-                logger.setLevel('INFO')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    if line.startswith('---'):
-                        line = line + "rules_location: %s" % COMPILED_RULES_FILE.replace(
-                            '/', '////'
-                        )
-                    if line.startswith("filesystem_scan_only:"):
-                        line = line + "- %s\n- %s" % (
-                            TEMP_TEST_DIR.replace('/', '///'),
-                            MALWARE_TEST_FILE.replace('/', '///'),
-                        )
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert mdc.rules_location == COMPILED_RULES_FILE.replace('/', '////')
-                assert mdc.rules_file == COMPILED_RULES_FILE
-                assert mdc.scan_fsobjects == [TEMP_TEST_DIR, MALWARE_TEST_FILE]
-                mdc.scan_filesystem()
-                rule_match = mdc.host_scan['MalwareDetectionClientRule']
-                assert rule_match[0]['source'] == MALWARE_TEST_FILE
-                assert (
-                    "Matched rule MalwareDetectionClientRule in file %s" % MALWARE_TEST_FILE
-                    in caplog.text
-                )
-                assert (
-                    "Matched rule MiscellaneousStringsRule in file %s" % MALWARE_TEST_FILE
-                    in caplog.text
-                )
-                # Won't match anything in the rules file because we are not specifically scanning that
-                assert (
-                    "Matched rule MalwareDetectionClientRule in file %s" % COMPILED_RULES_FILE
-                    not in caplog.text
-                )
-                assert (
-                    "Matched rule MiscellaneousStringsRule in file %s" % COMPILED_RULES_FILE
-                    not in caplog.text
-                )
-
-            def test_files_with_extra_slashes_4(self, create_test_files_real_yara, caplog):
-                # Test behaviour when rules_location file and scan_only files have extra slashes in them
-
-                # Chaos monkey! - add extra slashes to rules_file and scan_fsobjects AFTER they have been verified
-                # This is a contrived test and shouldn't happen in normal code flow but done to make sure malware behaves well
-                # Testing passing double slashes directly into mdc just before mdc.scan_filesystems, eg
-                # mdc.scan_fsobjects = ['//home//bob']; mdc.scan_filesystem()
-                logger.setLevel('INFO')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    line = (
-                        line + "rules_location: %s" % COMPILED_RULES_FILE
-                        if line.startswith("---")
-                        else line
-                    )
-                    line = (
-                        line + "- %s\n- %s" % (TEMP_TEST_DIR, MALWARE_TEST_FILE)
-                        if line.startswith("filesystem_scan_only:")
-                        else line
-                    )
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert mdc.rules_file == COMPILED_RULES_FILE
-                assert mdc.scan_fsobjects == [TEMP_TEST_DIR, MALWARE_TEST_FILE]
-                # Modify rules_file and scan_fsobjects AFTER they have been verified
-                mdc.rules_file = COMPILED_RULES_FILE.replace('/', '//')
-                mdc.scan_fsobjects = [
-                    TEMP_TEST_DIR.replace('/', '//'),
-                    MALWARE_TEST_FILE.replace('/', '//'),
-                ]
-                mdc.scan_filesystem()
-                assert "Scanning specified files in %s" % tld(TEMP_TEST_DIR) in caplog.text
-                rule_match = mdc.host_scan['MalwareDetectionClientRule']
-                assert rule_match[0]['source'] == MALWARE_TEST_FILE
-                rule_match = mdc.host_scan['MiscellaneousStringsRule']
-                assert rule_match[0]['source'] == MALWARE_TEST_FILE
-                assert (
-                    "Matched rule MalwareDetectionClientRule in file %s" % MALWARE_TEST_FILE
-                    in caplog.text
-                )
-                assert (
-                    "Matched rule MiscellaneousStringsRule in file %s" % MALWARE_TEST_FILE
-                    in caplog.text
-                )
-
-            def test_scan_exclude_with_extra_slashes_1(self, create_test_files_real_yara, caplog):
-                # Testing we handle the situation where items in scan_exclude contain multiple slashes!
-                logger.setLevel('INFO')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    line = (
-                        line + "rules_location: %s" % COMPILED_RULES_FILE
-                        if line.startswith("---")
-                        else line
-                    )
-                    line = line + "- //\n" if line.startswith("filesystem_scan_exclude:") else line
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                result = mdc.scan_filesystem()
-                assert (
-                    "No filesystem items to scan because the specified exclude items cancel them out"
-                    in caplog.text
-                )
-                assert result is False
-
-            def test_scan_exclude_with_extra_slashes_2(self, create_test_files_real_yara, caplog):
-                # Testing we handle the situation where items in scan_exclude contain multiple slashes!
-                # Chaos monkey! - add extra slashes to scan_exclude items AFTER they have been verified
-                # This is a contrived test and shouldn't happen in normal code flow but done to make sure malware behaves well
-                logger.setLevel('INFO')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    line = (
-                        line + "rules_location: %s" % COMPILED_RULES_FILE
-                        if line.startswith("---")
-                        else line
-                    )
-                    line = (
-                        "filesystem_scan_only: %s" % TEMP_TEST_DIR
-                        if line.startswith("filesystem_scan_only:")
-                        else line
-                    )
-                    line = (
-                        line + "- %s\n" % TEMP_TEST_DIR
-                        if line.startswith("filesystem_scan_exclude:")
-                        else line
-                    )
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert mdc.scan_fsobjects == [TEMP_TEST_DIR]
-                assert TEMP_TEST_DIR in mdc.filesystem_scan_exclude_list
-                # Modify rules_file and scan_fsobjects AFTER they have been verified
-                mdc.filesystem_scan_exclude_list = [TEMP_TEST_DIR.replace('/', '//')]
-                result = mdc.scan_filesystem()
-                assert (
-                    "No filesystem items to scan because the specified exclude items cancel them out"
-                    in caplog.text
-                )
-                assert result is False
-
-            def test_scanning_pytest_process(self, create_test_files_real_yara, caplog):
-                # Do a test scan to scan the python pytest process whilst its running the tests
-                logger.setLevel('INFO')
-                test_pid = str(os.getpid())
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = (
-                        line + "rules_location: %s" % COMPILED_RULES_FILE
-                        if line.startswith("---")
-                        else line
-                    )
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert "and the current process (PID %s)" % test_pid in caplog.text
-                assert mdc.do_filesystem_scan is True
-                assert mdc.do_process_scan is True
-
-                mdc.scan_processes()
-                assert "Scanning process %s ..." % test_pid in caplog.text
-                assert (
-                    "Matched rule MalwareDetectionClientRule in process %s" % test_pid
-                    in caplog.text
-                )
-                assert (
-                    "Matched rule MiscellaneousStringsRule in process %s" % test_pid in caplog.text
-                )
-                # Matches both rules in the PID
-                assert mdc.matches == 2
-                rule_match = mdc.host_scan['MalwareDetectionClientRule']
-                assert len(rule_match) == 1
-                assert rule_match[0]['source'] == test_pid
-                assert rule_match[0]['string_data'] == 'MalwareDetectionClient'
-                assert rule_match[0]['string_identifier'] == '$text1'
-                assert rule_match[0]['string_offset'] > 0
-                metadata = rule_match[0]['metadata']
-                assert metadata['source_type'] == 'process'
-                # The process running the tests should have any of these strings in its name
-                assert any([s in metadata['process_name'] for s in ('python', 'pytest', 'tests')])
-                # Check that file related metadata keys are not present
-                assert all(
-                    [key not in ['file_type', 'md5sum', 'line_number'] for key in metadata.keys()]
-                )
-
-            def test_filenames_containing_spaces(self, create_test_files_real_yara, caplog):
-                # Check that filenames with spaces in them are handled ok
-                logger.setLevel('DEBUG')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    line = (
-                        line + "rules_location: %s" % RULE_RULE_FILE
-                        if line.startswith("---")
-                        else line
-                    )
-                    line = (
-                        "filesystem_scan_only: %s" % ANOTHER_MATCHING_ENTITY_FILE
-                        if line.startswith("filesystem_scan_only:")
-                        else line
-                    )
-                    print(line)
-                mdc = MalwareDetectionClient(None)
-                assert (
-                    "Scan only the specified filesystem item: ['%s']" % ANOTHER_MATCHING_ENTITY_FILE
-                    in caplog.text
-                )
-                assert "Using specified rules file: %s" % RULE_RULE_FILE in caplog.text
-                assert (
-                    "Yara command: ['nice', '-n', '19', '%s', '-s', '-N', '-a', '3600', '-p', '%s', '-r', '-f', '%s']"
-                    % (REAL_YARA, CPUS, RULE_RULE_FILE)
-                    in caplog.text
-                )
-                mdc.scan_filesystem()
-                rule_match = mdc.host_scan['Rule']
-                assert len(rule_match) == 8
-
-        @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
-        class TestLineNumberMetadata:
-
-            @patch(GET_RULES_TARGET, return_value=RULE_RULE_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            def test_rule_rule_scan_another_matching_entity(
-                self, disabled, rules, create_test_files_real_yara
-            ):
-                mdc = MalwareDetectionClient(None)
-                mdc.scan_fsobjects = [ANOTHER_MATCHING_ENTITY_FILE]
-                mdc.scan_filesystem()
-
-                # 8 matching strings for 'Rule' in 'another matching_entity' file
-                rule_match = mdc.host_scan['Rule']
-                assert len(rule_match) == 8
-
-                assert rule_match[0]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert (
-                    rule_match[0]['string_data']
-                    == "string match containing error scanning but it's ok because its not in a rule line"
-                )
-                assert rule_match[0]['string_identifier'] == '$match3'
-                assert rule_match[0]['string_offset'] == 2
-                metadata = rule_match[0]['metadata']
-                assert metadata['source_type'] == 'file'
-                assert metadata['file_type'] == 'ASCII text'
-                assert metadata['mime_type'] == 'text/plain; charset=us-ascii'
-                assert metadata['md5sum'] == '64764d295e92ffeec36d3fcd646a3af4'
-                assert metadata['line_number'] == 3
-                assert metadata['line'] == urlencode(
-                    "string match containing error scanning but it's ok because its not in a rule line"
-                )
-
-                assert rule_match[1]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[1]['string_data'] == "contains ="
-                assert rule_match[1]['string_identifier'] == '$grep1'
-                assert rule_match[1]['string_offset'] == 97
-                metadata = rule_match[1]['metadata']
-                assert metadata['md5sum'] == '64764d295e92ffeec36d3fcd646a3af4'
-                assert metadata['line_number'] == 7
-                assert metadata['line'] == urlencode("This line contains = char")
-
-                assert rule_match[2]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[2]['string_data'] == "contains .+"
-                assert rule_match[2]['string_identifier'] == '$grep2'
-                assert rule_match[2]['string_offset'] == 153
-                metadata = rule_match[2]['metadata']
-                assert metadata['line_number'] == 9
-                assert metadata['line'] == urlencode("This line contains .+ chars")
-
-                assert rule_match[3]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[3]['string_data'] == 'contains "'
-                assert rule_match[3]['string_identifier'] == '$grep3'
-                assert rule_match[3]['string_offset'] == 213
-                metadata = rule_match[3]['metadata']
-                assert metadata['line_number'] == 11
-                assert metadata['line'] == urlencode('This line contains "" chars')
-
-                assert rule_match[4]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[4]['string_data'] == "contains '"
-                assert rule_match[4]['string_identifier'] == '$grep4'
-                assert rule_match[4]['string_offset'] == 241
-                metadata = rule_match[4]['metadata']
-                assert metadata['line_number'] == 12
-                assert metadata['line'] == urlencode("This line contains '' chars")
-
-                assert rule_match[5]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[5]['string_data'] == 'contains ()[]'
-                assert rule_match[5]['string_identifier'] == '$grep5'
-                assert rule_match[5]['string_offset'] == 269
-                metadata = rule_match[5]['metadata']
-                assert metadata['line_number'] == 13
-                assert metadata['line'] == urlencode("This line contains ()[] chars")
-
-                assert rule_match[6]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[6]['string_data'] == 'contains {'
-                assert rule_match[6]['string_identifier'] == '$grep6'
-                assert rule_match[6]['string_offset'] == 299
-                metadata = rule_match[6]['metadata']
-                assert metadata['line_number'] == 14
-                assert metadata['line'] == urlencode("This line contains {} chars")
-
-                assert rule_match[7]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[7]['string_data'] == 'contains ^$'
-                assert rule_match[7]['string_identifier'] == '$grep7'
-                assert rule_match[7]['string_offset'] == 327
-                metadata = rule_match[7]['metadata']
-                assert metadata['line_number'] == 15
-                assert metadata['line'] == urlencode("This line contains ^$ chars")
-
-            @patch(GET_RULES_TARGET, return_value=RULE_METADATA_TEST_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            def test_rule_metadata_test_scanning_itself(
-                self, disabled, rules, create_test_files_real_yara
-            ):
-                # Taking some complicated rule strings to make sure grepping for line numbers is working correctly
-                mdc = MalwareDetectionClient(None)
-                mdc.scan_fsobjects = [RULE_METADATA_TEST_FILE]
-                mdc.scan_filesystem()
-
-                rule_match = mdc.host_scan['MetadataTestRule']
-                assert len(rule_match) == 9
-
-                assert rule_match[0]['source'] == RULE_METADATA_TEST_FILE
-                assert (
-                    rule_match[0]['string_data']
-                    == r'echo -e "[-] Ping \\033[31m${host_name}\\033[0m bad"'
-                )
-                assert rule_match[0]['string_identifier'] == '$s1'
-                assert rule_match[0]['string_offset'] == 392
-                metadata = rule_match[0]['metadata']
-                assert metadata['source_type'] == 'file'
-                assert metadata['file_type'] == 'UTF-8 Unicode text'
-                assert metadata['mime_type'] == 'text/plain; charset=utf-8'
-                assert metadata['md5sum'] == '6ea8306ed20cede50ea10964dddc8d47'
-                assert metadata['line_number'] == 9
-                assert metadata['line'] == urlencode(
-                    r'Testing $s1 = "echo -e "[-] Ping \\033[31m${host_name}\\033[0m bad" ascii fullword'
-                )
-
-                assert rule_match[1]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[1]['string_data'] == '"${user_name}"@"${host_name}" -p "${port}'
-                assert rule_match[1]['string_identifier'] == '$s2'
-                assert rule_match[1]['string_offset'] == 477
-                metadata = rule_match[1]['metadata']
-                assert metadata['line_number'] == 10
-                assert metadata['line'] == urlencode(
-                    'Testing $s2 = ""${user_name}"@"${host_name}" -p "${port}" ascii fullword'
-                )
-
-                assert rule_match[2]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[2]['string_data'] == """'$password' &" <<< GMANcode27'"""
-                assert rule_match[2]['string_identifier'] == '$s3'
-                assert rule_match[2]['string_offset'] == 554
-                metadata = rule_match[2]['metadata']
-                assert metadata['line_number'] == 11
-                assert metadata['line'] == urlencode(
-                    """Testing $s3 = "'$password' &" <<< GMANcode27'" ascii fullword"""
-                )
-
-                assert rule_match[3]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[3]['string_data'] == "for ssh_creds in ${allThreads[@]}; do"
-                assert rule_match[3]['string_identifier'] == '$s4'
-                assert rule_match[3]['string_offset'] == 119
-                metadata = rule_match[3]['metadata']
-                assert metadata['line_number'] == 4
-                assert metadata['line'] == urlencode(
-                    'Testing $s4 = "for ssh_creds in ${allThreads[@]}; do" ascii fullword'
-                )
-
-                assert rule_match[4]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[4]['string_data'] == '"text=$MSG" "$MSG_URL$id&"'
-                assert rule_match[4]['string_identifier'] == '$s5'
-                assert rule_match[4]['string_offset'] == 620
-                metadata = rule_match[4]['metadata']
-                assert metadata['line_number'] == 12
-                assert metadata['line'] == urlencode(
-                    'Testing $s5 = ""text=$MSG" "$MSG_URL$id&"" ascii fullword'
-                )
-
-                # Cannot match line_numbers for this rule due to non-ascii chars
-                assert rule_match[5]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[5]['string_data'] == r"--exclude=\\*.\\xE2\\x98\\xA2 -l"
-                assert rule_match[5]['string_identifier'] == '$s6'
-                assert rule_match[5]['string_offset'] == 682
-                metadata = rule_match[5]['metadata']
-                assert all([key not in ['line_number', 'line'] for key in metadata.keys()])
-
-                assert rule_match[6]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[6]['string_data'] == r"--include=\\*.{txt,sh,exe}"
-                assert rule_match[6]['string_identifier'] == '$s7'
-                assert rule_match[6]['string_offset'] == 731
-                metadata = rule_match[6]['metadata']
-                assert metadata['line_number'] == 14
-                assert metadata['line'] == urlencode(
-                    r'Testing $s7 = "--include=\*.{txt,sh,exe}" ascii fullword'
-                )
-
-                assert rule_match[7]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[7]['string_data'] == "allThreads=($1)"
-                assert rule_match[7]['string_identifier'] == '$s8'
-                assert rule_match[7]['string_offset'] == 192
-                metadata = rule_match[7]['metadata']
-                assert metadata['line_number'] == 5
-                assert metadata['line'] == urlencode(
-                    'Testing $s8 = "allThreads=($1)" ascii fullword'
-                )
-
-                assert rule_match[8]['source'] == RULE_METADATA_TEST_FILE
-                assert rule_match[8]['string_data'] == "$(host): encrypt files. Done."
-                assert rule_match[8]['string_identifier'] == '$s9'
-                assert rule_match[8]['string_offset'] == 243
-                metadata = rule_match[8]['metadata']
-                assert metadata['line_number'] == 6
-                assert metadata['line'] == urlencode(
-                    'Testing $s9 = "$(host): encrypt files. Done." ascii fullword'
-                )
-
-        @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
-        # Rule used is irrelevant for these tests because we aren't actually scanning, just parsing canned yara output
-        @patch(GET_RULES_TARGET, return_value=TEST_RULE_FILE)
-        @patch(DISABLED_RULES_TARGET, return_value=[])
-        class TestParseScanOutput:
-
-            def test_contrived_scan_output(
-                self, disabled, rules, create_test_files_real_yara, caplog
-            ):
-                # Parse the CONTRIVED_SCAN_OUTPUT to find actual rule matches amongst malformed output lines
-                # The rules_location is irrelevant to the test but it just makes the initialization of
-                # MalwareDetectionClient easier if done this way (and its simpler than using @patch ... maybe)
-                logger.setLevel(
-                    'DEBUG'
-                )  # Make sure the logging level is set *before* performing the scan
-                mdc = MalwareDetectionClient(None)
-                mdc.add_metadata = False
-                mdc.parse_scan_output(CONTRIVED_SCAN_OUTPUT)
-
-                # Expect 5 rule matches and 8 source/file matches across the 5 rules
-                # 1 source/file match for rule 'this', 3 source/file matches for rule 'Rule',
-                # 2 for 'another_matching_rule', 1 for 'Iyamtho' and 1 for 'n_m3_t00'
-                assert len(mdc.host_scan) == 5  # 5 rules matched
-                assert mdc.matches == 8  # 8 sources/files matched across the 5 rules
-
-                # 1 matching source/file and 1 matching string for rule 'this'
-                rule_match = mdc.host_scan['this']
-                rule_sources = set(map(lambda x: x['source'], rule_match))
-                assert len(rule_sources) == 1
-                assert len(rule_match) == 1
-                assert 'e-r-r-o-r s-c-a-n-n-i-n-g' in rule_match[0]['source']
-                assert rule_match[0]['string_data'] == "matches 'this' rule"
-                assert rule_match[0]['string_identifier'] == '$match'
-                assert rule_match[0]['string_offset'] == 291
-
-                # 3 source/file matches and 14 matching strings across those sources for rule 'Rule'
-                rule_match = mdc.host_scan['Rule']
-                rule_sources = set(map(lambda x: x['source'], rule_match))
-                assert len(rule_sources) == 3
-                assert len(rule_match) == 14
-                assert rule_match[0]['source'] == MATCHING_ENTITY_FILE
-                assert rule_match[0]['string_data'] == 'string match in the file "matching_entity"'
-                assert rule_match[0]['string_identifier'] == '$match0'
-                assert rule_match[0]['string_offset'] == 21
-                assert rule_match[1]['source'] == MATCHING_ENTITY_FILE
-                assert rule_match[1]['string_data'] == "another string match in matching_entity"
-                assert rule_match[1]['string_identifier'] == '$match1'
-                assert rule_match[1]['string_offset'] == 83
-                assert rule_match[2]['source'] == MATCHING_ENTITY_FILE
-                assert (
-                    rule_match[2]['string_data']
-                    == 'string with different types of quotes \'here\' and "here"'
-                )
-                assert rule_match[2]['string_identifier'] == '$match2'
-                assert rule_match[2]['string_offset'] == 230
-
-                # Rule matches for ANOTHER_MATCHING_ENTITY_FILE (which has a space in the filename)
-                assert rule_match[3]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert (
-                    rule_match[3]['string_data']
-                    == "string match containing error scanning but it's ok because its not in a rule line"
-                )
-                assert rule_match[3]['string_identifier'] == '$match3'
-                assert rule_match[3]['string_offset'] == 2
-                assert rule_match[4]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[4]['string_data'] == "contains ="
-                assert rule_match[4]['string_identifier'] == '$grep1'
-                assert rule_match[4]['string_offset'] == 97
-                assert rule_match[6]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[6]['string_data'] == "contains .+"
-                assert rule_match[6]['string_identifier'] == '$grep2'
-                assert rule_match[6]['string_offset'] == 153
-                assert rule_match[8]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[8]['string_data'] == 'contains "'
-                assert rule_match[8]['string_identifier'] == '$grep3'
-                assert rule_match[8]['string_offset'] == 213
-                assert rule_match[9]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[9]['string_data'] == "contains '"
-                assert rule_match[9]['string_identifier'] == '$grep4'
-                assert rule_match[9]['string_offset'] == 241
-                assert rule_match[10]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[10]['string_data'] == 'contains ()[]'
-                assert rule_match[10]['string_identifier'] == '$grep5'
-                assert rule_match[10]['string_offset'] == 269
-                assert rule_match[11]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[11]['string_data'] == 'contains {'
-                assert rule_match[11]['string_identifier'] == '$grep6'
-                assert rule_match[11]['string_offset'] == 299
-                assert rule_match[12]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[12]['string_data'] == 'contains ^$'
-                assert rule_match[12]['string_identifier'] == '$grep7'
-                assert rule_match[12]['string_offset'] == 327
-
-                assert rule_match[13]['source'].startswith('matching_entity_3')
-                assert rule_match[13]['string_data'] == ''
-                assert rule_match[13]['string_identifier'] == ''
-                assert rule_match[13]['string_offset'] == -1
-
-                # 2 source matches and 4 matching strings for 'another_matching_rule'
-                rule_match = mdc.host_scan['another_matching_rule']
-                rule_sources = set(map(lambda x: x['source'], rule_match))
-                assert len(rule_sources) == 2
-                assert len(rule_match) == 4
-                assert rule_match[2]['source'].endswith(
-                    'snap/signal-desktop/350/opt/Signal/resources/app.asar'
-                )
-                assert rule_match[2]['string_data'] == '#!/bin/sh'
-                assert rule_match[2]['string_identifier'] == '$s0'
-                assert rule_match[2]['string_offset'] == 60783814
-                assert rule_match[3]['source'] == '1234567'
-                assert rule_match[3]['string_data'] == '#!/bin/sh'
-                assert rule_match[3]['string_identifier'] == '$s0'
-                assert rule_match[3]['string_offset'] == 0
-
-                # 1 matching source and 1 matching string for 'Iyamtho'
-                rule_match = mdc.host_scan['Iyamtho']
-                assert len(rule_match) == 1
-                assert rule_match[0]['source'] == " yep"
-                assert rule_match[0]['string_data'] == ''
-                assert rule_match[0]['string_identifier'] == ''
-                assert rule_match[0]['string_offset'] == -1
-
-                # 1 matching source and 1 matching string for 'n_m3_t00'
-                rule_match = mdc.host_scan['n_m3_t00']
-                assert len(rule_match) == 1
-                assert rule_match[0]['source'] == "damn   straight"
-                assert rule_match[0]['string_data'] == ''
-                assert rule_match[0]['string_identifier'] == ''
-                assert rule_match[0]['string_offset'] == -1
-
-                assert (
-                    "Error parsing string match '0x1badoffset:$s1: skip this line': " in caplog.text
-                )
-                assert (
-                    "Error parsing string match '0x2error scanning skip/this/line/too: need more colons': "
-                    in caplog.text
-                )
-
-            def test_contrived_scan_output_metadata(
-                self, disabled, rules, create_test_files_real_yara, caplog
-            ):
-                # Again, parse the CONTRIVED_SCAN_OUTPUT to find actual rule matches amongst malformed output lines,
-                # but this time check the expected metadata values too
-
-                # Again, need to populate rules_file_location with any rule, but its not relevant for the tests
-                logger.setLevel('DEBUG')
-                mdc = MalwareDetectionClient(None)
-                mdc.parse_scan_output(CONTRIVED_SCAN_OUTPUT)
-
-                # Matches and metadata for MATCHING_ENTITY_FILE
-                # assert "grep -Ebon  -e 'another string match in matching_entity'" in caplog.text
-                rule_match = mdc.host_scan['Rule']
-                assert rule_match[0]['source'] == MATCHING_ENTITY_FILE
-                assert rule_match[0]['string_offset'] == 21
-                metadata = rule_match[0]['metadata']
-                assert metadata['source_type'] == 'file'
-                assert metadata['file_type'] == 'ASCII text'
-                assert metadata['mime_type'] == 'text/plain; charset=us-ascii'
-                assert metadata['md5sum'] == '9dd5c5e00d28520dc9da3c509c0db2a0'
-                assert metadata['line_number'] == 1
-                assert metadata['line'] == urlencode(
-                    'This line contains a string match in the file "matching_entity"'
-                )
-
-                # Testing displaying long lines
-                assert rule_match[1]['source'] == MATCHING_ENTITY_FILE
-                assert rule_match[1]['string_offset'] == 83
-                metadata = rule_match[1]['metadata']
-                assert metadata['source_type'] == 'file'
-                assert metadata['file_type'] == 'ASCII text'
-                assert metadata['mime_type'] == 'text/plain; charset=us-ascii'
-                assert metadata['md5sum'] == '9dd5c5e00d28520dc9da3c509c0db2a0'
-                assert metadata['line_number'] == 2
-                assert metadata['line'] == urlencode(
-                    'This line contains another string match in matching_entity and it is very long for testing the ellipses that are added o...'
-                )
-
-                # Testing matching/displaying a mixture of quote types in the string_data
-                assert rule_match[2]['source'] == MATCHING_ENTITY_FILE
-                assert rule_match[2]['string_offset'] == 230
-                metadata = rule_match[2]['metadata']
-                assert metadata['source_type'] == 'file'
-                assert metadata['file_type'] == 'ASCII text'
-                assert metadata['mime_type'] == 'text/plain; charset=us-ascii'
-                assert metadata['md5sum'] == '9dd5c5e00d28520dc9da3c509c0db2a0'
-                assert metadata['line_number'] == 4
-                assert metadata['line'] == urlencode(
-                    """And this line contains a string with different types of quotes 'here' and "here" and its long too but not long enough"""
-                )
-
-                # Rule match metadata for ANOTHER_MATCHING_ENTITY_FILE
-                # assert "[]' -e 'contains =' -e 'contains '\"'\"''" in caplog.text
-                assert rule_match[3]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[3]['string_offset'] == 2
-                metadata = rule_match[3]['metadata']
-                assert metadata['source_type'] == 'file'
-                assert metadata['file_type'] == 'ASCII text'
-                assert metadata['mime_type'] == 'text/plain; charset=us-ascii'
-                assert metadata['md5sum'] == '64764d295e92ffeec36d3fcd646a3af4'
-                assert metadata['line_number'] == 3
-                assert metadata['line'] == urlencode(
-                    "string match containing error scanning but it's ok because its not in a rule line"
-                )
-
-                assert rule_match[4]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[4]['string_offset'] == 97
-                metadata = rule_match[4]['metadata']
-                assert metadata['md5sum'] == '64764d295e92ffeec36d3fcd646a3af4'
-                assert metadata['line_number'] == 7
-                assert metadata['line'] == urlencode("This line contains = char")
-
-                assert rule_match[5]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[5]['string_offset'] == 123
-                metadata = rule_match[5]['metadata']
-                assert metadata['line_number'] == 8
-                assert metadata['line'] == urlencode("This line contains = char too")
-
-                assert rule_match[6]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[6]['string_offset'] == 153
-                metadata = rule_match[6]['metadata']
-                assert metadata['line_number'] == 9
-                assert metadata['line'] == urlencode("This line contains .+ chars")
-
-                assert rule_match[8]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[8]['string_offset'] == 213
-                metadata = rule_match[8]['metadata']
-                assert metadata['line_number'] == 11
-                assert metadata['line'] == urlencode('This line contains "" chars')
-
-                assert rule_match[9]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[9]['string_offset'] == 241
-                metadata = rule_match[9]['metadata']
-                assert metadata['line_number'] == 12
-                assert metadata['line'] == urlencode("This line contains '' chars")
-
-                assert rule_match[10]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[10]['string_offset'] == 269
-                metadata = rule_match[10]['metadata']
-                assert metadata['line_number'] == 13
-                assert metadata['line'] == urlencode("This line contains ()[] chars")
-
-                assert rule_match[11]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[11]['string_offset'] == 299
-                metadata = rule_match[11]['metadata']
-                assert metadata['line_number'] == 14
-                assert metadata['line'] == urlencode("This line contains {} chars")
-
-                assert rule_match[12]['source'] == ANOTHER_MATCHING_ENTITY_FILE
-                assert rule_match[12]['string_offset'] == 327
-                metadata = rule_match[12]['metadata']
-                assert metadata['line_number'] == 15
-                assert metadata['line'] == urlencode("This line contains ^$ chars")
-
-                # Testing a missing file - expect minimal metadata because we can't know the other values
-                assert (
-                    rule_match[13]['source']
-                    == "matching_entity_3, but without any string matches - yes that's ok"
-                )
-                metadata = rule_match[13]['metadata']
-                assert metadata['source_type'] == 'file'
-                assert all(
-                    [key not in ['file_type', 'md5sum', 'line_number'] for key in metadata.keys()]
-                )
-
-                # Testing a missing file for another rule - again, expect minimal metadata because we can't find out more info
-                rule_match = mdc.host_scan['another_matching_rule']
-                assert rule_match[2]['source'].endswith(
-                    'snap/signal-desktop/350/opt/Signal/resources/app.asar'
-                )
-                metadata = rule_match[2]['metadata']
-                assert metadata['source_type'] == 'file'
-                assert all(
-                    [key not in ['file_type', 'md5sum', 'line_number'] for key in metadata.keys()]
-                )
-
-                # Testing a missing process - again, expect minimal metadata because we can't find out more info
-                assert rule_match[3]['source'] == '1234567'
-                metadata = rule_match[3]['metadata']
-                assert metadata['source_type'] == 'process'
-                assert all(
-                    [
-                        key not in ['process_name', 'file_type', 'md5sum', 'line_number']
-                        for key in metadata.keys()
-                    ]
-                )
-
-            def test_contrived_scan_output_with_disabled_rules(
-                self, disabled, rules, create_test_files_real_yara, caplog
-            ):
-                # Parse the CONTRIVED_SCAN_OUTPUT but with a number of disabled rules
-                # Disable 3 of the rules in CONTRIVED_SCAN_OUTPUT, expect 2 matching rules
-                logger.setLevel('DEBUG')
-                disabled.return_value = ['this', 'rule', 'another_matching_rule']
-                mdc = MalwareDetectionClient(None)
-                assert mdc.disabled_rules == ['this', 'rule', 'another_matching_rule']
-                mdc.parse_scan_output(CONTRIVED_SCAN_OUTPUT)
-                assert mdc.matches == 2
-                assert all(
-                    list(
-                        map(
-                            lambda x: x not in ['this', 'Rule', 'another_matching_rule'],
-                            mdc.host_scan,
-                        )
-                    )
-                )
-                assert all(list(map(lambda x: x in ['Iyamtho', 'n_m3_t00'], mdc.host_scan)))
-                assert 'Skipping matches for disabled rule this in file' in caplog.text
-                assert 'Skipping matches for disabled rule Rule in file' in caplog.text
-                assert (
-                    'Skipping matches for disabled rule another_matching_rule in file'
-                    in caplog.text
-                )
-                assert 'Matched rule Iyamtho in file' in caplog.text
-                assert 'Matched rule n_m3_t00 in file' in caplog.text
-
-                # disable all rules except 'Rule', because it isn't excluded
-                caplog.clear()
-                disabled.return_value = [
-                    'this',
-                    'rool',
-                    'another_matching_rule',
-                    'iyamtho',
-                    'n_m3_t00',
-                ]
-                mdc = MalwareDetectionClient(None)
-                mdc.parse_scan_output(CONTRIVED_SCAN_OUTPUT)
-                assert list(mdc.host_scan) == ['Rule']
-                assert mdc.matches == 3
-                sources = set(map(lambda x: x['source'], mdc.host_scan['Rule']))
-                assert len(sources) == 3
-                assert 'Skipping matches for disabled rule Rule in file' not in caplog.text
-                assert 'Matched rule Rule in file' in caplog.text
-
-            def test_error_scan_output(self, disabled, rules, create_test_files_real_yara, caplog):
-                logger.setLevel('DEBUG')
-                mdc = MalwareDetectionClient(None)
-                mdc.parse_scan_output(ERROR_SCAN_OUTPUT)
-
-                assert mdc.matches == 0
-                assert mdc.host_scan == {}
-                assert (
-                    'error scanning /var/lib/snapd//snap/core/10859/dev/core: could not open file'
-                    in caplog.text
-                )
-
-            def test_error4_scan_output(self, disabled, rules, create_test_files_real_yara, caplog):
-                logger.setLevel('DEBUG')
-                mdc = MalwareDetectionClient(None)
-                mdc.parse_scan_output(ERROR4_SCAN_OUTPUT)
-
-                assert mdc.matches == 0
-                assert mdc.host_scan == {}
-                assert (
-                    'error scanning /var/lib/snapd/snap/core/10859/dev/core: error: 4'
-                    in caplog.text
-                )
-
-            def test_random_output(self, disabled, rules, create_test_files_real_yara):
-                mdc = MalwareDetectionClient(None)
-                mdc.parse_scan_output(RANDOM_OUTPUT)
-
-                assert mdc.matches == 2
-                rule_match = mdc.host_scan['Lorem']
-                assert rule_match[0]['source'].startswith('ipsum dolor')
-                assert rule_match[0]['string_data'] == ''
-                assert rule_match[0]['string_identifier'] == ''
-                assert rule_match[0]['string_offset'] == -1
-                rule_match = mdc.host_scan['Dictum']
-                assert rule_match[0]['source'].startswith('at tempor')
-                assert rule_match[0]['string_data'] == ''
-                assert rule_match[0]['string_identifier'] == ''
-                assert rule_match[0]['string_offset'] == -1
-
-            def test_random_output_with_disabled_rules(
-                self, disabled, rules, create_test_files_real_yara, caplog
-            ):
-                # Test various disabled rules with parsing RANDOM_OUTPUT
-                # Disable 'Lorem' rule (and others) and expect just to match the 'Dictum' rule
-                logger.setLevel('DEBUG')
-                disabled.return_value = ['random', 'rules', 'and', 'lorem']
-                mdc = MalwareDetectionClient(None)
-                mdc.parse_scan_output(RANDOM_OUTPUT)
-                assert mdc.matches == 1
-                assert list(mdc.host_scan) == ['Dictum']
-                assert 'Skipping matches for disabled rule Lorem in file' in caplog.text
-
-                # Disable both 'Lorem' and 'Dictum' rules and expect to have no matches
-                caplog.clear()
-                disabled.return_value = ['dictum', 'lorem']
-                mdc = MalwareDetectionClient(None)
-                mdc.parse_scan_output(RANDOM_OUTPUT)
-                assert mdc.matches == 0
-                assert mdc.host_scan == {}
-                assert 'Skipping matches for disabled rule Dictum in file' in caplog.text
-                assert 'Skipping matches for disabled rule Lorem in file' in caplog.text
-
-                # Disable rules other than 'Lorem' and 'Dictum' and expect match both those rules
-                caplog.clear()
-                disabled.return_value = ['dictumm', 'lore', 'and', 'other', 'rules']
-                mdc = MalwareDetectionClient(None)
-                mdc.parse_scan_output(RANDOM_OUTPUT)
-                assert mdc.matches == 2
-                assert sorted(mdc.host_scan) == ['Dictum', 'Lorem']
-                assert 'Skipping matches for disabled rule Dictum in file' not in caplog.text
-                assert 'Skipping matches for disabled rule Lorem in file' not in caplog.text
-                assert 'Matched rule Dictum in file' in caplog.text
-                assert 'Matched rule Lorem in file' in caplog.text
-
-        @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
-        class TestFilesystemIncludeExcludeProcessing:
-
-            @patch(GET_RULES_TARGET, return_value=COMPILED_RULES_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            @patch.dict(os.environ, {'TEST_SCAN': 'false'})
-            def test_process_include_exclude_items_simple(
-                self, disabled, rules, create_test_files_real_yara, caplog
-            ):
-                # Test the process_include_exclude_items function with simple modified include and exclude items
-                # Simple in that the include and exclude files are modified in such a way that
-                # directory listings aren't required get the list of included files
-                # Add a single toplevel directory to the include file - expect only a single directory to scan
-                logger.setLevel('INFO')
-                mdc = MalwareDetectionClient(None)
-                mdc.scan_fsobjects = ['/etc']
-                mdc.filesystem_scan_exclude_list = []
-                scan_dict = process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert list(scan_dict.keys()) == ['/etc']
-                assert 'include' not in scan_dict['/etc']
-                assert 'exclude' not in scan_dict['/etc']
-
-                # Add some extra subdirectories to scan
-                mdc.scan_fsobjects.extend(['/var/lib', '/var/log'])
-                scan_dict = process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert sorted(scan_dict.keys()) == ['/etc', '/var']
-                assert sorted(list(scan_dict['/var']['include'])) == ['/var/lib', '/var/log']
-                assert 'exclude' not in scan_dict['/var']
-
-                # Add some extra directories to exclude that won't impact the already included directories
-                mdc.filesystem_scan_exclude_list.extend(['/tmp', '/var/run'])
-                scan_dict = process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert sorted(scan_dict.keys()) == ['/etc', '/var']
-                assert sorted(scan_dict['/var']['include']) == ['/var/lib', '/var/log']
-                assert scan_dict['/var']['exclude']['items'] == ['/var/run']
-
-                # Exclude /var which will remove it from the list of directories to scan
-                mdc.filesystem_scan_exclude_list.append('/var')
-                scan_dict = process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert list(scan_dict.keys()) == ['/etc']
-
-                # Exclude /etc which means there will be no directories to scan
-                caplog.clear()
-                mdc.filesystem_scan_exclude_list.append('/etc')
-                process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert (
-                    "No filesystem items to scan because the specified exclude items cancel them out"
-                    in caplog.text
-                )
-                assert list(scan_dict.keys()) == ['/etc']
-
-            @patch(GET_RULES_TARGET, return_value=COMPILED_RULES_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            @patch.dict(os.environ, {'TEST_SCAN': 'false'})
-            def test_process_include_exclude_files_complex(
-                self, disabled, rules, create_test_files_real_yara
-            ):
-                # Test the process function with modified include and exclude files that will require more complex
-                # processing to generate the list of items to be scanned
-                # Because we are including items in /var/lib, we only need to list the contents of the /var/lib directory
-                # We don't need to list the contents of the /var directory
-                mdc = MalwareDetectionClient(None)
-                mdc.scan_fsobjects = ['/var/lib', '/var/log']
-                mdc.filesystem_scan_exclude_list = [
-                    '/var/lib/systemd',
-                    '/var/lib/misc/',
-                    '/var/log/wtmp',
-                ]
-
-                scan_dict = process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert list(scan_dict.keys()) == ['/var']
-                assert sorted(scan_dict['/var']['exclude']['items']) == [
-                    '/var/lib/misc',
-                    '/var/lib/systemd',
-                    '/var/log/wtmp',
-                ]
-                # The exclude items shouldn't be in the include items
-                # Nor should other items that aren't in the explicitly included items
-                assert all(
-                    [
-                        x not in scan_dict['/var']['include']
-                        for x in [
-                            '/var/lib/misc',
-                            '/var/lib/systemd',
-                            '/var/log/wtmp',
-                            '/var/cache',
-                            '/var/lib',
-                            '/var/log',
-                            '/var/tmp',
-                            '/tmp',
-                        ]
-                    ]
-                )
-                # In 'include' will be items that are in the same directory as the excluded items, eg /var/log/lastlog
-                # but not the excluded items, eg /var/log/wtmp
-                # Some of these directories may not exist on the test system, but if they do they will be included
-                maybe_dirs = list(
-                    filter(
-                        lambda path: os.path.exists(path),
-                        ['/var/lib/dbus', '/var/lib/pam', '/var/lib/rpm', '/var/log/lastlog'],
-                    )
-                )
-                assert all([x in scan_dict['/var']['include'] for x in maybe_dirs])
-
-                # Change the include directory to /var
-                # Now immediate child directories of /var will be in the include list, eg /var/cache and /var/tmp
-                # Because now we have to list the contents of the /var and /var/lib directories
-                mdc.scan_fsobjects.append('/var')
-                scan_dict = process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert list(scan_dict.keys()) == ['/var']
-                assert sorted(scan_dict['/var']['exclude']['items']) == [
-                    '/var/lib/misc',
-                    '/var/lib/systemd',
-                    '/var/log/wtmp',
-                ]
-                assert all(
-                    [
-                        x not in scan_dict['/var']['include']
-                        for x in [
-                            '/var/lib/misc',
-                            '/var/lib/systemd',
-                            '/var/log/wtmp',
-                            '/var/lib',
-                            '/var/log',
-                            '/tmp',
-                        ]
-                    ]
-                )
-                # Some of these directories may not exist on the test system, but if they do they will be included
-                maybe_dirs = list(
-                    filter(
-                        lambda path: os.path.exists(path),
-                        [
-                            '/var/cache',
-                            '/var/tmp',
-                            '/var/lib/dbus',
-                            '/var/lib/pam',
-                            '/var/lib/rpm',
-                            '/var/log/lastlog',
-                        ],
-                    )
-                )
-                assert all([x in scan_dict['/var']['include'] for x in maybe_dirs])
-
-            @pytest.mark.skipif(
-                not os.path.exists('/usr/local/libexec'), reason="No /usr/local/libexec"
+            assert sorted(mdc.host_scan) == ["Dictum", "Lorem"]
+            log_mock.info.assert_any_call(
+                "Matched rule %s in %s %s", "Dictum", "file", ANY
             )
-            @patch(GET_RULES_TARGET, return_value=COMPILED_RULES_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            @patch.dict(os.environ, {'TEST_SCAN': 'false'})
-            def test_process_include_exclude_files_similar_names(
-                self, disabled, rules, create_test_files_real_yara
-            ):
-                # Now test including/excluding items that have similar names, eg /usr/local/lib and /usr/local/libexec
-                # /usr/local has sub directories /usr/local/lib and /usr/local/libexec (ie similar names)
-                # If we exclude /usr/local/lib then /usr/local/libexec should still be included
-                mdc = MalwareDetectionClient(None)
-                mdc.scan_fsobjects = ['/usr/local']
-                mdc.filesystem_scan_exclude_list.append('/usr/local/lib')
+            log_mock.info.assert_any_call(
+                "Matched rule %s in %s %s", "Lorem", "file", ANY
+            )
 
-                scan_dict = process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert list(scan_dict.keys()) == ['/usr']
-                assert list(scan_dict['/usr']['exclude']['items']) == ['/usr/local/lib']
-                # Ensure /usr/local/lib is NOT in the list of items to scan
-                assert all(
-                    [
-                        x not in scan_dict['/usr']['include']
-                        for x in ['/usr', '/usr/lib', '/usr/local', '/usr/local/lib']
-                    ]
-                )
-                # But ensure /usr/local/libexec IS in the list of items to scan
-                assert all(
-                    [
-                        x in scan_dict['/usr']['include']
-                        for x in ['/usr/local/bin', '/usr/local/share', '/usr/local/libexec']
-                    ]
-                )
 
-                # Add /usr/local/libexec as an item to exclude and ensure both /usr/local/lib and libexec are excluded now
-                mdc.filesystem_scan_exclude_list.append('/usr/local/libexec')
-                scan_dict = process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert list(scan_dict.keys()) == ['/usr']
-                assert sorted(scan_dict['/usr']['exclude']['items']) == [
-                    '/usr/local/lib',
-                    '/usr/local/libexec',
-                ]
-                # Ensure /usr/local/lib and /usr/local/libexec are both not in the list of items to scan
-                assert all(
-                    [
-                        x not in scan_dict['/usr']['include']
-                        for x in [
-                            '/usr',
-                            '/usr/lib',
-                            '/usr/local',
-                            '/usr/local/lib',
-                            '/usr/local/libexec',
-                        ]
-                    ]
-                )
-                assert all(
-                    [
-                        x in scan_dict['/usr']['include']
-                        for x in ['/usr/local/bin', '/usr/local/share']
-                    ]
-                )
-
-                # Test including /usr/local/lib and excluding an item from it
-                # Confirm that only items from /usr/local/lib are included and NOT from any other directory
-                usr_local_lib = sorted(
-                    filter(
-                        lambda x: not os.path.islink(x),
-                        map(lambda x: '/usr/local/lib/' + x, os.listdir('/usr/local/lib')),
-                    )
-                )
-                assert len(usr_local_lib) > 2
-                excluded_item1 = usr_local_lib[0]
-                excluded_item2 = usr_local_lib[1]
-                mdc.scan_fsobjects = ['/usr/local/lib']
-                mdc.filesystem_scan_exclude_list = [excluded_item1, excluded_item2]
-                scan_dict = process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert list(scan_dict.keys()) == ['/usr']
-                assert sorted(scan_dict['/usr']['exclude']['items']) == [
-                    excluded_item1,
-                    excluded_item2,
-                ]
-                # Ensure only /usr/local/lib items are included (except the first 2 in the directory)
-                assert all(
-                    [
-                        x not in scan_dict['/usr']['include']
-                        for x in [
-                            '/usr',
-                            '/usr/local',
-                            '/usr/local/lib',
-                            '/usr/local/libexec',
-                            excluded_item1,
-                            excluded_item2,
-                        ]
-                    ]
-                )
-                assert all([x in scan_dict['/usr']['include'] for x in usr_local_lib[2:]])
-
-            @patch(GET_RULES_TARGET, return_value=RULE_RULE_FILE)
-            @patch(DISABLED_RULES_TARGET)
-            def test_scan_tmp_files(
-                self, disabled, rules, create_test_files_real_yara, extract_tmp_files, caplog
-            ):
-                # Scan the files in the tmp file and set scan_only, scan_exclude to same values as above
-                logger.setLevel('INFO')
-                scan_me_file = os.path.join(TEMP_TEST_DIR, 'scan_me/scan_me_file')
-                scan_me_too_file = os.path.join(TEMP_TEST_DIR, 'scan_me_too/scan_me_too_file')
-                scan_only = tuple(
-                    map(lambda x: os.path.join(TEMP_TEST_DIR, x), ['scan_me', 'scan_me_too'])
-                )
-                scan_exclude = tuple(
-                    map(
-                        lambda x: os.path.join(TEMP_TEST_DIR, x),
-                        ['scan_me_not', 'scan_me/dont_scan_me', 'scan_me_too/dont_scan_me_too'],
-                    )
-                )
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    line = (
-                        line + '- %s\n- %s' % scan_only
-                        if line.startswith("filesystem_scan_only:")
-                        else line
-                    )
-                    line = (
-                        line + "- %s\n- %s\n- %s" % scan_exclude
-                        if line.startswith("filesystem_scan_exclude:")
-                        else line
-                    )
-                    print(line)
-
-                mdc = MalwareDetectionClient(None)
-                scan_dict = process_include_exclude_items(
-                    include_items=mdc.scan_fsobjects, exclude_items=mdc.filesystem_scan_exclude_list
-                )
-                assert list(scan_dict.keys()) == ['/tmp']
-                assert sorted(list(scan_dict['/tmp']['exclude']['items'])) == sorted(scan_exclude)
-
-                mdc.scan_filesystem()
-                assert mdc.matches == 2  # There were only 2 files the matched the rule
-                rule_match = mdc.host_scan['Rule']
-                assert len(rule_match) == 11  # There were 11 strings matched in the 2 files
-                # Asserting the names of the 2 files that were matched
-                sources = set([rm['source'] for rm in rule_match])
-                assert len(sources) == 2
-                assert scan_me_file in sources
-                assert scan_me_too_file in sources
-
-                # With the same scan_only and scan_exclude values, add scan_since: last into the mix and set the last scan
-                # time to now.  There should be no matches because no files have been modified since now
-                caplog.clear()
-                last_scan = time.time()
-                last_scan_fmt = datetime.fromtimestamp(last_scan).strftime('%Y-%m-%d %H:%M:%S')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = (
-                        "filesystem_scan_since: last"
-                        if line.startswith("filesystem_scan_since:")
-                        else line
-                    )
-                    print(line)
-                with patch(
-                    "insights.specs.datasources.malware_detection.get_scan_since_timestamp",
-                    return_value=last_scan,
-                ):
-                    mdc = MalwareDetectionClient(None)
-                assert mdc.filesystem_scan_since_dict['timestamp'] == last_scan
-                assert mdc.filesystem_scan_since_dict['datetime'] == last_scan_fmt
-                assert (
-                    "Scan for files created/modified since last successful scan on %s"
-                    % last_scan_fmt
-                    in caplog.text
-                )
-                mdc.scan_filesystem()
-                assert mdc.matches == 0  # There were no files modified since 'last_scan'
-
-                # Try again, keeping the same last_scan time, but this time touch one of the matching files
-                # Should get a match on the touched file because it has been 'modified' since the last scan
-                caplog.clear()
-                os.system('touch %s' % scan_me_file)
-                with patch(
-                    "insights.specs.datasources.malware_detection.get_scan_since_timestamp",
-                    return_value=last_scan,
-                ):
-                    mdc = MalwareDetectionClient(None)
-                mdc.scan_filesystem()
-                assert mdc.matches == 1  # There was 1 file modified since last_scan
-                rule_match = mdc.host_scan['Rule']
-                assert len(rule_match) == 8  # There were 8 strings matched in the 2 files
-                assert rule_match[0]['source'] == scan_me_file
-
-                # Touch another of the matching files, keeping the same last_scan time.
-                # Expect to get 2 matching files this time
-                caplog.clear()
-                os.system('touch %s' % scan_me_too_file)
-                with patch(
-                    "insights.specs.datasources.malware_detection.get_scan_since_timestamp",
-                    return_value=last_scan,
-                ):
-                    mdc = MalwareDetectionClient(None)
-                mdc.scan_filesystem()
-                assert (
-                    mdc.matches == 2
-                )  # There were 2 files modified since last_scan the matched the rule
-                rule_match = mdc.host_scan['Rule']
-                assert len(rule_match) == 11  # There were 11 strings matched in the 2 files
-                # Asserting the names of the 2 files that were matched
-                sources = set([rm['source'] for rm in rule_match])
-                assert len(sources) == 2
-                assert scan_me_file in sources
-                assert scan_me_too_file in sources
-
-        @patch(NAMEDTMPFILE_TARGET)
-        @patch.object(
-            InsightsConnection, 'get', return_value=Mock(status_code=200, content=b"Rule Content")
-        )
-        @patch.object(InsightsConnection, 'get_proxies')
-        @patch.object(InsightsConnection, '_init_session', return_value=Mock())
-        @patch(DISABLED_RULES_TARGET, return_value=[])
-        @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
-        class TestGetRules:
-
-            @patch.dict(os.environ)
-            def test_get_regular_rules_location_urls(
-                self, disabled, init_session, get_proxies, get, tmpfile, caplog
-            ):
-                # Test the standard rules_location urls, depending on whether test rule or cert auth is set
-                # With test scan true, expect to download test-rule.yar
-                test_rule_url = (
-                    "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
-                )
-                signatures_url = (
-                    "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar?yara_version=%s"
-                    % REAL_YARA_VERSION
-                )
-                logger.setLevel('DEBUG')
-                os.environ['TEST_SCAN'] = 'true'
-                with pytest.raises(SystemExit):
-                    MalwareDetectionClient(InsightsConfig())
-                get.assert_called_with(
-                    test_rule_url, log_response_text=True, verify=True, stream=True
-                )
-                assert test_rule_url in caplog.text
-
-                caplog.clear()
-                with pytest.raises(SystemExit):
-                    MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
-                get.assert_called_with(
-                    test_rule_url, log_response_text=True, verify=True, stream=True
-                )
-                assert test_rule_url in caplog.text
-
-                # With authmethod=BASIC and test scan false ...
-                # Expect to still use cert auth because no username or password specified
-                caplog.clear()
-                os.environ['TEST_SCAN'] = 'false'
-                with pytest.raises(SystemExit):
-                    MalwareDetectionClient(InsightsConfig(authmethod='BASIC'))
-                get.assert_called_with(
-                    signatures_url, log_response_text=False, verify=True, stream=True
-                )
-                assert signatures_url in caplog.text
-
-                caplog.clear()
-                with pytest.raises(SystemExit):
-                    MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
-                get.assert_called_with(
-                    signatures_url, log_response_text=False, verify=True, stream=True
-                )
-                assert signatures_url in caplog.text
-
-            def test_get_irregular_rules_location_urls(
-                self,
-                disabled,
-                init_session,
-                get_proxies,
-                get,
-                tmpfile,
-                create_test_files_real_yara,
-                caplog,
-            ):
-                # Non-standard rules URLs
-                # Without https:// at the start and not signatures.yar
-                logger.setLevel('DEBUG')
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = (
-                        line + "rules_location: console.redhat.com/rules.yar"
-                        if line.startswith("---")
-                        else line
-                    )
-                    print(line)
-                with pytest.raises(SystemExit):
-                    MalwareDetectionClient(InsightsConfig())
-                get.assert_called_with(
-                    "https://cert.console.redhat.com/test-rule.yar",
-                    log_response_text=True,
-                    verify=True,
-                    stream=True,
-                )
-                assert "https://cert.console.redhat.com/test-rule.yar" in caplog.text
-
-                caplog.clear()
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    print(line)
-                with pytest.raises(SystemExit):
-                    MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
-                get.assert_called_with(
-                    "https://cert.console.redhat.com/rules.yar",
-                    log_response_text=False,
-                    verify=True,
-                    stream=True,
-                )
-                assert "https://cert.console.redhat.com/rules.yar" in caplog.text
-
-            def test_get_rules_location_files(
-                self,
-                disabled,
-                init_session,
-                get_proxies,
-                get,
-                tmpfile,
-                create_test_files_real_yara,
-                caplog,
-            ):
-                # Test using files for rules_location, esp irregular file names
-                # Re-writing the rule to be test-rule.yar doesn't apply to local files
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = (
-                        line + "rules_location: //console.redhat.com/rules.yar"
-                        if line.startswith("---")
-                        else line
-                    )
-                    print(line)
-                with pytest.raises(SystemExit):
-                    MalwareDetectionClient(None)
-                assert (
-                    "Couldn't find specified rules file: /console.redhat.com/rules.yar"
-                    in caplog.text
-                )
-
-                caplog.clear()
-                for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
-                    line = "test_scan: false" if line.startswith("test_scan:") else line
-                    print(line)
-                with pytest.raises(SystemExit):
-                    MalwareDetectionClient(None)
-                assert (
-                    "Couldn't find specified rules file: /console.redhat.com/rules.yar"
-                    in caplog.text
-                )
+# Base64 representation of a tgz file containing simple files to be extracted into /tmp to be used for scanning
+# It is decoded and unzipped in the extract_tmp_files fixture
+SCAN_FILES_BASE64 = """
+H4sIAD+feGEAA+1a247TMBDtc79iVCEVhARxrk888A+8IajSxt1Ym8YlcXZVIf6dcbZG2WzTkm5t
+ijpnH3KxHbt7PPaZGdertFxs+MeJRXiIJIn0lSWR170aTFjIgpixJAyCicdY5IcTiGwOyqCpVVoB
+TDZ5o/Ij9U6V/6eo9/yX/HGxFgW30YcmOI7DEfwHvh9NwLMxmD6I/5Z/WWRXxT/ziX8XMPxvxZbb
+mgBn8B8kyQRiC2N5AeK/5T+TpVrUdsTA+P0/ZFFE+78LHOR/k6pVLsq7BS+VULvX9nHK/iMv6PGf
++Fid1n8H+JKLGgpRcljhDEhFWUMKtaqQfWinAYgSVM5B7w0w682M2fRQ+1Jig+rFV3ptsV4GQgG2
+f+DVDgqJldeyAsVrpRvqXnlRiG3Na3xIFaQVhzTLeAbYl+w00wOop9PP+EV15Ac9CpVDJtZrXuEY
+QO22+GW5hh+NxE5hjqPm83ZcM3072w+xfupESQnLRgH+vKcXvJTNXT791xS+Csbkl5W85+UC/3H3
+F+/jaf1PRqz/MYtw//dtDsrgxu3f8G9p628xfv8P8I/2fxfo86/XvYVYpJsL9jFe/4dJRP6fE/T4
+t+ICtvyHw/wnQdTn34ti4t8FptNnMm2vmfQLXlUoxvS8aB+18hFqjnrpHpZ8lTY1b6WRVkMo7lKo
+GhSIWnhNEQdk4SdY5Wk1XKL11aHSD+/b4vpY2VDb2Wy47Xw+XPb23ddvw6U/fw2XfX9zumw/Wg7b
+ij8I2ezrpUa9SnzQYlPLXXFXygoFb6olMN+175Z8J9u6HDK+TptCAfOey+1CbIT6G2Vq7F9rLJvx
+n1H6z2e4AqD+s+mUGty4/Zt1H83YWg5ovP7zQ4/yP07Q5d9WDugM/cc8yv84QZd/WzmgM/j3EtL/
+TtDl31YO6Az+/YjyP07Q5f/PPX/g1QXVwPj9P/KZR/u/Cwzzb8L4r9fdp+z/hf/v4zWh9d8FyP8n
+/9/YvyUP+4z8bxSxgOzfBSj/S/lfY/+2YoCj438sCWKd/7W1IHVx4/Zv+MfJfV3xPzr/5QRd/rvh
+9ktOiDP8v4QlxL8LHOX/Qi7geP/PDyn/6wbk/5H/Z8z9qvI/ZP9O0OX/qvI/5P87QZf/a8r/xB7l
+f1ygy7+t49Zn+P9ee/6Hzn9bR5d/W7GA8f5fGOv1n/w/+xjg/6LbQLv+Hzn/eyD+j7e0/7sAxf8p
+/m/s/2ri/34Y+EHv/O8lA1Jd3Lj9EwgEAoFAIBBuC78BaSEregBQAAA=""".replace(
+    "\n", ""
+)
 
 
 MATCHING_ENTITY_FILE_CONTENTS = """
@@ -5364,6 +4739,17 @@ The previous line and this one too are ignored as they are beyond the default 10
 TEST_RULE_FILE_CONTENTS = """
 rule TEST_RedHatInsightsMalwareDetection
 // Verifies the Red Hat Insights Malware Detection Client app is present on the system
+{
+    strings:
+        $re1 = /Malware ?Detection ?Client/
+    condition:
+        $re1
+}
+""".lstrip()
+
+THIRD_PARTY_RULES_FILE_CONTENTS = """
+rule TEST_3RD_PARTY_RULES
+// 3rd party rules added to system to be used by malware detection
 {
     strings:
         $re1 = /Malware ?Detection ?Client/
@@ -5464,7 +4850,7 @@ TtDl31YO6Az+/YjyP07Q5f/PPX/g1QXVwPj9P/KZR/u/Cwzzb8L4r9fdp+z/hf/v4zWh9d8FyP8n
 9ktOiDP8v4QlxL8LHOX/Qi7geP/PDyn/6wbk/5H/Z8z9qvI/ZP9O0OX/qvI/5P87QZf/a8r/xB7l
 f1ygy7+t49Zn+P9ee/6Hzn9bR5d/W7GA8f5fGOv1n/w/+xjg/6LbQLv+Hzn/eyD+j7e0/7sAxf8p
 /m/s/2ri/34Y+EHv/O8lA1Jd3Lj9EwgEAoFAIBBuC78BaSEregBQAAA=""".replace(
-    '\n', ''
+    "\n", ""
 )
 
 TEST_RULE1 = b"""


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Add support for scanning third-party YARA rules alongside the built-in rules and refactor the malware detection client to use a new config and utilities structure.

New Features:
- Enable loading and scanning of additional YARA rule files from a configurable directory
- Support multiple compiled and uncompiled rules files in a single malware detection run

Enhancements:
- Extract configuration loading into a dedicated module with load_or_create_malware_config and find_yara APIs
- Centralize include/exclude path processing in utility functions (process_include_items, process_exclude_items, process_include_exclude_items)
- Update the datasource plugin to invoke parse_scan_options, load_rules, load_disabled_rules, and build_yara_commands methods
- Simplify test scaffolding with fixtures for third-party rule files and write_data_to_file utility

Tests:
- Expand and update tests to cover remote rule downloads, disabled rule queries, and third-party rule handling

Chores:
- Move DEFAULT_MALWARE_CONFIG and related constants into config module
- Reorganize imports and module structure for config, utils, and rules