### PR TITLE
fix: revert the ls specs removed

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -481,6 +481,19 @@ class DefaultSpecs(Specs):
     ls_lan_filtered = command_with_args(
         '/bin/ls -lan %s', ls.list_with_lan_filtered, save_as='ls_lan_filtered', keep_rc=True
     )  # Result is filtered
+    ls_lanL = command_with_args(
+        '/bin/ls -lanL %s', ls.list_with_lanL, save_as='ls_lanL', keep_rc=True
+    )
+    ls_lanR = command_with_args(
+        '/bin/ls -lanR %s', ls.list_with_lanR, save_as='ls_lanR', keep_rc=True
+    )
+    ls_lanRL = command_with_args(
+        '/bin/ls -lanRL %s', ls.list_with_lanRL, save_as='ls_lanRL', keep_rc=True
+    )
+    ls_laRZ = command_with_args(
+        '/bin/ls -laRZ %s', ls.list_with_laRZ, save_as='ls_laRZ', keep_rc=True
+    )
+    ls_laZ = command_with_args('/bin/ls -laZ %s', ls.list_with_laZ, save_as='ls_laZ', keep_rc=True)
     lsattr = command_with_args("/bin/lsattr %s", lsattr.paths_to_lsattr)
     lsblk = simple_command("/bin/lsblk")
     lsblk_pairs = simple_command(


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [x] Is backport to the `3.0_egg` branch required? Refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
These ls Specs were removed by mistake when resolving rebase conflicts in #4511, 
