### PR TITLE
feat: New spec and parser for '/var/log/foreman-installer/foreman.log'

### DIFF
--- a/insights/parsers/foreman_log.py
+++ b/insights/parsers/foreman_log.py
@@ -54,9 +54,10 @@ class SatelliteLog(LogFileOutput):
     """Class for parsing ``foreman-installer/satellite.log`` file."""
     pass
 
+
 @parser(Specs.foreman_log)
 class ForemanLog(LogFileOutput):
-    """Class for parsing ``/var/log/foreman-installer/foreman.log` file."""
+    """Class for parsing ``/var/log/foreman-installer/foreman.log`` file."""
     pass
 
 

--- a/insights/parsers/foreman_log.py
+++ b/insights/parsers/foreman_log.py
@@ -31,6 +31,8 @@ ForemanSSLAccessLog - file ``/var/log/httpd/foreman-ssl_access_ssl.log``
 ForemanSSLErrorLog - file ``/var/log/httpd/foreman-ssl_error_ssl.log``
 ----------------------------------------------------------------------
 
+ForemanLog - file ``/var/log/foreman-installer/foreman.log``
+------------------------------------------------------------
 """
 from datetime import datetime
 
@@ -50,6 +52,11 @@ class ProxyLog(LogFileOutput):
 @parser(Specs.foreman_satellite_log)
 class SatelliteLog(LogFileOutput):
     """Class for parsing ``foreman-installer/satellite.log`` file."""
+    pass
+
+@parser(Specs.foreman_log)
+class ForemanLog(LogFileOutput):
+    """Class for parsing ``/var/log/foreman-installer/foreman.log` file."""
     pass
 
 

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -236,6 +236,7 @@ class Specs(SpecSet):
     foreman_proxy_log = RegistryPoint(filterable=True)
     foreman_rake_db_migrate_status = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     foreman_satellite_log = RegistryPoint(filterable=True)
+    foreman_log = RegistryPoint(filterable=True)
     foreman_ssl_access_ssl_log = RegistryPoint(filterable=True)
     foreman_ssl_error_ssl_log = RegistryPoint(filterable=True)
     foreman_tasks_config = RegistryPoint(filterable=True)

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -95,6 +95,7 @@ class SosSpecs(Specs):
     foreman_proxy_conf = first_of([simple_file("/etc/foreman-proxy/settings.yml"), simple_file("sos_commands/foreman/foreman-debug/etc/foreman-proxy/settings.yml")])
     foreman_proxy_log = first_of([simple_file("/var/log/foreman-proxy/proxy.log"), simple_file("sos_commands/foreman/foreman-debug/var/log/foreman-proxy/proxy.log")])
     foreman_satellite_log = first_of([simple_file("/var/log/foreman-installer/satellite.log"), simple_file("sos_commands/foreman/foreman-debug/var/log/foreman-installer/satellite.log")])
+    foreman_log = simple_file("/var/log/foreman-installer/foreman.log")
     foreman_ssl_access_ssl_log = first_file(["var/log/httpd/foreman-ssl_access_ssl.log", r"sos_commands/foreman/foreman-debug/var/log/httpd/foreman-ssl_access_ssl.log"])
     foreman_tasks_config = first_file(["/etc/sysconfig/foreman-tasks", "/etc/sysconfig/dynflowd"])
     freeipa_healthcheck_log = simple_file("/var/log/ipa/healthcheck/healthcheck.log")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Add support for parsing the `/var/log/foreman-installer/foreman.log` configuration by registering a new spec, providing a ForemanLog parser, and including corresponding test.

New Features:

Introduce a **foreman_log** filterable registry point for `/var/log/foreman-installer/foreman.log` in the specs
Implement ForemanLog parser to the logs for the corresponding file.
Enhancements:

Register the new "foreman_log" spec in the default spec set
Documentation:

Tests:

Add unit tests for the ForemanLog parser


```
py.test -sv /Users/atewari/Desktop/tier3-rules/insights-core/insights/tests/parsers/test_foreman_log.py                                                                   ok  virtual_env py 
============================================================================================================================== test session starts ==============================================================================================================================
platform darwin -- Python 3.9.6, pytest-8.4.1, pluggy-1.6.0 -- /Users/atewari/Desktop/tier3-rules/virtual_env/bin/python3
cachedir: .pytest_cache
rootdir: /Users/atewari/Desktop/tier3-rules/insights-core
configfile: pyproject.toml
plugins: cov-5.0.0, anyio-4.8.0, langsmith-0.3.1
collected 9 items                                                                                                                                                                                                                                                               

insights/tests/parsers/test_foreman_log.py::test_foreman_log PASSED
insights/tests/parsers/test_foreman_log.py::test_production_log PASSED
insights/tests/parsers/test_foreman_log.py::test_proxy_log PASSED
insights/tests/parsers/test_foreman_log.py::test_candlepin_log PASSED
insights/tests/parsers/test_foreman_log.py::test_satellite_log PASSED
insights/tests/parsers/test_foreman_log.py::test_candlepin_error_log PASSED
insights/tests/parsers/test_foreman_log.py::test_foreman_ssl_access_ssl_log PASSED
insights/tests/parsers/test_foreman_log.py::test_foreman_ssl_error_ssl_log PASSED
insights/tests/parsers/test_foreman_log.py::test_doc PASSED

=============================================================================================================================== 9 passed in 0.09s ===============================================================================================================================
```