### PR TITLE
fix: remove the deps from insights_ausearch spec

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -16,7 +16,7 @@ import signal
 # - keep line length less than 80 characters
 from insights.components.ceph import IsCephMonitor
 from insights.components.cloud_provider import IsAzure, IsGCP
-from insights.components.rhel_version import IsGtOrRhel84, IsGtOrRhel86
+from insights.components.rhel_version import IsGtOrRhel84
 from insights.components.satellite import (
     IsSatellite,
     IsSatellite611,
@@ -130,7 +130,6 @@ class DefaultSpecs(Specs):
     audispd_conf = simple_file("/etc/audisp/audispd.conf")
     ausearch_insights = simple_command(
         "/usr/sbin/ausearch -i -m avc,user_avc,selinux_err,user_selinux_err -ts recent",
-        deps=[IsGtOrRhel86],
         keep_rc=True,
     )
     aws_instance_id_doc = command_with_args(

--- a/insights/specs/manifests.py
+++ b/insights/specs/manifests.py
@@ -205,10 +205,6 @@ plugins:
     - name: insights.parsers.iris.IrisCpf
       enabled: true
 
-    # needed for ausearch_insights
-    - name: insights.components.rhel_version.IsGtOrRhel86
-      enabled: true
-
     # needed for spec: subscription_manager_syspurpose
     - name: insights.components.rhel_version.IsGtOrRhel84
       enabled: true


### PR DESCRIPTION
With the 'deps' being specified, the execution of insights_ausearch will be resorted regardless the 'prio=-1' as it's involved in the dependency graph and restored before running.
Remove its 'deps=IsGtOrRhel86' as in the RPM will be supported from RHEL 9.
Jira: RHINENG-21426

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Remove the RHEL 8.6 version check from the ausearch_insights spec and manifest to ensure proper execution order and reflect updated RPM support

Bug Fixes:
- Drop deps=[IsGtOrRhel86] from the ausearch_insights spec to prevent unwanted restoration before execution

Chores:
- Remove the IsGtOrRhel86 component from manifests as it is no longer needed