### PR TITLE
feat: Add spec rear_default_conf

### DIFF
--- a/insights/parsers/rear_conf.py
+++ b/insights/parsers/rear_conf.py
@@ -1,6 +1,13 @@
 """
-RearLocalConf - File /etc/rear/local.conf
-=========================================
+RearConf - Configuration files of Rear
+======================================
+
+Parsers included in this module are:
+
+RearLocalConf - file ``/etc/rear/local.conf``
+---------------------------------------------
+RearDefaultConf - file ``/usr/share/rear/conf/default.conf``
+------------------------------------------------------------
 """
 
 from insights.core import TextFileOutput
@@ -15,7 +22,7 @@ class RearLocalConf(TextFileOutput):
     """
     Parses content of "/etc/rear/local.conf".
 
-    Typical content of "/etc/rear/local.conf" is::
+    Typical content of "/etc/rear/local.conf"::
 
         BACKUP_RESTORE_MOVE_AWAY_FILES=( /boot/grub/grubenv /boot/grub2/grubenv )
 
@@ -31,4 +38,30 @@ class RearLocalConf(TextFileOutput):
         content = get_active_lines(content)
         if not content:
             raise SkipComponent
-        super(RearLocalConf, self).parse_content(content)
+        else:
+            super(RearLocalConf, self).parse_content(content)
+
+
+@parser(Specs.rear_default_conf)
+class RearDefaultConf(TextFileOutput):
+    """
+    Parses content of "/usr/share/rear/conf/default.conf".
+
+    Typical content of "/usr/share/rear/conf/default.conf"::
+
+        COPY_AS_IS_EXCLUDE=( $VAR_DIR/output/ dev/.udev dev/shm dev/shm/ dev/oracleasm dev/mapper dev/watchdog )
+
+
+    Examples:
+        >>> type(default_conf)
+        <class 'insights.parsers.rear_conf.RearDefaultConf'>
+        >>> default_conf.lines[0] == 'COPY_AS_IS_EXCLUDE=( $VAR_DIR/output/ dev/.udev dev/shm dev/shm/ dev/oracleasm dev/mapper dev/watchdog )'
+        True
+    """
+
+    def parse_content(self, content):
+        content = get_active_lines(content)
+        if not content:
+            raise SkipComponent
+        else:
+            super(RearDefaultConf, self).parse_content(content)

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -673,6 +673,7 @@ class Specs(SpecSet):
     readlink_e_etc_mtab = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     readlink_e_shift_cert_client = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     readlink_e_shift_cert_server = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
+    rear_default_conf = RegistryPoint(filterable=True)
     rear_local_conf = RegistryPoint(filterable=True)
     recvq_socket_buffer = RegistryPoint()
     redhat_release = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -724,6 +724,7 @@ class DefaultSpecs(Specs):
     readlink_e_shift_cert_server = simple_command(
         "/usr/bin/readlink -e /etc/origin/node/certificates/kubelet-server-current.pem"
     )
+    rear_default_conf = simple_file("/usr/share/rear/conf/default.conf")
     rear_local_conf = simple_file("/etc/rear/local.conf")
     redhat_release = simple_file("/etc/redhat-release")
     repquota_agnpuv = simple_command("/usr/sbin/repquota -agnpuv")

--- a/insights/tests/parsers/test_rear_conf.py
+++ b/insights/tests/parsers/test_rear_conf.py
@@ -3,7 +3,7 @@ import pytest
 
 from insights.core.exceptions import SkipComponent
 from insights.parsers import rear_conf
-from insights.parsers.rear_conf import RearLocalConf
+from insights.parsers.rear_conf import RearLocalConf, RearDefaultConf
 from insights.tests import context_wrap
 
 RDMA_CONFIG = """
@@ -31,21 +31,33 @@ BACKUP_RESTORE_MOVE_AWAY_FILES=( /boot/grub/grubenv /boot/grub2/grubenv )
 REAR_CONF_EMPTY = """
 """.strip()
 
+REAR_DEFAULT_CONF = """
+COPY_AS_IS_EXCLUDE=( $VAR_DIR/output/ dev/.udev dev/shm dev/shm/ dev/oracleasm dev/mapper dev/watchdog )
+""".strip()
+
 
 def test_rdma_config():
     local_conf = RearLocalConf(context_wrap(RDMA_CONFIG))
     assert len(local_conf.lines) == 1
     assert local_conf.lines[0] == "BACKUP_RESTORE_MOVE_AWAY_FILES=( /boot/grub/grubenv /boot/grub2/grubenv )"
 
+    default_conf = RearDefaultConf(context_wrap(REAR_DEFAULT_CONF))
+    assert len(default_conf.lines) == 1
+    assert default_conf.lines[0] == "COPY_AS_IS_EXCLUDE=( $VAR_DIR/output/ dev/.udev dev/shm dev/shm/ dev/oracleasm dev/mapper dev/watchdog )"
+
 
 def test_rdma_config_empty():
     with pytest.raises(SkipComponent):
         RearLocalConf(context_wrap(REAR_CONF_EMPTY))
 
+    with pytest.raises(SkipComponent):
+        RearDefaultConf(context_wrap(REAR_CONF_EMPTY))
+
 
 def test_rdma_config_doc():
     env = {
             'local_conf': RearLocalConf(context_wrap(RDMA_CONFIG)),
+            'default_conf': RearDefaultConf(context_wrap(REAR_DEFAULT_CONF)),
           }
     failed, total = doctest.testmod(rear_conf, globs=env)
     assert failed == 0


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [x] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID


### Complete Description of Additions/Changes:

Add this spec for new advisor rule

## Summary by Sourcery

Add a new RearDefaultConf parser to parse the default rear configuration file, register its spec in the Specs and DefaultSpecs, and include comprehensive tests.

New Features:
- Add RearDefaultConf parser for /usr/share/rear/conf/default.conf

Enhancements:
- Register new rear_default_conf spec in Specs and DefaultSpecs

Tests:
- Add unit tests and doctests for the new RearDefaultConf parser