### PR TITLE
chore: place the build target in spec instead of passing macro

### DIFF
--- a/build_core_rpm.sh
+++ b/build_core_rpm.sh
@@ -73,9 +73,11 @@ if [ "$TARGET" == "release" ]; then
         exit 1
     fi
 fi
+# Place the build target in ".spec" file
+sed -i -e "s/# placeholder/%global ${BUILDTARGET}/g" insights-core.spec
 # Build the RPM/SRPM
-rpmbuild -D "${BUILDTARGET}" -D "_topdir $PWD" -D "_sourcedir $PWD/dist" -ba insights-core.spec
+rpmbuild -D "_topdir $PWD" -D "_sourcedir $PWD/dist" -ba insights-core.spec
 
 # Cleanup
 rm -rf dist BUILD BUILDROOT
-git checkout -- pyproject.toml setup.py MANIFEST.in insights/COMMIT
+git checkout -- pyproject.toml setup.py MANIFEST.in insights/COMMIT insights_core.spec

--- a/insights-core.spec
+++ b/insights-core.spec
@@ -1,6 +1,8 @@
 %define distro redhat
 %global debug_package %{nil}
 %global modulename insights_core
+# placeholder
+
 %if 0%{?with_selinux}
 %global selinuxtype targeted
 %if 0%{?rhel} == 9


### PR DESCRIPTION
The build target is useful for buiding RPM in dist-git

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Place the RPM build target definition in the spec file via a placeholder replacement step and include the spec file in the cleanup checkout.

Enhancements:
- Add a sed command in build_core_rpm.sh to inject the build target macro into insights-core.spec
- Include insights_core.spec in the git checkout cleanup to revert spec modifications