### PR TITLE
fix: collect yum_updates on all supported RHEL

### DIFF
--- a/insights/specs/datasources/yum_updates.py
+++ b/insights/specs/datasources/yum_updates.py
@@ -10,7 +10,6 @@ import time
 from functools import cmp_to_key
 
 from insights import datasource, HostContext, SkipComponent
-from insights.components.rhel_version import IsRhel7, IsRhel8, IsRhel9
 from insights.core.spec_factory import DatasourceProvider
 from insights.util.rpm_vercmp import version_compare
 
@@ -255,7 +254,9 @@ except ImportError:
         UpdatesManager = None
 
 
-@datasource(HostContext, [IsRhel7, IsRhel8, IsRhel9], timeout=0)
+# This datasource is fit for all supported RHEL releases:
+# - Oct 2025: 7/8/9/10
+@datasource(HostContext, timeout=0)
 def yum_updates(broker):
     """
     This datasource provides a list of available updates on the system.


### PR DESCRIPTION
- the yum_updates spec is Ok to be collected on all supported RHEL Releases
- remove the At_Least_One list from it's requires list
- Jira: RHINENG-21274


(cherry picked from commit 6bae8d63f3c89759e1a1f58f59807ffa2a277c71)

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [x] Is this a backport from `master`? Yes, this is a backport of #4607 
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Enable the yum_updates datasource on all supported RHEL releases by removing the version-specific decorator constraints.

Enhancements:
- Remove the RHEL7/8/9 requirement from the yum_updates datasource decorator
- Allow yum_updates to run on RHEL10 and future supported releases

Chores:
- Backport the fix from master (commit 6bae8d63)