### PR TITLE
chore(spec): remove unused *_config_perms from collection

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -353,7 +353,6 @@ class DefaultSpecs(Specs):
     gluster_v_info = simple_command("/usr/sbin/gluster volume info")
     greenboot_status = simple_command("/usr/libexec/greenboot/greenboot-status")  # used by puptoo
     group_info = command_with_args("/usr/bin/getent group %s", user_group.group_filters)
-    grub1_config_perms = simple_command("/bin/ls -lH /boot/grub/grub.conf")  # RHEL6
     grub2_cfg = simple_file("/boot/grub2/grub.cfg")
     grub2_efi_cfg = simple_file("boot/efi/EFI/redhat/grub.cfg")
     grubby_default_index = simple_command(
@@ -362,9 +361,6 @@ class DefaultSpecs(Specs):
     grubby_default_kernel = simple_command("/sbin/grubby --default-kernel")
     grubby_info_all = simple_command("/usr/sbin/grubby --info=ALL")
     grub_conf = simple_file("/boot/grub/grub.conf")
-    grub_config_perms = simple_command(
-        "/bin/ls -lH /boot/grub2/grub.cfg"
-    )  # only RHEL7 and updwards
     grub_efi_conf = simple_file("/boot/efi/EFI/redhat/grub.conf")
     grubenv = simple_command("/usr/bin/grub2-editenv list", keep_rc=True)
     haproxy_cfg = first_file(
@@ -474,7 +470,9 @@ class DefaultSpecs(Specs):
     lpstat_protocol_printers = lpstat.lpstat_protocol_printers_info
     lpstat_queued_jobs_count = lpstat.lpstat_queued_jobs_count
     lru_gen_enabled = simple_file("/sys/kernel/mm/lru_gen/enabled")
-    ls_files = command_with_args('/bin/ls -lH %s', ls.list_files_with_lH, save_as='ls_files', keep_rc=True)
+    ls_files = command_with_args(
+        '/bin/ls -lH %s', ls.list_files_with_lH, save_as='ls_files', keep_rc=True
+    )
     ls_la = command_with_args('/bin/ls -la %s', ls.list_with_la, save_as='ls_la', keep_rc=True)
     ls_la_filtered = command_with_args(
         '/bin/ls -la %s', ls.list_with_la_filtered, save_as='ls_la_filtered', keep_rc=True
@@ -839,12 +837,12 @@ class DefaultSpecs(Specs):
     ssh_config_d = glob_file(r"/etc/ssh/ssh_config.d/*.conf")
     sshd_config = simple_file("/etc/ssh/sshd_config")
     sshd_config_d = glob_file(r"/etc/ssh/sshd_config.d/*.conf")
-    sshd_config_perms = simple_command("/bin/ls -lH /etc/ssh/sshd_config")
     sshd_test_mode = simple_command("/usr/sbin/sshd -T")
     sssd_config = simple_file("/etc/sssd/sssd.conf")
     sssd_conf_d = glob_file("/etc/sssd/conf.d/*.conf")
     subscription_manager_facts = simple_command(
-        "/usr/sbin/subscription-manager facts", override_env={"LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"}
+        "/usr/sbin/subscription-manager facts",
+        override_env={"LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"},
     )
     subscription_manager_id = simple_command(
         "/usr/sbin/subscription-manager identity",  # use "/usr/sbin" here, BZ#1690529
@@ -854,7 +852,8 @@ class DefaultSpecs(Specs):
         r"/usr/bin/find /etc/pki/product-default/ /etc/pki/product/ -name '*pem' -exec rct cat-cert --no-content '{}' \;"
     )
     subscription_manager_status = simple_command(
-        "/usr/sbin/subscription-manager status", override_env={"LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"}
+        "/usr/sbin/subscription-manager status",
+        override_env={"LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"},
     )
     subscription_manager_syspurpose = simple_command(
         "/usr/sbin/subscription-manager syspurpose --show",


### PR DESCRIPTION
- These specs are no longer used by any rules 
- Jira: RHINENG-16904

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Remove unused *_config_perms specs from DefaultSpecs and reformat long command invocations for consistency

Enhancements:
- Reformat command_with_args and simple_command calls to use multi-line style with trailing commas

Chores:
- Remove unused grub1_config_perms spec
- Remove unused grub_config_perms spec
- Remove unused sshd_config_perms spec