### PR TITLE
fix(doc): add required configuration for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,3 +13,6 @@ python:
       path: .
       extra_requirements:
         - docs
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Jira RHINENG-20750


(cherry picked from commit c73cf997d84d9f9ed2c3fe03bcde51cdccb749fd)

This is a backport of #4565

## Summary by Sourcery

Documentation:
- Include sphinx section in .readthedocs.yaml so ReadTheDocs recognizes the Sphinx builder