### PR TITLE
feat: Add spec vmware_tools_conf

### DIFF
--- a/insights/parsers/vmware_tools_conf.py
+++ b/insights/parsers/vmware_tools_conf.py
@@ -1,41 +1,36 @@
 """
-VMwareToolsConf - file ``/etc/vmware-tools/tools.conf``
+VmwareToolsConf - file ``/etc/vmware-tools/tools.conf``
 =======================================================
+This parser is used to parse the content of file ``/etc/vmware-tools/tools.conf``.
 """
+
 from insights.core import IniConfigFile
+from insights.core.filters import add_filter
 from insights.core.plugins import parser
 from insights.specs import Specs
 
+add_filter(Specs.vmware_tools_conf, ["["])
+
 
 @parser(Specs.vmware_tools_conf)
-class VMwareToolsConf(IniConfigFile):
+class VmwareToolsConf(IniConfigFile):
     """
-    The VMware tools configuration file ``/etc/vmware-tools/tools.conf``
-    is in the standard 'ini' format and is read by the IniConfigFile
-    parser. ``vmtoolsd.service`` provided by ``open-vm-tools`` package is
-    configured using ``/etc/vmware-tools/tools.conf``.
+    Parse the ``/etc/vmware-tools/tools.conf`` configuration file.
 
-    Sample ``/etc/vmware-tools/tools.conf`` file::
+    Sample configuration::
 
-        [guestinfo]
-        disable-query-diskinfo = true
+         [servicediscovery]
+         disabled=false
 
-        [logging]
-        log = true
-        vmtoolsd.level = debug
-        vmtoolsd.handler = file
-        vmtoolsd.data = /tmp/vmtoolsd.log
+         [gueststoreupgrade]
+         poll-interval=3600
 
     Examples:
-        >>> type(conf)
-        <class 'insights.parsers.vmware_tools_conf.VMwareToolsConf'>
-        >>> list(conf.sections()) == [u'guestinfo', u'logging']
+        >>> type(vmware_tools_conf_parser)
+        <class 'insights.parsers.vmware_tools_conf.VmwareToolsConf'>
+        >>> vmware_tools_conf_parser.has_option("servicediscovery", "disabled")
         True
-        >>> conf.has_option('guestinfo', 'disable-query-diskinfo')
+        >>> vmware_tools_conf_parser.get("servicediscovery", "disabled") == "false"
         True
-        >>> conf.getboolean('guestinfo', 'disable-query-diskinfo')
-        True
-        >>> conf.get('logging', 'vmtoolsd.data')
-        '/tmp/vmtoolsd.log'
     """
     pass

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -922,7 +922,7 @@ class Specs(SpecSet):
     virtlogd_conf = RegistryPoint(filterable=True)
     vma_ra_enabled = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     vmcore_dmesg = RegistryPoint(multi_output=True, filterable=True)
-    vmware_tools_conf = RegistryPoint()
+    vmware_tools_conf = RegistryPoint(filterable=True)
     vsftpd = RegistryPoint()
     vsftpd_conf = RegistryPoint(filterable=True)
     watchdog_conf = RegistryPoint(filterable=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -972,6 +972,7 @@ class DefaultSpecs(Specs):
     virsh_list_all = simple_command("/usr/bin/virsh --readonly list --all")
     virt_what = simple_command("/usr/sbin/virt-what")
     vma_ra_enabled = simple_file("/sys/kernel/mm/swap/vma_ra_enabled")
+    vmware_tools_conf = simple_file("/etc/vmware-tools/tools.conf")
     vsftpd = simple_file("/etc/pam.d/vsftpd")
     vsftpd_conf = simple_file("/etc/vsftpd/vsftpd.conf")
     watchdog_conf = simple_file("/etc/watchdog.conf")

--- a/insights/tests/parsers/test_vmware_tools_conf.py
+++ b/insights/tests/parsers/test_vmware_tools_conf.py
@@ -1,34 +1,26 @@
 import doctest
-
 from insights.parsers import vmware_tools_conf
+from insights.parsers.vmware_tools_conf import VmwareToolsConf
 from insights.tests import context_wrap
 
-CONF = '''
-[guestinfo]
-disable-query-diskinfo = true
 
-[logging]
-log = true
+L3_AGENT_INI = """
+[servicediscovery]
+disabled=false
 
-vmtoolsd.level = debug
-vmtoolsd.handler = file
-vmtoolsd.data = /tmp/vmtoolsd.log
-'''
+[gueststoreupgrade]
+poll-interval=3600
+""".strip()
 
 
 def test_vmware_tools_conf():
-    conf = vmware_tools_conf.VMwareToolsConf(context_wrap(CONF))
-    assert list(conf.sections()) == ['guestinfo', 'logging']
-    assert conf.has_option('guestinfo', 'disable-query-diskinfo') is True
-    assert conf.getboolean('guestinfo', 'disable-query-diskinfo') is True
-    assert conf.get('guestinfo', 'disable-query-diskinfo') == 'true'
-    assert conf.get('logging', 'vmtoolsd.handler') == 'file'
-    assert conf.get('logging', 'vmtoolsd.data') == '/tmp/vmtoolsd.log'
+    result = VmwareToolsConf(context_wrap(L3_AGENT_INI))
+    assert result.has_option("servicediscovery", "disabled")
+    assert result.get("servicediscovery", "disabled") == "false"
+    assert result.get("gueststoreupgrade", "poll-interval") == "3600"
 
 
-def test_vmware_tools_conf_documentation():
-    failed_count, tests = doctest.testmod(
-        vmware_tools_conf,
-        globs={'conf': vmware_tools_conf.VMwareToolsConf(context_wrap(CONF))}
-    )
-    assert failed_count == 0
+def test_doc():
+    env = {"vmware_tools_conf_parser": VmwareToolsConf(context_wrap(L3_AGENT_INI))}
+    failed, total = doctest.testmod(vmware_tools_conf, globs=env)
+    assert failed == 0


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID

This new parser is for a new Advisor rule

## Summary by Sourcery

Introduce a new parser for the VMware Tools configuration file and integrate it into the core specs with filtering support, along with corresponding test and documentation updates.

New Features:
- Add VmwareToolsConf parser to parse /etc/vmware-tools/tools.conf.

Enhancements:
- Mark Specs.vmware_tools_conf as filterable and define its default simple_file spec path.
- Apply a content filter on the vmware_tools_conf spec to only include section headers.
- Rename parser class to VmwareToolsConf for naming consistency.

Documentation:
- Refresh parser docstrings and example usage to match the new configuration format.

Tests:
- Implement and update unit tests and doctests for the new parser.