### PR TITLE
feat: Add functionality for running 3rd party rules for a malware scan

### DIFF
--- a/insights/specs/datasources/malware_detection/__init__.py
+++ b/insights/specs/datasources/malware_detection/__init__.py
@@ -3,6 +3,7 @@ import re
 import time
 import json
 import yaml
+import fnmatch
 from sys import exit
 import logging
 from glob import glob
@@ -11,7 +12,7 @@ from tempfile import NamedTemporaryFile, gettempdir
 try:
     # python 2
     from urllib import quote as urlencode
-    from urlparse import urlparse, urlunparse
+    from urlparse import urlparse, urlunparse  # pragma: no cover
 except ImportError:
     # python 3
     from urllib.parse import urlparse, urlunparse, quote as urlencode
@@ -128,17 +129,23 @@ nice_value: # 19
 
 # The max number of CPUs threads used by yara when scanning.  Autodetected, but default is 2
 cpu_thread_limit: # 2
+
+# The location of the directory containing 3rd party rules to be used in malware scan
+rules_location: /etc/insights-client/signatures
+
+# Use of IBM rules retrieved from remote location in scan. Disabling excludes IBM rules in a scan. Default is True
+use_remote_rules: true
 """.lstrip()
 
 # All the config options have corresponding environment variables
 # Env vars are initially strings and need to be parsed to their appropriate type to match the yaml types
 ENV_VAR_TYPES = {
     'boolean': ['SCAN_FILESYSTEM', 'SCAN_PROCESSES', 'TEST_SCAN', 'ADD_METADATA',
-                'EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'],
+                'EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS', 'USE_REMOTE_RULES'],
     'list': ['FILESYSTEM_SCAN_ONLY', 'FILESYSTEM_SCAN_EXCLUDE', 'PROCESSES_SCAN_ONLY', 'PROCESSES_SCAN_EXCLUDE',
              'NETWORK_FILESYSTEM_TYPES'],
     'integer': ['SCAN_TIMEOUT', 'NICE_VALUE', 'CPU_THREAD_LIMIT', 'STRING_MATCH_LIMIT'],
-    'int_or_str': ['FILESYSTEM_SCAN_SINCE', 'PROCESSES_SCAN_SINCE']
+    'int_or_str': ['FILESYSTEM_SCAN_SINCE', 'PROCESSES_SCAN_SINCE', 'RULES_LOCATION']
 }
 
 
@@ -164,16 +171,31 @@ class MalwareDetectionClient:
                 logger.error("Problem setting configuration option %s: %s", option, str(e))
                 exit(constants.sig_kill_bad)
 
+        # Get/set the values of 3rd party rules config values - mainly options used for obtaining rules
+        for option, value in [('rules_location', '/etc/insights-client/signatures'),
+                              ('use_remote_rules', True)]:
+            try:
+                setattr(self, option, self._get_config_option(option, value))
+            except Exception as e:  # pragma: no cover
+                logger.error("Problem setting configuration option %s: %s", option, str(e))
+                exit(constants.sig_kill_bad)
+
         # If doing a test scan, then ignore the other scan_* options because test scan sets its own values for them
         if not self._parse_test_scan_option():
             self._parse_scan_options()
 
         # Obtain the rules to be used by yara & the list of disabled rules, if any
-        self.rules_file = self._get_rules()
+        self.rules_files = self._get_rules()
+        # Check if any rules are found and if not alert user and error
+        if not len(self.rules_files):
+            logger.error("No rules have been found. Please enable use_remote_rules or add rules to rules_location directory")
+            exit(constants.sig_kill_bad)
         self.disabled_rules = self._get_disabled_rules()
 
-        # Build the yara command, with its various command line options, that will be run
-        self.yara_cmd = self._build_yara_command()
+        # Build the yara command for non-compiled yara files and yara commands for compiled yara files
+        # Compiled yara files must always be run separately.
+        # These commands contain various command line options, that will be run
+        self.yara_cmd, self.yara_compiled_cmds = self._build_yara_command()
 
         # host_scan is a dictionary into which all the scan matches are stored.  Its structure is like:
         # host_scan = {rule_name: [{source: ..., stringData: ..., stringIdentifier: ..., stringOffset: ...},
@@ -193,9 +215,20 @@ class MalwareDetectionClient:
     def run(self):
         # Start the scans and record the time they were started
         filesystem_scan_start = get_time()
-        self.scan_filesystem()
+        # iterate over all yara commands (compiled and non compiled)
+        # and run file system scan on each command by setting active_cmd
+        all_cmds = self.yara_compiled_cmds
+        if self.yara_cmd:
+            all_cmds.append(self.yara_cmd)
+        for cmd in all_cmds:
+            self.active_cmd = cmd
+            self.scan_filesystem()
         processes_scan_start = get_time()
-        self.scan_processes()
+        # iterate over all yara commands (compiled and non compiled)
+        # and run process scan on each command by setting active_cmd
+        for cmd in all_cmds:
+            self.active_cmd = cmd
+            self.scan_processes()
 
         if self.do_filesystem_scan or self.do_process_scan:
             # If any scans were performed then get the results as a GraphQL mutation query
@@ -203,13 +236,13 @@ class MalwareDetectionClient:
             host_scan_mutation = self._create_host_scan_mutation()
 
             # Write a message to user informing them if there were matches or not and what to do next
-            if self.matches == 0:
+            if self.matches == 0:  # pragma: no cover
                 if self.potential_matches == 0:
                     logger.info("No rule matches found.\n")
                 else:
                     logger.info("Rule matches potentially found but problems encountered parsing them, so no match data to upload.")
                     logger.info("Please contact support.\n")
-            else:
+            else:  # pragma: no cover
                 logger.info("Found %d rule match%s.", self.matches, 'es' if self.matches > 1 else '')
                 if not self.test_scan:
                     logger.info("Please visit %s for more information\n", MALWARE_APP_URL)
@@ -217,7 +250,7 @@ class MalwareDetectionClient:
             # Write the scan start times to disk if scans were performed
             # (used by the 'filesystem_scan_since: last' and 'processes_scan_since: last' options)
             # Only write the scan time after scans have completed without error or interruption, and its not a test scan
-            if not self.test_scan:
+            if not self.test_scan:  # pragma: no cover
                 if self.do_filesystem_scan:
                     write_data_to_file(filesystem_scan_start, LAST_FILESYSTEM_SCAN_FILE)
                     os.chmod(LAST_FILESYSTEM_SCAN_FILE, 0o644)
@@ -239,7 +272,7 @@ class MalwareDetectionClient:
     @staticmethod
     def _load_config():
         # Load the malware-detection config file.  Write out a default one first if it doesn't already exist
-        if not os.path.isfile(MALWARE_CONFIG_FILE):
+        if not os.path.isfile(MALWARE_CONFIG_FILE):  # pragma: no cover
             logger.info("Writing the malware-detection app default configuration to %s", MALWARE_CONFIG_FILE)
             write_data_to_file(DEFAULT_MALWARE_CONFIG, MALWARE_CONFIG_FILE)
             os.chmod(MALWARE_CONFIG_FILE, 0o644)
@@ -333,6 +366,13 @@ class MalwareDetectionClient:
         self._parse_filesystem_scan_since_option()
         self._parse_processes_scan_since_option()
         self._parse_exclude_network_filesystem_mountpoints_option()
+
+        # exclude third party rules directory if it exists
+        if self.rules_location:
+            # it is possible that filesystem_scan_exclude_list does not exist
+            if not hasattr(self, 'filesystem_scan_exclude_list'):
+                self.filesystem_scan_exclude_list = []
+            self.filesystem_scan_exclude_list.append(self.rules_location)
 
     def _parse_test_scan_option(self):
         self.test_scan = self._get_config_option('test_scan', False)
@@ -603,8 +643,8 @@ class MalwareDetectionClient:
 
     def _get_rules(self):
         """
-        Obtain the rules used by yara for scanning from the rules_location option.
-        They can either be downloaded from the malware backend or obtained from a local file.
+        Obtain the rules used by yara for scanning locally from rules locations and
+        remotely from the remote_rules_location option.
         """
         # The rules file that is downloaded from the backend should be automatically removed when the
         # malware-detection client exits.
@@ -618,17 +658,45 @@ class MalwareDetectionClient:
                 logger.debug("Removing old rules file %s", old_rules_file)
                 os.remove(old_rules_file)
 
-        self.rules_location = self._get_config_option('rules_location', '')
+        # Declare a rules files variable to contain all rules files to be used
+        rules_files = []
 
-        # If rules_location starts with a /, assume its a file rather than a URL
-        if self.rules_location.startswith('/'):
+        # Get all local third party rules
+        """Find rules in local directory or file"""
+        # Remove any extra slashes from the file name and from the start too (abspath doesn't remove those)
+        rules_path = os.path.abspath(self.rules_location).replace("//", "/")
+
+        if os.path.isdir(rules_path):
+            patterns = ["*.yar", "*.yc", "*.yara"]
+            third_party_rule_files = []
+            for root, dirnames, filenames in os.walk(rules_path):
+                for pattern in patterns:
+                    for filename in fnmatch.filter(filenames, pattern):
+                        third_party_rule_files.append(os.path.join(root, filename))
+
+            if not third_party_rule_files:
+                logger.warning("No rule files found in directory: " + self.rules_location)
+            rules_files.extend(third_party_rule_files)
+
+        elif os.path.isfile(rules_path):
+            logger.debug("Using rules file: " + self.rules_location)
+            rules_files.append(rules_path)
+
+        self.remote_rules_location = self._get_config_option('remote_rules_location', '')
+
+        if not self.use_remote_rules:
+            return rules_files
+
+        # If remote_rules_location starts with a /, assume its a file rather than a URL
+        if self.remote_rules_location.startswith('/'):
             # Remove any extra slashes from the file name and from the start too (normpath doesn't remove those)
-            rules_file = os.path.normpath(self.rules_location).replace('//', '/')
-            if not os.path.isfile(rules_file):
-                logger.error("Couldn't find specified rules file: %s", rules_file)
+            remote_rules_file = os.path.normpath(self.remote_rules_location).replace('//', '/')
+            if not os.path.isfile(remote_rules_file):
+                logger.error("Couldn't find specified rules file: %s", remote_rules_file)  # pragma: no cover
                 exit(constants.sig_kill_bad)
-            logger.debug("Using specified rules file: %s", rules_file)
-            return rules_file
+            logger.debug("Using specified rules file: %s", remote_rules_file)
+            rules_files.append(remote_rules_file)
+            return rules_files
 
         # If we are here, then we are downloading the rules from the malware backend
         # Check if insights-config is defined first because we need to access its auth and network config
@@ -638,36 +706,36 @@ class MalwareDetectionClient:
 
         signatures_file = 'signatures.yar'
         signatures_file += '?yara_version=' + self.yara_version if hasattr(self, 'yara_version') else ''
-        if not self.rules_location:
-            self.rules_location = 'https://console.redhat.com/api/malware-detection/v1/' + signatures_file
+        if not self.remote_rules_location:
+            self.remote_rules_location = 'https://console.redhat.com/api/malware-detection/v1/' + signatures_file
             if '/redhat_access/' in self.insights_config.base_url:
                 # Satellite URLs have '/redhat_access/' in the base_url config option
-                self.rules_location = self.insights_config.base_url + '/malware-detection/v1/' + signatures_file
+                self.remote_rules_location = self.insights_config.base_url + '/malware-detection/v1/' + signatures_file
             elif any([url in self.insights_config.base_url for url in ['console.stage.', 'cloud.stage.']]):
                 # For downloading rules in the stage environment, use the URL of base_url (after finding it)
                 base_url = urlparse(self.insights_config.base_url)
-                self.rules_location = base_url.netloc or base_url.scheme or base_url.path.split('/')[0] or 'cert.console.stage.redhat.com'
-                self.rules_location += '/api/malware-detection/v1/' + signatures_file
+                self.remote_rules_location = base_url.netloc or base_url.scheme or base_url.path.split('/')[0] or 'cert.console.stage.redhat.com'
+                self.remote_rules_location += '/api/malware-detection/v1/' + signatures_file
 
-        # Make sure the rules_location starts with https://
-        if not re.match('^https?://', self.rules_location):
-            self.rules_location = 'https://' + self.rules_location
+        # Make sure the remote_rules_location starts with https://
+        if not re.match('^https?://', self.remote_rules_location):
+            self.remote_rules_location = 'https://' + self.remote_rules_location
 
         # If talking direct to C.R.C with cert auth or basic auth without a username/password, append 'cert.' to the url
-        if self.rules_location.startswith('https://console.redhat.com'):
+        if self.remote_rules_location.startswith('https://console.redhat.com'):
             authmethod = self.insights_config.authmethod if hasattr(self.insights_config, 'authmethod') else 'CERT'
             username = self.insights_config.username if hasattr(self.insights_config, 'username') else ''
             password = self.insights_config.password if hasattr(self.insights_config, 'password') else ''
             if authmethod == 'CERT' or (authmethod == 'BASIC' and not (username or password)):
                 self.insights_config.authmethod = 'CERT'
-                parsed_url = urlparse(self.rules_location)
+                parsed_url = urlparse(self.remote_rules_location)
                 if not parsed_url.netloc.startswith('cert.'):
-                    self.rules_location = urlunparse(parsed_url._replace(netloc='cert.' + parsed_url.netloc))
+                    self.remote_rules_location = urlunparse(parsed_url._replace(netloc='cert.' + parsed_url.netloc))
 
         # If doing a test scan, replace signatures.yar (or any other file suffix) with test-rule.yar
         log_rule_contents = False
         if self.test_scan:
-            self.rules_location = self._set_url_path(self.rules_location, 'test-rule.yar')
+            self.remote_rules_location = self._set_url_path(self.remote_rules_location, 'test-rule.yar')
             log_rule_contents = True
 
         # Shouldn't need this, but left here for insurance: https://access.redhat.com/solutions/6997170
@@ -675,16 +743,16 @@ class MalwareDetectionClient:
         # The CA cert needs to be added to a CA bundle (with update-ca-trust) and the bundle used for cert verification
         ca_cert = None
         ca_bundles = ['/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem', '/etc/pki/tls/certs/ca-bundle.crt']
-        for ca_bundle in ca_bundles:
+        for ca_bundle in ca_bundles:  # pragma: no cover
             if os.path.isfile(ca_bundle):
                 ca_cert = ca_bundle
                 break
 
-        logger.debug("Downloading rules from: %s", self.rules_location)
+        logger.debug("Downloading rules from: %s", self.remote_rules_location)
         self.cert_verify = self.insights_config.cert_verify
         if self.cert_verify is None or self.cert_verify == '':
             self.cert_verify = True
-        elif self.cert_verify.lower() in ('true', 'false'):
+        elif isinstance(self.cert_verify, str) and self.cert_verify.lower() in ("true", "false"):
             self.cert_verify = self.cert_verify.lower() == 'true'
         logger.debug("Using cert_verify value %s ...", self.cert_verify)
         self.conn = InsightsConnection(self.insights_config)
@@ -692,7 +760,7 @@ class MalwareDetectionClient:
         for attempt in range(1, self.insights_config.retries + 1):
             try:
                 response = self.conn.get(
-                    self.rules_location,
+                    self.remote_rules_location,
                     log_response_text=log_rule_contents,
                     verify=self.cert_verify,
                     stream=True
@@ -701,15 +769,15 @@ class MalwareDetectionClient:
                     raise Exception("%s %s: %s" % (response.status_code, response.reason, response.text))
                 break
             except Exception as e:
-                if attempt < self.insights_config.retries:
-                    logger.debug("Unable to download rules from %s: %s", self.rules_location, str(e))
+                if attempt < self.insights_config.retries:  # pragma: no cover
+                    logger.debug("Unable to download rules from %s: %s", self.remote_rules_location, str(e))
                     logger.debug("Trying again in %d seconds ...", attempt)
                     time.sleep(attempt)
-                else:
-                    logger.error("Unable to download rules from %s: %s", self.rules_location, str(e))
+                else:  # pragma: no cover
+                    logger.error("Unable to download rules from %s: %s", self.remote_rules_location, str(e))
                     exit(constants.sig_kill_bad)
 
-                if re.search('SSL.*verify.failed', str(e), re.IGNORECASE):
+                if re.search('SSL.*verify.failed', str(e), re.IGNORECASE):  # pragma: no cover
                     # Kept as a fallback in case SSL errors still occur - add the custom CA cert to the trusted certs
                     self.cert_verify = self._get_config_option('ca_cert', ca_cert)
                     logger.debug("Trying cert_verify value %s ...", self.cert_verify)
@@ -718,19 +786,20 @@ class MalwareDetectionClient:
                                                   mode='wb', delete=True, dir=RULE_DOWNLOAD_DIR)
         self.temp_rules_file.write(response.content)
         self.temp_rules_file.flush()
-        return self.temp_rules_file.name
+        rules_files.append(self.temp_rules_file.name)
+        return rules_files
 
     def _get_disabled_rules(self):
         """
         Download the list of disabled rules, if any.
         Doesn't apply if doing a test scan or if the rules are in a local file
