### PR TITLE
fix: add dep ds containers_with_shell for container specs

### DIFF
--- a/insights/core/spec_factory.py
+++ b/insights/core/spec_factory.py
@@ -515,11 +515,11 @@ class ContainerFileProvider(ContainerProvider):
 class ContainerCommandProvider(ContainerProvider):
     def _misc_settings(self):
         # cmd: <podman|docker> exec -e <env> container_id \
-        #               bash -c "command -v cmd_exec > /dev/null && cmd"
+        #               sh -c "command -v cmd_exec > /dev/null && cmd"
         engine, _, _, _, container_id, _cmd = self.cmd.split(None, 5)
         cmd = (
             _cmd.split('&&', 1)[-1].strip(' "')
-            if _cmd.startswith('bash -c "command -v ') and ' && ' in _cmd
+            if _cmd.startswith('sh -c "command -v ') and ' && ' in _cmd
             else _cmd
         )
         self.engine = os.path.basename(engine)
@@ -1372,7 +1372,7 @@ class container_execute(foreach_execute):
                 cmd = self.cmd % args if args else self.cmd
                 # wrap cmd with existence pre_check
                 cmd_exec = self.cmd.split(None, 1)[0]
-                wrapped_cmd = 'bash -c "command -v %s > /dev/null && %s"' % (cmd_exec, cmd)
+                wrapped_cmd = 'sh -c "command -v %s > /dev/null && %s"' % (cmd_exec, cmd)
                 # the_cmd = <podman|docker> exec -e <env> container_id wrapped_cmd
                 the_cmd = '/usr/bin/%s exec -e "%s" %s %s' % (
                     engine,

--- a/insights/specs/datasources/container/__init__.py
+++ b/insights/specs/datasources/container/__init__.py
@@ -12,10 +12,10 @@ from insights.specs.datasources import DEFAULT_SHELL_TIMEOUT
 
 
 @datasource([PodmanListContainers, DockerListContainers], HostContext, timeout=240)
-def running_rhel_containers(broker):
+def containers_with_shell(broker):
     """
-    Returns a list of tuple of (image, <podman|docker>, container_id) of the running
-    containers.
+    Returns a list of tuple of (image, <podman|docker>, container_id) of the
+    running containers with /bin/sh shell available.
 
     From RHEL 8, the "docker" command is from the package "podman-docker". In
     general when using command "docker" to access a container, the following
@@ -27,19 +27,17 @@ def running_rhel_containers(broker):
     necessary to remove the duplicated containers from the output of "docker".
     """
 
-    def _is_rhel_image(ctx, c_info):
-        """Only collect the containers based from RHEL images"""
+    def _is_shell_available_image(ctx, c_info):
+        """Only collect the containers with shell"""
         try:
             engine, cid = c_info
-            # cmd with existence pre_check of `cat`
-            cmd = 'bash -c "command -v cat > /dev/null && cat /etc/redhat-release"'
-            # the_cmd = <podman|docker> exec -e <env> container_id cmd
-            the_cmd = '/usr/bin/%s exec -e "%s" %s %s' % (engine, PATH_ENV_OVERRIDER, cid, cmd)
-            ret = ctx.shell_out(the_cmd, timeout=DEFAULT_SHELL_TIMEOUT)
-            if ret and len(ret) == 1 and "red hat enterprise linux" in ret[0].lower():
+            shell_exec_path = "/bin/sh"
+            # the_cmd = <podman|docker> cp container_id:/bin/sh -
+            the_cmd = '/usr/bin/%s cp %s:%s -' % (engine, cid, shell_exec_path)
+            rc, _ = ctx.shell_out(the_cmd, split=False, keep_rc=True, timeout=DEFAULT_SHELL_TIMEOUT)
+            if rc == 0:
                 return True
         except Exception:
-            # return False when there is no such file "/etc/redhat-release"
             pass
         return False
 
@@ -51,8 +49,8 @@ def running_rhel_containers(broker):
             container_id = podman_c.containers[name]['CONTAINER ID']
             podman_container.add(container_id)
             c_info = ('podman', container_id[:12])
-            if not _is_rhel_image(broker[HostContext], c_info):
-                # skip containers from non-rhel image
+            if not _is_shell_available_image(broker[HostContext], c_info):
+                # skip containers from non-shell-available image
                 continue
             cs.append((podman_c.containers[name]['IMAGE'],) + c_info)
     if DockerListContainers in broker:
@@ -60,14 +58,46 @@ def running_rhel_containers(broker):
         for name in docker_c.running_containers:
             container_id = docker_c.containers[name]['CONTAINER ID']
             c_info = ('docker', container_id[:12])
-            if container_id in podman_container or not _is_rhel_image(broker[HostContext], c_info):
-                # skip containers from non-rhel image and
+            if container_id in podman_container or not _is_shell_available_image(
+                broker[HostContext], c_info
+            ):
+                # skip containers from non-shell-available image and
                 # skip duplicated containers managed by "podman"
                 continue
             cs.append((docker_c.containers[name]['IMAGE'],) + c_info)
     if cs:
         # Return list of tuple:
         # - (image, <podman|docker>, container_id)
+        return cs
+
+    raise SkipComponent
+
+
+@datasource(containers_with_shell, HostContext, timeout=240)
+def running_rhel_containers(broker):
+    """
+    Returns a list of tuple of (image, <podman|docker>, container_id) of the
+    running rhel containers.
+    """
+
+    def _is_rhel_image(ctx, c_info):
+        """Only collect the containers based from RHEL images"""
+        try:
+            _, engine, cid = c_info
+            # cmd with existence pre_check of `cat`
+            cmd = 'sh -c "command -v cat > /dev/null && cat /etc/redhat-release"'
+            # the_cmd = <podman|docker> exec -e <env> container_id cmd
+            the_cmd = '/usr/bin/%s exec -e "%s" %s %s' % (engine, PATH_ENV_OVERRIDER, cid, cmd)
+            ret = ctx.shell_out(the_cmd, timeout=DEFAULT_SHELL_TIMEOUT)
+            if ret and len(ret) == 1 and "red hat enterprise linux" in ret[0].lower():
+                return True
+        except Exception:
+            # return False when there is no such file "/etc/redhat-release"
+            pass
+        return False
+
+    cs = [c for c in broker[containers_with_shell] if _is_rhel_image(broker[HostContext], c)]
+    if cs:
         return cs
 
     raise SkipComponent

--- a/insights/tests/datasources/container/test_nginx_conf.py
+++ b/insights/tests/datasources/container/test_nginx_conf.py
@@ -7,7 +7,7 @@ from insights.core.exceptions import SkipComponent, ContentException
 from insights.core.spec_factory import ContainerCommandProvider
 from insights.specs.datasources.container.nginx_conf import LocalSpecs, nginx_conf
 
-CONTAINER_CMD = '%s exec -e "PATH=$PATH" %s bash -c "command -v find && find /etc/ /opt/ *.conf"'
+CONTAINER_CMD = '%s exec -e "PATH=$PATH" %s sh -c "command -v find && find /etc/ /opt/ *.conf"'
 
 find_list = [
     '/etc/nginx/nginx.conf',

--- a/insights/tests/datasources/container/test_running_rhel_containers.py
+++ b/insights/tests/datasources/container/test_running_rhel_containers.py
@@ -6,7 +6,7 @@ from insights.core.context import HostContext
 from insights.core.exceptions import SkipComponent
 from insights.parsers.docker_list import DockerListContainers
 from insights.parsers.podman_list import PodmanListContainers
-from insights.specs.datasources.container import running_rhel_containers
+from insights.specs.datasources.container import containers_with_shell, running_rhel_containers
 from insights.tests import context_wrap
 
 PODMAN_LIST_CONTAINERS_2_UP = """
@@ -29,29 +29,49 @@ REDHAT_RELEASE7 = """
 Red Hat Enterprise Linux release 7.3
 """.strip()
 
+DS_CONTAINERS_WITH_SHELL_RET = [
+    ('rhel7_httpd', 'podman', '03e2861336a7'),
+    ('bd8638c869ea', 'podman', '05516ea08b56'),
+    ('rhel7_httpd', 'docker', 'd3e2861336a7'),
+]
+
 
 def fake_shell_out(cmd, split=True, timeout=None, keep_rc=False, env=None, signum=None):
     tmp_cmd = cmd.strip().split()
-    if 'podman' in tmp_cmd[0]:
-        return [REDHAT_RELEASE7, ]
-    if 'docker' in tmp_cmd[0]:
-        return [FEDORA, ]
+    if keep_rc:  # fake for ds containers_with_shell
+        if '05516ea08b56' in tmp_cmd[2]:  # for test cov
+            raise Exception
+        if 'podman' in tmp_cmd[0]:
+            return [0, "abc"]
+        if 'docker' in tmp_cmd[0]:
+            return [125, "err"]
+    else:  # fake for ds running_rhel_containers
+        if '05516ea08b56' in tmp_cmd[4]:  # for test cov
+            raise Exception
+        if 'podman' in tmp_cmd[0]:
+            return [
+                REDHAT_RELEASE7,
+            ]
+        if 'docker' in tmp_cmd[0]:
+            return [
+                FEDORA,
+            ]
     raise Exception()
 
 
-@patch("insights.core.context.HostContext.shell_out", return_value=[REDHAT_RELEASE7, ])
-def test_get_running_rhel_containers_both_ok(fso):
+# ### Test on containers_with_shell
+
+
+@patch("insights.core.context.HostContext.shell_out", return_value=[0, "abc"])
+def test_get_containers_with_shell_both_ok(fso):
     p_ctn = PodmanListContainers(context_wrap(PODMAN_LIST_CONTAINERS_2_UP))
     d_ctn = DockerListContainers(context_wrap(DOCKER_LIST_CONTAINERS_1_UP))
     assert p_ctn is not None
     assert d_ctn is not None
 
-    broker = {
-        PodmanListContainers: p_ctn,
-        DockerListContainers: d_ctn,
-        HostContext: HostContext()}
+    broker = {PodmanListContainers: p_ctn, DockerListContainers: d_ctn, HostContext: HostContext()}
 
-    ret = running_rhel_containers(broker)
+    ret = containers_with_shell(broker)
     assert len(ret) == 3
     assert ('rhel7_httpd', 'podman', '03e2861336a7') in ret
     assert ('bd8638c869ea', 'podman', '05516ea08b56') in ret
@@ -60,55 +80,98 @@ def test_get_running_rhel_containers_both_ok(fso):
 
 
 @patch("insights.core.context.HostContext.shell_out", side_effect=fake_shell_out)
-def test_get_running_rhel_containers_podman_only(fso):
+def test_get_containers_with_shell_podman_only(fso):
     p_ctn = PodmanListContainers(context_wrap(PODMAN_LIST_CONTAINERS_2_UP))
     d_ctn = DockerListContainers(context_wrap(DOCKER_LIST_CONTAINERS_1_UP))
     assert p_ctn is not None
     assert d_ctn is not None
 
-    broker = {
-        PodmanListContainers: p_ctn,
-        DockerListContainers: d_ctn,
-        HostContext: HostContext()}
+    broker = {PodmanListContainers: p_ctn, DockerListContainers: d_ctn, HostContext: HostContext()}
 
-    ret = running_rhel_containers(broker)
-    assert len(ret) == 2
+    ret = containers_with_shell(broker)
+    assert len(ret) == 1
     assert ('rhel7_httpd', 'podman', '03e2861336a7') in ret
-    assert ('bd8638c869ea', 'podman', '05516ea08b56') in ret
+    # container 05516ea08b56 be patched to raise error
     # docker container is from Fedora image, not collected
 
 
-@patch("insights.core.context.HostContext.shell_out", return_value=[REDHAT_RELEASE7, ])
-def test_get_running_rhel_containers_skip_dup(fso):
+@patch("insights.core.context.HostContext.shell_out", return_value=[0, "abc"])
+def test_get_containers_with_shell_skip_dup(fso):
     p_ctn = PodmanListContainers(context_wrap(PODMAN_LIST_CONTAINERS_2_UP))
     # use the 'podman list' result as input for docker
     d_ctn = DockerListContainers(context_wrap(PODMAN_LIST_CONTAINERS_2_UP))
     assert p_ctn is not None
     assert d_ctn is not None
 
-    broker = {
-        PodmanListContainers: p_ctn,
-        DockerListContainers: d_ctn,
-        HostContext: HostContext()}
+    broker = {PodmanListContainers: p_ctn, DockerListContainers: d_ctn, HostContext: HostContext()}
 
-    ret = running_rhel_containers(broker)
+    ret = containers_with_shell(broker)
     assert len(ret) == 2
     assert ('rhel7_httpd', 'podman', '03e2861336a7') in ret
     assert ('bd8638c869ea', 'podman', '05516ea08b56') in ret
     # duplicated container is removed from docker, not collected
 
 
-@patch("insights.core.context.HostContext.shell_out", return_value=[FEDORA, ])
-def test_get_running_rhel_containers_empty(fso):
+@patch("insights.core.context.HostContext.shell_out", return_value=[125, "err"])
+def test_get_containers_with_shell_none(fso):
     p_ctn = PodmanListContainers(context_wrap(PODMAN_LIST_CONTAINERS_2_UP))
     d_ctn = DockerListContainers(context_wrap(DOCKER_LIST_CONTAINERS_1_UP))
     assert p_ctn is not None
     assert d_ctn is not None
 
-    broker = {
-        PodmanListContainers: p_ctn,
-        DockerListContainers: d_ctn,
-        HostContext: HostContext()}
+    broker = {PodmanListContainers: p_ctn, DockerListContainers: d_ctn, HostContext: HostContext()}
+
+    with pytest.raises(SkipComponent):
+        ret = containers_with_shell(broker)
+        assert len(ret) == 0
+
+
+@patch("insights.core.context.HostContext.shell_out", return_value=[0, "abc"])
+def test_get_containers_with_shell_empty(fso):
+    broker = {HostContext: HostContext()}
+
+    with pytest.raises(SkipComponent):
+        ret = containers_with_shell(broker)
+        assert len(ret) == 0
+
+
+# ### Test on running_rhel_containers
+
+
+@patch(
+    "insights.core.context.HostContext.shell_out",
+    return_value=[
+        REDHAT_RELEASE7,
+    ],
+)
+def test_get_running_rhel_containers_all_rhel(fso):
+    broker = {containers_with_shell: DS_CONTAINERS_WITH_SHELL_RET, HostContext: HostContext()}
+
+    ret = running_rhel_containers(broker)
+    assert len(ret) == 3
+    assert ('rhel7_httpd', 'podman', '03e2861336a7') in ret
+    assert ('bd8638c869ea', 'podman', '05516ea08b56') in ret
+    assert ('rhel7_httpd', 'docker', 'd3e2861336a7') in ret
+
+
+@patch("insights.core.context.HostContext.shell_out", side_effect=fake_shell_out)
+def test_get_running_rhel_containers_some_rhel(fso):
+    broker = {containers_with_shell: DS_CONTAINERS_WITH_SHELL_RET, HostContext: HostContext()}
+
+    ret = running_rhel_containers(broker)
+    assert len(ret) == 1
+    assert ('rhel7_httpd', 'podman', '03e2861336a7') in ret
+    # container 05516ea08b56 be patched to raise error
+
+
+@patch(
+    "insights.core.context.HostContext.shell_out",
+    return_value=[
+        FEDORA,
+    ],
+)
+def test_get_running_rhel_containers_none_rhel(fso):
+    broker = {containers_with_shell: DS_CONTAINERS_WITH_SHELL_RET, HostContext: HostContext()}
 
     with pytest.raises(SkipComponent):
         ret = running_rhel_containers(broker)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?
* [x] Is backport to the `3.0_egg` branch required? Refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.

### Complete Description of Additions/Changes:

When running command `podman exec` against the containers without `/bin/sh` shell, the related conmon error log will be printed on host.
To avoid this case, adding ds `containers_with_shell`  as a dependency to ds `running_rhel_containers`, to assure the existence of `/bin/sh` shell before the later `podman exec` run for spec collection.

Jira: RHINENG-19679

## Summary by Sourcery

Introduce containers_with_shell datasource to ensure containers have /bin/sh before execution and refactor running_rhel_containers to depend on it; switch container command wrappers to use sh instead of bash; update related tests accordingly.

New Features:
- Add containers_with_shell datasource to filter containers with /bin/sh shell available

Enhancements:
- Refactor running_rhel_containers to depend on containers_with_shell
- Switch container command pre-checks and wrappers from bash to sh in ContainerCommandProvider
- Update nginx_conf datasource to use sh for command wrapping

Tests:
- Add and update tests for containers_with_shell and running_rhel_containers behaviors