### PR TITLE
fix: exclude irrelevant logrotate configuration files

### DIFF
--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -151,6 +151,15 @@ insights.specs.datasources.leapp
     :undoc-members:
 
 
+insights.specs.datasources.logrotate
+------------------------------------
+
+.. automodule:: insights.specs.datasources.logrotate
+    :members: logrotate_conf_list
+    :show-inheritance:
+    :undoc-members:
+
+
 insights.specs.datasources.ls
 -----------------------------
 

--- a/insights/specs/datasources/logrotate.py
+++ b/insights/specs/datasources/logrotate.py
@@ -1,0 +1,30 @@
+"""
+Custom datasources for logrotate
+"""
+
+import os
+
+from insights.core.context import HostContext
+from insights.core.plugins import datasource
+
+
+@datasource(HostContext)
+def logrotate_conf_list(broker):
+    """
+    This datasource returns the list of logrotate configuration files.
+    - "/etc/logrotate.conf" is the one must be collected.
+    - Files without extension under "/etc/logrotate.d/" will be collected.
+    - Files with extension, only the ".conf" files will be collected.
+
+    Returns:
+        list: The list of logrotate configuration files.
+              ["/etc/logrotate.conf"] by default
+    """
+    conf_files = ["/etc/logrotate.conf"]
+    root = "/etc/logrotate.d/"
+    if os.path.isdir(root):
+        for file_name in os.listdir(root):
+            file_path = os.path.join(root, file_name)
+            if ('.' not in file_name or file_name.endswith('.conf')) and os.path.isfile(file_path):
+                conf_files.append(file_path)
+    return conf_files

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -59,6 +59,7 @@ from insights.specs.datasources import (
     ipcs,
     kernel,
     leapp,
+    logrotate,
     lpstat,
     ls,
     lsattr,
@@ -463,7 +464,7 @@ class DefaultSpecs(Specs):
     localectl_status = simple_command("/usr/bin/localectl status")
     localtime = simple_command("/usr/bin/file -L /etc/localtime")
     login_pam_conf = simple_file("/etc/pam.d/login")
-    logrotate_conf = glob_file(["/etc/logrotate.conf", "/etc/logrotate.d/*"])
+    logrotate_conf = foreach_collect(logrotate.logrotate_conf_list, "%s")
     losetup = simple_command("/usr/sbin/losetup -l")
     lpfc_max_luns = simple_file("/sys/module/lpfc/parameters/lpfc_max_luns")
     lpstat_p = simple_command("/usr/bin/lpstat -p")

--- a/insights/tests/datasources/test_logrotate.py
+++ b/insights/tests/datasources/test_logrotate.py
@@ -1,0 +1,31 @@
+try:
+    from unittest.mock import patch
+except Exception:
+    from mock import patch
+
+
+from insights.specs.datasources.logrotate import logrotate_conf_list
+
+
+@patch("os.listdir", return_value=[])
+def test_logrotate_conf_list_empty(listdir):
+    ret = logrotate_conf_list({})
+    assert ret == ["/etc/logrotate.conf"]
+
+
+@patch("os.path.isdir", return_value=False)
+def test_logrotate_conf_list_no_such_d(isdir):
+    ret = logrotate_conf_list({})
+    assert ret == ["/etc/logrotate.conf"]
+
+
+@patch("os.listdir", return_value=['a.conf', 'b', 'c.cc', 'd.o.conf', 'e.o.c', '.f.conf', '.g'])
+@patch("os.path.isfile", return_value=True)
+def test_logrotate_conf_list(isfile, listdir):
+    ret = logrotate_conf_list({})
+    assert len(ret) == 5
+    assert "/etc/logrotate.conf" in ret
+    assert "/etc/logrotate.d/a.conf" in ret
+    assert "/etc/logrotate.d/b" in ret
+    assert '/etc/logrotate.d/d.o.conf' in ret
+    assert '/etc/logrotate.d/.f.conf' in ret


### PR DESCRIPTION
Exclude these non-configuration files from the collection of logrotate_conf Spec.
- In the '/etc/logrotate.d' directory, some irrelevant files, e.g. '.log' files sometimes are placed by mistake.  Those large log files are harmful to the insights-engine server.
- Jira: RHINENG-20597


(cherry picked from commit f6794e421afa2cc97cb0f4607756cbe283184ed3)

This is a backport of #4551 
