### PR TITLE
chore(spec): add new spec keyctl_show for analytics

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -373,6 +373,7 @@ class Specs(SpecSet):
     kernel_crash_kexec_post_notifiers = RegistryPoint(
         no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac']
     )
+    keyctl_show = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     kexec_crash_loaded = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     kexec_crash_size = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     keystone_conf = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -450,6 +450,7 @@ class DefaultSpecs(Specs):
     kernel_crash_kexec_post_notifiers = simple_file(
         "/sys/module/kernel/parameters/crash_kexec_post_notifiers"
     )
+    keyctl_show = simple_file("/usr/bin/keyctl show %:.platform")
     kexec_crash_size = simple_file("/sys/kernel/kexec_crash_size")
     kpatch_list = simple_command("/usr/sbin/kpatch list")
     krb5 = glob_file([r"etc/krb5.conf", r"etc/krb5.conf.d/*"])


### PR DESCRIPTION
- Command: "keyctl show %:.platform"
- Jira: RHINENG-21020
- No parser is required


(cherry picked from commit 0a937f2b4e6935e598c18f56c5d40344ecd9791e)

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [x] Is this a backport from `master`? Yes, this is a backport of #4611 
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Add new keyctl_show spec to capture the output of `keyctl show %:.platform` for analytics

New Features:
- Introduce a RegistryPoint entry `keyctl_show` in Specs with no obfuscation
- Add a DefaultSpecs simple_file for `keyctl_show` pointing to `/usr/bin/keyctl show %:.platform`