### PR TITLE
feat: prepare for metadata cmd and args removal

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -1613,8 +1613,8 @@ def deserialize_command_output(_type, data, root, ctx, ds):
     res = SerializedOutputProvider(rel, root=root, ctx=ctx, ds=ds)
 
     res.rc = data["rc"]
-    res.cmd = data["cmd"]
-    res.args = data["args"]
+    res.cmd = data.get("cmd")
+    res.args = data.get("args")
     return res
 
 
@@ -1740,8 +1740,8 @@ def deserialize_container_command(_type, data, root, ctx, ds):
     rel = data["relative_path"]
     res = SerializedOutputProvider(rel, root=root, ctx=ctx, ds=ds)
     res.rc = data["rc"]
-    res.cmd = data["cmd"]
-    res.args = data["args"]
+    res.cmd = data.get("cmd")
+    res.args = data.get("args")
     res.image = data["image"]
     res.engine = data["engine"]
     res.container_id = data["container_id"]


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

  When removing the metadata cmd and args from both serialize and
  deserialize functions of CommandOutputProvider, this would intro a gap
  between the data collection (newest core egg) and data processing
  (running core egg) during the testing.
  To not broken the testing, intro a middle state for the removal: let
  the data processing(running core egg) accept a metadata.results.object
  without cmd and args. Then the further removal of cmd and args data
  collection won't cause error in the data processing part in testing.

serves for the redo of https://github.com/RedHatInsights/insights-core/pull/4539 in the future
