### PR TITLE
fix(parser/sshd_config): keep inline comments when parsing config lines

### DIFF
--- a/insights/tests/parsers/test_ssh.py
+++ b/insights/tests/parsers/test_ssh.py
@@ -23,6 +23,40 @@ AllowUsers
 Protocol 1
 """.strip()
 
+SSHD_CONFIG_INLINE_COMMENTS = """
+# Full line comment
+Port 22   # ssh port
+
+HostKey /etc/ssh/ssh_host_rsa_key   # main host key
+PermitRootLogin no    # disable root login
+""".strip()
+
+
+def test_sshd_config_inline_comments_preserved():
+    config = SshDConfig(context_wrap(SSHD_CONFIG_INLINE_COMMENTS))
+    assert config is not None
+
+    # Full line comment should not appear as a key
+    assert "# Full line comment" not in [kv.line for kv in config.lines]
+
+    # Keys should exist
+    assert "Port" in config
+    assert "HostKey" in config
+    assert "PermitRootLogin" in config
+
+    # Inline comments should be preserved in the 'line' field
+    port_line = config.get("Port")[0].line
+    assert port_line == "Port 22   # ssh port"
+    assert "# ssh port" in port_line
+
+    hostkey_line = config.get("HostKey")[0].line
+    assert hostkey_line == "HostKey /etc/ssh/ssh_host_rsa_key   # main host key"
+    assert "# main host key" in hostkey_line
+
+    permit_line = config.get("PermitRootLogin")[0].line
+    assert permit_line == "PermitRootLogin no    # disable root login"
+    assert "# disable root login" in permit_line
+
 
 def test_sshd_config():
     sshd_config = SshDConfig(context_wrap(SSHD_CONFIG_INPUT))


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [✅ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [✅ ] No Sensitive Data in this change?
* [✅] Is this PR to correct an issue?
* [✅ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This is a backport of #4546 

#### Problem :
Some rules require verifying whether a directive in `sshd_config` has an inline comment or not.

For example:

✅ Should trigger rule
`PermitRootLogin yes`

❌ Should not trigger rule (inline comment present)
`PermitRootLogin yes   # rootlogin is required`

However, the parser previously relied on `get_active_lines(content)`, which strips inline comments. As a result, both examples were parsed identically as:

`PermitRootLogin yes`

This made it impossible for rules to correctly detect inline comments.

#### Solution :
- Update the parser to iterate directly over content instead of using `get_active_lines()`.
- Skip only blank lines and full-line comments (lines starting with #).


### updated parser pytest output after changes : 

```
 py.test -sv /home/aytiwari/tier-3-rules/insights-core/insights/tests/parsers/test_ssh.py 
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.13.3, pytest-8.4.1, pluggy-1.5.0 -- /home/aytiwari/tier-3-rules/gss_venv/bin/python
cachedir: .pytest_cache
rootdir: /home/aytiwari/tier-3-rules/insights-core
configfile: pyproject.toml
plugins: cov-6.1.1
collected 6 items                                                                                                                                                                         

insights/tests/parsers/test_ssh.py::test_sshd_config_inline_comments_preserved PASSED
insights/tests/parsers/test_ssh.py::test_sshd_config PASSED
insights/tests/parsers/test_ssh.py::test_sshd_config_complete PASSED
insights/tests/parsers/test_ssh.py::test_sshd_test_mode PASSED
insights/tests/parsers/test_ssh.py::test_sshd_configuration_d PASSED
insights/tests/parsers/test_ssh.py::test_sshd_test_mode_docs PASSED

==================================================================================== warnings summary =====================================================================================
insights/tests/parsers/test_ssh.py: 44 warnings
  /home/aytiwari/tier-3-rules/insights-core/insights/parsers/ssh.py:85: DeprecationWarning: 'maxsplit' is passed as positional argument
    line_splits = [s.strip() for s in re.split(r"[\s=]+", line, 1)]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 6 passed, 44 warnings in 0.21s ==============================================================================
```

## Summary by Sourcery

Fix the SSHD config parser to preserve inline comments by iterating over raw content lines and only skipping blank lines and full-line comments.

Bug Fixes:
- Restore inline comments in parsed SSHD config lines so policies can detect their presence correctly

Enhancements:
- Switch parsing logic to iterate over original content lines instead of using get_active_lines()
- Skip only blank lines and full-line comments when parsing SSHD config directives

## Summary by Sourcery

Fix the SSHD config parser to preserve inline comments when parsing configuration directives by iterating over raw content lines and skipping only blank lines and full-line comments.

Bug Fixes:
- Restore inline comments in parsed SSHD config lines so rules can detect their presence correctly.

Enhancements:
- Switch parsing logic to iterate over raw content lines instead of using get_active_lines().
- Skip only blank lines and full-line comments when parsing SSHD config directives.
- Update class docstring to note preservation of inline comments in the line field.

Documentation:
- Update SshDConfig docstring to mention inline comment preservation.

Tests:
- Add pytest test to verify inline comments are preserved in parsed SSHD config lines.