### PR TITLE
fix: revert the cmd&args key for CommandOutputProvider in meta_data

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -1599,6 +1599,8 @@ def serialize_command_output(obj, root):
     rc = obj.write(dst)
     return {
         "rc": rc,
+        "cmd": None,  # placeholder
+        "args": obj.args,
         "save_as": bool(obj.save_as),
         "relative_path": rel,
     }
@@ -1611,6 +1613,8 @@ def deserialize_command_output(_type, data, root, ctx, ds):
     res = SerializedOutputProvider(rel, root=root, ctx=ctx, ds=ds)
 
     res.rc = data["rc"]
+    res.cmd = data["cmd"]
+    res.args = data["args"]
     return res
 
 
@@ -1721,6 +1725,8 @@ def serialize_container_command(obj, root):
     rc = obj.write(dst)
     return {
         "rc": rc,
+        "cmd": None,  # placeholder
+        "args": obj.args,
         "save_as": bool(obj.save_as),
         "relative_path": rel,
         "image": obj.image,
@@ -1734,6 +1740,8 @@ def deserialize_container_command(_type, data, root, ctx, ds):
     rel = data["relative_path"]
     res = SerializedOutputProvider(rel, root=root, ctx=ctx, ds=ds)
     res.rc = data["rc"]
+    res.cmd = data["cmd"]
+    res.args = data["args"]
     res.image = data["image"]
     res.engine = data["engine"]
     res.container_id = data["container_id"]


### PR DESCRIPTION
The "cmd" and "args" keys (not values) are required for some CommandOutputProvier particully for new register systems.

Jira: RHINENG-20531

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
