### PR TITLE
fix(test): regression issue of yaml.SafeLoader in rule testing

### DIFF
--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -22,15 +22,15 @@ except ImportError:
 import insights
 
 from insights import apply_filters
-from insights.core import dr, filters, spec_factory
+from insights.core import dr, filters, spec_factory, _PatchedSafeLoader  # noqa: F401
 from insights.core.context import Context
 from insights.core.plugins import make_none
 from insights.specs import Specs
 
 
-# Use yaml.SafeLoader only when pytesting, as the yaml.CSafeLoader does not
-# work well with coverage test.
-insights.core.SafeLoader = SafeLoader
+# Use yaml.SafeLoader when testing plugins, as the yaml.CSafeLoader
+# does not work well with coverage test.
+insights.core._PatchedSafeLoader = SafeLoader
 # we intercept the add_filter call during integration testing so we can ensure
 # that rules add filters to datasources that *should* be filterable
 ADDED_FILTERS = defaultdict(set)

--- a/insights/tests/test_yaml_parser.py
+++ b/insights/tests/test_yaml_parser.py
@@ -1,9 +1,10 @@
 import datetime
 import pytest
 
+import insights
 from insights.core import YAMLParser
 from insights.core.exceptions import ParseException, SkipComponent
-from insights.tests import context_wrap
+from insights.tests import context_wrap, _PatchedSafeLoader
 
 
 bi_conf_content = """
@@ -101,6 +102,9 @@ def test_empty_content():
 
 
 def test_yaml_parser_with_equal_value():
+    # Ensure original _PatchedSafeLoader is used for this test
+    insights.core._PatchedSafeLoader = _PatchedSafeLoader
+
     ctx = context_wrap("key: =")
     assert FakeYamlParser(ctx).data == {"key": "="}
 


### PR DESCRIPTION
- This is an regression issue of (RHINENG-17357) which was
  fixed in https://github.com/RedHatInsights/insights-core/pull/4466, but introduced again in https://github.com/RedHatInsights/insights-core/pull/4508 as a new
  _PatchedSafeLoader is introduced
- Corresponding test cases should be developed and added
  in the compatibility test suite to avoid such regression again.
- Jira: RHINENG-20647

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [x] Is backport to the `3.0_egg` branch required? Refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Bug Fixes:
- Reintroduce insights.core._PatchedSafeLoader assignment to SafeLoader to prevent test failures due to missing loader compatibility