### PR TITLE
chore(spec): don't need strictly version match

### DIFF
--- a/insights-core.spec
+++ b/insights-core.spec
@@ -56,7 +56,7 @@ Requires:       python3-six
 %endif
 
 %if 0%{?with_selinux}
-Requires:       ((%{name}-selinux = %{version}-%{release}) if selinux-policy-%{selinuxtype})
+Requires:       ((%{name}-selinux >= %{version}-%{release}) if selinux-policy-%{selinuxtype})
 %endif
 
 %description


### PR DESCRIPTION
It's okay to ensure the version of core-selinux is newer than core

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Enhancements:
- Change selinux subpackage Requires constraint from exact version match to greater-than-or-equal version