### PR TITLE
fix(script): revert to update setup.py

### DIFF
--- a/build_core_rpm.sh
+++ b/build_core_rpm.sh
@@ -36,9 +36,9 @@ elif [ "$TARGET" == "release" ] || [ "$TARGET" == "testing" ]; then
     fi
     MANIFEST="MANIFEST.in.client"
     # - remove depedencies for data processing
-    sed -i -e '/cachecontrol/d' -e '/defusedxml/d' -e '/jinja2/d' -e '/lockfile/d' -e '/redis/d' -e '/setuptools;/d' pyproject.toml
+    sed -i -e '/cachecontrol/d' -e '/defusedxml/d' -e '/jinja2/d' -e '/lockfile/d' -e '/redis/d' -e '/setuptools;/d' pyproject.toml setup.py
     # - remove entrypoints for data processing
-    sed -i -e '/insights =/d' -e '/insights-dupkey/d' -e '/insights-run/d' -e '/insights-inspect/d' -e '/mangle =/d' pyproject.toml
+    sed -i -e '/insights =/d' -e '/insights-dupkey/d' -e '/insights-run/d' -e '/insights-inspect/d' -e '/mangle =/d' pyproject.toml setup.py
 else
     echo "Error: invalid build target: '$TARGET'. Use 'internal', 'release', or 'testing'"
     exit 1
@@ -86,4 +86,4 @@ rpmbuild -D "_topdir $PWD" -D "_sourcedir $PWD/dist" -ba insights-core.spec
 
 # Cleanup
 rm -rf dist BUILD BUILDROOT
-git checkout -- pyproject.toml MANIFEST.in insights-core.spec insights/COMMIT insights/RELEASE
+git checkout -- pyproject.toml setup.py MANIFEST.in insights-core.spec insights/COMMIT insights/RELEASE


### PR DESCRIPTION
The setup.py is still used for brew/koji building, it should be updated as well and cannot be removed.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Revert the removal of setup.py updates in the RPM build script by including setup.py in the sed commands for dependency and entrypoint removal on release/testing targets

Bug Fixes:
- Include setup.py alongside pyproject.toml in sed commands for dependency removal in build_core_rpm.sh
- Include setup.py alongside pyproject.toml in sed commands for entrypoint removal in build_core_rpm.sh