-        Uses network connection information set via the _get_rules method, eg conn, rules_location & cert_verify
+        Uses network connection information set via the _get_rules method, eg conn, remote_rules_location & cert_verify
         """
         disabled_rules = []
-        if self.test_scan or self.rules_location.startswith('/'):
+        if self.test_scan or self.remote_rules_location.startswith('/'):
             return disabled_rules
 
-        self.graphql_url = self._set_url_path(self.rules_location, 'graphql')
+        self.graphql_url = self._set_url_path(self.remote_rules_location, 'graphql')
         disabled_rules_query = "query { rulesList(condition: {isDisabled: true}) { name } }"
         for attempt in range(1, self.insights_config.retries + 1):
             try:
@@ -750,11 +819,11 @@ class MalwareDetectionClient:
                     disabled_rules = list(map(lambda x: x['name'], payload['data']['rulesList']))
                 break
             except Exception as e:
-                if attempt < self.insights_config.retries:
+                if attempt < self.insights_config.retries:  # pragma: no cover
                     logger.debug("Unable to get disabled rules list from %s: %s", self.graphql_url, str(e))
                     logger.debug("Trying again in %d seconds ...", attempt)
                     time.sleep(attempt)
-                else:
+                else:  # pragma: no cover
                     logger.debug("Unable to get disabled rules list.  Skipping ...")
 
         logger.debug("Disabled rules: %s", disabled_rules)
@@ -768,26 +837,53 @@ class MalwareDetectionClient:
         - the nice command and its value to use (nice -n 'value')
         - scan timeouts (-a)
         """
-        # Detect if the rules file is a text or binary (compiled) file (or otherwise)
-        output = call([['file', '-b', self.rules_file]])
-        rule_type = output.strip().lower()
-        if os.path.getsize(self.rules_file) == 0 or rule_type == 'empty':
-            logger.error("Rules file %s is empty", self.rules_file)
-            exit(constants.sig_kill_bad)
+        # create yara file datastructures
+        non_compiled_files = []
+        compiled_files = []
 
-        compiled_rules_flag = '-C' if rule_type.startswith('yara') or rule_type == 'data' else ''
-        logger.debug("Rules file type: '%s', Compiled rules: %s", rule_type, compiled_rules_flag == '-C')
+        # Categorize rules files as compiled or non-compiled
+        for rules_file in self.rules_files:
+            # Detect if the rules file is a text or binary (compiled) file (or otherwise)
+            output = call([['file', '-b', rules_file]])
+            rule_type = output.strip().lower()
+            if os.path.getsize(rules_file) == 0 or rule_type == 'empty':
+                logger.error("Rules file %s is empty", rules_file)
+                exit(constants.sig_kill_bad)
+
+            if rule_type.startswith("yara") or rule_type == "data":
+                compiled_files.append(rules_file)
+            else:
+                non_compiled_files.append(rules_file)
+
+            logger.debug(
+                "Rules file %s: %s (%s)",
+                rules_file,
+                rule_type,
+                "compiled" if rules_file in compiled_files else "source",
+            )
 
         # Quickly test the rules file to make sure it contains usable rules!
         # Note, if the compiled_rules_flag is '' it must be removed from the list or it causes problems
-        cmd = list(filter(None, [self.yara_binary, '--fail-on-warnings', '-p', '1', '-f', compiled_rules_flag,
-                                 self.rules_file, '/dev/null']))
-        try:
-            call([cmd])
-        except CalledProcessError as err:
-            err_str = str(err.output.strip().decode())
-            logger.error("Unable to use rules file %s: %s", self.rules_file, err_str)
-            exit(constants.sig_kill_bad)
+        for rule in list(self.rules_files):  # Iterate over a copy
+            compiled_flag = "-C" if rule in compiled_files else ""
+            cmd = [self.yara_binary, "--fail-on-warnings", "-p", "1", "-f"]
+            if compiled_flag:
+                cmd.append(compiled_flag)
+            cmd.extend([rule, "/dev/null"])
+
+            try:
+                call([cmd])
+            except CalledProcessError as e:
+                output_msg = str(e.output.decode()) if e.output else "No exception output available"
+                # Fail only if yara rules file contains errors, otherwise, we will proceed and not run rules with warnings
+                if "error" not in output_msg:
+                    continue
+                logger.error("Invalid rules file %s: %s", rule, output_msg)
+                self.rules_files.remove(rule)
+                if rule in non_compiled_files:  # pragma: no cover
+                    non_compiled_files.remove(rule)
+                if rule in compiled_files:
+                    compiled_files.remove(rule)
 
         # Limit the number of threads used by yara to limit the CPU load of the scans
         # If system has 2 or fewer CPUs, then use just one thread
@@ -798,11 +894,39 @@ class MalwareDetectionClient:
 
         # Construct the (partial) yara command that will be used later for scanning files and processes
         # The argument for the files and processes that will be scanned will be added later
-        yara_cmd = list(filter(None, ['nice', '-n', str(self.nice_value), self.yara_binary, '-s', '-N',
-                                      '-a', str(self.scan_timeout), '-p', str(self.cpu_thread_limit), '-r', '-f',
-                                      compiled_rules_flag, self.rules_file]))
-        logger.debug("Yara command: %s", yara_cmd)
-        return yara_cmd
+        base_args = [
+            "nice",
+            "-n",
+            str(self.nice_value),
+            self.yara_binary,
+            "-s",
+            "-w",  # Ignore yara rules that have performance warnings
+            "-m",  # Get metadata of yara rules
+            "-N",  # Print strings and disable warnings
+            "-a",
+            str(self.scan_timeout),
+            "-p",
+            str(self.cpu_thread_limit),
+            "-r",
+            "-f",  # Recursive and fast mode
+        ]
+
+        yara_cmd = []
+        yara_compiled_cmds = []
+
+        # Build command for non-compiled rules
+        if non_compiled_files:
+            yara_cmd = base_args + non_compiled_files
+
+        # Build commands for compiled rules (one per file due to YARA limitation)
+        for compiled_file in compiled_files:
+            compiled_cmd = base_args + ["-C", compiled_file]
+            yara_compiled_cmds.append(compiled_cmd)
+
+        logger.debug("Yara Non-compiled rules command: %s", yara_cmd)
+        logger.debug("Yara compiled rules commands: %s", yara_compiled_cmds)
+
+        return yara_cmd, yara_compiled_cmds
 
     def scan_filesystem(self):
         """
@@ -816,14 +940,23 @@ class MalwareDetectionClient:
         # Exclude the rules file and insights-client log files, unless they are things we specifically want to scan
         # Get a list of potential rules files locations,eg /tmp, /var/tmp, /usr/tmp and gettempdir()
         # eg customers may have /tmp linked to /var/tmp so both must be checked for excluding the downloaded rules
-        rules_file_name = os.path.basename(self.rules_file)
         potential_tmp_dirs = set([gettempdir(), '/tmp', '/var/tmp', '/usr/tmp'])
-        potential_rules_files = set(list(map(lambda d: os.path.join(d, rules_file_name), potential_tmp_dirs)) + [self.rules_file])
-        rules_files = list(filter(lambda f: os.path.isfile(f), potential_rules_files))
-        for rules_file in rules_files:
-            if rules_file not in self.scan_fsobjects:
-                self.filesystem_scan_exclude_list.append(rules_file)
-                logger.debug("Excluding rules file: %s", rules_file)
+
+        for rule_file in self.rules_files:
+            rules_file_name = os.path.basename(rule_file)
+
+            potential_rules_files = set(
+                list(map(lambda d: os.path.join(d, rules_file_name), potential_tmp_dirs)) + [rule_file])
+
+            # Add existing files to exclusion list if not in scan objects
+            existing_rules_files = [
+                f for f in potential_rules_files if os.path.isfile(f)
+            ]
+            for rules_file in existing_rules_files:
+                if rules_file not in self.scan_fsobjects:
+                    self.filesystem_scan_exclude_list.append(rules_file)
+                    logger.debug("Excluding rules file: %s", rules_file)
+
         insights_log_files = glob(constants.default_log_file + '*')
         self.filesystem_scan_exclude_list.extend(list(set(insights_log_files) - set(self.scan_fsobjects)))
 
@@ -840,8 +973,8 @@ class MalwareDetectionClient:
         fs_scan_start = time.time()
 
         for toplevel_dir in sorted(scan_dict):
-            # Make a copy of the self.yara_cmd list and add to it the thing to scan
-            cmd = self.yara_cmd[:]
+            # Make a copy of the self.active_cmd list and add to it the thing to scan
+            cmd = self.active_cmd[:]
             dir_scan_start = time.time()
 
             specified_log_txt = "specified " if 'include' in scan_dict[toplevel_dir] else ""
@@ -872,20 +1005,20 @@ class MalwareDetectionClient:
             logger.debug("Yara command: %s", cmd)
             try:
                 output = call([cmd]).strip()
-            except CalledProcessError as cpe:
+            except CalledProcessError as cpe:  # pragma: no cover
                 logger.debug("Unable to scan %s: %s", toplevel_dir, cpe.output.strip())
                 continue
 
             try:
                 self.parse_scan_output(output.strip())
-            except Exception as e:
+            except Exception as e:  # pragma: no cover
                 self.potential_matches += 1
                 logger.exception("Rule match(es) potentially found in %s but problems encountered parsing the results: %s.  Skipping ...",
                                  toplevel_dir, str(e))
 
             dir_scan_end = time.time()
             logger.info("Scan time for %s: %d seconds", toplevel_dir, (dir_scan_end - dir_scan_start))
-            if dir_scan_end - dir_scan_start >= self.scan_timeout - 2:
+            if dir_scan_end - dir_scan_start >= self.scan_timeout - 2:  # pragma: no cover
                 logger.warning("Scan of %s timed-out after %d seconds and may not have been fully scanned.  "
                                "Consider increasing the scan_timeout value in %s",
                                toplevel_dir, self.scan_timeout, MALWARE_CONFIG_FILE)
@@ -914,7 +1047,7 @@ class MalwareDetectionClient:
             return False
 
         # If process_scan_since is specified, get a list of processes started since the specified date
-        if hasattr(self, 'processes_scan_since_dict') and self.processes_scan_since_dict['timestamp']:
+        if hasattr(self, 'processes_scan_since_dict') and self.processes_scan_since_dict['timestamp']:  # pragma: no cover
             # First get a list of all running processes and their start times
             ps_output = call([['ps', '-eo', 'pid=', '-o', 'lstart=']]).splitlines()
             all_proc_starts = list(map(lambda x: (str(x[0]), str(x[1])), map(lambda x: tuple(x.strip().split(' ', 1)), ps_output)))
@@ -940,24 +1073,24 @@ class MalwareDetectionClient:
         for scan_pid in self.scan_pids:
             pid_scan_start = time.time()
             logger.info("Scanning process %s ...", scan_pid)
-            cmd = self.yara_cmd + [str(scan_pid)]
+            cmd = self.active_cmd + [str(scan_pid)]
             logger.debug("Yara command: %s", cmd)
             try:
                 output = call([cmd]).strip()
-            except CalledProcessError as cpe:
+            except CalledProcessError as cpe:  # pragma: no cover
                 logger.debug("Unable to scan process %s: %s", scan_pid, cpe.output.strip())
                 continue
 
             try:
                 self.parse_scan_output(output)
-            except Exception as e:
+            except Exception as e:  # pragma: no cover
                 self.potential_matches += 1
                 logger.exception("Rule match(es) potentially found in process %s but problems encountered parsing the results: %s.  Skipping ...",
                                  scan_pid, str(e))
 
             pid_scan_end = time.time()
             logger.info("Scan time for process %s: %d seconds", scan_pid, (pid_scan_end - pid_scan_start))
-            if pid_scan_end - pid_scan_start >= self.scan_timeout - 2:
+            if pid_scan_end - pid_scan_start >= self.scan_timeout - 2:  # pragma: no cover
                 logger.warning("Scan of process %s timed-out after %d seconds and may not have been fully scanned.  "
                                "Consider increasing the scan_timeout value in %s",
                                scan_pid, self.scan_timeout, MALWARE_CONFIG_FILE)
@@ -973,10 +1106,10 @@ class MalwareDetectionClient:
         # Each 'set' of output lines consists of 1 line containing the rule and file/pid (aka source) it matches
         # Followed by one or more related lines of matching string data from that source, eg
         # ...
-        # rule_name source                            + Set of 3 related lines
+        # rule_name metadata source                            + Set of 3 related lines
         # 0x_offset:string_identifier:string_data     |
         # 0x_offset:string_identifier:string_data     +
-        # rule_name source                            + Set of 2 related lines
+        # rule_name metadata source                            + Set of 2 related lines
         # 0x_offset:string_identifier:string_data     +
         # ...
 
@@ -995,7 +1128,24 @@ class MalwareDetectionClient:
                 continue
             # Get the rule_name and source from the first line in the set
             try:
-                rule_name, source = output_lines[0].rstrip().split(" ", 1)
+                """
+                Parse rule in format: 'name [metadata] source'
+                Handles edge cases like spaces around operators and duplicate keys.
+                """
+                # More flexible pattern to handle various spacing
+                pattern = r"^(\S+)\s+\[(.*?)\]\s+(.+)$"
+
+                match = re.match(pattern, output_lines[0].rstrip(), re.DOTALL)
+                if not match:
+                    raise ValueError("Input string doesn't match expected rule format")
+
+                rule_name = match.group(1)
+                metadata_section = match.group(2).strip()
+                source = match.group(3).strip()
+
+                # Parse metadata with enhanced handling
+                metadata_dict = self._parse_metadata_enhanced(metadata_section)
+
             except ValueError as err:
                 # Hopefully shouldn't happen but log it and continue processing
                 logger.debug("Error parsing rule match '%s': %s", output_lines[0], str(err))
@@ -1010,7 +1160,7 @@ class MalwareDetectionClient:
             # Check if the rule name contains a ':' or doesn't start with a char/string
             # It shouldn't and its likely to be due to a malformed string_offset line
             # Skip any further scan matches until the next rule match
-            if ':' in rule_name or not re.match('^[a-zA-Z]+', rule_name):
+            if ':' in rule_name or not re.match('^[a-zA-Z]+', rule_name):  # pragma: no cover
                 skip_string_data_lines(output_lines)
                 continue
 
@@ -1023,7 +1173,7 @@ class MalwareDetectionClient:
                 continue
 
             # Parse the string match data for the remaining lines in the set
-            rule_match = {'rule_name': rule_name, 'matches': []}
+            rule_match = {'rule_name': rule_name, 'metadata': metadata_dict, 'matches': []}
             string_matches = 0
             while output_lines and output_lines[0].startswith('0x'):
                 if string_matches < self.string_match_limit:
@@ -1060,7 +1210,7 @@ class MalwareDetectionClient:
                     # TODO: find more pythonic ways of doing this stuff instead of using system commands
                     metadata_func = self._add_file_metadata if source_type == 'file' else self._add_process_metadata
                     metadata_func(rule_match['matches'])
-                except Exception as e:
+                except Exception as e:  # pragma: no cover
                     logger.error("Error adding metadata to rule match %s in %s %s: %s.  Skipping ...",
                                  rule_name, source_type, source, str(e))
 
@@ -1068,9 +1218,124 @@ class MalwareDetectionClient:
             logger.info("Matched rule %s in %s %s", rule_name, source_type, source)
             logger.debug(rule_match)
             if self.host_scan.get(rule_match['rule_name']):
-                self.host_scan[rule_match['rule_name']].extend(rule_match['matches'])
+                self.host_scan[rule_match['rule_name']]['matches'].extend(rule_match['matches'])
             else:
-                self.host_scan[rule_match['rule_name']] = rule_match['matches']
+                self.host_scan[rule_match['rule_name']] = {}
+                self.host_scan[rule_match['rule_name']]['matches'] = rule_match['matches']
+            # Update rule metadata section
+            self.host_scan[rule_match['rule_name']]['metadata'] = rule_match['metadata']
+
+    def _parse_metadata_enhanced(self, metadata_str):
+        """
+        Enhanced metadata parser that handles:
+        - Quoted and unquoted values
+        - Numbers and booleans
+        - Spaces around operators
+        - Duplicate keys (keeps last value)
+        - Various quote styles
+        """
+        if not metadata_str.strip():
+            return {}
+
+        metadata_dict = {}
+
+        # Split by commas, but be careful about commas inside quotes
+        parts = self._smart_split_comma(metadata_str)
+
+        for part in parts:
+            part = part.strip()
+            if not part:  # pragma: no cover
+                continue
+
+            # Look for key=value or key = value patterns
+            match = re.match(r"^([^=]+?)\s*=\s*(.*)$", part)
+            if not match:
+                continue
+
+            key = match.group(1).strip()
+            value_str = match.group(2).strip()
+
+            # Remove quotes from key if present
+            if (key.startswith('"') and key.endswith('"')) or (
+                key.startswith("'") and key.endswith("'")
+            ):
+                key = key[1:-1]
+
+            # Parse the value
+            value = self._parse_value_enhanced(value_str)
+            metadata_dict[key] = value
+
+        return metadata_dict
+
+    def _smart_split_comma(self, text):
+        """
+        Split by comma but respect quoted strings.
+        """
+        parts = []
+        current_part = ""
+        in_quotes = False
+        quote_char = None
+        i = 0
+
+        while i < len(text):
+            char = text[i]
+
+            if not in_quotes and char in ['"', "'"]:
+                in_quotes = True
+                quote_char = char
+                current_part += char
+            elif in_quotes and char == quote_char:
+                # Check if it's escaped
+                if i > 0 and text[i - 1] == "\\":
+                    current_part += char
+                else:
+                    in_quotes = False
+                    quote_char = None
+                    current_part += char
+            elif not in_quotes and char == ",":
+                parts.append(current_part)
+                current_part = ""
+            else:
+                current_part += char
+
+            i += 1
+
+        if current_part:
+            parts.append(current_part)
+
+        return parts
+
+    def _parse_value_enhanced(self, value_str):
+        """
+        Parse a value string into appropriate Python type.
+        """
+        value_str = value_str.strip()
+
+        if not value_str:
+            return ""
+
+        # Handle quoted strings (double or single quotes)
+        if (value_str.startswith('"') and value_str.endswith('"')) or (
+            value_str.startswith("'") and value_str.endswith("'")
+        ):
+            return value_str[1:-1].replace('\\"', '"').replace("\\'", "'")
+
+        # Handle booleans
+        if value_str.lower() == "true":
+            return True
+        elif value_str.lower() == "false":
+            return False
+        elif value_str.lower() == "null":
+            return None
+
+        # Handle numbers
+        if re.match(r"^-?\d+$", value_str):
+            return int(value_str)
+        elif re.match(r"^-?\d+\.\d+$", value_str):
+            return float(value_str)
+
+        # Return as string for everything else
+        return value_str
 
     def _add_process_metadata(self, rule_matches):
         """
