### PR TITLE
fix: use try_auto_configuration to re-configure for compliance

### DIFF
--- a/insights/specs/datasources/compliance/__init__.py
+++ b/insights/specs/datasources/compliance/__init__.py
@@ -8,6 +8,7 @@ from logging import getLogger
 from re import findall
 from sys import exit
 
+from insights.client.auto_config import try_auto_configuration
 from insights.client.connection import InsightsConnection
 from insights.client.constants import InsightsConstants as constants
 from insights.util.subproc import call
@@ -35,11 +36,10 @@ class ComplianceClient:
         self.os_major, self.os_minor = os_version if os_version else [None, None]
         self.ssg_version = ssg_version
         config = copy.deepcopy(config)
-        # Do nothing when it's already `legacy_upload=False`
-        if config.legacy_upload:
-            # use legacy_upload=False basic configurations by force
+        if config.legacy_upload is True:
+            # For compliance, use "legacy_upload=False" by force
             config.legacy_upload = False
-            config.base_url = constants.base_url
+            try_auto_configuration(config)
         self.conn = InsightsConnection(config)
 
     def fetch_tailoring_content(self, policy):

--- a/insights/tests/datasources/compliance/test_compliance.py
+++ b/insights/tests/datasources/compliance/test_compliance.py
@@ -32,38 +32,48 @@ def teardown_function(func):
             env.update(TZ=ENV_TZ)
 
 
-@mark.parametrize("legacy_upload", [True, False])
-def test_get_system_policies(legacy_upload):
-    config = InsightsConfig(
-        legacy_upload=legacy_upload, base_url='localhost/app', systemid='', proxy=None
-    )
-    if legacy_upload:
-        constants.base_url = config.base_url
+@mark.parametrize(
+    ("legacy_upload", "base_url", "expected_url"),
+    [
+        (True, "cert-api.access.redhat.com/app", "cert-api.access.redhat.com/app"),
+        (False, "cert-api.access.redhat.com/app", "cert-api.access.redhat.com/app"),
+        # Satellite
+        (True, "localhost/app", "localhost/app"),
+        (False, "localhost/app", "localhost/app"),
+    ],
+)
+def test_get_system_policies(legacy_upload, base_url, expected_url):
+    config = InsightsConfig(legacy_upload=legacy_upload, base_url=base_url, systemid='', proxy=None)
     compliance_client = ComplianceClient(config=config)
     compliance_client._inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
     compliance_client.conn.session.get = Mock(
         return_value=Mock(status_code=200, json=Mock(return_value={'data': ['test']}))
     )
     assert compliance_client.get_system_policies() == ['test']
-    url = "https://localhost/app/compliance/v2/systems/{0}/policies".format(
-        compliance_client.inventory_id
+    url = "https://{0}/compliance/v2/systems/{1}/policies".format(
+        expected_url, compliance_client.inventory_id
     )
     compliance_client.conn.session.get.assert_called_with(url)
 
 
-@mark.parametrize("legacy_upload", [True, False])
-def test_get_system_policies_error(legacy_upload):
-    config = InsightsConfig(
-        legacy_upload=legacy_upload, base_url='localhost/app', systemid='', proxy=None
-    )
-    if legacy_upload:
-        constants.base_url = config.base_url
+@mark.parametrize(
+    ("legacy_upload", "base_url", "expected_url"),
+    [
+        (True, "cert-api.access.redhat.com/app", "cert-api.access.redhat.com/app"),
+        (False, "cert-api.access.redhat.com/app", "cert-api.access.redhat.com/app"),
+        # Satellite
+        (True, "localhost/app", "localhost/app"),
+        (False, "localhost/app", "localhost/app"),
+    ],
+)
+def test_get_system_policies_error(legacy_upload, base_url, expected_url):
+    config = InsightsConfig(legacy_upload=legacy_upload, base_url=base_url, systemid='', proxy=None)
     compliance_client = ComplianceClient(config=config)
     compliance_client._inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
     compliance_client.conn.session.get = Mock(return_value=Mock(status_code=500))
-    assert compliance_client.get_system_policies() == []
-    url = "https://localhost/app/compliance/v2/systems/{0}/policies".format(
-        compliance_client.inventory_id
+    assert compliance_client.get_system_policies() == []  # empty
+    url = "https://{0}/compliance/v2/systems/{1}/policies".format(
+        expected_url, compliance_client.inventory_id
     )
     compliance_client.conn.session.get.assert_called_with(url)
 


### PR DESCRIPTION
- The compliance datasource needs "legacy_upload=False", when
  it's set as "legacy_upload=True". It's necessary to re-configure
  the "base_url".  Instead of processing the config.base_url
  specially, using   the "try_auto_configuration" provided by
  client code, in which   it processes the Satellite host content
  in the standard way
- Jira: RHINENG-21116


### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [x] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Restrict base_url override in the compliance datasource to only apply for direct RHSM (cert-api) endpoints when legacy_upload is enabled, preserving custom URLs for Satellite-managed hosts.

Bug Fixes:
- Prevent resetting base_url for Satellite-managed hosts, only override for cert-api.access.redhat.com endpoints when legacy_upload is true.

Tests:
- Parameterize compliance client tests with combinations of legacy_upload and base_url to validate correct URL construction for both RHSM and Satellite scenarios.

## Summary by Sourcery

Restrict base_url override in the compliance datasource to only apply for RHSM endpoints when legacy_upload is enabled by forcing legacy_upload to False and using try_auto_configuration, preserving custom URLs for Satellite guests, and extend tests to cover all URL and upload scenarios

Bug Fixes:
- Prevent resetting custom base_url for Satellite-managed hosts by only overriding it for RHSM endpoints when legacy_upload is enabled

Enhancements:
- Delegate compliance datasource configuration to try_auto_configuration instead of manual base_url override when enforcing legacy_upload=False

Tests:
- Parameterize compliance client tests over legacy_upload and base_url combinations for both success and error cases to verify correct URL construction