### PR TITLE
fix: do not collect egg_release file in RPM delivery

### DIFF
--- a/insights/specs/datasources/client_metadata.py
+++ b/insights/specs/datasources/client_metadata.py
@@ -179,34 +179,6 @@ def display_name(broker):
 
 
 @datasource(HostContext)
-def egg_release(broker):
-    """
-    Custom datasource for ``display_name`` getting from insights-client
-    configuration.
-
-    Raises:
-        SkipComponent: When cannot get the `egg_release`.
-
-    Returns:
-        str: The JSON strings
-    """
-    egg_release = ''
-    try:
-        with open(constants.egg_release_file) as fil:
-            egg_release = fil.read()
-    except (IOError, MemoryError) as e:
-        logger.debug('Could not read the egg release file: %s', str(e))
-    try:
-        os.remove(constants.egg_release_file)
-    except OSError as e:
-        logger.debug('Could not remove the egg release file: %s', str(e))
-
-    if egg_release:
-        return DatasourceProvider(content=egg_release, relative_path='egg_release')
-    raise SkipComponent
-
-
-@datasource(HostContext)
 def tags(broker):
     """
     Custom datasource for ``tags`` getting from insights-client configuration.

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -107,7 +107,6 @@ class DefaultSpecs(Specs):
     blacklisted_specs = client_metadata.blacklisted_specs
     branch_info = client_metadata.branch_info
     display_name = client_metadata.display_name
-    egg_release = client_metadata.egg_release
     tags = client_metadata.tags
     version_info = client_metadata.version_info
 

--- a/insights/tests/datasources/test_client_metadata.py
+++ b/insights/tests/datasources/test_client_metadata.py
@@ -22,7 +22,6 @@ from insights.specs.datasources.client_metadata import (
     blacklisted_specs,
     branch_info,
     display_name,
-    egg_release,
     version_info,
     tags,
 )
@@ -151,18 +150,6 @@ def test_display_name():
     ic = InsightsConfig()
     with pytest.raises(SkipComponent):
         display_name({'client_config': ic})
-
-
-@patch(builtin_open, mock_open(read_data='/testing'))
-def test_egg_release():
-    result = egg_release({})
-    assert result.content == ['/testing']
-
-
-@patch(builtin_open, mock_open(read_data=''))
-def test_egg_release_empty():
-    with pytest.raises(SkipComponent):
-        egg_release({})
 
 
 @patch("yaml.safe_load", return_value=yaml.load(TAGS_YAML, Loader=yaml.Loader))


### PR DESCRIPTION
If the insights-core is delivered with RPM, do not collect the 'egg_release' file, as it's only for Egg Canary release.

See also: RHINENG-20595

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Is backport to the `3.0_egg` branch required? Refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
