### PR TITLE
chore(spec): change ip_route_show_table_all to filterable=True

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -330,7 +330,7 @@ class Specs(SpecSet):
     ip_netns_exec_namespace_lsof = RegistryPoint(
         multi_output=True, filterable=True, no_obfuscate=['ipv4', 'ipv6', 'mac']
     )
-    ip_route_show_table_all = RegistryPoint(no_obfuscate=['hostname'])
+    ip_route_show_table_all = RegistryPoint(filterable=True, no_obfuscate=['hostname'])
     ip_s_link = RegistryPoint(no_obfuscate=['hostname'])
     ipa_default_conf = RegistryPoint()
     ipaupgrade_log = RegistryPoint(filterable=True)


### PR DESCRIPTION
Change it to filterable=True as on some hosts to reduce side, as its output is significant large and results in Engine pod OOM.

- Jira: RHINENG-20896, RHINENG-20872


(cherry picked from commit 8e32487b56d7f9ee61b4e91b4b4ec8dcb7ee8589)

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [x] Is this a backport from `master`? Yes, this is a backport of #4597 
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Bug Fixes:
- Add filterable=True to ip_route_show_table_all to reduce output size and avoid Engine pod OOM