### PR TITLE
[3.0_egg] fix(client): do not retry upload on successful upload

### DIFF
--- a/insights/client/client.py
+++ b/insights/client/client.py
@@ -422,6 +422,7 @@ def upload(config, pconn, tar_file, content_type, collection_duration=None):
             os.chmod(constants.lastupload_file, 0o644)
             msg_name = determine_hostname(config.display_name)
             logger.info("Successfully uploaded report for %s.", msg_name)
+            return
         elif upload.status_code in (413, 415):
             pconn.handle_fail_rcs(upload)
             raise RuntimeError('Upload failed.')


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [x] Is this a backport from `master`? Yes, this is a backport of #4586 
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Bug Fixes:
- Prevent upload function from retrying after a successful report upload by returning immediately after success