### PR TITLE
feat: Add spec and parser for compliance_policies_enabled

### DIFF
--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -51,6 +51,14 @@ insights.specs.datasources.cloud_init
     :show-inheritance:
     :undoc-members:
 
+insights.specs.datasources.compliance.compliance_ds
+---------------------------------------------------
+
+.. automodule:: insights.specs.datasources.compliance.compliance_ds
+    :members: compliance_enabled, compliance_policies_enabled, compliance_assign_enabled, compliance_unassign_enabled, os_version, package_check, compliance, compliance_policies, compliance_assign, compliance_unassign, compliance_advisor_rule_enabled
+    :show-inheritance:
+    :undoc-members:
+
 insights.specs.datasources.container
 ------------------------------------
 

--- a/docs/shared_parsers_catalog/compliance_enabled_policies.rst
+++ b/docs/shared_parsers_catalog/compliance_enabled_policies.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.compliance_enabled_policies
+   :members:
+   :show-inheritance:

--- a/insights/parsers/compliance_enabled_policies.py
+++ b/insights/parsers/compliance_enabled_policies.py
@@ -1,0 +1,67 @@
+"""
+ComplianceEnabledPolicies - datasource ``compliance_advisor_rule_enabled``
+==========================================================================
+This parser is used to parse the output of datasouce compliance_ds.compliance_advisor_rule_enabled
+"""
+
+from insights.core import JSONParser
+from insights.core.plugins import parser
+from insights.specs import Specs
+
+
+@parser(Specs.compliance_enabled_policies)
+class ComplianceEnabledPolicies(JSONParser):
+    """
+    Parses the output of datasouce compliance_ds.compliance_advisor_rule_enabled
+
+    Typical output of the datasouce::
+
+        {
+            "enabled_policies":[
+                {
+                    "id":"12345678-aaaa-bbbb-cccc-1234567890ab",
+                    "title":"advisor rule test - CIS Red Hat Enterprise Linux 8 Benchmark for Level 1 - Server",
+                    "ref_id":"xccdf_org.ssgproject.content_profile_cis_server_l1",
+                    "description":"This profile defines a baseline that aligns to the Level 1 - Server"
+                },
+                {
+                    "id":"12345678-aaaa-bbbb-cccc-1234567890xy",
+                    "title":"CIS Red Hat Enterprise Linux 8 Benchmark for Level 2 - Server",
+                    "ref_id":"xccdf_org.ssgproject.content_profile_cis_server_l2",
+                    "description":"This profile defines a baseline that aligns to the Level 2 - Server"
+                }
+            ],
+            "tailoring_policies":[
+                {
+                    "ref_id":"xccdf_org.ssgproject.content_profile_cis_server_l1",
+                    "check_items":[
+                        {
+                            "idref":"xccdf_org.ssgproject.content_rule_bios_disable_usb_boot",
+                            "selected":"true"
+                        },
+                        {
+                            "idref":"xccdf_org.ssgproject.content_rule_ssh_keys_passphrase_protected",
+                            "selected":"true"
+                        },
+                        {
+                            "idref":"xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_shared_media",
+                            "selected":"true"
+                        },
+                        {
+                            "idref":"xccdf_org.ssgproject.content_rule_accounts_password_pam_ocredit",
+                            "selected":"false"
+                        }
+                    ]
+                }
+            ]
+        }
+
+    Examples:
+        >>> type(compliance_enabled_policies)
+        <class 'insights.parsers.compliance_enabled_policies.ComplianceEnabledPolicies'>
+        >>> compliance_enabled_policies['enabled_policies'][0]['ref_id'] == 'xccdf_org.ssgproject.content_profile_cis_server_l1'
+        True
+        >>> compliance_enabled_policies['tailoring_policies'][0]['ref_id'] == 'xccdf_org.ssgproject.content_profile_cis_server_l1'
+        True
+    """
+    pass

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -109,6 +109,7 @@ class Specs(SpecSet):
     cni_podman_bridge_conf = RegistryPoint()
     cobbler_modules_conf = RegistryPoint()
     cobbler_settings = RegistryPoint()
+    compliance_enabled_policies = RegistryPoint()
     containers_policy = RegistryPoint()
     controller_manager_log = RegistryPoint(multi_output=True)
     convert2rhel_facts = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -215,6 +215,7 @@ class DefaultSpecs(Specs):
     cluster_conf = simple_file("/etc/cluster/cluster.conf")
     cmdline = simple_file("/proc/cmdline")
     cni_podman_bridge_conf = simple_file("/etc/cni/net.d/87-podman-bridge.conflist")
+    compliance_enabled_policies = compliance_ds.compliance_advisor_rule_enabled
     convert2rhel_facts = simple_file("/etc/rhsm/facts/convert2rhel.facts")
     corosync = simple_file("/etc/sysconfig/corosync")
     corosync_cmapctl = foreach_execute(corosync_ds.corosync_cmapctl_cmds, "%s")

