### PR TITLE
fix(MANIFEST): add the 'public.gpg' required by playbook_verifier

### DIFF
--- a/MANIFEST.in.client
+++ b/MANIFEST.in.client
@@ -1,3 +1,4 @@
+graft insights/client
 include LICENSE
 include NOTICE
 include insights/COMMIT


### PR DESCRIPTION
Use the graft to add the whole 'insights/client' folder's content 
Jira: RHINENG-21373

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Update MANIFEST.in.client to include public.gpg and the entire insights/client directory for playbook_verifier compatibility

Bug Fixes:
- Add public.gpg to the package manifest required by playbook_verifier

Enhancements:
- Graft the insights/client folder in MANIFEST.in.client to include its contents