### PR TITLE
fix(parser/sshd_config): keep inline comments when parsing config lines

### DIFF
--- a/insights/parsers/ssh.py
+++ b/insights/parsers/ssh.py
@@ -79,7 +79,9 @@ class SshDConfig(Parser):
 
     def parse_content(self, content):
         self.lines = []
-        for line in get_active_lines(content):
+        for line in content:
+            if not line.strip() or line.strip().startswith("#"):
+                continue
             line_splits = [s.strip() for s in re.split(r"[\s=]+", line, 1)]
             kw, val = line_splits[0], line_splits[1].strip('"') if \
                 len(line_splits) == 2 else ''

--- a/insights/parsers/ssh.py
+++ b/insights/parsers/ssh.py
@@ -11,6 +11,7 @@ SshDConfigD - file ``/etc/ssh/sshd_config.d/*.conf``
 SshdTestMode - command ``sshd -T``
 ----------------------------------
 """
+
 from collections import namedtuple
 from .. import Parser, parser, get_active_lines
 from insights.specs import Specs
@@ -79,22 +80,19 @@ class SshDConfig(Parser):
 
     def parse_content(self, content):
         self.lines = []
-        content_iter = iter(content)
-        for line in get_active_lines(content):
-            raw_line = next(
-                (r for r in content_iter if r.lstrip().startswith(line.split()[0])),
-                line
-            )
-            line_splits = [s.strip() for s in re.split(r"[\s=]+", line, 1)]
-            kw = line_splits[0]
-            val = line_splits[1].strip('"') if len(line_splits) == 2 else ''
-            self.lines.append(self.KeyValue(
-                kw,
-                val,
-                kw.lower(),
-                raw_line.rstrip()
-            ))
-        self.keywords = {k.kw_lower for k in self.lines}
+
+        for line in content:
+            raw_line = line.strip()
+            if raw_line and not raw_line.startswith('#'):
+                line_no_comment = raw_line.split('#', 1)[0].strip()
+                if not line_no_comment:
+                    continue
+                line_splits = [s.strip() for s in re.split(r"[\s=]+", line_no_comment, 1)]
+                kw = line_splits[0]
+                val = line_splits[1].strip('"') if len(line_splits) == 2 else ''
+                self.lines.append(self.KeyValue(kw, val, kw.lower(), raw_line))
+
+        self.keywords = {kv.kw_lower for kv in self.lines}
 
     def __contains__(self, keyword):
         """
@@ -182,9 +180,7 @@ class SshDConfig(Parser):
         if lines:
             return lines[-1].line
         else:
-            return "{keyword} {value}  # Implicit default".format(
-                keyword=keyword, value=default
-            )
+            return "{keyword} {value}  # Implicit default".format(keyword=keyword, value=default)
 
     def line_uses_plus(self, keyword):
         """
@@ -271,6 +267,7 @@ class SshdTestMode(Parser, dict):
         >>> sshd_test_mode.get("ciphers")
         ['aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr,aes128-gcm@openssh.com,aes128-ctr']
     """
+
     def parse_content(self, content):
         result = {}
         for line in get_active_lines(content):
@@ -306,4 +303,5 @@ class SshDConfigD(SshDConfig):
         keywords (set): Set of keywords present in the configuration
             file, each keyword has been converted to lowercase.
     """
+
     pass

--- a/insights/tests/parsers/test_ssh.py
+++ b/insights/tests/parsers/test_ssh.py
@@ -37,25 +37,25 @@ def test_sshd_config_inline_comments_preserved():
     assert config is not None
 
     # Full line comment should not appear as a key
-    assert "# Full line comment" not in config
+    assert "# Full line comment" not in [kv.line for kv in config.lines]
 
     # Keys should exist
     assert "Port" in config
     assert "HostKey" in config
     assert "PermitRootLogin" in config
 
-    # Inline comments should be preserved in values
-    port_value = config.get("Port")[0].value
-    assert port_value == "22   # ssh port"
-    assert "# ssh port" in port_value
+    # Inline comments should be preserved in the 'line' field
+    port_line = config.get("Port")[0].line
+    assert port_line == "Port 22   # ssh port"
+    assert "# ssh port" in port_line
 
-    hostkey_value = config.get("HostKey")[0].value
-    assert hostkey_value == "/etc/ssh/ssh_host_rsa_key   # main host key"
-    assert "# main host key" in hostkey_value
+    hostkey_line = config.get("HostKey")[0].line
+    assert hostkey_line == "HostKey /etc/ssh/ssh_host_rsa_key   # main host key"
+    assert "# main host key" in hostkey_line
 
-    permit_value = config.get("PermitRootLogin")[0].value
-    assert permit_value == "no    # disable root login"
-    assert "# disable root login" in permit_value
+    permit_line = config.get("PermitRootLogin")[0].line
+    assert permit_line == "PermitRootLogin no    # disable root login"
+    assert "# disable root login" in permit_line
 
 
 def test_sshd_config():

--- a/insights/tests/parsers/test_ssh.py
+++ b/insights/tests/parsers/test_ssh.py
@@ -23,6 +23,40 @@ AllowUsers
 Protocol 1
 """.strip()
 
+SSHD_CONFIG_INLINE_COMMENTS = """
+# Full line comment
+Port 22   # ssh port
+
+HostKey /etc/ssh/ssh_host_rsa_key   # main host key
+PermitRootLogin no    # disable root login
+""".strip()
+
+
+def test_sshd_config_inline_comments_preserved():
+    config = SshDConfig(context_wrap(SSHD_CONFIG_INLINE_COMMENTS))
+    assert config is not None
+
+    # Full line comment should not appear as a key
+    assert "# Full line comment" not in config
+
+    # Keys should exist
+    assert "Port" in config
+    assert "HostKey" in config
+    assert "PermitRootLogin" in config
+
+    # Inline comments should be preserved in values
+    port_value = config.get("Port")[0].value
+    assert port_value == "22   # ssh port"
+    assert "# ssh port" in port_value
+
+    hostkey_value = config.get("HostKey")[0].value
+    assert hostkey_value == "/etc/ssh/ssh_host_rsa_key   # main host key"
+    assert "# main host key" in hostkey_value
+
+    permit_value = config.get("PermitRootLogin")[0].value
+    assert permit_value == "no    # disable root login"
+    assert "# disable root login" in permit_value
+
 
 def test_sshd_config():
     sshd_config = SshDConfig(context_wrap(SSHD_CONFIG_INPUT))


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [✅ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [✅ ] No Sensitive Data in this change?
* [ ✅] Is this PR to correct an issue?
* [✅ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

#### Problem :
Some rules require verifying whether a directive in `sshd_config` has an inline comment or not.

For example:

✅ Should trigger rule
`PermitRootLogin yes`

❌ Should not trigger rule (inline comment present)
`PermitRootLogin yes   # rootlogin is required`

However, the parser previously relied on `get_active_lines(content)`, which strips inline comments. As a result, both examples were parsed identically as:

`PermitRootLogin yes`

This made it impossible for rules to correctly detect inline comments.

#### Solution :
- Update the parser to iterate directly over content instead of using `get_active_lines()`.
- Skip only blank lines and full-line comments (lines starting with #).


### updated parser pytest output after changes : 

```
 py.test -sv /home/aytiwari/tier-3-rules/insights-core/insights/tests/parsers/test_ssh.py 
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.13.3, pytest-8.4.1, pluggy-1.5.0 -- /home/aytiwari/tier-3-rules/gss_venv/bin/python
cachedir: .pytest_cache
rootdir: /home/aytiwari/tier-3-rules/insights-core
configfile: pyproject.toml
plugins: cov-6.1.1
collected 5 items                                                                                                                                                                         

insights/tests/parsers/test_ssh.py::test_sshd_config PASSED
insights/tests/parsers/test_ssh.py::test_sshd_config_complete PASSED
insights/tests/parsers/test_ssh.py::test_sshd_test_mode PASSED
insights/tests/parsers/test_ssh.py::test_sshd_configuration_d PASSED
insights/tests/parsers/test_ssh.py::test_sshd_test_mode_docs PASSED

==================================================================================== warnings summary =====================================================================================
insights/tests/parsers/test_ssh.py: 41 warnings
  /home/aytiwari/tier-3-rules/insights-core/insights/parsers/ssh.py:85: DeprecationWarning: 'maxsplit' is passed as positional argument
    line_splits = [s.strip() for s in re.split(r"[\s=]+", line, 1)]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 5 passed, 41 warnings in 0.22s ==============================================================================
```

## Summary by Sourcery

Fix the SSHD config parser to preserve inline comments by iterating over raw content lines and only skipping blank lines and full-line comments.

Bug Fixes:
- Restore inline comments in parsed SSHD config lines so policies can detect their presence correctly

Enhancements:
- Switch parsing logic to iterate over original content lines instead of using get_active_lines()
- Skip only blank lines and full-line comments when parsing SSHD config directives