--- a/insights/tests/parsers/test_compliance_enabled_policies.py
+++ b/insights/tests/parsers/test_compliance_enabled_policies.py
@@ -1,0 +1,109 @@
+import doctest
+import pytest
+
+from insights.core.exceptions import SkipComponent
+from insights.parsers import compliance_enabled_policies
+from insights.parsers.compliance_enabled_policies import ComplianceEnabledPolicies
+from insights.tests import context_wrap
+
+COMPLIANCE_ENABLE_POLICIES = '''
+{
+    "enabled_policies": [
+        {
+            "id": "12345678-aaaa-bbbb-cccc-1234567890ab",
+            "title": "advisor rule test - CIS Red Hat Enterprise Linux 8 Benchmark for Level 1 - Server",
+            "description": "This profile defines a baseline that aligns to the Level 1 - Server",
+            "business_objective": null,
+            "compliance_threshold": 100.0,
+            "total_system_count": 1,
+            "type": "policy",
+            "os_major_version": 8,
+            "profile_title": "CIS Red Hat Enterprise Linux 8 Benchmark for Level 1 - Server",
+            "ref_id": "xccdf_org.ssgproject.content_profile_cis_server_l1"
+        },
+        {
+            "id": "12345678-aaaa-bbbb-cccc-1234567890xy",
+            "title": "CIS Red Hat Enterprise Linux 8 Benchmark for Level 2 - Server",
+            "description": "This profile defines a baseline that aligns to the Level 2 - Server",
+            "business_objective": null,
+            "compliance_threshold": 100.0,
+            "total_system_count": 1,
+            "type": "policy",
+            "os_major_version": 8,
+            "profile_title": "CIS Red Hat Enterprise Linux 8 Benchmark for Level 2 - Server",
+            "ref_id": "xccdf_org.ssgproject.content_profile_cis"
+        }
+    ],
+    "tailoring_policies": [
+        {
+            "ref_id": "xccdf_org.ssgproject.content_profile_cis_server_l1",
+            "check_items": [
+                {
+                    "idref": "xccdf_org.ssgproject.content_rule_bios_disable_usb_boot",
+                    "selected": "true"
+                },
+                {
+                    "idref": "xccdf_org.ssgproject.content_rule_ssh_keys_passphrase_protected",
+                    "selected": "true"
+                },
+                {
+                    "idref": "xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_shared_media",
+                    "selected": "true"
+                },
+                {
+                    "idref": "xccdf_org.ssgproject.content_rule_accounts_password_pam_ocredit",
+                    "selected": "false"
+                }
+            ]
+        }
+    ]
+}
+'''.strip()
+
+
+def test_compliance_enabled_policies_skip():
+    with pytest.raises(SkipComponent) as ex:
+        ComplianceEnabledPolicies(context_wrap(""))
+    assert "Empty output." in str(ex)
+
+
+def test_compliance_enabled_policies_malformed_json():
+    malformed_json = "{not: valid, json:}"
+    with pytest.raises(Exception):
+        ComplianceEnabledPolicies(context_wrap(malformed_json))
+
+
+def test_compliance_enabled_policies():
+    compliance_enabled_policies_info = ComplianceEnabledPolicies(context_wrap(COMPLIANCE_ENABLE_POLICIES))
+    assert compliance_enabled_policies_info['enabled_policies'][0]['ref_id'] == 'xccdf_org.ssgproject.content_profile_cis_server_l1'
+    assert compliance_enabled_policies_info['tailoring_policies'][0]['ref_id'] == 'xccdf_org.ssgproject.content_profile_cis_server_l1'
+    assert len(compliance_enabled_policies_info['enabled_policies']) == 2
+    assert len(compliance_enabled_policies_info['tailoring_policies'][0]['check_items']) == 4
+
+
+def test_compliance_enabled_policies_only_enabled():
+    """
+    Test parser with only enabled_policies and no tailoring_policies.
+    """
+    only_enabled_policies = '''
+    {
+        "enabled_policies": [
+            {
+                "id": "12345678-aaaa-bbbb-cccc-1234567890ab",
+                "ref_id": "xccdf_org.ssgproject.content_profile_standard"
+            }
+        ]
+    }
+    '''
+    compliance_enabled_policies_info = ComplianceEnabledPolicies(context_wrap(only_enabled_policies))
+    assert 'enabled_policies' in compliance_enabled_policies_info
+    assert compliance_enabled_policies_info['enabled_policies'][0]['ref_id'] == 'xccdf_org.ssgproject.content_profile_standard'
+    assert 'tailoring_policies' not in compliance_enabled_policies_info or not compliance_enabled_policies_info.get('tailoring_policies')
+
+
+def test_compliance_enabled_policies_doc_examples():
+    env = {
+        "compliance_enabled_policies": ComplianceEnabledPolicies(context_wrap(COMPLIANCE_ENABLE_POLICIES)),
+    }
+    failed, total = doctest.testmod(compliance_enabled_policies, globs=env)
+    assert failed == 0


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [x] Is backport to the `3.0_egg` branch required? Refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.

Add this spec for 3.0_egg, https://github.com/RedHatInsights/insights-core/pull/4536

## Summary by Sourcery

Add support for a new compliance_policies_enabled workflow by implementing a datasource to retrieve enabled policies and tailoring settings, registering it in specs, providing a JSON parser, updating related datasources for optional compliance flags, and expanding tests and documentation accordingly.

New Features:
- Add compliance_advisor_rule_enabled datasource to fetch enabled compliance policies and their tailoring items
- Introduce ComplianceEnabledPolicies JSON parser to parse the output of the new datasource

Enhancements:
- Modify os_version and package_check datasources to skip components when compliance flags are absent instead of always exiting with error
- Register the new compliance_enabled_policies spec and hook it into the default spec set

Documentation:
- Add documentation for the compliance_enabled_policies parser and datasource in shared_parsers_catalog

Tests:
- Update existing compliance datasource tests to cover optional compliance flags behavior
- Add unit tests for the compliance_advisor_rule_enabled datasource and ComplianceEnabledPolicies parser