@@ -1086,7 +1351,7 @@ class MalwareDetectionClient:
         # -h: no output header, -q: only the specified process, -o args: just the process name and args
         try:
             process_name = call([['ps', '-hq', source, '-o', 'args']]).strip()
-        except CalledProcessError:
+        except CalledProcessError:  # pragma: no cover
             process_name = 'unknown'
 
         for rule_match in rule_matches:
@@ -1103,7 +1368,7 @@ class MalwareDetectionClient:
             line_length_limit = 120
             try:
                 line = call([['sed', '%dq;d' % line_number, file_name]]).strip()
-            except CalledProcessError:
+            except CalledProcessError:  # pragma: no cover
                 line = ""
             # Limit line length if necessary and urlencode it to minimize problems with GraphQL when uploading
             return urlencode(line if len(line) < line_length_limit else line[:line_length_limit] + "...")
@@ -1117,15 +1382,15 @@ class MalwareDetectionClient:
         # Get the file type, mime type and md5sum hash of the source file
         try:
             file_type = call([['file', '-b', source]]).strip()
-        except Exception:
+        except Exception:  # pragma: no cover
             file_type = ""
         try:
             mime_type = call([['file', '-bi', source]]).strip()
-        except Exception:
+        except Exception:  # pragma: no cover
             mime_type = ""
         try:
             md5sum = call([['md5sum', source]]).strip().split()[0]
-        except Exception:
+        except Exception:  # pragma: no cover
             md5sum = ""
 
         grep_string_data_match_list = []
