### PR TITLE
fix: exclude irrelevant logrotate configuration files

### DIFF
--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -151,6 +151,15 @@ insights.specs.datasources.leapp
     :undoc-members:
 
 
+insights.specs.datasources.logrotate
+------------------------------------
+
+.. automodule:: insights.specs.datasources.logrotate
+    :members: logrotate_conf_list
+    :show-inheritance:
+    :undoc-members:
+
+
 insights.specs.datasources.ls
 -----------------------------
 

--- a/insights/specs/datasources/logrotate.py
+++ b/insights/specs/datasources/logrotate.py
@@ -1,0 +1,30 @@
+"""
+Custom datasources for logrotate
+"""
+
+import os
+
+from insights.core.context import HostContext
+from insights.core.plugins import datasource
+
+
+@datasource(HostContext)
+def logrotate_conf_list(broker):
+    """
+    This datasource returns the list of logrotate configuration files.
+    - "/etc/logrotate.conf" is the one must be collected.
+    - Files without extension under "/etc/logrotate.d/" will be collected.
+    - Files with extension, only the ".conf" files will be collected.
+
+    Returns:
+        list: The list of logrotate configuration files.
+              ["/etc/logrotate.conf"] by default
+    """
+    conf_files = ["/etc/logrotate.conf"]
+    root = "/etc/logrotate.d/"
+    if os.path.isdir(root):
+        for file_name in os.listdir(root):
+            file_path = os.path.join(root, file_name)
+            if ('.' not in file_name or file_name.endswith('.conf')) and os.path.isfile(file_path):
+                conf_files.append(file_path)
+    return conf_files

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -59,6 +59,7 @@ from insights.specs.datasources import (
     ipcs,
     kernel,
     leapp,
+    logrotate,
     lpstat,
     ls,
     lsattr,
@@ -463,7 +464,7 @@ class DefaultSpecs(Specs):
     localectl_status = simple_command("/usr/bin/localectl status")
     localtime = simple_command("/usr/bin/file -L /etc/localtime")
     login_pam_conf = simple_file("/etc/pam.d/login")
-    logrotate_conf = glob_file(["/etc/logrotate.conf", "/etc/logrotate.d/*"])
+    logrotate_conf = foreach_collect(logrotate.logrotate_conf_list, "%s")
     losetup = simple_command("/usr/sbin/losetup -l")
     lpfc_max_luns = simple_file("/sys/module/lpfc/parameters/lpfc_max_luns")
     lpstat_p = simple_command("/usr/bin/lpstat -p")

--- a/insights/tests/datasources/test_logrotate.py
+++ b/insights/tests/datasources/test_logrotate.py
@@ -1,0 +1,31 @@
+try:
+    from unittest.mock import patch
+except Exception:
+    from mock import patch
+
+
+from insights.specs.datasources.logrotate import logrotate_conf_list
+
+
+@patch("os.listdir", return_value=[])
+def test_logrotate_conf_list_empty(listdir):
+    ret = logrotate_conf_list({})
+    assert ret == ["/etc/logrotate.conf"]
+
+
+@patch("os.path.isdir", return_value=False)
+def test_logrotate_conf_list_no_such_d(isdir):
+    ret = logrotate_conf_list({})
+    assert ret == ["/etc/logrotate.conf"]
+
+
+@patch("os.listdir", return_value=['a.conf', 'b', 'c.cc', 'd.o.conf', 'e.o.c', '.f.conf', '.g'])
+@patch("os.path.isfile", return_value=True)
+def test_logrotate_conf_list(isfile, listdir):
+    ret = logrotate_conf_list({})
+    assert len(ret) == 5
+    assert "/etc/logrotate.conf" in ret
+    assert "/etc/logrotate.d/a.conf" in ret
+    assert "/etc/logrotate.d/b" in ret
+    assert '/etc/logrotate.d/d.o.conf' in ret
+    assert '/etc/logrotate.d/.f.conf' in ret


### PR DESCRIPTION
Exclude these non-configuration files from the collection of logrotate_conf Spec.
- In the '/etc/logrotate.d' directory, some irrelevant files, e.g. '.log' files sometimes are placed by mistake.  Those large log files are harmful to the insights-engine server.
- Jira: RHINENG-20597

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [x] Is backport to the `3.0_egg` branch required? Refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Improve the logrotate_conf spec by using a custom datasource to collect only relevant .conf files (or files without extensions) from /etc/logrotate.d, preventing accidental inclusion of large log files.

New Features:
- Add a custom datasource that lists valid logrotate configuration files under /etc/logrotate.d

Enhancements:
- Replace the glob-based logrotate_conf spec with the new datasource to filter out non-.conf files and files without extensions

Tests:
- Add unit tests for the logrotate_conf_list datasource covering empty and mixed directory contents