### PR TITLE
fix: Skip RpmVPackage only when no error and no installed

### DIFF
--- a/insights/tests/parsers/test_rpm_v_packages.py
+++ b/insights/tests/parsers/test_rpm_v_packages.py
@@ -25,6 +25,14 @@ error: db5 error(-30973) from dbenv->failchk: BDB0087 DB_RUNRECOVERY: Fatal erro
 error: cannot open Packages index using db5 - (-30973)
 """
 
+TEST_RPM_V_PACKAGE_4 = """
+error: rpmdb: BDB0113 Thread/process 259/139 failed: BDB1507 Thread died in Berkeley DB library
+error: db5 error(-30973) from dbenv->failchk: BDB0087 DB_RUNRECOVERY: Fatal error, run database recovery
+error: cannot open Packages index using db5 - (-30973)
+
+package sudo is not installed
+"""
+
 CONTEXT_PATH_1 = "insights_commands/rpm_-V_sudo"
 
 
@@ -75,10 +83,18 @@ def test_rpm_pkg_erros():
     assert len(rpm_pkg.error_lines) == 3
 
 
+def test_rpm_pkg_erros_other_lines():
+    rpm_pkg = RpmVPackage(context_wrap(TEST_RPM_V_PACKAGE_4, CONTEXT_PATH_1))
+    assert rpm_pkg.package_name == 'sudo'
+    assert rpm_pkg.discrepancies == []
+    assert len(rpm_pkg.error_lines) == 3
+    assert "package sudo is not installed" not in rpm_pkg.error_lines
+
+
 def test_rpm_pkg_not_installed():
     with pytest.raises(SkipComponent) as exc:
         RpmVPackage(context_wrap(TEST_RPM_V_PACKAGE_2, CONTEXT_PATH_1))
-    assert 'Invalid Contents' in str(exc)
+    assert 'Package is not installed' in str(exc)
 
 
 def test_doc_examples():


### PR DESCRIPTION
Jira: RHINENG-20600

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?
* [x] Is backport to the `3.0_egg` branch required? Refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
Ref: https://github.com/RedHatInsights/insights-core/pull/4550

## Summary by Sourcery

Refine the RpmVPackage parser to conditionally skip only when no errors are reported and the package is uninstalled, improve discrepancy handling, and adjust tests to cover this behavior.

Bug Fixes:
- Only skip RpmVPackage when encountering 'package is not installed' with no prior errors, updating the skip exception message accordingly

Enhancements:
- Prevent appending empty discrepancy entries in the RpmVPackage parser
- Add internal docstring to describe the new skip behavior for uninstalled packages

Tests:
- Add a test for error lines followed by a 'not installed' message and update the existing test to expect the new skip exception message