### PR TITLE
fix(client): Suppress link message after upload

### DIFF
--- a/insights/client/phase/v2.py
+++ b/insights/client/phase/v2.py
@@ -333,6 +333,5 @@ def collect_and_output(client, config):
         if resp:
             if config.to_json:
                 print(json.dumps(resp))
-            client.show_inventory_deep_link()
 
     client.delete_cached_branch_info()


### PR DESCRIPTION
* Card ID: CCT-1602
* Card ID: CCT-1469

Drops reference to now-dead method that prints a link to ConsoleDot.

This is a follow-up fix to 36af4ca5.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

## Summary by Sourcery

Bug Fixes:
- Suppress link message after upload by dropping the now-dead show_inventory_deep_link invocation