### PR TITLE
fix(spec): ignore errors when collecting bootloader data

### DIFF
--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -182,7 +182,7 @@ class DefaultSpecs(Specs):
     bond_dynamic_lb = glob_file("/sys/class/net/*/bonding/tlb_dynamic_lb")
     boot_loader_entries = glob_file("/boot/loader/entries/*.conf")
     bootc_status = simple_command("/usr/bin/bootc status --json")
-    bootctl_status = simple_command("/usr/bin/bootctl status")
+    bootctl_status = simple_command("/usr/bin/bootctl status", keep_rc=True)
     buddyinfo = simple_file("/proc/buddyinfo")
     brctl_show = simple_command("/usr/sbin/brctl show")
     candlepin_log = simple_file("/var/log/candlepin/candlepin.log")
@@ -451,7 +451,7 @@ class DefaultSpecs(Specs):
     kernel_crash_kexec_post_notifiers = simple_file(
         "/sys/module/kernel/parameters/crash_kexec_post_notifiers"
     )
-    keyctl_show = simple_file("/usr/bin/keyctl show %:.platform")
+    keyctl_show = simple_file("/usr/bin/keyctl show %:.platform", keep_rc=True)
     kexec_crash_size = simple_file("/sys/kernel/kexec_crash_size")
     kpatch_list = simple_command("/usr/sbin/kpatch list")
     krb5 = glob_file([r"etc/krb5.conf", r"etc/krb5.conf.d/*"])
@@ -546,7 +546,7 @@ class DefaultSpecs(Specs):
     messages = simple_file("/var/log/messages")
     modinfo_filtered_modules = command_with_args('modinfo %s', kernel.kernel_module_filters)
     modprobe = glob_file(["/etc/modprobe.conf", "/etc/modprobe.d/*.conf"])
-    mokutil_list_enrolled = simple_command("/bin/mokutil --list-enrolled")
+    mokutil_list_enrolled = simple_command("/bin/mokutil --list-enrolled", keep_rc=True)
     mokutil_sbstate = simple_command("/bin/mokutil --sb-state")
     mount = simple_command("/bin/mount")
     mountinfo = simple_file("/proc/self/mountinfo")


### PR DESCRIPTION
- some commands may exit with an error code and result in collection failure add keep_rc=True to collect them and avoid the error code


(cherry picked from commit e4447389f439cd35bda8f1e649bc974150017977)

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #4636 
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Bug Fixes:
- Enable keep_rc=True for bootctl status, keyctl show %:.platform, and mokutil --list-enrolled specs to ignore errors