### PR TITLE
feat: Add spec krb5_localauth_plugin

### DIFF
--- a/docs/shared_parsers_catalog/krb5_localauth_plugin.rst
+++ b/docs/shared_parsers_catalog/krb5_localauth_plugin.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.krb5_localauth_plugin
+   :members:
+   :show-inheritance:

--- a/insights/parsers/krb5_localauth_plugin.py
+++ b/insights/parsers/krb5_localauth_plugin.py
@@ -1,0 +1,47 @@
+"""
+Krb5 localauth_plugin configuration - file ``/var/lib/sss/pubconf/krb5.include.d/localauth_plugin``
+===================================================================================================
+"""
+from insights.core import Parser, LegacyItemAccess
+from insights.core.plugins import parser
+from insights.parsers import get_active_lines
+from insights.specs import Specs
+
+
+@parser(Specs.krb5_localauth_plugin)
+class Krb5LocalauthPlugin(Parser, LegacyItemAccess):
+    """
+    This parser is used to parse the file "/var/lib/sss/pubconf/krb5.include.d/localauth_plugin"
+
+    Sample input::
+
+        [plugins]
+         localauth = {
+          module = sssd:/usr/lib64/sssd/modules/sssd_krb5_localauth_plugin.so
+         }
+
+    Examples:
+
+        >>> type(conf)
+        <class 'insights.parsers.krb5_localauth_plugin.Krb5LocalauthPlugin'>
+        >>> conf['plugins']['localauth']['module']
+        'sssd:/usr/lib64/sssd/modules/sssd_krb5_localauth_plugin.so'
+    """
+    def parse_content(self, content):
+        dict_all = {}
+        section_name = ""
+        sub_section = ""
+        for line in get_active_lines(content):
+            line = line.strip()
+            if line.startswith("[") and line.endswith("]"):
+                section_name = line.strip("[]")
+                section_value = {}
+                if section_name:
+                    dict_all[section_name] = section_value
+            elif "=" in line and line.endswith("{"):
+                sub_section = line.split("=")[0].strip()
+                dict_all[section_name][sub_section] = {}
+            elif "=" in line and not line.endswith("{"):
+                key, value = line.split("=", 1)
+                dict_all[section_name][sub_section][key.strip()] = value.strip()
+        self.data = dict_all

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -382,6 +382,7 @@ class Specs(SpecSet):
     keystone_log = RegistryPoint(filterable=True)
     kpatch_list = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     krb5 = RegistryPoint(multi_output=True)
+    krb5_localauth_plugin = RegistryPoint()
     ksmstate = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     ktimer_lockless = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     kubelet_conf = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -453,6 +453,7 @@ class DefaultSpecs(Specs):
     kexec_crash_size = simple_file("/sys/kernel/kexec_crash_size")
     kpatch_list = simple_command("/usr/sbin/kpatch list")
     krb5 = glob_file([r"etc/krb5.conf", r"etc/krb5.conf.d/*"])
+    krb5_localauth_plugin = simple_command("/var/lib/sss/pubconf/krb5.include.d/localauth_plugin")
     ksmstate = simple_file("/sys/kernel/mm/ksm/run")
     lastupload = glob_file(
         ["/etc/redhat-access-insights/.lastupload", "/etc/insights-client/.lastupload"]

--- a/insights/tests/parsers/test_krb5_localauth_plugin.py
+++ b/insights/tests/parsers/test_krb5_localauth_plugin.py
@@ -1,0 +1,24 @@
+import doctest
+
+from insights.parsers import krb5_localauth_plugin
+from insights.tests import context_wrap
+
+conf_content = """
+[plugins]
+ localauth = {
+  module = sssd:/usr/lib64/sssd/modules/sssd_krb5_localauth_plugin.so
+ }
+""".strip()
+
+
+def test_krb5_localauth_plugin_conf():
+    result = krb5_localauth_plugin.Krb5LocalauthPlugin(context_wrap(conf_content))
+    assert result['plugins']['localauth']['module'] == 'sssd:/usr/lib64/sssd/modules/sssd_krb5_localauth_plugin.so'
+
+
+def test_doc_examples():
+    env = {
+        'conf': krb5_localauth_plugin.Krb5LocalauthPlugin(context_wrap(conf_content))
+    }
+    failed, total = doctest.testmod(krb5_localauth_plugin, globs=env)
+    assert failed == 0


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID

Add this spec for a new advisor rule

## Summary by Sourcery

Add support for the new krb5_localauth_plugin by defining its spec, implementing the parser, and providing corresponding tests and documentation

New Features:
- Add krb5_localauth_plugin RegistryPoint and default spec command
- Introduce Krb5LocalauthPlugin parser for localauth_plugin configuration

Documentation:
- Add documentation entry for the krb5_localauth_plugin parser in the shared parsers catalog

Tests:
- Add unit tests and doctests for the Krb5LocalauthPlugin parser