### PR TITLE
chore(spec): Add back spec vmware_tools_conf

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -972,6 +972,7 @@ class DefaultSpecs(Specs):
     virsh_list_all = simple_command("/usr/bin/virsh --readonly list --all")
     virt_what = simple_command("/usr/sbin/virt-what")
     vma_ra_enabled = simple_file("/sys/kernel/mm/swap/vma_ra_enabled")
+    vmware_tools_conf = simple_file("/etc/vmware-tools/tools.conf")
     vsftpd = simple_file("/etc/pam.d/vsftpd")
     vsftpd_conf = simple_file("/etc/vsftpd/vsftpd.conf")
     watchdog_conf = simple_file("/etc/watchdog.conf")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [x] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID

This spec is required by a new Advisor rule

## Summary by Sourcery

New Features:
- Add vmware_tools_conf spec to read /etc/vmware-tools/tools.conf