### PR TITLE
chore: Move parser "WatchDogLog" to "watchdog.py" file

### DIFF
--- a/insights/parsers/watchdog.py
+++ b/insights/parsers/watchdog.py
@@ -4,9 +4,11 @@ Parsers for watchdog configuration
 
 WatchDogConf - file ``/etc/watchdog.conf``
 ------------------------------------------
+WatchDogLog - file ``/var/log/watchdog/*.std*``
+-----------------------------------------------
 """
 
-from insights import parser, Parser, SkipComponent
+from insights import parser, Parser, SkipComponent, LogFileOutput
 from insights.specs import Specs
 from insights.parsers import split_kv_pairs
 
@@ -42,3 +44,30 @@ class WatchDogConf(Parser, dict):
         self.update(split_kv_pairs(content))
         if not self:
             raise SkipComponent('Not available data')
+
+
+@parser(Specs.watchdog_logs)
+class WatchDogLog(LogFileOutput):
+    """
+    Class for parsing ``/var/log/watchdog/*.std*`` files.
+
+    Sample Input::
+
+        DEBUG:root:0
+
+        INFO:root:Executing: /usr/bin/sg_persist -n -i -k -d /dev/mapper/mpathb
+
+        DEBUG:root:0   PR generation=0xc2, 4 registered reservation keys follow:
+            0xfdfe0001
+            0xfdfe0001
+            0xfdfe0000
+            0xfdfe0000
+
+
+        DEBUG:root:key fdfe0001 registered with device /dev/mapper/mpathb
+        INFO:root:Executing: /usr/bin/sg_turs /dev/mapper/mpathb
+
+        DEBUG:root:0
+    """
+
+    time_format = None

--- a/insights/parsers/watchdog_logs.py
+++ b/insights/parsers/watchdog_logs.py
@@ -5,11 +5,16 @@ WatchDogLog - file ``/var/log/watchdog/*.std*``
 
 from insights import LogFileOutput, parser
 from insights.specs import Specs
+from insights.util import deprecated
 
 
 @parser(Specs.watchdog_logs)
 class WatchDogLog(LogFileOutput):
     """
+    .. warning::
+        This parser is deprecated, please use
+        :py:class:`insights.parsers.watchdog.WatchDogLog` instead.
+
     Class for parsing ``/var/log/watchdog/*.std*`` files.
 
     Sample Input::
@@ -30,5 +35,9 @@ class WatchDogLog(LogFileOutput):
 
         DEBUG:root:0
     """
+
+    def __init__(self, *args, **kwargs):
+        deprecated(WatchDogLog, "Please use the :class:`insights.parsers.watchdog.WatchDogLog` instead.", "3.8.0")
+        super(WatchDogLog, self).__init__(*args, **kwargs)
 
     time_format = None

--- a/insights/tests/parsers/test_watchdog.py
+++ b/insights/tests/parsers/test_watchdog.py
@@ -2,7 +2,7 @@ import doctest
 import pytest
 
 from insights.parsers import watchdog, SkipComponent
-from insights.parsers.watchdog import WatchDogConf
+from insights.parsers.watchdog import WatchDogConf, WatchDogLog
 from insights.tests import context_wrap
 
 WATCHDOG_CONF = """
@@ -15,6 +15,18 @@ retry-timeout          = 60
 repair-maximum         = 1
 realtime               = yes
 priority               = 1
+""".strip()
+
+WATCHDOG_LOG = """
+DEBUG:root:0
+
+INFO:root:Executing: /usr/bin/sg_persist -n -i -k -d /dev/mapper/mpathb
+
+DEBUG:root:0   PR generation=0xc2, 4 registered reservation keys follow:
+    0xfdfe0001
+    0xfdfe0001
+    0xfdfe0000
+    0xfdfe0000
 """.strip()
 
 
@@ -30,6 +42,19 @@ def test_watchdog_conf():
 def test_watchdog_skip():
     with pytest.raises(SkipComponent):
         WatchDogConf(context_wrap(''))
+
+
+def test_watchdog_log():
+    WatchDogLog.last_scan('register_line', 'registered reservation keys')
+    watch_log = WatchDogLog(context_wrap(WATCHDOG_LOG))
+    assert watch_log.register_line is not None
+    assert watch_log.register_line.get('raw_message') == 'DEBUG:root:0   PR generation=0xc2, 4 registered reservation keys follow:'
+
+
+def test_watchdog_log_exception():
+    watch_log = WatchDogLog(context_wrap(WATCHDOG_LOG))
+    with pytest.raises(RuntimeError):
+        list(watch_log.get_after('2013-1-1'))
 
 
 def test_doc():


### PR DESCRIPTION
* Move all the parsers related with watchdog to one file to eliminate files count

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

## Summary by Sourcery

Consolidate the WatchDogLog parser into the main watchdog.py module, deprecate the old module, and update tests accordingly

Enhancements:
- Consolidate WatchDogLog parser into watchdog.py alongside other watchdog parsers
- Deprecate the WatchDogLog class in watchdog_logs.py with a warning pointing to the new location

Tests:
- Update tests to import WatchDogLog from watchdog.py
- Add tests for WatchDogLog parsing and its exception behavior when requesting logs before the first scan