### PR TITLE
New parser for sos_commands/crio/crictl_ps (#4497)

### DIFF
--- a/docs/shared_parsers_catalog/crictl_ps.rst
+++ b/docs/shared_parsers_catalog/crictl_ps.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.crictl_ps
+   :members:
+   :show-inheritance:

--- a/insights/parsers/crictl_ps.py
+++ b/insights/parsers/crictl_ps.py
@@ -1,0 +1,175 @@
+"""
+CrictlPs - command ``crictl ps --quiet``
+========================================
+
+This parser reads the output of ``crictl ps --quiet`` command and returns a list of
+container records with their associated metadata. The parser handles various container
+states and time formats in the "created" field.
+
+The parser is designed to handle the complex structure of crictl output where the
+"created" field may contain spaces (e.g., "About a minute ago", "2 hours ago") and
+uses intelligent parsing to correctly separate fields.
+"""  # noqa: E501
+
+from insights.core import CommandParser
+from insights.core.plugins import parser
+from insights.specs import Specs
+from insights.core.exceptions import ParseException, SkipComponent
+
+
+@parser(Specs.crictl_ps)
+class CrictlPs(CommandParser, list):
+    """
+    Parser for the output of ``crictl ps --quiet`` command.
+
+    The parser is designed to handle the complex structure of crictl output where the
+    "created" field may contain spaces (e.g., "About a minute ago", "2 hours ago") and
+    uses intelligent parsing to correctly separate fields.
+
+    Sample input::
+
+        CONTAINER           IMAGE                                                                                                                        CREATED              STATE               NAME                                          ATTEMPT             POD ID              POD
+        93b10093a8263       bea2d277eb71530a376a68be9760260cedb59f2392bb6e7793b05d5350df8d4c                                                             About a minute ago   Running             oauth-apiserver                               185                 19d971fe5c478       apiserver-7cd97c59ff-dwckz
+        e34ce05ade472       2c96c7c72cf99490b4bdbb7389020b7e4b5bb7dc43ea9cadc4d5af43cb300b3f                                                             9 days ago           Running             guard                                         1                   c48cc19e5b0b1       etcd-guard-nah-4jnq5-master-v8z5h-0
+        471d75b135b5b       90e50eece96ef2a252b729a76a2ee3360d3623295cceb7d3e623b55cb7aef30a                                                             9 days ago           Running             etcd                                          39                  d2dd84f8db754       etcd-nah-4jnq5-master-v8z5h-0
+
+    The parser returns a list of dictionaries, each containing one container record with the
+    following fields:
+    - container_id (str): The container ID (e.g., '93b10093a8263')
+    - image (str): The container image hash or reference (e.g., 'bea2d277eb71530a...')
+    - created (str): When the container was created (e.g., 'About a minute ago', '9 days ago')
+    - state (str): Current container state (e.g., 'Running', 'Exited', 'ContainerCreating', 'Unknown')
+    - name (str): Container name (e.g., 'oauth-apiserver')
+    - attempt (str): Container restart attempt number (e.g., '185')
+    - pod_id (str): Associated pod ID (e.g., '19d971fe5c478')
+    - pod (str): Associated pod name (e.g., 'apiserver-7cd97c59ff-dwckz')
+
+    Supported Container States:
+    - Running: Container is currently running
+    - Exited: Container has exited
+    - Created: Container has been created but not started
+    - ContainerCreating: Container is in the process of being created
+    - Unknown: Container state is unknown
+    - Pending: Container is pending (waiting for resources)
+
+    Examples:
+
+        Basic usage:
+        >>> crictl_ps = CrictlPs(context)
+        >>> len(crictl_ps)
+        3
+        >>> crictl_ps[0]['container_id']
+        '93b10093a8263'
+        >>> crictl_ps[0]['image']
+        'bea2d277eb71530a376a68be9760260cedb59f2392bb6e7793b05d5350df8d4c'
+        >>> crictl_ps[0]['created']
+        'About a minute ago'
+        >>> crictl_ps[0]['state']
+        'Running'
+        >>> crictl_ps[0]['name']
+        'oauth-apiserver'
+        >>> crictl_ps[0]['attempt']
+        '185'
+        >>> crictl_ps[0]['pod_id']
+        '19d971fe5c478'
+        >>> crictl_ps[0]['pod']
+        'apiserver-7cd97c59ff-dwckz'
+
+    Raises:
+        ParseException: If the input content is invalid or doesn't contain the expected
+            header line with "CONTAINER" keyword.
+        SkipComponent: If no container records are found after parsing.
+    """
+
+    def parse_content(self, content):
+        """
+        Parse the crictl ps output content.
+
+        Args:
+            content (list): List of strings representing the crictl ps output lines.
+
+        Raises:
+            ParseException: If the content is invalid or doesn't contain the expected header.
+            SkipComponent: If no container records are found after parsing.
+        """
+        if len(content) < 1 or "CONTAINER" not in content[0]:
+            raise ParseException("invalid content: {0}".format(content) if content else 'empty file')
+
+        # Skip the header line
+        for line in content[1:]:
+            line = line.strip()
+            if not line:
+                continue
+
+            # Parse each line manually to handle the space-containing "created" field
+            parsed = self._parse_line(line)
+            if parsed:
+                self.append(parsed)
+
+        # Raise SkipComponent if no containers were found
+        if not self:
+            raise SkipComponent("No container records found")
+
+    def _parse_line(self, line):
+        """
+        Parse a single line of crictl ps output.
+
+        This method handles the complex parsing logic required for crictl output
+        where the "created" field may contain spaces and the image field can be
+        very long.
+
+        Args:
+            line (str): A single line from crictl ps output.
+
+        Returns:
+            dict: Parsed container record with all fields, or None if parsing fails.
+
+        Note:
+            The parsing logic:
+            1. Splits the line by whitespace
+            2. First two fields are always container_id and image
+            3. Finds the state field by looking for known state keywords
+            4. Everything between image and state is the "created" field
+            5. Remaining fields are mapped in order: name, attempt, pod_id, pod
+        """
+        # Split by whitespace
+        parts = line.split()
+
+        if len(parts) < 8:
+            return None
+
+        # The structure is:
+        # container_id image created... state name attempt pod_id pod
+
+        # Find the state field (it's always a single word like "Running", "Exited", etc.)
+        # Look for common state values
+        state_keywords = ['Running', 'Exited', 'Created', 'Unknown', 'ContainerCreating', 'Pending']
+        state_index = None
+        for i, part in enumerate(parts[2:], 2):
+            if part in state_keywords:
+                state_index = i
+                break
+
+        if state_index is None:
+            return None
+
+        # The remaining parts after state
+        remaining = parts[state_index + 1:]
+
+        if len(remaining) < 4:
+            return None
+
+        return {
+            'container_id': parts[0],  # First two parts are always container_id and image
+            'image': parts[1],
+            'created': ' '.join(parts[2:state_index]),  # Everything between image and state is the "created" field
+            'state': parts[state_index],  # The state is at state_index
+            'name': remaining[-4],  # The last 4 parts are: name, attempt, pod_id, pod
+            'attempt': remaining[-3],
+            'pod_id': remaining[-2],
+            'pod': remaining[-1]
+        }
+
+    @property
+    def container_ids(self):
+        return [record['container_id'] for record in self]

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -127,6 +127,7 @@ class Specs(SpecSet):
     cpuinfo = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     cpupower_frequency_info = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     cpuset_cpus = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
+    crictl_ps = RegistryPoint()
     crictl_logs = RegistryPoint(multi_output=True, filterable=True)
     crio_conf = RegistryPoint(multi_output=True)
     cron_daily_rhsmd = RegistryPoint(filterable=True)

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -57,6 +57,7 @@ class SosSpecs(Specs):
     cpe = simple_file("/etc/system-release-cpe")
     cpu_smt_control = simple_file("sys/devices/system/cpu/smt/control")
     cpupower_frequency_info = simple_file("sos_commands/processor/cpupower_frequency-info")
+    crictl_ps = simple_file("sos_commands/crio/crictl_ps")
     crictl_logs = glob_file(["sos_commands/crio/containers/crictl_logs_-t*", "sos_commands/crio/containers/logs/crictl_logs_-t*"])
     crio_conf = glob_file([r"etc/crio/crio.conf", r"etc/crio/crio.conf.d/*"])
     cups_files_conf = simple_file("/etc/cups/cups-files.conf")

--- a/insights/tests/parsers/test_crictl_ps.py
+++ b/insights/tests/parsers/test_crictl_ps.py
@@ -1,0 +1,217 @@
+from insights.parsers.crictl_ps import CrictlPs
+from insights.tests import context_wrap
+from insights.core.exceptions import ParseException, SkipComponent
+import pytest
+
+
+CRICTL_PS = """
+CONTAINER           IMAGE                                                                                                                        CREATED              STATE               NAME                                          ATTEMPT             POD ID              POD
+93b10093a8263       bea2d277eb71530a376a68be9760260cedb59f2392bb6e7793b05d5350df8d4c                                                             About a minute ago   Running             oauth-apiserver                               185                 19d971fe5c478       apiserver-7cd97c59ff-dwckz
+e34ce05ade472       2c96c7c72cf99490b4bdbb7389020b7e4b5bb7dc43ea9cadc4d5af43cb300b3f                                                             9 days ago           Running             guard                                         1                   c48cc19e5b0b1       etcd-guard-nah-4jnq5-master-v8z5h-0
+471d75b135b5b       90e50eece96ef2a252b729a76a2ee3360d3623295cceb7d3e623b55cb7aef30a                                                             9 days ago           Running             etcd                                          39                  d2dd84f8db754       etcd-nah-4jnq5-master-v8z5h-0
+""".strip()
+
+CRICTL_PS_WITH_DIFFERENT_STATES = """
+CONTAINER           IMAGE                                                                                                                        CREATED              STATE               NAME                                          ATTEMPT             POD ID              POD
+93b10093a8263       bea2d277eb71530a376a68be9760260cedb59f2392bb6e7793b05d5350df8d4c                                                             About a minute ago   Running             oauth-apiserver                               185                 19d971fe5c478       apiserver-7cd97c59ff-dwckz
+e34ce05ade472       2c96c7c72cf99490b4bdbb7389020b7e4b5bb7dc43ea9cadc4d5af43cb300b3f                                                             2 hours ago          Exited              guard                                         1                   c48cc19e5b0b1       etcd-guard-nah-4jnq5-master-v8z5h-0
+471d75b135b5b       90e50eece96ef2a252b729a76a2ee3360d3623295cceb7d3e623b55cb7aef30a                                                             1 day ago            ContainerCreating   etcd                                          39                  d2dd84f8db754       etcd-nah-4jnq5-master-v8z5h-0
+abc123def456        sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef             3 weeks ago         Unknown              test-container                              5                   f1f2f3f4f5f6       test-pod-123
+""".strip()
+
+CRICTL_PS_EMPTY = """
+CONTAINER           IMAGE                                                                                                                        CREATED              STATE               NAME                                          ATTEMPT             POD ID              POD
+""".strip()
+
+CRICTL_PS_INVALID_HEADER = """
+INVALID HEADER
+93b10093a8263       bea2d277eb71530a376a68be9760260cedb59f2392bb6e7793b05d5350df8d4c                                                             About a minute ago   Running             oauth-apiserver                               185                 19d971fe5c478       apiserver-7cd97c59ff-dwckz
+""".strip()
+
+
+def test_crictl_ps():
+    """Test basic crictl ps parsing with standard output"""
+    result = CrictlPs(context_wrap(CRICTL_PS))
+
+    # Test number of records
+    assert len(result) == 3
+
+    # Test first record
+    first_record = result[0]
+    assert first_record['container_id'] == '93b10093a8263'
+    assert first_record['image'] == 'bea2d277eb71530a376a68be9760260cedb59f2392bb6e7793b05d5350df8d4c'
+    assert first_record['created'] == 'About a minute ago'
+    assert first_record['state'] == 'Running'
+    assert first_record['name'] == 'oauth-apiserver'
+    assert first_record['attempt'] == '185'
+    assert first_record['pod_id'] == '19d971fe5c478'
+    assert first_record['pod'] == 'apiserver-7cd97c59ff-dwckz'
+
+    # Test second record
+    second_record = result[1]
+    assert second_record['container_id'] == 'e34ce05ade472'
+    assert second_record['image'] == '2c96c7c72cf99490b4bdbb7389020b7e4b5bb7dc43ea9cadc4d5af43cb300b3f'
+    assert second_record['created'] == '9 days ago'
+    assert second_record['state'] == 'Running'
+    assert second_record['name'] == 'guard'
+    assert second_record['attempt'] == '1'
+    assert second_record['pod_id'] == 'c48cc19e5b0b1'
+    assert second_record['pod'] == 'etcd-guard-nah-4jnq5-master-v8z5h-0'
+
+    # Test third record
+    third_record = result[2]
+    assert third_record['container_id'] == '471d75b135b5b'
+    assert third_record['image'] == '90e50eece96ef2a252b729a76a2ee3360d3623295cceb7d3e623b55cb7aef30a'
+    assert third_record['created'] == '9 days ago'
+    assert third_record['state'] == 'Running'
+    assert third_record['name'] == 'etcd'
+    assert third_record['attempt'] == '39'
+    assert third_record['pod_id'] == 'd2dd84f8db754'
+    assert third_record['pod'] == 'etcd-nah-4jnq5-master-v8z5h-0'
+
+
+def test_crictl_ps_different_states():
+    """Test crictl ps parsing with different container states"""
+    result = CrictlPs(context_wrap(CRICTL_PS_WITH_DIFFERENT_STATES))
+
+    # Test number of records
+    assert len(result) == 4
+
+    # Test different states
+    states = [record['state'] for record in result]
+    assert 'Running' in states
+    assert 'Exited' in states
+    assert 'ContainerCreating' in states
+    assert 'Unknown' in states
+
+    # Test different created formats
+    created_values = [record['created'] for record in result]
+    assert 'About a minute ago' in created_values
+    assert '2 hours ago' in created_values
+    assert '1 day ago' in created_values
+    assert '3 weeks ago' in created_values
+
+    # Test record with different image format (sha256:)
+    sha256_record = result[3]
+    assert sha256_record['container_id'] == 'abc123def456'
+    assert sha256_record['image'] == 'sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+    assert sha256_record['state'] == 'Unknown'
+    assert sha256_record['name'] == 'test-container'
+    assert sha256_record['attempt'] == '5'
+    assert sha256_record['pod_id'] == 'f1f2f3f4f5f6'
+    assert sha256_record['pod'] == 'test-pod-123'
+
+
+def test_crictl_ps_empty():
+    """Test crictl ps parsing with empty data"""
+    with pytest.raises(SkipComponent) as excinfo:
+        CrictlPs(context_wrap(CRICTL_PS_EMPTY))
+
+    assert "No container records found" in str(excinfo.value)
+
+
+def test_crictl_ps_invalid_header():
+    """Test crictl ps parsing with invalid header"""
+    with pytest.raises(ParseException) as excinfo:
+        CrictlPs(context_wrap(CRICTL_PS_INVALID_HEADER))
+
+    assert "invalid content" in str(excinfo.value)
+
+
+def test_crictl_ps_container_ids():
+    """Test accessing container IDs"""
+    result = CrictlPs(context_wrap(CRICTL_PS))
+
+    # Test container_ids property
+    expected_ids = ['93b10093a8263', 'e34ce05ade472', '471d75b135b5b']
+    assert result.container_ids == expected_ids
+
+
+def test_crictl_ps_indexing():
+    """Test indexing and iteration"""
+    result = CrictlPs(context_wrap(CRICTL_PS))
+
+    # Test indexing
+    assert result[0]['container_id'] == '93b10093a8263'
+    assert result[1]['container_id'] == 'e34ce05ade472'
+    assert result[2]['container_id'] == '471d75b135b5b'
+
+    # Test length
+    assert len(result) == 3
+
+    # Test iteration
+    container_ids = []
+    for record in result:
+        container_ids.append(record['container_id'])
+
+    expected_ids = ['93b10093a8263', 'e34ce05ade472', '471d75b135b5b']
+    assert container_ids == expected_ids
+
+
+def test_crictl_ps_contains():
+    """Test contains method"""
+    result = CrictlPs(context_wrap(CRICTL_PS))
+
+    # Test that records are in the data
+    first_record = result[0]
+    assert first_record in result
+
+    # Test that a non-existent record is not in the data
+    fake_record = {
+        'container_id': 'fake', 'image': 'fake', 'created': 'fake',
+        'state': 'fake', 'name': 'fake', 'attempt': 'fake',
+        'pod_id': 'fake', 'pod': 'fake'
+    }
+    assert fake_record not in result
+
+
+def test_crictl_ps_field_types():
+    """Test that all required fields are present and have correct types"""
+    result = CrictlPs(context_wrap(CRICTL_PS))
+
+    required_fields = ['container_id', 'image', 'created', 'state', 'name', 'attempt', 'pod_id', 'pod']
+
+    for record in result:
+        # Check all required fields are present
+        for field in required_fields:
+            assert field in record
+            assert isinstance(record[field], str)
+            assert record[field] != ''  # Fields should not be empty
+
+
+def test_crictl_ps_edge_cases():
+    """Test edge cases in parsing"""
+    # Test with minimal valid data
+    minimal_data = """
+CONTAINER           IMAGE                                                                                                                        CREATED              STATE               NAME                                          ATTEMPT             POD ID              POD
+abc123             def456                                                                                                                      1 hour ago           Running             test                                         1                   pod123              test-pod
+""".strip()
+
+    result = CrictlPs(context_wrap(minimal_data))
+    assert len(result) == 1
+
+    record = result[0]
+    assert record['container_id'] == 'abc123'
+    assert record['image'] == 'def456'
+    assert record['created'] == '1 hour ago'
+    assert record['state'] == 'Running'
+    assert record['name'] == 'test'
+    assert record['attempt'] == '1'
+    assert record['pod_id'] == 'pod123'
+    assert record['pod'] == 'test-pod'
+
+
+def test_crictl_ps_examples():
+    """Test the examples from the docstring"""
+    result = CrictlPs(context_wrap(CRICTL_PS))
+
+    # Test the examples from the docstring
+    assert len(result) == 3
+    assert result[0]['container_id'] == '93b10093a8263'
+    assert result[0]['image'] == 'bea2d277eb71530a376a68be9760260cedb59f2392bb6e7793b05d5350df8d4c'
+    assert result[0]['created'] == 'About a minute ago'
+    assert result[0]['state'] == 'Running'
+    assert result[0]['name'] == 'oauth-apiserver'
+    assert result[0]['attempt'] == '185'
+    assert result[0]['pod_id'] == '19d971fe5c478'
+    assert result[0]['pod'] == 'apiserver-7cd97c59ff-dwckz'


### PR DESCRIPTION
The Parser "CrictlPs" is for sos archive and internally usage only.


(cherry picked from commit 77bd068cfe9d1c9740d893741e25babffcebc46d)

This is a backport of #4497

## Summary by Sourcery

Add a new CrictlPs parser to handle `crictl ps --quiet` output and integrate it into the spec registry, including tests and documentation.

New Features:
- Introduce CrictlPs parser for parsing container records from `crictl ps --quiet` output.

Enhancements:
- Register the crictl_ps spec in both Specs and SosSpecs for sos archive support.

Documentation:
- Add documentation entry in the shared parsers catalog for the new CrictlPs parser.

Tests:
- Add unit tests covering normal parsing, various container states, empty output, invalid headers, and API behaviors.