### PR TITLE
chore(script): change release to 'dev' for PR testing builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,26 +4,29 @@ specfile_path: insights-core.spec
 
 actions:
   post-upstream-clone:
-    - sed -i -e '/cachecontrol/d' -e '/defusedxml/d' -e '/jinja2/d' -e '/lockfile/d' -e '/redis/d' -e '/setuptools;/d' pyproject.toml setup.py
-    - sed -i -e '/insights =/d' -e '/insights-dupkey/d' -e '/insights-run/d' -e '/insights-inspect/d' -e '/mangle =/d' pyproject.toml setup.py
+    - sed -i -e '/cachecontrol/d' -e '/defusedxml/d' -e '/jinja2/d' -e '/lockfile/d' -e '/redis/d' -e '/setuptools;/d' pyproject.toml
+    - sed -i -e '/insights =/d' -e '/insights-dupkey/d' -e '/insights-run/d' -e '/insights-inspect/d' -e '/mangle =/d' pyproject.toml
+    - echo "dev" > insights/RELEASE
     - cp MANIFEST.in.client MANIFEST.in
-    - python3 setup.py sdist
+    - python3 -m pip install build
+    - python3 -m build --sdist
   get-current-version:
     - awk '/^Version:/ {print $2;}' insights-core.spec
   create-archive:
     - bash -c 'ls dist/insights*.tar.*'
   fix-spec-file:
-    - echo 'nothing to fix'
+    - sed -i -e "s/1%{?dist}/dev%{?dist}/g" insights-core.spec
 
 jobs:
   - job: copr_build
     trigger: pull_request
     branch: master
     targets:
-      - rhel-9
-      - rhel-10
-      - centos-stream-10-x86_64
-      - centos-stream-10-aarch64
-      - centos-stream-10-s390x
-      - centos-stream-10-ppc64le
-      - fedora-all
+      - rhel-9-x86_64
+      - rhel-9-aarch64
+      - rhel-9-s390x
+      - rhel-9-ppc64le
+      - rhel-10-x86_64
+      - rhel-10-aarch64
+      - rhel-10-s390x
+      - rhel-10-ppc64le


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

For PR testing convenience, change the 'release" of RPM to 'dev' when building RPM for PR
<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Adjust build scripts and packit configuration to set RPM release to "dev" for PR testing builds and streamline the build process

Enhancements:
- Set RPM release to "dev" for the "testing" build target by writing to insights/RELEASE and updating the spec file distribution tag
- Remove setup.py from sed-based dependency and entrypoint removal, operating solely on pyproject.toml
- Switch sdist creation to use python -m build in both the shell script and packit actions, and reorganize build steps for clarity