### PR TITLE
chore(ci/cd): build Egg for PRs to 3.0_egg only

### DIFF
--- a/.github/workflows/build_egg.yml
+++ b/.github/workflows/build_egg.yml
@@ -2,9 +2,9 @@ name: Build Egg
 
 on:
   push:
-    branches: [ master, '3.0']
+    branches: [ '3.0_egg']
   pull_request:
-    branches: [ master ]
+    branches: [ '3.0_egg']
 
 jobs:
   build-egg:
@@ -24,4 +24,4 @@ jobs:
       with:
         name: egg
         path: insights.zip
-        retention-days: 7 
+        retention-days: 7


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Is backport to the `3.0_egg` branch required? Refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Limit the GitHub Actions egg build workflow to only run on the 3.0_egg branch for both pushes and pull requests

CI:
- Restrict build_egg workflow triggers to the 3.0_egg branch for push events
- Restrict build_egg workflow triggers to the 3.0_egg branch for pull_request events