### PR TITLE
chore(doc): update the guide steps for PR to 3.0_egg

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,11 +208,13 @@ from [insights-core-3.6.6](https://github.com/RedHatInsights/insights-core/relea
   `3.0_egg` branch after the PR is reviewed and before it's merged.
   Below is suggested backport steps:
 
-        git checkout branch_of_the_existing_PR && git rev-parse --short HEAD # get the commit-id
+        git checkout <branch_of_the_existing_PR>
+        BRANCH_NM=$(git rev-parse --abbrev-ref HEAD)  # branch name
+        COMMIT_ID=$(git rev-parse --short HEAD)       # commit-id
         git fetch upstream 3.0_egg
-        git checkout 3.0_egg && git checkout -b new_branch
-        git cherry-pick commit_id_got_above
-        git push origin new_branch
+        git checkout -b ${BRANCH_NM}_egg upstream/3.0_egg
+        git cherry-pick -x ${COMMIT_ID}               # NOTE "-x" is recommended
+        git push origin ${BRANCH_NM}_egg
 
 
 ## Review Checklist


### PR DESCRIPTION
(cherry picked from commit 011a2c482e199ff7a58d55068d72f9d6053a29a0)

This is a backport of #4566

## Summary by Sourcery

Update the CONTRIBUTING.md backport guide for the 3.0_egg branch to automate branch/commit retrieval and streamline cherry-pick commands.

Documentation:
- Revise backport steps to capture branch name and commit ID via git rev-parse
- Dynamically name backport branches based on the original branch and target 3.0_egg
- Recommend using the -x flag with git cherry-pick for clearer history