### PR TITLE
chore: update RPM building scripts and spec file

### DIFF
--- a/build_core_rpm.sh
+++ b/build_core_rpm.sh
@@ -20,19 +20,27 @@ fi
 
 # Check build target
 if [ "$TARGET" == "internal" ]; then
+    # backforward compatible with internal RPM building
     echo "Building insights-core RPM for internal usage."
     BUILDTARGET="for_internal 1"
     MANIFEST="MANIFEST.in.core"
-elif [ "$TARGET" == "client" ]; then
-    echo "Building insights-core RPM for insights-client."
-    BUILDTARGET="with_selinux 1"
+elif [ "$TARGET" == "client" ] || [ "$TARGET" == "testing" ]; then
+    if [ "$TARGET" == "client" ]; then
+        # for RPM release
+        echo "Building insights-core RPM for insights-client."
+        BUILDTARGET="with_selinux 1"
+    else
+        # for RPM testing (PR Check)
+        echo "Building insights-core RPM for testing with insights-client."
+        BUILDTARGET="with_selinux 0"
+    fi
     MANIFEST="MANIFEST.in.client"
     # - remove depedencies for data processing
     sed -i -e '/cachecontrol/d' -e '/defusedxml/d' -e '/jinja2/d' -e '/lockfile/d' -e '/redis/d' -e '/setuptools;/d' pyproject.toml setup.py
     # - remove entrypoints for data processing
     sed -i -e '/insights =/d' -e '/insights-dupkey/d' -e '/insights-run/d' -e '/insights-inspect/d' -e '/mangle =/d' pyproject.toml setup.py
 else
-    echo "Error: invalid build target: '$TARGET'. Use 'internal' or 'client'"
+    echo "Error: invalid build target: '$TARGET'. Use 'internal', 'client', or 'testing'"
     exit 1
 fi
 
@@ -40,7 +48,25 @@ rm -rf BUILD BUILDROOT RPMS SRPMS insights_core.egg-info
 # Prepare the tarbal
 git rev-parse --short HEAD > insights/COMMIT
 cp $MANIFEST MANIFEST.in
-$PYTHON setup.py sdist
+
+$PYTHON -m pip install build
+$PYTHON -m build --sdist
+
+if [ "$TARGET" == "client" ]; then
+    # keep compatible with old&new setuptools
+    VERSION=`cat insights/VERSION`
+    pushd dist
+    if [ -f insights_core-${VERSION}.tar.gz ]; then
+        tar xf insights_core-${VERSION}.tar.gz
+        rename _ - insights_core-${VERSION}
+        tar zcf insights-core-${VERSION}.tar.gz insights-core-${VERSION}
+    fi
+    popd
+    if [ ! -f dist/insights-core-${VERSION}.tar.gz ]; then
+        echo "Error: Source tarbal archive 'insights-core-${VERSION}.tar.gz' doesn't exist."
+        exit 1
+    fi
+fi
 # Build the RPM/SRPM
 rpmbuild -D "${BUILDTARGET}" -D "_topdir $PWD" -D "_sourcedir $PWD/dist" -ba insights-core.spec
 

--- a/insights-core.spec
+++ b/insights-core.spec
@@ -1,8 +1,14 @@
 %define distro redhat
 %global debug_package %{nil}
 %global modulename insights_core
-%global selinux_policy_version 42.1.1
+%if 0%{?with_selinux}
 %global selinuxtype targeted
+%if 0%{?rhel} == 9
+%global selinux_policy_version 38.1.60
+%elif 0%{?rhel} == 10
+%global selinux_policy_version 42.1.1
+%endif
+%endif
 
 Name:           insights-core
 Version:        3.0.8
@@ -11,9 +17,11 @@ Summary:        Insights Core is a data collection and analysis framework.
 
 License:        Apache-2.0
 URL:            https://github.com/RedHatInsights/insights-core
-Source0:        https://github.com/RedHatInsights/insights-core/archive/refs/tags/%{name}-%{version}.tar.gz
 %if 0%{?with_selinux}
-Source1:        https://github.com/xiangce/insights-core-selinux/archive/refs/tags/%{name}-selinux-%{version}.tar.gz
+Source0:        %{name}-%{version}.tar.gz
+Source1:        %{name}-selinux-%{version}.tar.gz
+%else
+Source0:        %{modulename}-%{version}.tar.gz
 %endif
 
 BuildArch:      noarch
@@ -56,7 +64,7 @@ Insights Core is a data collection and analysis framework.
 %if 0%{?with_selinux}
 %setup -q -n %{name}-%{version} -a 1
 %else
-%setup -q -n %{name}-%{version}
+%setup -q -n %{modulename}-%{version}
 %endif
 
 %if 0%{?with_selinux}


### PR DESCRIPTION
- Add a `testing` entry to build RPM for PR check
- Update spec file to decide selinux version per RHEL
  By doing this, it's not required to specify the version by hand
  when building RPM.
- Rename Source0 to use the `modulename` per the latest setuptools
- Remove the URL link from Sources of spec

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Update the RPM spec file to automatically select the appropriate SELinux policy version based on the target RHEL release instead of hard-coding a single version

Chores:
- Add conditional logic in insights-core.spec to define selinux_policy_version for RHEL 9 and RHEL 10
- Remove the previous fixed selinux_policy_version entry from the spec file