### PR TITLE
chore(spec): add new spec bootctl_status for analytics

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -61,6 +61,7 @@ class Specs(SpecSet):
     )
     boot_loader_entries = RegistryPoint(multi_output=True)
     bootc_status = RegistryPoint(no_obfuscate=['hostname'])
+    bootctl_status = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     brctl_show = RegistryPoint()
     buddyinfo = RegistryPoint()
     candlepin_broker = RegistryPoint()

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -182,6 +182,7 @@ class DefaultSpecs(Specs):
     bond_dynamic_lb = glob_file("/sys/class/net/*/bonding/tlb_dynamic_lb")
     boot_loader_entries = glob_file("/boot/loader/entries/*.conf")
     bootc_status = simple_command("/usr/bin/bootc status --json")
+    bootctl_status = simple_command("/usr/bin/bootctl status")
     buddyinfo = simple_file("/proc/buddyinfo")
     brctl_show = simple_command("/usr/sbin/brctl show")
     candlepin_log = simple_file("/var/log/candlepin/candlepin.log")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [x] Is this a backport from `master`? Yes, this is a backport of #4613 
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Introduce a new bootctl_status spec for analytics by adding a corresponding registry point and default command spec.

New Features:
- Add bootctl_status registry point with no-obfuscation of hostname, IPv4, IPv6, and MAC addresses
- Define default simple_command spec to collect the output of "/usr/bin/bootctl status"