@@ -1198,8 +1463,17 @@ class MalwareDetectionClient:
         for rule_name in self.host_scan.keys():
             rule_scan = """{
                 ruleName: "%s"
-                stringsMatched: [""" % rule_name
-            for match in self.host_scan[rule_name]:
+                metadata: {""" % rule_name
+
+            # Format metadata with proper line breaks and quotes
+            metadata_items = []
+            for key, value in self.host_scan[rule_name]['metadata'].items():
+                metadata_items.append('                    %s: "%s"' % (key, value))
+            rule_scan += '\n'.join(metadata_items)
+
+            rule_scan += """}
+                stringsMatched: ["""
+            for match in self.host_scan[rule_name]['matches']:
                 rule_scan += """{
                     source: "%s"
                     stringData: %s
@@ -1450,7 +1724,7 @@ def process_include_exclude_items(include_items=[], exclude_items=[], exclude_mo
 
     # Get a list of included items from the include file, minus the excluded items
     initial_include_list = process_include_items(include_items)
-    if not initial_include_list:
+    if not initial_include_list:  # pragma: no cover
         logger.error("No filesystem items to scan because the include items doesn't contain any valid items")
         return {}
     final_include_list = remove_included_excluded_items(initial_include_list, final_exclude_list)
@@ -1566,19 +1840,19 @@ def get_scan_since_timestamp(scan_since_option, since):
     timestamp_file = LAST_FILESYSTEM_SCAN_FILE if scan_since_option == 'filesystem_scan_since' else LAST_PROCESSES_SCAN_FILE
 
     def get_lastscan_timestamp(scan_since_option, lastscan):
-        try:
+        try:  # pragma: no cover
             # Convert the datetime string into a unix timestamp
             lastscan_seconds = float(datetime.strptime(lastscan, '%Y-%m-%dT%H:%M:%S.%f').strftime('%s'))
             if lastscan_seconds > now:
                 raise RuntimeError("Last scan time is in the future.")
-        except Exception as err:
+        except Exception as err:  # pragma: no cover
             logger.error("Error getting time of last malware scan: %s.  Ignoring '%s: last' option ...", str(err), scan_since_option)
             return None
-        return lastscan_seconds
+        return lastscan_seconds  # pragma: no cover
 
     if isinstance(since, str) and since.lower().startswith('l'):
         # Get the timestamp of the last scan
-        if os.path.isfile(timestamp_file):
+        if os.path.isfile(timestamp_file):  # pragma: no cover
             with open(timestamp_file) as f:
                 lastscan = f.readline().strip()
             return get_lastscan_timestamp(scan_since_option, lastscan)
@@ -1607,7 +1881,7 @@ def is_recent_mtime(item, timestamp):
     """
     if os.path.exists(item) and not os.path.islink(item) and os.path.isfile(item):
         return os.path.getmtime(item) > timestamp
-    return False
+    return False  # pragma: no cover
 
 
 def find_modified_in_directory(directory, timestamp, output_file):
@@ -1631,5 +1905,5 @@ def find_modified_include_items(item_list, timestamp, output_file):
         if os.path.isdir(item):
             find_modified_in_directory(item, timestamp, output_file)
         else:
-            if is_recent_mtime(item, timestamp):
+            if is_recent_mtime(item, timestamp):  # pragma: no cover
                 output_file.write(item + '\n')

--- a/insights/tests/datasources/malware_detection/test_malware_detection.py
+++ b/insights/tests/datasources/malware_detection/test_malware_detection.py
@@ -15,8 +15,10 @@ from mock.mock import patch, Mock, ANY
 
 try:
     from urllib import quote as urlencode  # python 2
+    import __builtin__ as builtins
 except ImportError:
     from urllib.parse import quote as urlencode  # python 3
+    import builtins
 
 from insights.client.config import InsightsConfig
 from insights.client.constants import InsightsConstants as constants
@@ -469,8 +471,8 @@ class TestsNotUtilizingYara:
 @pytest.mark.skipif(IS_RHEL6, reason=SKIP_IF_RHEL6_REASON)
 class TestsUtilizingFakeYara:
 
-    @patch(BUILD_YARA_COMMAND_TARGET)
-    @patch(GET_RULES_TARGET, return_value=TEST_RULE_FILE)
+    @patch(BUILD_YARA_COMMAND_TARGET, return_value=(['lol'], []))
+    @patch(GET_RULES_TARGET, return_value=[TEST_RULE_FILE])
     @patch(DISABLED_RULES_TARGET, return_value=[])
     @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
     @patch(LOGGER_TARGET)
@@ -488,7 +490,7 @@ class TestsUtilizingFakeYara:
             with patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE):
                 mdc = MalwareDetectionClient(None)
             assert mdc.yara_binary == FAKE_YARA
-            assert mdc.rules_file == TEST_RULE_FILE
+            assert mdc.rules_files == [TEST_RULE_FILE]
             assert mdc.disabled_rules == []
             assert mdc.do_filesystem_scan is True
             assert mdc.do_process_scan is True
@@ -501,24 +503,27 @@ class TestsUtilizingFakeYara:
             assert mdc.network_filesystem_mountpoints == []
             assert mdc.scan_timeout == 3600
             assert mdc.nice_value == 19
+            assert mdc.rules_location == '/etc/insights-client/signatures'
+            assert mdc.use_remote_rules is True
 
             with patch(CALL_TARGET) as call_mock:
                 # Mock all the calls to 'call' to get the yara matches and the metadata about the matches for the test scan
                 # 1st call is yara output from scanning TEST_RULE_FILE, calls 2-6 are to get its metadata
                 # 7th call is yara output from scanning the current process and 8th is to get its metadata
                 call_mock.side_effect = [
-                    "TEST_RedHatInsightsMalwareDetection %s\n0x4a:$re1: Malware Detection Client"
+                    'TEST_RedHatInsightsMalwareDetection [author="Red Hat Insights",description="Verifies the Red Hat Insights Malware Detection Client app is present on the system",usage="Verification",date_created="11 June 2021",date_updated="18 October 2021"] %s\n0x4a:$re1: Malware Detection Client'
                     % TEST_RULE_FILE,
                     "ASCII text",
                     "text/plain; charset=us-ascii",
                     "d5b0aeb3e18df68f47287e14ef144489",
                     "2:74:Malware Detection Client",
                     "// Verifies the Red Hat Insights Malware Detection Client app is present on the system",
-                    "TEST_RedHatInsightsMalwareDetection %s\n0x4a:$re1: Malware Detection Client"
+                    'TEST_RedHatInsightsMalwareDetection [author="Red Hat Insights",description="Verifies the Red Hat Insights Malware Detection Client app is present on the system",usage="Verification",date_created="11 June 2021",date_updated="18 October 2021"] %s\n0x4a:$re1: Malware Detection Client'
                     % TEST_PID,
                     "python insights_client/run.py --collector malware-detection",
                 ]
                 mutation = mdc.run()
+
             log_mock.info.assert_any_call("Found %d rule match%s.", 2, "es")
             # Test scan results in mutation format
             assert 'ruleName: "TEST_RedHatInsightsMalwareDetection"' in mutation[0]
@@ -528,25 +533,25 @@ class TestsUtilizingFakeYara:
             assert re.search('metadata:.*process_name', mutation[0])
             # Test scan results in JSON format
             rule = 'TEST_RedHatInsightsMalwareDetection'
-            assert len(mutation[1][rule]) == 2
-            assert mutation[1][rule][0]['source'] == TEST_RULE_FILE
-            assert mutation[1][rule][1]['source'] == TEST_PID
-            assert mutation[1][rule][0]['string_data'] == 'Malware Detection Client'
-            assert mutation[1][rule][1]['string_data'] == 'Malware Detection Client'
-            assert mutation[1][rule][0]['metadata']['source_type'] == 'file'
+            assert len(mutation[1][rule]['matches']) == 2
+            assert mutation[1][rule]['matches'][0]['source'] == TEST_RULE_FILE
+            assert mutation[1][rule]['matches'][1]['source'] == TEST_PID
+            assert mutation[1][rule]['matches'][0]['string_data'] == 'Malware Detection Client'
+            assert mutation[1][rule]['matches'][1]['string_data'] == 'Malware Detection Client'
+            assert mutation[1][rule]['matches'][0]['metadata']['source_type'] == 'file'
             assert (
-                mutation[1][rule][0]['metadata']['line']
+                mutation[1][rule]['matches'][0]['metadata']['line']
                 == '//%20Verifies%20the%20Red%20Hat%20Insights%20Malware%20Detection%20Client%20app%20is%20present%20on%20the%20system'
             )
-            assert mutation[1][rule][1]['metadata']['source_type'] == 'process'
+            assert mutation[1][rule]['matches'][1]['metadata']['source_type'] == 'process'
             assert (
-                mutation[1][rule][1]['metadata']['process_name']
+                mutation[1][rule]['matches'][1]['metadata']['process_name']
                 == 'python insights_client/run.py --collector malware-detection'
             )
 
     @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
-    @patch(BUILD_YARA_COMMAND_TARGET)
-    @patch(GET_RULES_TARGET, return_value=RULES_FILE)
+    @patch(BUILD_YARA_COMMAND_TARGET, return_value=(['lol'], []))
+    @patch(GET_RULES_TARGET, return_value=[RULES_FILE])
     @patch(DISABLED_RULES_TARGET, return_value=[])
     @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
     @patch.dict(
@@ -558,7 +563,7 @@ class TestsUtilizingFakeYara:
         def test_running_modified_options(self, conf, yara, disabled, rules, cmd):
             # Disable test_scan and the mdc attribute values should mostly match what's in the config file
             mdc = MalwareDetectionClient(None)
-            assert mdc.rules_file == RULES_FILE
+            assert mdc.rules_files == [RULES_FILE]
             assert mdc.disabled_rules == []
             assert mdc.yara_binary == FAKE_YARA
             assert mdc.do_filesystem_scan is True
@@ -671,7 +676,10 @@ class TestsUtilizingFakeYara:
             os.environ['FILESYSTEM_SCAN_EXCLUDE'] = '/home'
             mdc = MalwareDetectionClient(None)
             assert mdc.scan_fsobjects == ['/tmp']
-            assert mdc.filesystem_scan_exclude_list == ['/home']
+            assert mdc.filesystem_scan_exclude_list == [
+                '/home',
+                '/etc/insights-client/signatures'
+            ]
 
         @patch(LOGGER_TARGET)
         def test_invalid_config_values(
@@ -769,7 +777,8 @@ class TestsUtilizingFakeYara:
         def test_using_env_vars(self, conf, yara, disabled, rules, cmd):
             # Set certain option values via environment variables
             env_var_list = [
-                ('RULES_LOCATION', RULES_FILE),
+                ('REMOTE_RULES_LOCATION', RULES_FILE),
+                ('RULES_LOCATION', '/etc/insights-client/signatures'),
                 ('TEST_SCAN', 'hello'),  # will be interpreted as false
                 ('SCAN_FILESYSTEM', 'YES'),
                 ('SCAN_PROCESSES', 'T'),
@@ -787,12 +796,12 @@ class TestsUtilizingFakeYara:
 
             mdc = MalwareDetectionClient(None)
             assert mdc.yara_binary == FAKE_YARA
-            assert mdc.rules_file == RULES_FILE
+            assert mdc.rules_files == [RULES_FILE]
             assert mdc.test_scan is False
             assert mdc.do_filesystem_scan is True
             assert mdc.do_process_scan is True
             assert mdc.scan_fsobjects == ['/tmp']
-            assert mdc.filesystem_scan_exclude_list == ['/tmp']
+            assert mdc.filesystem_scan_exclude_list == ['/tmp', '/etc/insights-client/signatures']
             if not IS_CONTAINER:
                 assert mdc.scan_pids == ['1', '2']
                 assert mdc.processes_scan_exclude_list == ['1', '2']
@@ -802,6 +811,8 @@ class TestsUtilizingFakeYara:
             # Not env vars, but just checking they have the expected values
             assert mdc.nice_value == 19
             assert mdc.cpu_thread_limit == 1
+            assert mdc.rules_location == '/etc/insights-client/signatures'
+            assert mdc.use_remote_rules is True
 
             # Start a filesystem scan and expect scan_only and scan_exclude to cancel each other out
             mdc.scan_filesystem()
@@ -821,7 +832,7 @@ class TestsUtilizingFakeYara:
             mdc = MalwareDetectionClient(None)
             assert mdc.do_filesystem_scan is True
             assert mdc.scan_fsobjects == ['/tmp', '/', '/var/tmp']
-            assert mdc.filesystem_scan_exclude_list == ['/home', '/']
+            assert mdc.filesystem_scan_exclude_list == ['/home', '/', '/etc/insights-client/signatures']
             mdc.scan_filesystem()
             assert mdc.do_filesystem_scan is False
 
@@ -830,7 +841,7 @@ class TestsUtilizingFakeYara:
             mdc = MalwareDetectionClient(None)
             assert mdc.do_filesystem_scan is True
             assert mdc.scan_fsobjects == []
-            assert mdc.filesystem_scan_exclude_list == ['/home', '/']
+            assert mdc.filesystem_scan_exclude_list == ['/home', '/', '/etc/insights-client/signatures']
             mdc.scan_filesystem()
             assert mdc.do_filesystem_scan is False
 
@@ -838,7 +849,7 @@ class TestsUtilizingFakeYara:
             os.environ['FILESYSTEM_SCAN_EXCLUDE'] = ''
             mdc = MalwareDetectionClient(None)
             assert mdc.scan_fsobjects == []
-            assert mdc.filesystem_scan_exclude_list == []
+            assert mdc.filesystem_scan_exclude_list == ['/etc/insights-client/signatures']
 
             if not IS_CONTAINER:
                 # Test when FILESYSTEM_SCAN_EXCLUDE is empty
@@ -1049,7 +1060,7 @@ class TestsUtilizingFakeYara:
             os.environ['FILESYSTEM_SCAN_ONLY'] = scan_only
             os.environ['FILESYSTEM_SCAN_EXCLUDE'] = "%s,%s" % (symlink, broken_symlink)
             mdc = MalwareDetectionClient(None)
-            assert mdc.filesystem_scan_exclude_list == []
+            assert mdc.filesystem_scan_exclude_list == ['/etc/insights-client/signatures']
             assert mdc.scan_fsobjects == [scan_only]
             log_mock.info.assert_any_call(
                 "Skipping symlink filesystem_scan_exclude item: '%s'.  Please use non-symlink items",
@@ -1087,7 +1098,7 @@ class TestsUtilizingFakeYara:
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "test_scan: false" if line.startswith("test_scan:") else line
                 line = (
-                    line + "rules_location: %s\n" % TEST_RULE_FILE
+                    line + "remote_rules_location: %s\n" % TEST_RULE_FILE
                     if line.startswith('---')
                     else line
                 )
@@ -1159,7 +1170,7 @@ class TestsUtilizingFakeYara:
             {
                 'EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS': 'true',
                 'TEST_SCAN': 'false',
-                'RULES_LOCATION': TEST_RULE_FILE,
+                'REMOTE_RULES_LOCATION': TEST_RULE_FILE,
                 'FILESYSTEM_SCAN_ONLY': TEMP_TEST_DIR,
             },
         )
@@ -1375,8 +1386,8 @@ class TestsUtilizingFakeYara:
                 "Unable to find the items specified for the processes_scan_exclude option.  Not excluding any processes."
             )
 
-    @patch(BUILD_YARA_COMMAND_TARGET)
-    @patch(GET_RULES_TARGET, return_value=RULES_FILE)
+    @patch(BUILD_YARA_COMMAND_TARGET, return_value=(['lol'], []))
+    @patch(GET_RULES_TARGET, return_value=[RULES_FILE])
     @patch(DISABLED_RULES_TARGET)
     @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
     @patch(LOGGER_TARGET)
@@ -1466,19 +1477,232 @@ class TestsUtilizingFakeYara:
     @patch.object(InsightsConnection, 'get_proxies')
     @patch.object(InsightsConnection, '_init_session', return_value=Mock())
     @patch.object(MalwareDetectionClient, '_get_disabled_rules', return_value=[])
-    @patch.object(MalwareDetectionClient, '_build_yara_command')
+    @patch.object(MalwareDetectionClient, '_build_yara_command', return_value=(['lol'], []))
     @patch.object(MalwareDetectionClient, '_load_config', return_value=CONFIG)
     # NOTE: Downloading the malware rules file happens within the malware client code so it's possible to test it here
     # However uploading the results archive is done outside the malware client code so it's not possible to test here
     class TestGetRules:
         """Testing the _get_rules method"""
 
+        @patch('os.path.isdir')
+        @patch('os.walk')
+        @patch('fnmatch.filter')
+        @patch(LOGGER_TARGET)
+        @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
+        @patch.dict(os.environ, {'RULES_LOCATION': '/test/rules'})
+        def test_get_rules_directory_with_matching_files(
+                self, yara, log_mock, fnmatch_mock, walk_mock, isdir_mock,
+                conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile
+        ):
+            """Test _get_rules when rules_path is a directory containing matching rule files"""
+            # Mock directory structure with rule files
+            isdir_mock.return_value = True
+            walk_mock.return_value = [
+                ('/test/rules', ['subdir'], ['rule1.yar', 'rule2.yc', 'other.txt']),
+                ('/test/rules/subdir', [], ['rule3.yara', 'readme.md'])
+            ]
+
+            # Mock fnmatch.filter to return matching files for each pattern
+            def filter_side_effect(filenames, pattern):
+                matches = {
+                    '*.yar': ['rule1.yar'],
+                    '*.yc': ['rule2.yc'],
+                    '*.yara': ['rule3.yara']
+                }
+                return matches.get(pattern, [])
+
+            fnmatch_mock.side_effect = filter_side_effect
+
+            # Create MalwareDetectionClient with mock rules_location
+            mdc = MalwareDetectionClient(InsightsConfig())
+
+            # Verify os.walk was called on the correct path
+            walk_mock.assert_called_once_with('/test/rules')
+
+            # Verify the correct rule files were found and added
+            expected_files = [
+                '/test/rules/rule1.yar',
+                '/test/rules/rule2.yc',
+                '/test/rules/subdir/rule3.yara'
+            ]
+            for expected_file in expected_files:
+                assert expected_file in mdc.rules_files
+
+            # Verify no warning was logged since files were found
+            log_mock.warning.assert_not_called()
+
+        @patch('os.path.isdir')
+        @patch('os.walk')
+        @patch('fnmatch.filter')
+        @patch(LOGGER_TARGET)
+        @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
+        @patch.dict(os.environ, {'RULES_LOCATION': '/test/rules'})
+        def test_get_rules_directory_with_no_matching_files(
+                self, yara, log_mock, fnmatch_mock, walk_mock, isdir_mock,
+                conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile
+        ):
+            """Test _get_rules when rules_path is a directory with no matching rule files"""
+            # Mock directory structure with no rule files
+            isdir_mock.return_value = True
+            walk_mock.return_value = [
+                ('/test/rules', ['subdir'], ['readme.txt', 'config.json']),
+                ('/test/rules/subdir', [], ['notes.md', 'script.sh'])
+            ]
+
+            # Mock fnmatch.filter to return empty lists (no matches)
+            fnmatch_mock.return_value = []
+
+            # Create MalwareDetectionClient with mock rules_location
+            mdc = MalwareDetectionClient(InsightsConfig())
+
+            # Verify os.walk was called
+            walk_mock.assert_called_once_with('/test/rules')
+
+            # Verify warning was logged for no rule files found
+            log_mock.warning.assert_called_once_with(
+                "No rule files found in directory: /test/rules"
+            )
+
+            # Verify no rule files were added (empty list or only remote rules)
+            # Note: rules_files might contain remote rules, so we check that no local files were added
+            local_rule_files = [f for f in mdc.rules_files if f.__str__().startswith('/test/rules')]
+            assert len(local_rule_files) == 0
+
+        @patch('os.path.isdir')
+        @patch('os.walk')
+        @patch('fnmatch.filter')
+        @patch(LOGGER_TARGET)
+        @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
+        @patch.dict(os.environ, {'RULES_LOCATION': '/test/empty'})
+        def test_get_rules_empty_directory(
+                self, yara, log_mock, fnmatch_mock, walk_mock, isdir_mock,
+                conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile
+        ):
+            """Test _get_rules when rules_path is an empty directory"""
+            # Mock empty directory
+            isdir_mock.return_value = True
+            walk_mock.return_value = [('/test/empty', [], [])]
+            fnmatch_mock.return_value = []
+
+            # Create MalwareDetectionClient with mock rules_location
+            MalwareDetectionClient(InsightsConfig())
+
+            # Verify os.walk was called
+            walk_mock.assert_called_once_with('/test/empty')
+
+            # Verify warning was logged
+            log_mock.warning.assert_called_once_with(
+                "No rule files found in directory: /test/empty"
+            )
+
+            os.environ['USE_REMOTE_RULES'] = 'false'
+            # Create MalwareDetectionClient with mock rules_location and remote rules disabled
+            with pytest.raises(SystemExit):
+                MalwareDetectionClient(InsightsConfig())
+            # Verify error was logged for no rule files found
+            log_mock.error.assert_called_once_with(
+                "No rules have been found. Please enable use_remote_rules or add rules to rules_location directory"
+            )
+
+            os.environ['USE_REMOTE_RULES'] = 'true'
+            os.environ['REMOTE_RULES_LOCATION'] = '/test/empty'
+            # Create MalwareDetectionClient with mock rules_location and remote rules location set to fake value
+            with pytest.raises(SystemExit):
+                MalwareDetectionClient(InsightsConfig())
+
+            # Verify error was logged for no rule files found
+            log_mock.error.assert_called_with("Couldn't find specified rules file: %s", '/test/empty')
+
+        @patch('os.path.isdir')
+        @patch('os.walk')
+        @patch('fnmatch.filter')
+        @patch(LOGGER_TARGET)
+        @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
+        @patch.dict(os.environ, {'RULES_LOCATION': '/test/mixed'})
+        def test_get_rules_directory_mixed_files(
+                self, yara, log_mock, fnmatch_mock, walk_mock, isdir_mock,
+                conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile
+        ):
+            """Test _get_rules with directory containing mix of rule and non-rule files"""
+            # Mock directory with mixed file types
+            isdir_mock.return_value = True
+            walk_mock.return_value = [
+                ('/test/mixed', ['sub1', 'sub2'], ['test.yar', 'readme.txt', 'malware.yc']),
+                ('/test/mixed/sub1', [], ['rules.yara', 'config.xml']),
+                ('/test/mixed/sub2', [], ['data.json', 'script.py'])
+            ]
+
+            # Mock fnmatch.filter to return appropriate matches per pattern
+            def filter_side_effect(filenames, pattern):
+                file_matches = {
+                    ('test.yar', 'readme.txt', 'malware.yc'): {
+                        '*.yar': ['test.yar'],
+                        '*.yc': ['malware.yc'],
+                        '*.yara': []
+                    },
+                    ('rules.yara', 'config.xml'): {
+                        '*.yar': [],
+                        '*.yc': [],
+                        '*.yara': ['rules.yara']
+                    },
+                    ('data.json', 'script.py'): {
+                        '*.yar': [],
+                        '*.yc': [],
+                        '*.yara': []
+                    }
+                }
+
+                for file_tuple, matches in file_matches.items():
+                    if set(filenames) == set(file_tuple):
+                        return matches.get(pattern, [])
+                return []
+
+            fnmatch_mock.side_effect = filter_side_effect
+
+            # Create MalwareDetectionClient with mock rules_location
+            mdc = MalwareDetectionClient(InsightsConfig())
+
+            # Verify expected rule files were found
+            expected_files = [
+                '/test/mixed/test.yar',
+                '/test/mixed/malware.yc',
+                '/test/mixed/sub1/rules.yara'
+            ]
+
+            for expected_file in expected_files:
+                assert expected_file in mdc.rules_files
+
+            # Verify no warning was logged since rule files were found
+            log_mock.warning.assert_not_called()
+
+        @patch('os.path.isdir')
+        @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
+        @patch.dict(os.environ, {'RULES_LOCATION': '/test/not_a_dir', 'USE_REMOTE_RULES': 'false'})
+        def test_get_rules_not_directory(
+                self, yara, isdir_mock, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile
+        ):
+            """Test _get_rules when rules_path is not a directory (skip directory processing)"""
+            # Mock that rules_path is not a directory
+            isdir_mock.return_value = False
+
+            # Create MalwareDetectionClient
+            # Mock os.path.isfile to return True to test the elif branch
+            with patch('os.path.isfile', return_value=True):
+                mdc = MalwareDetectionClient(InsightsConfig())
+
+                # Verify isdir was called but os.walk was not called
+                isdir_mock.assert_called_once()
+
+                # Since it's not a directory, the directory scanning code should be skipped
+                # and the file path should be added directly (tested in elif branch)
+                assert '/test/not_a_dir' in mdc.rules_files
+
         @patch.dict(os.environ, {'TEST_SCAN': 'true'})
         @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
         def test_download_rules_cert_auth(
             self, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile
         ):
-            # Test the standard rules_location urls, but will result in cert auth being used to download the rules
+            # Test the standard remote_rules_location urls, but will result in cert auth being used to download the rules
             # Test with insights-config None, expect an error when trying to use the insights-config object
             with pytest.raises(SystemExit):
                 MalwareDetectionClient(None)
@@ -1488,10 +1712,11 @@ class TestsUtilizingFakeYara:
             # Expect to use cert auth because no username or password specified and expect to download test-rule.yar
             mdc = MalwareDetectionClient(InsightsConfig())
             assert (
-                mdc.rules_location
+                mdc.remote_rules_location
                 == "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
             )
-            assert mdc.rules_file.startswith('/tmp')  # rules will be saved into a temp file
+            # assumes first rule will be remote rule
+            assert mdc.rules_files[0].startswith('/tmp')  # rules will be saved into a temp file
             get.assert_called_with(
                 "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar",
                 log_response_text=True,
@@ -1502,7 +1727,7 @@ class TestsUtilizingFakeYara:
             # With authmethod=CERT, expect 'cert.' to be prefixed to the url
             mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
             assert (
-                mdc.rules_location
+                mdc.remote_rules_location
                 == "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
             )
             get.assert_called_with(
@@ -1517,7 +1742,7 @@ class TestsUtilizingFakeYara:
             os.environ['TEST_SCAN'] = 'false'
             mdc = MalwareDetectionClient(InsightsConfig(authmethod='BASIC'))
             assert (
-                mdc.rules_location
+                mdc.remote_rules_location
                 == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
             )
             get.assert_called_with(
@@ -1529,7 +1754,7 @@ class TestsUtilizingFakeYara:
 
             mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
             assert (
-                mdc.rules_location
+                mdc.remote_rules_location
                 == "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
             )
             get.assert_called_with(
@@ -1556,7 +1781,7 @@ class TestsUtilizingFakeYara:
             remove,
             tmpfile,
         ):
-            # Test the standard rules_location urls, with basic auth attempting to be used to download the rules
+            # Test the standard remote_rules_location urls, with basic auth attempting to be used to download the rules
             # Basic auth is used by default, but needs to have a valid username and password for it to work
             # Without a username and password, then cert auth will be used
             expected_rules_url = "https://console.redhat.com/api/malware-detection/v1/test-rule.yar"
@@ -1601,7 +1826,7 @@ class TestsUtilizingFakeYara:
             # Test with 'correct' username and password - expect basic auth success
             get.return_value = Mock(status_code=200, content=b"Rule Content")
             mdc = MalwareDetectionClient(InsightsConfig(username='user', password='goodpass'))
-            assert mdc.rules_location == expected_rules_url
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
                 expected_rules_url, log_response_text=True, verify=True, stream=True
             )
@@ -1629,7 +1854,7 @@ class TestsUtilizingFakeYara:
             )
             mdc = MalwareDetectionClient(InsightsConfig())
             assert mdc.yara_version == '4.2.1'
-            assert mdc.rules_location == expected_rules_url + "?yara_version=4.2.1"
+            assert mdc.remote_rules_location == expected_rules_url + "?yara_version=4.2.1"
             get.assert_called_with(
                 expected_rules_url + "?yara_version=4.2.1",
                 log_response_text=False,
@@ -1639,7 +1864,7 @@ class TestsUtilizingFakeYara:
 
             version_mock.return_value = '4.1.0'
             mdc = MalwareDetectionClient(InsightsConfig())
-            assert mdc.rules_location == expected_rules_url + "?yara_version=4.1.0"
+            assert mdc.remote_rules_location == expected_rules_url + "?yara_version=4.1.0"
             get.assert_called_with(
                 expected_rules_url + "?yara_version=4.1.0",
                 log_response_text=False,
@@ -1649,7 +1874,7 @@ class TestsUtilizingFakeYara:
 
             version_mock.return_value = '10.100'
             mdc = MalwareDetectionClient(InsightsConfig())
-            assert mdc.rules_location == expected_rules_url + "?yara_version=10.100"
+            assert mdc.remote_rules_location == expected_rules_url + "?yara_version=10.100"
             get.assert_called_with(
                 expected_rules_url + "?yara_version=10.100",
                 log_response_text=False,
@@ -1661,7 +1886,7 @@ class TestsUtilizingFakeYara:
             with patch(FIND_YARA_TARGET, return_value=FAKE_YARA):
                 mdc = MalwareDetectionClient(InsightsConfig())
             assert not hasattr(mdc, 'yara_version')
-            assert mdc.rules_location == expected_rules_url
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
                 expected_rules_url, log_response_text=False, verify=True, stream=True
             )
@@ -1690,7 +1915,7 @@ class TestsUtilizingFakeYara:
             expected_rules_url = "https://cert.console.stage.example.com/api/malware-detection/v1/signatures.yar?yara_version=4.2.0"
             mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url, cert_verify='False'))
             assert mdc.yara_version == '4.2.0'
-            assert mdc.rules_location == expected_rules_url
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
                 expected_rules_url, log_response_text=False, verify=False, stream=True
             )
@@ -1700,7 +1925,7 @@ class TestsUtilizingFakeYara:
                 'cert.console.stage.example.com',
             ):
                 mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url, cert_verify='false'))
-                assert mdc.rules_location == expected_rules_url
+                assert mdc.remote_rules_location == expected_rules_url
                 get.assert_called_with(
                     expected_rules_url, log_response_text=False, verify=False, stream=True
                 )
@@ -1708,7 +1933,7 @@ class TestsUtilizingFakeYara:
             base_url = "https://cert.console.stage.example.com:443/r/insights"
             expected_rules_url = "https://cert.console.stage.example.com:443/api/malware-detection/v1/signatures.yar?yara_version=4.2.0"
             mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url, cert_verify='True'))
-            assert mdc.rules_location == expected_rules_url
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
                 expected_rules_url, log_response_text=False, verify=True, stream=True
             )
@@ -1719,13 +1944,13 @@ class TestsUtilizingFakeYara:
                 "https://cloud.stage.example.com/api/malware-detection/v1/test-rule.yar"
             )
             mdc = MalwareDetectionClient(InsightsConfig(base_url=base_url, cert_verify=''))
-            assert mdc.rules_location == expected_rules_url
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
                 expected_rules_url, log_response_text=True, verify=True, stream=True
             )
 
         @patch.dict(
-            os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': 'console.redhat.com/rules.yar'}
+            os.environ, {'TEST_SCAN': 'true', 'REMOTE_RULES_LOCATION': 'console.redhat.com/rules.yar'}
         )
         @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
         def test_get_rules_missing_protocol(
@@ -1734,7 +1959,7 @@ class TestsUtilizingFakeYara:
             # Non-standard rules URLS - without https:// at the start and not signatures.yar
             # test-scan true and BASIC auth by default expect test-rule.yar and no 'cert.' in URL
             mdc = MalwareDetectionClient(InsightsConfig(username='user', password='pass'))
-            assert mdc.rules_location == "https://console.redhat.com/test-rule.yar"
+            assert mdc.remote_rules_location == "https://console.redhat.com/test-rule.yar"
             get.assert_called_with(
                 "https://console.redhat.com/test-rule.yar",
                 log_response_text=True,
@@ -1745,7 +1970,7 @@ class TestsUtilizingFakeYara:
             # test-scan false and CERT auth - expect 'cert.' prefixed to the URL and not test-rule.yar
             os.environ['TEST_SCAN'] = 'false'
             mdc = MalwareDetectionClient(InsightsConfig(authmethod='CERT'))
-            assert mdc.rules_location == "https://cert.console.redhat.com/rules.yar"
+            assert mdc.remote_rules_location == "https://cert.console.redhat.com/rules.yar"
             get.assert_called_with(
                 "https://cert.console.redhat.com/rules.yar",
                 log_response_text=False,
@@ -1754,7 +1979,7 @@ class TestsUtilizingFakeYara:
             )
 
         @patch.dict(
-            os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'http://localhost/rules.yar'}
+            os.environ, {'TEST_SCAN': 'false', 'REMOTE_RULES_LOCATION': 'http://localhost/rules.yar'}
         )
         @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
         @patch(LOGGER_TARGET)
@@ -1775,9 +2000,9 @@ class TestsUtilizingFakeYara:
             from requests.exceptions import ConnectionError, Timeout
 
             # Test various problems downloading rules
-            expected_rules_url = os.environ['RULES_LOCATION']
+            expected_rules_url = os.environ['REMOTE_RULES_LOCATION']
 
-            # 404 error - unlikely to occur unless an incorrect rules_location was manually specified
+            # 404 error - unlikely to occur unless an incorrect remote_rules_location was manually specified
             get.return_value = Mock(status_code=404, reason="Not found", text="Nup")
             with pytest.raises(SystemExit):
                 MalwareDetectionClient(InsightsConfig())
@@ -1811,7 +2036,7 @@ class TestsUtilizingFakeYara:
             'Use TEST_DOWNLOAD_FAILURE_RETRIES=True to enable test',
         )
         @patch.dict(
-            os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'http://localhost/rules.yar'}
+            os.environ, {'TEST_SCAN': 'false', 'REMOTE_RULES_LOCATION': 'http://localhost/rules.yar'}
         )
         @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
         @patch("os.path.isfile", return_value=True)
@@ -1834,7 +2059,7 @@ class TestsUtilizingFakeYara:
             from requests.exceptions import ConnectionError, SSLError
 
             # Testing the download failure retry logic
-            expected_rules_url = os.environ['RULES_LOCATION']
+            expected_rules_url = os.environ['REMOTE_RULES_LOCATION']
 
             # Status code != 200 will trigger a retry, but only if retries > 1
             get.return_value = Mock(status_code=404, reason="Not found", text="Nup")
@@ -1898,26 +2123,26 @@ class TestsUtilizingFakeYara:
             )
 
         @patch.dict(
-            os.environ, {'TEST_SCAN': 'true', 'RULES_LOCATION': '//console.redhat.com/rules.yar'}
+            os.environ, {'TEST_SCAN': 'true', 'REMOTE_RULES_LOCATION': '//console.redhat.com/rules.yar'}
         )
         @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
         @patch("os.path.isfile", return_value=True)
         def test_get_rules_location_as_file(
             self, isfile, yara, conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile
         ):
-            # Test using files for rules_location, esp irregular file names
-            # rules_location that starts with a '/' is assumed to be a file, even if its a double '//'
+            # Test using files for remote_rules_location, esp irregular file names
+            # remote_rules_location that starts with a '/' is assumed to be a file, even if its a double '//'
             # Re-writing the rule to be test-rule.yar doesn't apply to local files
             mdc = MalwareDetectionClient(None)
-            assert mdc.rules_location == "//console.redhat.com/rules.yar"
-            assert mdc.rules_file == "/console.redhat.com/rules.yar"
+            assert mdc.remote_rules_location == "//console.redhat.com/rules.yar"
+            assert mdc.rules_files == ["/etc/insights-client/signatures", "/console.redhat.com/rules.yar"]
             get.assert_not_called()
 
             # Just to confirm the filename stays the same for regardless of test_rule value
             os.environ['TEST_SCAN'] = 'false'
             mdc = MalwareDetectionClient(None)
-            assert mdc.rules_location == "//console.redhat.com/rules.yar"
-            assert mdc.rules_file == "/console.redhat.com/rules.yar"
+            assert mdc.remote_rules_location == "//console.redhat.com/rules.yar"
+            assert mdc.rules_files == ["/etc/insights-client/signatures", "/console.redhat.com/rules.yar"]
             get.assert_not_called()
 
         @patch.dict(os.environ, {'TEST_SCAN': 'true'})
@@ -1939,7 +2164,7 @@ class TestsUtilizingFakeYara:
             expected_rules_url = expected_rules_url_prefix + "test-rule.yar"
             with patch(FIND_YARA_TARGET, return_value=FAKE_YARA):
                 mdc = MalwareDetectionClient(insights_config)
-            assert mdc.rules_location == expected_rules_url
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
                 expected_rules_url, log_response_text=True, verify=satellite_cert, stream=True
             )
@@ -1951,7 +2176,7 @@ class TestsUtilizingFakeYara:
             expected_rules_url = expected_rules_url_prefix + "signatures.yar"
             with patch(FIND_YARA_TARGET, return_value=FAKE_YARA):
                 mdc = MalwareDetectionClient(insights_config)
-            assert mdc.rules_location == expected_rules_url
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
                 expected_rules_url, log_response_text=False, verify=satellite_cert, stream=True
             )
@@ -1962,7 +2187,7 @@ class TestsUtilizingFakeYara:
             with patch('os.path.exists', return_value=True):
                 with patch(CALL_TARGET, return_value='4.1'):
                     mdc = MalwareDetectionClient(insights_config)
-            assert mdc.rules_location == expected_rules_url
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
                 expected_rules_url, log_response_text=False, verify=satellite_cert, stream=True
             )
@@ -1981,12 +2206,52 @@ class TestsUtilizingFakeYara:
                     mdc = MalwareDetectionClient(
                         InsightsConfig(base_url=satellite_url, verbose=True, cert_verify=None)
                     )
-            assert mdc.rules_location == expected_rules_url
+            assert mdc.remote_rules_location == expected_rules_url
             get.assert_called_with(
                 expected_rules_url, log_response_text=False, verify=True, stream=True
             )
             log_mock.debug.assert_called_with("Using cert_verify value %s ...", True)
             log_mock.debug.assert_any_call("Downloading rules from: %s", expected_rules_url)
+
+        @patch.object(builtins, 'sum')
+        @patch('os.path.exists')
+        @patch(LOGGER_TARGET)
+        @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
+        @patch.dict(os.environ, {'RULES_LOCATION': '/nonexistent', 'USE_REMOTE_RULES': 'false'})
+        def test_get_rules_old_rules_file_removal_with_existing_files(
+            self, yara, log_mock, exists_mock, sum_mock,
+            conf, cmd, disabled, session, proxies, get, findmnt, remove, tmpfile
+        ):
+            """Test _get_rules removes old rules files that exist"""
+            # Mock glob to return list of old rules files
+            old_files = [
+                '/tmp/malware-detection_yara_rules.123',
+                '/var/tmp/.tmpmdsigs456',
+                '/usr/tmp/tmp_malware-detection-client_rules.789'
+            ]
+            sum_mock.return_value = old_files
+
+            # Mock os.path.exists to return True for all files (they exist)
+            exists_mock.return_value = True
+
+            # Mock use_remote_rules to False as to avoid remote rules processing
+            with pytest.raises(SystemExit):
+                MalwareDetectionClient(InsightsConfig())
+
+            # Verify os.path.exists was called for each old rules file
+            assert exists_mock.call_count == 3
+            for f in old_files:
+                exists_mock.assert_any_call(f)
+
+            # Verify os.remove was called for each existing old rules file
+            assert remove.call_count == 3
+            for f in old_files:
+                remove.assert_any_call(f)
+
+            # Verify debug logging for each removed file
+            assert log_mock.debug.call_count == 5  # includes 2 debug logs for env vars
+            for f in old_files:
+                log_mock.debug.assert_any_call("Removing old rules file %s", f)
 
     @patch(
         NAMEDTMPFILE_TARGET
@@ -1994,7 +2259,7 @@ class TestsUtilizingFakeYara:
     @patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
     @patch(FINDMNT_TARGET)  # Don't run the command
     @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
-    @patch(BUILD_YARA_COMMAND_TARGET)
+    @patch(BUILD_YARA_COMMAND_TARGET, return_value=(['lol'], []))
     @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
     class TestDisabledRules:
         """Testing the _get_disabled_rules method"""
@@ -2003,13 +2268,13 @@ class TestsUtilizingFakeYara:
         def test_skip_getting_disabled_rules(self, conf, cmd, yara, findmnt, remove, tmpfile):
             # Skip getting disabled rules if doing a test scan
             os.environ['TEST_SCAN'] = 'true'
-            with patch(GET_RULES_TARGET, return_value=RULES_FILE):
+            with patch(GET_RULES_TARGET, return_value=[RULES_FILE]):
                 mdc = MalwareDetectionClient(None)
             assert mdc.disabled_rules == []
 
             # Skip getting disabled rules if the rules are coming from a file (which is really only for testing anyway)
             os.environ['TEST_SCAN'] = 'false'
-            os.environ['RULES_LOCATION'] = '/local/rules/file.yar'
+            os.environ['REMOTE_RULES_LOCATION'] = '/local/rules/file.yar'
             with patch("os.path.isfile", return_value=True):
                 mdc = MalwareDetectionClient(None)
             assert mdc.disabled_rules == []
@@ -2025,7 +2290,7 @@ class TestsUtilizingFakeYara:
             self, session, proxies, get, post, conf, cmd, yara, findmnt, remove, tmpfile
         ):
             # Test with no disabled rules
-            rules_location = (
+            remote_rules_location = (
                 "https://cert.console.redhat.com/api/malware-detection/v1/signatures.yar"
             )
             expected_graphql_url = (
@@ -2035,7 +2300,7 @@ class TestsUtilizingFakeYara:
                 status_code=200, json=Mock(return_value={'data': {'rulesList': []}})
             )
             mdc = MalwareDetectionClient(InsightsConfig())
-            assert mdc.rules_location == rules_location
+            assert mdc.remote_rules_location == remote_rules_location
             assert mdc.graphql_url == expected_graphql_url
             assert post.called_with(expected_graphql_url, ANY, ANY, verify=True, stream=True)
             assert mdc.disabled_rules == []
@@ -2048,9 +2313,9 @@ class TestsUtilizingFakeYara:
             mdc = MalwareDetectionClient(InsightsConfig())
             assert mdc.disabled_rules == ['rule1']
 
-            # Test with multiple disabled rules and a different rules_location
-            rules_location = "http://localhost/rules.yar"
-            os.environ['RULES_LOCATION'] = rules_location
+            # Test with multiple disabled rules and a different remote_rules_location
+            remote_rules_location = "http://localhost/rules.yar"
+            os.environ['REMOTE_RULES_LOCATION'] = remote_rules_location
             expected_graphql_url = "http://localhost/graphql"
             post.return_value = Mock(
                 status_code=200,
@@ -2068,7 +2333,7 @@ class TestsUtilizingFakeYara:
                 ),
             )
             mdc = MalwareDetectionClient(InsightsConfig())
-            assert mdc.rules_location == rules_location
+            assert mdc.remote_rules_location == remote_rules_location
             assert mdc.graphql_url == expected_graphql_url
             assert post.called_with(expected_graphql_url, ANY, ANY, verify=True, stream=True)
             assert mdc.disabled_rules == ['abc', 'rule1', 'rule2', 'xyz']
@@ -2084,7 +2349,7 @@ class TestsUtilizingFakeYara:
         )
         @patch.object(InsightsConnection, 'get_proxies')
         @patch.object(InsightsConnection, '_init_session', return_value=Mock())
-        @patch.dict(os.environ, {'TEST_SCAN': 'false', 'RULES_LOCATION': 'localhost/rules.yar'})
+        @patch.dict(os.environ, {'TEST_SCAN': 'false', 'REMOTE_RULES_LOCATION': 'localhost/rules.yar'})
         @patch(LOGGER_TARGET)
         def test_get_disabled_rules_failure(
             self, log, session, proxies, get, post, conf, cmd, yara, findmnt, remove, tmpfile
@@ -2093,7 +2358,7 @@ class TestsUtilizingFakeYara:
 
             expected_graphql_url = 'https://localhost/graphql'
 
-            # 404 error - unlikely to occur unless an incorrect rules_location was manually specified
+            # 404 error - unlikely to occur unless an incorrect remote_rules_location was manually specified
             post.return_value = Mock(status_code=404, reason="Not found", text="Nup")
             mdc = MalwareDetectionClient(InsightsConfig(retries=2))
             log.debug.assert_any_call(
@@ -2125,7 +2390,7 @@ class TestsUtilizingFakeYara:
             assert post.call_count == 3
             assert mdc.disabled_rules == []
 
-    @patch(GET_RULES_TARGET, return_value=RULES_FILE)
+    @patch(GET_RULES_TARGET, return_value=[RULES_FILE])
     @patch(DISABLED_RULES_TARGET)
     @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
     @patch(LOAD_CONFIG_TARGET, return_value=CONFIG)
@@ -2133,7 +2398,7 @@ class TestsUtilizingFakeYara:
 
         @patch('os.path.getsize')
         def test_build_yara_command_success(self, size, conf, yara, disabled, rules):
-            expected_yara_cmd = "nice -n 19 {0} -s -N -a 3600 -p 1 -r -f%s {1}".format(
+            expected_yara_cmd = "nice -n 19 {0} -s -w -m -N -a 3600 -p 1 -r -f%s {1}".format(
                 FAKE_YARA, RULES_FILE
             )
             size.return_value = 1
@@ -2149,13 +2414,14 @@ class TestsUtilizingFakeYara:
             with patch(CALL_TARGET, side_effect=['Yara 3.X', 'ok', '2']) as call_mock:
                 mdc = MalwareDetectionClient(None)
                 assert call_mock.call_count == 3
-            assert ' '.join(mdc.yara_cmd) == expected_yara_cmd % ' -C'
+            assert ' '.join(mdc.yara_compiled_cmds[0]) == expected_yara_cmd % ' -C'
 
             # Another test with compiled rules file - file type is 'data'
             with patch(CALL_TARGET, side_effect=['data', 'ok', '2']) as call_mock:
                 mdc = MalwareDetectionClient(None)
                 assert call_mock.call_count == 3
-            assert ' '.join(mdc.yara_cmd) == expected_yara_cmd % ' -C'
+
+            assert ' '.join(mdc.yara_compiled_cmds[0]) == expected_yara_cmd % ' -C'
 
         @patch(LOGGER_TARGET)
         @patch('os.path.getsize')
@@ -2179,16 +2445,23 @@ class TestsUtilizingFakeYara:
             # Test with 'invalid' rules file - raise CalledProcessError when running command
             with patch(CALL_TARGET) as call_mock:
                 call_mock.side_effect = ['yara', CalledProcessError(1, 'cmd', b'invalid\n'), '2']
-                with pytest.raises(SystemExit):
-                    MalwareDetectionClient(None)
-                assert call_mock.call_count == 2  # 2 calls to 'call' before we exit
+                mdc = MalwareDetectionClient(None)
+                assert call_mock.call_count == 3  # 3 calls to 'call' before we finish
+                assert len(mdc.yara_compiled_cmds) == 1  # assert rules file is still used
+
+            # Test with 'error' rules file - raise CalledProcessError when running command
+            with patch(CALL_TARGET) as call_mock:
+                call_mock.side_effect = ['yara', CalledProcessError(1, 'cmd', b'error\n'), '2']
+                mdc = MalwareDetectionClient(None)
+                assert call_mock.call_count == 3  # 3 calls to 'call' before we finish
+                assert len(mdc.yara_compiled_cmds) == 0  # assert rules file is removed
             log_mock.error.assert_called_with(
-                "Unable to use rules file %s: %s", RULES_FILE, "invalid"
+                "Invalid rules file %s: %s", RULES_FILE, 'error\n'
             )
 
     @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
-    @patch(BUILD_YARA_COMMAND_TARGET)
-    @patch(GET_RULES_TARGET, return_value=TEST_RULE_FILE)
+    @patch(BUILD_YARA_COMMAND_TARGET, return_value=(['lol'], []))
+    @patch(GET_RULES_TARGET, return_value=[TEST_RULE_FILE])
     @patch(DISABLED_RULES_TARGET)
     @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
     @patch(LOGGER_TARGET)
@@ -2207,7 +2480,7 @@ class TestsUtilizingFakeYara:
                 line = "add_metadata: false" if line.startswith("add_metadata:") else line
                 print(line)
             mdc = MalwareDetectionClient(None)
-            assert mdc.rules_file == TEST_RULE_FILE
+            assert mdc.rules_files == [TEST_RULE_FILE]
             assert mdc.do_filesystem_scan is True
             assert mdc.do_process_scan is True
             assert mdc.scan_pids == []
@@ -2215,7 +2488,14 @@ class TestsUtilizingFakeYara:
 
             # Patch the calls to yara so it doesn't actually try to scan any processes
             with patch(CALL_TARGET, return_value=""):
+                # have to manually set active cmd:
+                all_cmds = mdc.yara_compiled_cmds
+                if mdc.yara_cmd:
+                    all_cmds.append(mdc.yara_cmd)
+                for cmd in all_cmds:
+                    mdc.active_cmd = cmd
                 mdc.scan_processes()
+
             assert mdc.processes_scan_exclude_list == [TEST_PID]
             assert len(mdc.scan_pids) > 1
             assert '1' in mdc.scan_pids
@@ -2233,6 +2513,12 @@ class TestsUtilizingFakeYara:
             assert mdc.processes_scan_exclude_list == ['1']
             # Patch the calls to yara so it doesn't actually try to scan any processes
             with patch(CALL_TARGET, return_value=""):
+                # have to manually set active cmd:
+                all_cmds = mdc.yara_compiled_cmds
+                if mdc.yara_cmd:
+                    all_cmds.append(mdc.yara_cmd)
+                for cmd in all_cmds:
+                    mdc.active_cmd = cmd
                 mdc.scan_processes()
             assert mdc.processes_scan_exclude_list == ['1', TEST_PID]
             assert len(mdc.scan_pids) > 1
@@ -2245,6 +2531,12 @@ class TestsUtilizingFakeYara:
             assert '2' not in mdc.processes_scan_exclude_list
             # Patch the calls to yara so it doesn't actually try to scan any processes
             with patch(CALL_TARGET, return_value=""):
+                # have to manually set active cmd:
+                all_cmds = mdc.yara_compiled_cmds
+                if mdc.yara_cmd:
+                    all_cmds.append(mdc.yara_cmd)
+                for cmd in all_cmds:
+                    mdc.active_cmd = cmd
                 mdc.scan_processes()
             assert all([pid in mdc.processes_scan_exclude_list for pid in ['1', '3', TEST_PID]])
             assert len(mdc.scan_pids) > 1
@@ -2276,7 +2568,7 @@ class TestsUtilizingFakeYara:
                 line = "add_metadata: false" if line.startswith("add_metadata:") else line
                 print(line)
             mdc = MalwareDetectionClient(None)
-            assert mdc.rules_file == TEST_RULE_FILE
+            assert mdc.rules_files == [TEST_RULE_FILE]
             assert mdc.do_filesystem_scan is False
             assert mdc.do_process_scan is True
             # Match TEST_RULE_SCRIPT process from processes_scan_only
@@ -2305,6 +2597,12 @@ class TestsUtilizingFakeYara:
             # But when we run scan_processes() it won't be found because it wasn't started since the last scan
             # Patch the calls to yara so it doesn't actually try to scan any processes
             with patch(CALL_TARGET, return_value=ps_call_output):
+                # have to manually set active cmd:
+                all_cmds = mdc.yara_compiled_cmds
+                if mdc.yara_cmd:
+                    all_cmds.append(mdc.yara_cmd)
+                for cmd in all_cmds:
+                    mdc.active_cmd = cmd
                 mdc.scan_processes()
             assert len(mdc.scan_pids) == 0
             log_mock.error.assert_called_with(
@@ -2326,6 +2624,12 @@ class TestsUtilizingFakeYara:
                 # The first call is to ps to get the process list, which is what we want
                 # The second call is to yara, which we want to ignore since yara may not be installed
                 call_mock.side_effect = [ps_call_output, ""]
+                # have to manually set active cmd:
+                all_cmds = mdc.yara_compiled_cmds
+                if mdc.yara_cmd:
+                    all_cmds.append(mdc.yara_cmd)
+                for cmd in all_cmds:
+                    mdc.active_cmd = cmd
                 mdc.scan_processes()
             # Expect to find the TEST_RULE_SCRIPT process because it was started since a day ago
             assert len(mdc.scan_pids) == 1
@@ -2346,13 +2650,19 @@ class TestsUtilizingFakeYara:
             # But when we run scan_processes() only the latest one will be found
             with patch(CALL_TARGET) as call_mock:
                 call_mock.side_effect = [ps_call_output, ""]
+                # have to manually set active cmd:
+                all_cmds = mdc.yara_compiled_cmds
+                if mdc.yara_cmd:
+                    all_cmds.append(mdc.yara_cmd)
+                for cmd in all_cmds:
+                    mdc.active_cmd = cmd
                 mdc.scan_processes()
             # Only find the latest TEST_RULE_SCRIPT process
             assert len(mdc.scan_pids) == 1
 
     @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
     @patch('os.remove')  # Mock os.remove so it doesn't actually try to remove any existing files
-    @patch(BUILD_YARA_COMMAND_TARGET)
+    @patch(BUILD_YARA_COMMAND_TARGET, return_value=(['lol'], []))
     @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
     @patch(LOGGER_TARGET)
     class TestFilesystemScanning:
@@ -2360,13 +2670,13 @@ class TestsUtilizingFakeYara:
         def test_scan_rules_file_with_extra_slashes(
             self, log_mock, yara, cmd, remove, create_test_files_fake_yara
         ):
-            # Test scanning RULES_FILE with an extra slash only in the rules_location one
-            # Even with the extra slashes in the rules_location there will be rules matched
+            # Test scanning RULES_FILE with an extra slash only in the remote_rules_location one
+            # Even with the extra slashes in the remote_rules_location there will be rules matched
             # because */rules_compiled.yar and *//rules_compiled.yar are the same file
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "test_scan: false" if line.startswith("test_scan:") else line
                 line = (
-                    line + "rules_location: %s\n" % TEST_RULE_FILE.replace('/', '//')
+                    line + "remote_rules_location: %s\n" % TEST_RULE_FILE.replace('/', '//')
                     if line.startswith('---')
                     else line
                 )
@@ -2383,21 +2693,31 @@ class TestsUtilizingFakeYara:
                 )
                 print(line)
             mdc = MalwareDetectionClient(None)
-            assert mdc.rules_location == TEST_RULE_FILE.replace('/', '//')
-            assert mdc.rules_file == TEST_RULE_FILE
+            assert mdc.remote_rules_location == TEST_RULE_FILE.replace('/', '//')
+            assert mdc.rules_files == [TEST_RULE_FILE]
             assert mdc.scan_fsobjects == [TEST_RULE_FILE]
             with patch(CALL_TARGET) as call_mock:
                 # Mock the scan match data from yara
                 call_mock.return_value = (
-                    "TEST_RedHatInsightsMalwareDetection %s\n0x4a:$re1: Malware Detection Client"
+                    'TEST_RedHatInsightsMalwareDetection [author="Red Hat Insights",description="Verifies the Red Hat Insights Malware Detection Client app is present on the system",usage="Verification",date_created="11 June 2021",date_updated="18 October 2021"] %s\n0x4a:$re1: Malware Detection Client'
                     % TEST_RULE_FILE
                 )
+                # have to manually set active cmd:
+                all_cmds = mdc.yara_compiled_cmds
+                if mdc.yara_cmd:
+                    all_cmds.append(mdc.yara_cmd)
+                for cmd in all_cmds:
+                    mdc.active_cmd = cmd
                 mdc.scan_filesystem()
             rule_match = mdc.host_scan['TEST_RedHatInsightsMalwareDetection']
-            assert rule_match[0]['source'] == TEST_RULE_FILE
-            assert rule_match[0]['string_data'] == "Malware Detection Client"
-            assert rule_match[0]['string_identifier'] == '$re1'
-            assert rule_match[0]['string_offset'] == 74
+            assert rule_match['matches'][0]['source'] == TEST_RULE_FILE
+            assert rule_match['matches'][0]['string_data'] == "Malware Detection Client"
+            assert rule_match['matches'][0]['string_identifier'] == '$re1'
+            assert rule_match['matches'][0]['string_offset'] == 74
+            assert rule_match['metadata']['author'] == 'Red Hat Insights'
+            assert rule_match['metadata']['description'] == 'Verifies the Red Hat Insights Malware Detection Client app is present on the system'
+            assert rule_match['metadata']['usage'] == 'Verification'
+
             log_mock.info.assert_any_call(
                 "Matched rule %s in %s %s",
                 "TEST_RedHatInsightsMalwareDetection",
@@ -2412,7 +2732,7 @@ class TestsUtilizingFakeYara:
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "test_scan: false" if line.startswith("test_scan:") else line
                 line = (
-                    line + "rules_location: %s\n" % TEST_RULE_FILE
+                    line + "remote_rules_location: %s\n" % TEST_RULE_FILE
                     if line.startswith('---')
                     else line
                 )
@@ -2468,7 +2788,7 @@ class TestsUtilizingFakeYara:
             for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                 line = "test_scan: false" if line.startswith("test_scan:") else line
                 line = (
-                    line + "rules_location: %s\n" % TEST_RULE_FILE
+                    line + "remote_rules_location: %s\n" % TEST_RULE_FILE
                     if line.startswith('---')
                     else line
                 )
@@ -2502,6 +2822,12 @@ class TestsUtilizingFakeYara:
             # Also mock out the call to yara but we don't return anything since we aren't testing it
             with open(yara_file_list, 'w') as f:
                 tmp_file_mock.return_value = f
+                # have to manually set active cmd:
+                all_cmds = mdc.yara_compiled_cmds
+                if mdc.yara_cmd:
+                    all_cmds.append(mdc.yara_cmd)
+                for cmd in all_cmds:
+                    mdc.active_cmd = cmd
                 mdc.scan_filesystem()
             with open(yara_file_list, 'r') as f:
                 contents = f.read().splitlines()
@@ -2533,6 +2859,12 @@ class TestsUtilizingFakeYara:
             # Also mock out the call to yara, but we don't return anything since we aren't testing it
             with open(yara_file_list, 'w') as f:
                 tmp_file_mock.return_value = f
+                # have to manually set active cmd:
+                all_cmds = mdc.yara_compiled_cmds
+                if mdc.yara_cmd:
+                    all_cmds.append(mdc.yara_cmd)
+                for cmd in all_cmds:
+                    mdc.active_cmd = cmd
                 mdc.scan_filesystem()
             with open(yara_file_list, 'r') as f:
                 contents = f.read().splitlines()
@@ -2550,6 +2882,12 @@ class TestsUtilizingFakeYara:
 
             with open(yara_file_list, 'w') as f:
                 tmp_file_mock.return_value = f
+                # have to manually set active cmd:
+                all_cmds = mdc.yara_compiled_cmds
+                if mdc.yara_cmd:
+                    all_cmds.append(mdc.yara_cmd)
+                for cmd in all_cmds:
+                    mdc.active_cmd = cmd
                 mdc.scan_filesystem()
             with open(yara_file_list, 'r') as f:
                 contents = f.read().splitlines()
@@ -2577,6 +2915,12 @@ class TestsUtilizingFakeYara:
 
             with open(yara_file_list, 'w') as f:
                 tmp_file_mock.return_value = f
+                # have to manually set active cmd:
+                all_cmds = mdc.yara_compiled_cmds
+                if mdc.yara_cmd:
+                    all_cmds.append(mdc.yara_cmd)
+                for cmd in all_cmds:
+                    mdc.active_cmd = cmd
                 mdc.scan_filesystem()
             with open(yara_file_list, 'r') as f:
                 contents = f.read().splitlines()
@@ -2597,13 +2941,13 @@ class TestsUtilizingFakeYara:
             ]
             os.environ['TEST_SCAN'] = 'false'
             os.environ['EXCLUDE_NETWORK_FILESYSTEM_MOUNTPOINTS'] = 'false'
-            os.environ['RULES_LOCATION'] = TEST_RULE_FILE
+            os.environ['REMOTE_RULES_LOCATION'] = TEST_RULE_FILE
             os.environ['FILESYSTEM_SCAN_ONLY'] = "%s,%s" % (
                 TEMP_TEST_DIR,
                 glob_files[1],
             )  # we actually want to scan glob_files[1]
             mdc = MalwareDetectionClient(None)
-            assert mdc.rules_file == TEST_RULE_FILE
+            assert mdc.rules_files == [TEST_RULE_FILE]
             assert mdc.scan_fsobjects == [TEMP_TEST_DIR, glob_files[1]]
 
             # Patch the call to glob so it returns a specific list of files
@@ -2612,8 +2956,14 @@ class TestsUtilizingFakeYara:
                 "insights.specs.datasources.malware_detection.glob", return_value=glob_files
             ):
                 with patch(CALL_TARGET, return_value=""):
+                    # have to manually set active cmd:
+                    all_cmds = mdc.yara_compiled_cmds
+                    if mdc.yara_cmd:
+                        all_cmds.append(mdc.yara_cmd)
+                    for cmd in all_cmds:
+                        mdc.active_cmd = cmd
                     mdc.scan_filesystem()
-            assert mdc.rules_file in mdc.filesystem_scan_exclude_list
+            assert mdc.rules_files[0] in mdc.filesystem_scan_exclude_list
             assert glob_files[0] in mdc.filesystem_scan_exclude_list
             # Make sure glob_files[1] isn't excluded because we actually want to scan that file
             assert glob_files[1] not in mdc.filesystem_scan_exclude_list
@@ -2622,13 +2972,19 @@ class TestsUtilizingFakeYara:
             mdc = MalwareDetectionClient(None)
             with patch("insights.specs.datasources.malware_detection.glob", return_value=[]):
                 with patch(CALL_TARGET, return_value=""):
+                    # have to manually set active cmd:
+                    all_cmds = mdc.yara_compiled_cmds
+                    if mdc.yara_cmd:
+                        all_cmds.append(mdc.yara_cmd)
+                    for cmd in all_cmds:
+                        mdc.active_cmd = cmd
                     mdc.scan_filesystem()
-            assert mdc.rules_file in mdc.filesystem_scan_exclude_list
+            assert mdc.rules_files[0] in mdc.filesystem_scan_exclude_list
             # None of the glob files should be excluded this time
             assert all([f not in mdc.filesystem_scan_exclude_list for f in glob_files])
 
     @patch(FINDMNT_TARGET)
-    @patch(BUILD_YARA_COMMAND_TARGET)
+    @patch(BUILD_YARA_COMMAND_TARGET, return_value=(['lol'], []))
     @patch(GET_RULES_TARGET, return_value=RULES_FILE)
     @patch(DISABLED_RULES_TARGET)
     @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
@@ -2780,7 +3136,7 @@ class TestsUtilizingFakeYara:
             assert all([x in scan_dict['/var']['include'] for x in maybe_dirs])
 
     @patch(FINDMNT_TARGET)
-    @patch(BUILD_YARA_COMMAND_TARGET)
+    @patch(BUILD_YARA_COMMAND_TARGET, return_value=(['lol'], []))
     @patch(GET_RULES_TARGET, return_value=RULES_FILE)
     @patch(DISABLED_RULES_TARGET, return_value=[])
     @patch(FIND_YARA_TARGET, return_value=FAKE_YARA)
@@ -2802,7 +3158,7 @@ class TestsUtilizingFakeYara:
             assert mdc.matches == 8  # 8 sources/files matched across the 5 rules
 
             # 1 matching source/file and 1 matching string for rule 'this'
-            rule_match = mdc.host_scan['this']
+            rule_match = mdc.host_scan['this']['matches']
             rule_sources = set(map(lambda x: x['source'], rule_match))
             assert len(rule_sources) == 1
             assert len(rule_match) == 1
@@ -2812,7 +3168,7 @@ class TestsUtilizingFakeYara:
             assert rule_match[0]['string_offset'] == 291
 
             # 3 source/file matches and 14 matching strings across those sources for rule 'Rule'
-            rule_match = mdc.host_scan['Rule']
+            rule_match = mdc.host_scan['Rule']['matches']
             rule_sources = set(map(lambda x: x['source'], rule_match))
             assert len(rule_sources) == 3
             assert len(rule_match) == 14
@@ -2875,7 +3231,7 @@ class TestsUtilizingFakeYara:
             assert rule_match[13]['string_offset'] == -1
 
             # 2 source matches and 4 matching strings for 'another_matching_rule'
-            rule_match = mdc.host_scan['another_matching_rule']
+            rule_match = mdc.host_scan['another_matching_rule']['matches']
             rule_sources = set(map(lambda x: x['source'], rule_match))
             assert len(rule_sources) == 2
             assert len(rule_match) == 4
@@ -2891,15 +3247,15 @@ class TestsUtilizingFakeYara:
             assert rule_match[3]['string_offset'] == 0
 
             # 1 matching source and 1 matching string for 'Iyamtho'
-            rule_match = mdc.host_scan['Iyamtho']
+            rule_match = mdc.host_scan['Iyamtho']['matches']
             assert len(rule_match) == 1
-            assert rule_match[0]['source'] == " yep"
+            assert rule_match[0]['source'] == "yep"
             assert rule_match[0]['string_data'] == ''
             assert rule_match[0]['string_identifier'] == ''
             assert rule_match[0]['string_offset'] == -1
 
             # 1 matching source and 1 matching string for 'n_m3_t00'
-            rule_match = mdc.host_scan['n_m3_t00']
+            rule_match = mdc.host_scan['n_m3_t00']['matches']
             assert len(rule_match) == 1
             assert rule_match[0]['source'] == "damn   straight"
             assert rule_match[0]['string_data'] == ''
@@ -2917,7 +3273,7 @@ class TestsUtilizingFakeYara:
             mdc.parse_scan_output(CONTRIVED_SCAN_OUTPUT)
 
             # Matches and metadata for MATCHING_ENTITY_FILE
-            rule_match = mdc.host_scan['Rule']
+            rule_match = mdc.host_scan['Rule']['matches']
             assert rule_match[0]['source'] == MATCHING_ENTITY_FILE
             assert rule_match[0]['string_offset'] == 21
             metadata = rule_match[0]['metadata']
@@ -3030,7 +3386,7 @@ class TestsUtilizingFakeYara:
             )
 
             # Testing a missing file for another rule - again, expect minimal metadata because we can't find out more info
-            rule_match = mdc.host_scan['another_matching_rule']
+            rule_match = mdc.host_scan['another_matching_rule']['matches']
             assert rule_match[2]['source'].endswith(
                 'snap/signal-desktop/350/opt/Signal/resources/app.asar'
             )
@@ -3085,7 +3441,7 @@ class TestsUtilizingFakeYara:
             mdc.parse_scan_output(CONTRIVED_SCAN_OUTPUT)
             assert list(mdc.host_scan) == ['Rule']
             assert mdc.matches == 3
-            sources = set(map(lambda x: x['source'], mdc.host_scan['Rule']))
+            sources = set(map(lambda x: x['source'], mdc.host_scan['Rule']['matches']))
             assert len(sources) == 3
             log_mock.debug.assert_any_call(
                 'Skipping matches for disabled rule %s in %s %s', 'Iyamtho', 'file', ANY
@@ -3097,12 +3453,12 @@ class TestsUtilizingFakeYara:
             assert mdc.disabled_rules == []
             mdc.parse_scan_output(RANDOM_OUTPUT)
             assert mdc.matches == 2
-            rule_match = mdc.host_scan['Lorem']
+            rule_match = mdc.host_scan['Lorem']['matches']
             assert rule_match[0]['source'].startswith('ipsum dolor')
             assert rule_match[0]['string_data'] == ''
             assert rule_match[0]['string_identifier'] == ''
             assert rule_match[0]['string_offset'] == -1
-            rule_match = mdc.host_scan['Dictum']
+            rule_match = mdc.host_scan['Dictum']['matches']
             assert rule_match[0]['source'].startswith('at tempor')
             assert rule_match[0]['string_data'] == ''
             assert rule_match[0]['string_identifier'] == ''
@@ -3145,6 +3501,105 @@ class TestsUtilizingFakeYara:
             assert sorted(mdc.host_scan) == ['Dictum', 'Lorem']
             log_mock.info.assert_any_call('Matched rule %s in %s %s', 'Dictum', 'file', ANY)
             log_mock.info.assert_any_call('Matched rule %s in %s %s', 'Lorem', 'file', ANY)
+
+        def test_parse_metadata_enhanced(self, conf, yara, disabled, rules, cmd, findmnt):
+            """Test _parse_metadata_enhanced with various scenarios"""
+            mdc = MalwareDetectionClient(None)
+
+            # Test cases: (input, expected_output)
+            test_cases = [
+                # Empty and whitespace
+                ("", {}),
+                ("   ", {}),
+
+                # Simple key-value pairs
+                ("key=value", {"key": "value"}),
+                ("key1=value1,key2=value2", {"key1": "value1", "key2": "value2"}),
+
+                # Spaces around equals sign
+                ("key = value", {"key": "value"}),
+                ("key =value", {"key": "value"}),
+                ("key= value", {"key": "value"}),
+
+                # Quoted values
+                ('key="quoted value"', {"key": "quoted value"}),
+                ("key='quoted value'", {"key": "quoted value"}),
+
+                # Quoted keys
+                ('"key"=value', {"key": "value"}),
+                ("'key'=value", {"key": "value"}),
+
+                # Values with commas in quotes
+                ('key="value,with,commas"', {"key": "value,with,commas"}),
+
+                # Numbers
+                ("age=25", {"age": 25}),
+                ("price=19.99", {"price": 19.99}),
+
+                # Booleans
+                ("active=true", {"active": True}),
+                ("disabled=false", {"disabled": False}),
+                ("enabled=True", {"enabled": True}),
+                ("hidden=False", {"hidden": False}),
+
+                # Duplicate keys (last value wins)
+                ("key=first,key=second", {"key": "second"}),
+
+                # Mixed types
+                ('name="John",age=30,active=true', {"name": "John", "age": 30, "active": True}),
+
+                # Multiple spaces
+                ("key1  =  value1  ,  key2  =  value2", {"key1": "value1", "key2": "value2"}),
+
+                # Invalid parts (no equals sign) should be skipped
+                ("valid=value,invalid,another=value2", {"valid": "value", "another": "value2"}),
+
+                # Empty values
+                ("key=", {"key": ""}),
+
+                # Complex quoted values
+                ('title="Hello, World!",count=5', {"title": "Hello, World!", "count": 5}),
+            ]
+
+            for input_text, expected in test_cases:
+                result = mdc._parse_metadata_enhanced(input_text)
+                assert result == expected, "Failed for input: {!r}. Got: {!r}, Expected: {!r}".format(
+                    input_text, result, expected
+                )
+
+        def test_parse_value_enhanced(self, conf, yara, disabled, rules, cmd, findmnt):
+            """Test that _parse_value_enhanced parsing is done correctly"""
+            mdc = MalwareDetectionClient(None)
+            assert not mdc._parse_value_enhanced("")
+            assert mdc._parse_value_enhanced("true")
+            assert not mdc._parse_value_enhanced("false")
+            assert mdc._parse_value_enhanced("null") is None
+            assert mdc._parse_value_enhanced("4") == 4
+            assert mdc._parse_value_enhanced("4.5") == 4.5
+            assert mdc._parse_value_enhanced("lol") == "lol"
+
+        def test_smart_split_comma(self, conf, yara, disabled, rules, cmd, findmnt):
+            """Test _smart_split_comma with various scenarios"""
+            mdc = MalwareDetectionClient(None)
+
+            # Test cases: (input, expected_output)
+            test_cases = [
+                ("apple,banana,cherry", ["apple", "banana", "cherry"]),
+                ("apple,'banana,orange',cherry", ["apple", "'banana,orange'", "cherry"]),
+                ('apple,"banana,orange",cherry', ["apple", '"banana,orange"', "cherry"]),
+                (r'apple,"banana\",orange",cherry', ["apple", r'"banana\",orange"', "cherry"]),
+                ("", []),
+                ("apple", ["apple"]),
+                ('"first,part","second,part",third', ['"first,part"', '"second,part"', "third"]),
+                ("apple,,cherry", ["apple", "", "cherry"]),
+                ("apple,banana,", ["apple", "banana"]),
+                ("""'single,comma',"double,comma",plain""", ["'single,comma'", '"double,comma"', "plain"]),
+                ('''"He said 'hello, world'",next''', ['''"He said 'hello, world'"''', "next"]),
+            ]
+
+            for input_text, expected in test_cases:
+                result = mdc._smart_split_comma(input_text)
+                assert result == expected, "Failed for input: {!r}".format(input_text)
 
 
 ################################################################################################################
@@ -3220,7 +3675,7 @@ if REAL_YARA:
         @patch(CONFIG_FILE_TARGET, TEMP_CONFIG_FILE)
         class TestMalwareDetectionOptions:
 
-            @patch(GET_RULES_TARGET, return_value=TEST_RULE_FILE)
+            @patch(GET_RULES_TARGET, return_value=[TEST_RULE_FILE])
             @patch(DISABLED_RULES_TARGET, return_value=[])
             def test_running_default_options(
                 self, disabled, rules, create_test_files_real_yara, caplog
@@ -3233,7 +3688,7 @@ if REAL_YARA:
 
                 mdc = MalwareDetectionClient(None)
                 assert mdc.yara_binary == REAL_YARA
-                assert mdc.rules_file == TEST_RULE_FILE
+                assert mdc.rules_files == [TEST_RULE_FILE]
                 assert mdc.disabled_rules == []
                 assert mdc.do_process_scan is True
                 if os.path.isfile(TEMP_CONFIG_FILE):
@@ -3247,6 +3702,8 @@ if REAL_YARA:
                 assert mdc.network_filesystem_mountpoints == []
                 assert mdc.scan_timeout == 3600
                 assert mdc.nice_value == 19
+                assert mdc.rules_location == '/etc/insights-client/signatures'
+                assert mdc.use_remote_rules is True
                 yara_cmd = ' '.join(mdc.yara_cmd)
                 assert yara_cmd == "nice -n 19 %s -s -N -a 3600 -p %s -r -f %s" % (
                     REAL_YARA,
@@ -3317,7 +3774,7 @@ if REAL_YARA:
                 logger.setLevel('INFO')
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                     line = (
-                        line + "rules_location: %s\n" % COMPILED_RULES_FILE
+                        line + "remote_rules_location: %s\n" % COMPILED_RULES_FILE
                         if line.startswith('---')
                         else line
                     )
@@ -3482,7 +3939,7 @@ if REAL_YARA:
             def test_using_env_vars(self, create_test_files_real_yara, caplog):
                 # Set certain option values via environment variables
                 env_var_list = [
-                    ('RULES_LOCATION', COMPILED_RULES_FILE),
+                    ('REMOTE_RULES_LOCATION', COMPILED_RULES_FILE),
                     ('TEST_SCAN', 'false'),
                     ('SCAN_FILESYSTEM', 'YES'),
                     ('SCAN_PROCESSES', 'hello'),  # will be interpreted as false
@@ -3508,6 +3965,8 @@ if REAL_YARA:
                 # Not env vars, but just checking they have the expected values
                 assert mdc.nice_value == 19
                 assert mdc.cpu_thread_limit == CPUS
+                assert mdc.rules_location == '/etc/insights-client/signatures'
+                assert mdc.use_remote_rules is True
 
                 # Start a filesystem scan and expect scan_only and scan_exclude to cancel each other out
                 result = mdc.scan_filesystem()
@@ -3884,8 +4343,8 @@ if REAL_YARA:
             def test_bad_rules_files(self, create_test_files_real_yara, caplog):
                 # Tests with non-rules/problematic files
                 with open(TEMP_CONFIG_FILE, 'a') as tcf:
-                    # Append rules_location: and test_rule: to the bottom of the config file
-                    tcf.write("rules_location: %s\ntest_scan: false\n" % REAL_YARA)
+                    # Append remote_rules_location: and test_rule: to the bottom of the config file
+                    tcf.write("remote_rules_location: %s\ntest_scan: false\n" % REAL_YARA)
                 with pytest.raises(SystemExit) as exc_info:
                     MalwareDetectionClient(None)
                 assert "Unable to use rules file %s" % REAL_YARA in caplog.text
@@ -3896,8 +4355,8 @@ if REAL_YARA:
                 missing_file = os.path.join(TEMP_TEST_DIR, 'missing')
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                     line = (
-                        "rules_location: %s" % missing_file
-                        if line.startswith("rules_location:")
+                        "remote_rules_location: %s" % missing_file
+                        if line.startswith("remote_rules_location:")
                         else line
                     )
                     print(line)
@@ -3910,8 +4369,8 @@ if REAL_YARA:
                 caplog.clear()
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                     line = (
-                        "rules_location: %s" % TEMP_TEST_DIR
-                        if line.startswith("rules_location:")
+                        "remote_rules_location: %s" % TEMP_TEST_DIR
+                        if line.startswith("remote_rules_location:")
                         else line
                     )
                     print(line)
@@ -3921,15 +4380,15 @@ if REAL_YARA:
                 assert exc_info.value.code == constants.sig_kill_bad
 
             def test_files_with_extra_slashes_1(self, create_test_files_real_yara, caplog):
-                # Test behaviour when rules_location file and scan_only files have extra slashes in them
+                # Test behaviour when remote_rules_location file and scan_only files have extra slashes in them
                 logger.setLevel('INFO')
-                # Test scanning COMPILED_RULES_FILE with an extra slash only in the rules_location one
-                # Even with the extra slashes in the rules_location there will be rules matched
+                # Test scanning COMPILED_RULES_FILE with an extra slash only in the remote_rules_location one
+                # Even with the extra slashes in the remote_rules_location there will be rules matched
                 # because */rules_compiled.yar and *//rules_compiled.yar are the same file
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                     line = "test_scan: false" if line.startswith("test_scan:") else line
                     line = (
-                        line + "rules_location: %s\n" % COMPILED_RULES_FILE.replace('/', '//')
+                        line + "remote_rules_location: %s\n" % COMPILED_RULES_FILE.replace('/', '//')
                         if line.startswith('---')
                         else line
                     )
@@ -3940,7 +4399,7 @@ if REAL_YARA:
                     )
                     print(line)
                 mdc = MalwareDetectionClient(None)
-                assert mdc.rules_location == COMPILED_RULES_FILE.replace('/', '//')
+                assert mdc.remote_rules_location == COMPILED_RULES_FILE.replace('/', '//')
                 assert mdc.rules_file == COMPILED_RULES_FILE
                 assert mdc.scan_fsobjects == [COMPILED_RULES_FILE]
                 mdc.scan_filesystem()
@@ -3957,13 +4416,13 @@ if REAL_YARA:
                 )
 
             def test_files_with_extra_slashes_2(self, create_test_files_real_yara, caplog):
-                # Test behaviour when rules_location file and scan_only files have extra slashes in them
-                # Replace slashes in both rules_location and scan_only with double slashes
+                # Test behaviour when remote_rules_location file and scan_only files have extra slashes in them
+                # Replace slashes in both remote_rules_location and scan_only with double slashes
                 logger.setLevel('INFO')
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                     line = "test_scan: false" if line.startswith("test_scan:") else line
                     if line.startswith('---'):
-                        line = line + "rules_location: %s\n" % COMPILED_RULES_FILE.replace(
+                        line = line + "remote_rules_location: %s\n" % COMPILED_RULES_FILE.replace(
                             '/', '//'
                         )
                     if line.startswith("filesystem_scan_only:"):
@@ -3973,7 +4432,7 @@ if REAL_YARA:
                         )
                     print(line)
                 mdc = MalwareDetectionClient(None)
-                assert mdc.rules_location == COMPILED_RULES_FILE.replace('/', '//')
+                assert mdc.remote_rules_location == COMPILED_RULES_FILE.replace('/', '//')
                 assert mdc.rules_file == COMPILED_RULES_FILE
                 assert mdc.scan_fsobjects == [TEMP_TEST_DIR, MALWARE_TEST_FILE]
                 mdc.scan_filesystem()
@@ -3999,13 +4458,13 @@ if REAL_YARA:
                 )
 
             def test_files_with_extra_slashes_3(self, create_test_files_real_yara, caplog):
-                # Test behaviour when rules_location file and scan_only files have extra slashes in them
+                # Test behaviour when remote_rules_location file and scan_only files have extra slashes in them
                 # For completeness (silliness?), try with even more slashes in the file names
                 logger.setLevel('INFO')
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                     line = "test_scan: false" if line.startswith("test_scan:") else line
                     if line.startswith('---'):
-                        line = line + "rules_location: %s" % COMPILED_RULES_FILE.replace(
+                        line = line + "remote_rules_location: %s" % COMPILED_RULES_FILE.replace(
                             '/', '////'
                         )
                     if line.startswith("filesystem_scan_only:"):
@@ -4015,7 +4474,7 @@ if REAL_YARA:
                         )
                     print(line)
                 mdc = MalwareDetectionClient(None)
-                assert mdc.rules_location == COMPILED_RULES_FILE.replace('/', '////')
+                assert mdc.remote_rules_location == COMPILED_RULES_FILE.replace('/', '////')
                 assert mdc.rules_file == COMPILED_RULES_FILE
                 assert mdc.scan_fsobjects == [TEMP_TEST_DIR, MALWARE_TEST_FILE]
                 mdc.scan_filesystem()
@@ -4040,7 +4499,7 @@ if REAL_YARA:
                 )
 
             def test_files_with_extra_slashes_4(self, create_test_files_real_yara, caplog):
-                # Test behaviour when rules_location file and scan_only files have extra slashes in them
+                # Test behaviour when remote_rules_location file and scan_only files have extra slashes in them
 
                 # Chaos monkey! - add extra slashes to rules_file and scan_fsobjects AFTER they have been verified
                 # This is a contrived test and shouldn't happen in normal code flow but done to make sure malware behaves well
@@ -4050,7 +4509,7 @@ if REAL_YARA:
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                     line = "test_scan: false" if line.startswith("test_scan:") else line
                     line = (
-                        line + "rules_location: %s" % COMPILED_RULES_FILE
+                        line + "remote_rules_location: %s" % COMPILED_RULES_FILE
                         if line.startswith("---")
                         else line
                     )
@@ -4090,7 +4549,7 @@ if REAL_YARA:
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                     line = "test_scan: false" if line.startswith("test_scan:") else line
                     line = (
-                        line + "rules_location: %s" % COMPILED_RULES_FILE
+                        line + "remote_rules_location: %s" % COMPILED_RULES_FILE
                         if line.startswith("---")
                         else line
                     )
@@ -4112,7 +4571,7 @@ if REAL_YARA:
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                     line = "test_scan: false" if line.startswith("test_scan:") else line
                     line = (
-                        line + "rules_location: %s" % COMPILED_RULES_FILE
+                        line + "remote_rules_location: %s" % COMPILED_RULES_FILE
                         if line.startswith("---")
                         else line
                     )
@@ -4145,7 +4604,7 @@ if REAL_YARA:
                 test_pid = str(os.getpid())
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                     line = (
-                        line + "rules_location: %s" % COMPILED_RULES_FILE
+                        line + "remote_rules_location: %s" % COMPILED_RULES_FILE
                         if line.startswith("---")
                         else line
                     )
@@ -4187,7 +4646,7 @@ if REAL_YARA:
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                     line = "test_scan: false" if line.startswith("test_scan:") else line
                     line = (
-                        line + "rules_location: %s" % RULE_RULE_FILE
+                        line + "remote_rules_location: %s" % RULE_RULE_FILE
                         if line.startswith("---")
                         else line
                     )
@@ -4420,7 +4879,7 @@ if REAL_YARA:
                 self, disabled, rules, create_test_files_real_yara, caplog
             ):
                 # Parse the CONTRIVED_SCAN_OUTPUT to find actual rule matches amongst malformed output lines
-                # The rules_location is irrelevant to the test but it just makes the initialization of
+                # The remote_rules_location is irrelevant to the test but it just makes the initialization of
                 # MalwareDetectionClient easier if done this way (and its simpler than using @patch ... maybe)
                 logger.setLevel(
                     'DEBUG'
@@ -5205,7 +5664,7 @@ if REAL_YARA:
             def test_get_regular_rules_location_urls(
                 self, disabled, init_session, get_proxies, get, tmpfile, caplog
             ):
-                # Test the standard rules_location urls, depending on whether test rule or cert auth is set
+                # Test the standard remote_rules_location urls, depending on whether test rule or cert auth is set
                 # With test scan true, expect to download test-rule.yar
                 test_rule_url = (
                     "https://cert.console.redhat.com/api/malware-detection/v1/test-rule.yar"
@@ -5265,7 +5724,7 @@ if REAL_YARA:
                 logger.setLevel('DEBUG')
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                     line = (
-                        line + "rules_location: console.redhat.com/rules.yar"
+                        line + "remote_rules_location: console.redhat.com/rules.yar"
                         if line.startswith("---")
                         else line
                     )
@@ -5304,11 +5763,11 @@ if REAL_YARA:
                 create_test_files_real_yara,
                 caplog,
             ):
-                # Test using files for rules_location, esp irregular file names
+                # Test using files for remote_rules_location, esp irregular file names
                 # Re-writing the rule to be test-rule.yar doesn't apply to local files
                 for line in fileinput.FileInput(TEMP_CONFIG_FILE, inplace=1):
                     line = (
-                        line + "rules_location: //console.redhat.com/rules.yar"
+                        line + "remote_rules_location: //console.redhat.com/rules.yar"
                         if line.startswith("---")
                         else line
                     )
@@ -5385,17 +5844,17 @@ this line also contains error scanning so it will be skipped too
 0x1:$string1: skip me coz the rule line had an error
 0x11:$string2: skip me too
 0x111:$string3: skip me three
-this line doesn't contain e-r-r-o-r s-c-a-n-n-i-n-g so will be considered a scan match, even though it shouldn't
+this [] line doesn't contain e-r-r-o-r s-c-a-n-n-i-n-g so will be considered a scan match, even though it shouldn't
 0x123:$match: matches 'this' rule
 BadFormat
 0x1:$skipme: the previous line will fail because it doesn't follow the 'rule matching_entity' format
 Rule:matching_entity
 0x1:$alsoskipme: the previous line also fails because it has a ":" instead of a " " between rule & matching_entity
-Rule %s
+Rule [] %s
 0x15:$match0: string match in the file "matching_entity"
 0x53:$match1: another string match in matching_entity
 0xe6:$match2: string with different types of quotes 'here' and "here"
-Rule %s
+Rule [] %s
 0x2:$match3: string match containing error scanning but it's ok because its not in a rule line
 0x61:$grep1: contains =
 0x7b:$grep1: contains =
@@ -5408,17 +5867,17 @@ Rule %s
 0x147:$grep7: contains ^$
 0x163:$grep7: contains ^$
 0x179:$ignored: The previous line and this one too are ignored as they are beyond the default 10 string match limit
-Rule matching_entity_3, but without any string matches - yes that's ok
+Rule [] matching_entity_3, but without any string matches - yes that's ok
 more error scanning this line
-another_matching_rule /var/lib/snapd/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/signal-desktop/350/opt/Signal/resources/app.asar
+another_matching_rule [] /var/lib/snapd/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/signal-desktop/350/opt/Signal/resources/app.asar
 0x212f197:$s0: #!/bin/sh
 0x2130313:$s0: #!/bin/sh
 0x39f7cc6:$s0: #!/bin/sh
-another_matching_rule /var/lib/snapd/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859error scanning /dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/signal-desktop/350/opt/Signal/resources/app2.asar
+another_matching_rule [] /var/lib/snapd/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859error scanning /dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/signal-desktop/350/opt/Signal/resources/app2.asar
 0x212f197:$s0: #!/bin/sh
 0x2130313:$s0: #!/bin/sh
 0x39f7cc6:$s0: #!/bin/sh
-another_matching_rule 1234567
+another_matching_rule [] 1234567
 0x0:$s0: #!/bin/sh
 0x1badoffset:$s1: skip this line
 0x2error scanning skip/this/line/too: need more colons
@@ -5428,8 +5887,8 @@ badoffset_but_notarule:$s2: a bad offset line that looks a bit like a rule line 
 _me neither
  same here
 nor: I
-Iyamtho  yep
-n_m3_t00 damn   straight
+Iyamtho [] yep
+n_m3_t00 [] damn   straight
 error scanning /var/lib/snapd/snap/core/10859/dev/core: error: 4
 error scanning /var/lib/snapd/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/fd/3/snap/core/10859/dev/core: error: 4
 error scanning /var/lib/snapd//cookie/snap.gnome-3-28-1804: could not open file
@@ -5440,8 +5899,8 @@ error scanning /var/lib/snapd//device/private-keys-v1/_53ir43FCxbgdSyj8NriGt9gfo
 )
 
 RANDOM_OUTPUT = """
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-Dictum at tempor commodo ullamcorper a lacus vestibulum sed. Non odio euismod lacinia at quis risus sed.
+Lorem [] ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Dictum [] at tempor commodo ullamcorper a lacus vestibulum sed. Non odio euismod lacinia at quis risus sed.
 """
 
 # Base64 representation of a tgz file containing simple files to be extracted into /tmp to be used for scanning


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [x] Is this a backport from `master`? Yes, this is a backport of #4571 
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
