### PR TITLE
fix(parser/rpm_v_packages): skip the lines that are not error messages

### DIFF
--- a/insights/parsers/rpm_v_packages.py
+++ b/insights/parsers/rpm_v_packages.py
@@ -54,10 +54,15 @@ class RpmVPackage(CommandParser):
         self.error_lines = []
         self.discrepancies = []
         self.package_name = self.file_name.split('_')[-1] if self.file_name else None
+        is_error_info = False
 
         for line in content:
             if line.startswith("error: "):
                 self.error_lines.append(line)
+                is_error_info = True
+                continue
+
+            if is_error_info:
                 continue
 
             line_parts = line.split()

--- a/insights/tests/parsers/test_rpm_v_packages.py
+++ b/insights/tests/parsers/test_rpm_v_packages.py
@@ -25,6 +25,13 @@ error: db5 error(-30973) from dbenv->failchk: BDB0087 DB_RUNRECOVERY: Fatal erro
 error: cannot open Packages index using db5 - (-30973)
 """
 
+TEST_RPM_V_PACKAGE_4 = """
+error: rpmdb: BDB0113 Thread/process 259/139 failed: BDB1507 Thread died in Berkeley DB library
+error: db5 error(-30973) from dbenv->failchk: BDB0087 DB_RUNRECOVERY: Fatal error, run database recovery
+error: cannot open Packages index using db5 - (-30973)
+package sudo is not installed
+"""
+
 CONTEXT_PATH_1 = "insights_commands/rpm_-V_sudo"
 
 
@@ -73,6 +80,13 @@ def test_rpm_pkg_erros():
     assert rpm_pkg.package_name == 'sudo'
     assert rpm_pkg.error_lines is not None
     assert len(rpm_pkg.error_lines) == 3
+
+
+def test_rpm_pkg_erros_other_lines():
+    rpm_pkg = RpmVPackage(context_wrap(TEST_RPM_V_PACKAGE_4, CONTEXT_PATH_1))
+    assert rpm_pkg.package_name == 'sudo'
+    assert len(rpm_pkg.error_lines) == 3
+    assert "package sudo is not installed" not in rpm_pkg.error_lines
 
 
 def test_rpm_pkg_not_installed():


### PR DESCRIPTION
Jira: RHINENG-20600

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x ] Is this PR an enhancement?
* [x] Is backport to the `3.0_egg` branch required? Refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

Backport to 3.0 egg. 
https://github.com/RedHatInsights/insights-core/pull/4550

## Summary by Sourcery

Ensure rpm_v_packages parser only captures genuine error messages by skipping non-error lines following an error and add a test case to verify this behavior.

Enhancements:
- Add flag in parser to skip any lines after an error message block that do not start with "error:"

Tests:
- Introduce TEST_RPM_V_PACKAGE_4 fixture and test_rpm_pkg_erros_other_lines to validate non-error lines are ignored after errors are detected