### PR TITLE
chore: update the PR template to 3.0_egg

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Check all that apply:
 * [ ] No Sensitive Data in this change?
 * [ ] Is this PR to correct an issue?
 * [ ] Is this PR an enhancement?
-* [ ] Is backport to the `3.0_egg` branch required? Refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
+* [ ] Is this a backport from master branch? Yes, this is a backport of #PR-ID?
 
 ### Complete Description of Additions/Changes:
 


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Is this a backport from master branch? Yes, this is a backport of #PR-ID?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Update the GitHub pull request template to generalize the backport question to reference master branch instead of the 3.0_egg branch

Chores:
- Revise backport prompt in PR template to ask if this is a backport from master
- Remove specific reference to the 3.0_egg branch and associated delivery link