### PR TITLE
 feat: Add spec rear_default_conf_3.0_egg

### DIFF
--- a/insights/parsers/rear_conf.py
+++ b/insights/parsers/rear_conf.py
@@ -31,4 +31,30 @@ class RearLocalConf(TextFileOutput):
         content = get_active_lines(content)
         if not content:
             raise SkipComponent
-        super(RearLocalConf, self).parse_content(content)
+        else:
+            super(RearLocalConf, self).parse_content(content)
+
+
+@parser(Specs.rear_default_conf)
+class RearDefaultConf(TextFileOutput):
+    """
+    Parses content of "/usr/share/rear/conf/default.conf".
+
+    Typical content of "/usr/share/rear/conf/default.conf"::
+
+        COPY_AS_IS_EXCLUDE=( $VAR_DIR/output/ dev/.udev dev/shm dev/shm/ dev/oracleasm dev/mapper dev/watchdog )
+
+
+    Examples:
+        >>> type(default_conf)
+        <class 'insights.parsers.rear_conf.RearDefaultConf'>
+        >>> default_conf.lines[0] == 'COPY_AS_IS_EXCLUDE=( $VAR_DIR/output/ dev/.udev dev/shm dev/shm/ dev/oracleasm dev/mapper dev/watchdog )'
+        True
+    """
+
+    def parse_content(self, content):
+        content = get_active_lines(content)
+        if not content:
+            raise SkipComponent
+        else:
+            super(RearDefaultConf, self).parse_content(content)


### PR DESCRIPTION
(cherry picked from commit b4c42f9d9878c6a14c23d029c18acc292471c17b)

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [x] Is this a backport from `master`? Yes, this is a backport of #4625

### Complete Description of Additions/Changes:

Add this new spec for a new advisor rule

## Summary by Sourcery

Introduce a new parser for default rear configurations and align parse_content logic in existing RearLocalConf parser

New Features:
- Add RearDefaultConf parser to process "rear_default_conf" specification and parse "/usr/share/rear/conf/default.conf" content

Enhancements:
- Refactor parse_content in RearLocalConf to wrap super() call in an else block for consistency