### PR TITLE
fix: reduce the size of CalledProcessError exception

### DIFF
--- a/insights/tests/test_subproc.py
+++ b/insights/tests/test_subproc.py
@@ -1,6 +1,8 @@
+import os
 import pytest
 import shlex
 import sys
+import stat
 
 from insights.core.exceptions import CalledProcessError
 from insights.util import subproc
@@ -23,3 +25,31 @@ def test_call_timeout():
     if sys.platform != "darwin":
         with pytest.raises(CalledProcessError):
             subproc.call('sleep 3', timeout=1)
+
+
+SCRIPT_CONTENT = """
+#!/bin/bash
+echo '0123456789'
+exit 1
+""".strip()
+
+
+@pytest.fixture(scope="module")
+def tmp_script(tmpdir_factory):
+    root = str(tmpdir_factory.mktemp("test_subproc"))
+    file_path = os.path.join(root, 'tmp.sh')
+    with open(file_path, 'w') as fd:
+        for line in SCRIPT_CONTENT.splitlines():
+            fd.write(line + '\n')
+    st = os.stat(file_path)
+    os.chmod(file_path, st.st_mode | stat.S_IEXEC)
+    return file_path
+
+
+def test_call_error_output(tmp_script):
+    env = os.environ
+    env.update(MAX_FAILURE_OUTPUT="6")
+    with pytest.raises(CalledProcessError) as cpe:
+        subproc.call(tmp_script, env=env)
+    assert "012345" in str(cpe)
+    assert "0123456" not in str(cpe)

--- a/insights/util/subproc.py
+++ b/insights/util/subproc.py
@@ -45,7 +45,14 @@ class Pipeline(object):
 
         self.bufsize = kwargs.get("bufsize", -1)
         self.env = kwargs.get("env", os.environ)
-        self.max_failure_output = int(self.env.get("MAX_FAILURE_OUTPUT", "1024"))
+        max_failure_output_env = self.env.get("MAX_FAILURE_OUTPUT", "1024")
+        try:
+            max_failure_output = int(max_failure_output_env)
+            if max_failure_output <= 0:
+                raise ValueError
+        except (ValueError, TypeError):
+            max_failure_output = 1024
+        self.max_failure_output = max_failure_output
         timeout = kwargs.get("timeout")
         signum = kwargs.get("signum", signal.SIGKILL)
 

--- a/insights/util/subproc.py
+++ b/insights/util/subproc.py
@@ -27,6 +27,7 @@ class Pipeline(object):
     >>> output = p()
     >>> p.write("pythons.txt")
     """
+
     def __init__(self, *cmds, **kwargs):
         """
         cmds (list): one or more commands. Each command will be shlex.split if
@@ -44,6 +45,7 @@ class Pipeline(object):
 
         self.bufsize = kwargs.get("bufsize", -1)
         self.env = kwargs.get("env", os.environ)
+        self.max_failure_output = int(self.env.get("MAX_FAILURE_OUTPUT", "1024"))
         timeout = kwargs.get("timeout")
         signum = kwargs.get("signum", signal.SIGKILL)
 
@@ -62,15 +64,43 @@ class Pipeline(object):
     def _build_pipes(self, out_stream=PIPE):
         log.debug("Executing: %s" % str(self.cmds))
         if len(self.cmds) == 1:
-            return Popen(self.cmds[0], bufsize=self.bufsize, stdin=DEVNULL, stderr=STDOUT, stdout=out_stream, env=self.env)
+            return Popen(
+                self.cmds[0],
+                bufsize=self.bufsize,
+                stdin=DEVNULL,
+                stderr=STDOUT,
+                stdout=out_stream,
+                env=self.env,
+            )
 
-        stdout = Popen(self.cmds[0], bufsize=self.bufsize, stdin=DEVNULL, stderr=STDOUT, stdout=PIPE, env=self.env).stdout
+        stdout = Popen(
+            self.cmds[0],
+            bufsize=self.bufsize,
+            stdin=DEVNULL,
+            stderr=STDOUT,
+            stdout=PIPE,
+            env=self.env,
+        ).stdout
         last = len(self.cmds) - 2
         for i, arg in enumerate(self.cmds[1:]):
             if i < last:
-                stdout = Popen(arg, bufsize=self.bufsize, stdin=stdout, stderr=STDOUT, stdout=PIPE, env=self.env).stdout
+                stdout = Popen(
+                    arg,
+                    bufsize=self.bufsize,
+                    stdin=stdout,
+                    stderr=STDOUT,
+                    stdout=PIPE,
+                    env=self.env,
+                ).stdout
             else:
-                return Popen(arg, bufsize=self.bufsize, stdin=stdout, stderr=STDOUT, stdout=out_stream, env=self.env)
+                return Popen(
+                    arg,
+                    bufsize=self.bufsize,
+                    stdin=stdout,
+                    stderr=STDOUT,
+                    stdout=out_stream,
+                    env=self.env,
+                )
 
     def __call__(self, keep_rc=False):
         """
@@ -89,7 +119,8 @@ class Pipeline(object):
         if keep_rc:
             return (rc, output)
         if rc:
-            raise CalledProcessError(rc, self.cmds[0], output)
+            # it's enough for trobuleshooting to keep the first 1024 charactersof the failure output
+            raise CalledProcessError(rc, self.cmds[0], output[: self.max_failure_output])
         return output
 
     def write(self, output, mode="w", keep_rc=False):
@@ -133,12 +164,7 @@ class Pipeline(object):
                 raise CalledProcessError(rc, self.cmds[0], "")
 
 
-def call(cmd,
-         timeout=None,
-         signum=signal.SIGKILL,
-         keep_rc=False,
-         encoding="utf-8",
-         env=os.environ):
+def call(cmd, timeout=None, signum=signal.SIGKILL, keep_rc=False, encoding="utf-8", env=os.environ):
     """
     Execute a cmd or list of commands with an optional timeout in seconds.
 


### PR DESCRIPTION
- In some edge cases, some command outputs are significant large
      even when the command failed. To hold the whole output in the
      Traceback is not reasonable, as it will cause container being
      killed due to OOM when loading the meta_data Spec JSON.
- In fact the Traceback + "head" (1024 chars) of the output are
      good enough for devs to debug and troubleshoot it.
- Jira: RHINENG-20300

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Reduce the size of CalledProcessError exception output by keeping only its initial 1024 characters and add tests to ensure this behavior

Enhancements:
- Truncate CalledProcessError output to the first 1024 characters to avoid excessive exception payloads

Tests:
- Add unit tests to verify that CalledProcessError output is correctly truncated or preserved when below the limit

## Summary by Sourcery

Limit failure outputs in subproc calls to avoid OOM risks by slicing CalledProcessError output and add tests to enforce this behavior

Enhancements:
- Truncate CalledProcessError output to the first 1024 characters by default to prevent excessive exception payloads (configurable via MAX_FAILURE_OUTPUT)

Tests:
- Add unit tests to verify that error output is correctly truncated when exceeding the limit