### PR TITLE
fix(test): regression issue of yaml.SafeLoader in rule testing

### DIFF
--- a/insights/tests/__init__.py
+++ b/insights/tests/__init__.py
@@ -22,15 +22,15 @@ except ImportError:
 import insights
 
 from insights import apply_filters
-from insights.core import dr, filters, spec_factory
+from insights.core import dr, filters, spec_factory, _PatchedSafeLoader  # noqa: F401
 from insights.core.context import Context
 from insights.core.plugins import make_none
 from insights.specs import Specs
 
 
-# Use yaml.SafeLoader only when pytesting, as the yaml.CSafeLoader does not
-# work well with coverage test.
-insights.core.SafeLoader = SafeLoader
+# Use yaml.SafeLoader when testing plugins, as the yaml.CSafeLoader
+# does not work well with coverage test.
+insights.core._PatchedSafeLoader = SafeLoader
 # we intercept the add_filter call during integration testing so we can ensure
 # that rules add filters to datasources that *should* be filterable
 ADDED_FILTERS = defaultdict(set)

--- a/insights/tests/test_yaml_parser.py
+++ b/insights/tests/test_yaml_parser.py
@@ -1,9 +1,10 @@
 import datetime
 import pytest
 
+import insights
 from insights.core import YAMLParser
 from insights.core.exceptions import ParseException, SkipComponent
-from insights.tests import context_wrap
+from insights.tests import context_wrap, _PatchedSafeLoader
 
 
 bi_conf_content = """
@@ -101,6 +102,9 @@ def test_empty_content():
 
 
 def test_yaml_parser_with_equal_value():
+    # Ensure original _PatchedSafeLoader is used for this test
+    insights.core._PatchedSafeLoader = _PatchedSafeLoader
+
     ctx = context_wrap("key: =")
     assert FakeYamlParser(ctx).data == {"key": "="}
 


### PR DESCRIPTION
- Fix the regression of (RHINENG-17357, #4466). The issue was introduced again in #4508.
  Using @patch in archive_provider instead of impacting all tests.
- Corresponding test cases should be developed and added in the compatibility test suite.
- Jira: RHINENG-20647


(cherry picked from commit e3fa9410be9b221f87bb45fcc384413ca0213ef0)

This is a backport of #4557 