### PR TITLE
fix: handle error lines of spec grubby_default_index

### DIFF
--- a/insights/parsers/grubby.py
+++ b/insights/parsers/grubby.py
@@ -41,14 +41,23 @@ class GrubbyDefaultIndex(CommandParser):
 
     Attributes:
         default_index (int): the numeric index of the current default boot entry, count from 0
+        error_lines (list): the error messages from the grubby command
     """
 
     def parse_content(self, content):
         if not content:
             raise SkipComponent('Empty output')
-        if len(content) != 1 or not content[0].isdigit():
-            raise ParseException('Invalid output: {0}', content)
-        self.default_index = int(content[0])
+
+        self.error_lines = []
+        default_index_line = content[0]
+        if len(content) != 1:
+            default_index_line = content[-1]
+            self.error_lines = content[:-1]
+
+        if not default_index_line.strip().isdigit():
+            raise ParseException('Invalid output: {0}'.format(content))
+
+        self.default_index = int(default_index_line.strip())
 
 
 @parser(Specs.grubby_default_kernel)
@@ -102,12 +111,16 @@ class GrubbyDefaultKernel(CommandParser):
                     if not default_kernel_str:
                         default_kernel_str = line.strip()
                     else:
-                        raise ParseException('Invalid output: duplicate kernel lines: {0}', content)
+                        raise ParseException(
+                            'Invalid output: duplicate kernel lines: {0}'.format(line)
+                        )
 
         if not default_kernel_str:
-            raise ParseException('Invalid output: no kernel line: {0}', content)
+            raise ParseException('Invalid output: no kernel line: {0}'.format(content))
         if len(default_kernel_str.split()) > 1:
-            raise ParseException('Invalid output: unparsable kernel line: {0}', content)
+            raise ParseException(
+                'Invalid output: unparsable kernel line: {0}'.format(default_kernel_str)
+            )
 
         self.default_kernel = default_kernel_str
 
@@ -189,7 +202,7 @@ class GrubbyInfoAll(CommandParser):
                         self.boot_entries[entry_data["index"]] = entry_data
                     entry_data = {k: int(v)}
                 else:
-                    raise ParseException('Invalid index value: {0}', _line)
+                    raise ParseException('Invalid index value: {0}'.format(_line))
             elif k == "args":
                 entry_data[k] = _parse_args(v)
             else:

--- a/insights/tests/parsers/test_grubby.py
+++ b/insights/tests/parsers/test_grubby.py
@@ -10,6 +10,14 @@ DEFAULT_INDEX_1 = '0'
 DEFAULT_INDEX_2 = '1'
 ABDEFAULT_INDEX_EMPTY = ''
 DEFAULT_INDEX_AB = '-2'
+DEFAULT_INDEX_W_ERR_MSG = """
+/usr/libexec/grubby/grubby-bls: line 37: /etc/machine-id: No such file or directory
+0
+""".strip()
+DEFAULT_INDEX_AB_W_ERR_MSG = """
+/usr/libexec/grubby/grubby-bls: line 37: /etc/machine-id: No such file or directory
+some-other-not-index-line
+""".strip()
 
 DEFAULT_KERNEL = "/boot/vmlinuz-2.6.32-573.el6.x86_64"
 DEFAULT_KERNEL_EMPTY = ""
@@ -43,6 +51,10 @@ DEFAULT_KERNEL_WITH_ERRORS_MSGS_4 = """
 /etc/os-release: line 5: VERSION_ID-Peter=8.7: command not found
 /etc/os-release: line 6: PLATFORM_ID-Peter=platform:el8: command not found
 /boot/vmlinuz-4.18.0-425.10.1.el8_7.x86_64
+""".strip()
+DEFAULT_KERNEL_WITH_ERRORS_MSGS_5 = """
+/usr/libexec/grubby/grubby-bls: line 37: /etc/machine-id: No such file or directory
+/boot/vmlinuz-4.18.0-553.56.1.el8_10.x86_64
 """.strip()
 
 GRUBBY_INFO_ALL_1 = """
@@ -114,6 +126,9 @@ def test_grubby_default_index():
     res = GrubbyDefaultIndex(context_wrap(DEFAULT_INDEX_2))
     assert res.default_index == 1
 
+    res = GrubbyDefaultIndex(context_wrap(DEFAULT_INDEX_W_ERR_MSG))
+    assert res.default_index == 0
+
 
 def test_grubby_default_index_ab():
     with pytest.raises(SkipComponent) as excinfo:
@@ -122,6 +137,10 @@ def test_grubby_default_index_ab():
 
     with pytest.raises(ParseException) as excinfo:
         GrubbyDefaultIndex(context_wrap(DEFAULT_INDEX_AB))
+    assert 'Invalid output:' in str(excinfo.value)
+
+    with pytest.raises(ParseException) as excinfo:
+        GrubbyDefaultIndex(context_wrap(DEFAULT_INDEX_AB_W_ERR_MSG))
     assert 'Invalid output:' in str(excinfo.value)
 
 
@@ -134,6 +153,7 @@ def test_grubby_default_kernel():
         DEFAULT_KERNEL_WITH_ERRORS_MSGS_2,
         DEFAULT_KERNEL_WITH_ERRORS_MSGS_3,
         DEFAULT_KERNEL_WITH_ERRORS_MSGS_4,
+        DEFAULT_KERNEL_WITH_ERRORS_MSGS_5,
     ]
     for content in content_with_error_msgs:
         this_res = GrubbyDefaultKernel(context_wrap(content))


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Issue: Found the unexpected error lines case in grubby command output among rat analysis.

Resolution: Enhance parser `GrubbyDefaultIndex` to handle it better. 

This can facilitate the grubby combiner.

Jira: RHINENG-15775 

## Summary by Sourcery

Enhance grubby parsers to capture and expose error lines preceding the actual output value and streamline exception message formatting.

Enhancements:
- Extend GrubbyDefaultIndex parser to collect preceding lines as error_lines and use the final line as the default index
- Strip whitespace before validating numeric output in GrubbyDefaultIndex parser
- Simplify and unify exception messages in GrubbyDefaultIndex, GrubbyDefaultKernel, and argument parsing routines

Tests:
- Add tests for GrubbyDefaultIndex to verify correct default_index extraction when error lines are present
- Add a test case for GrubbyDefaultKernel to handle error messages before the kernel line