### PR TITLE
spec: new datasource & parser for ls -ldH

### DIFF
--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -172,7 +172,7 @@ insights.specs.datasources.ls
 -----------------------------
 
 .. automodule:: insights.specs.datasources.ls
-    :members: list_with_la, list_with_la_filtered, list_with_lan, list_with_lan_filtered, list_with_lanL, list_with_lanR, list_with_lanRL, list_with_laRZ, list_with_laZ, files_dirs_number
+    :members: list_with_la, list_with_la_filtered, list_with_lan, list_with_lan_filtered, list_with_lanL, list_with_lanR, list_with_lanRL, list_with_laRZ, list_with_laZ, files_dirs_number, list_with_ldH
     :show-inheritance:
     :undoc-members:
 

--- a/insights/core/ls_parser.py
+++ b/insights/core/ls_parser.py
@@ -217,14 +217,18 @@ def parse(lines, root=None):
     """
     doc = {}
     entries = []
+    error_lines = []
     name = None
     total = None
     for line in lines:
         line = line.strip()
         # Skip empty line and non-exist dir line
-        if not line or ': No such file or directory' in line:
+        if not line:
             continue
-        if line and line[0] == "/" and line[-1] == ":":
+        elif "ls: cannot access" in line or "No such file or directory" in line:
+            error_lines.append(line)
+            continue
+        elif line[0] == "/" and line[-1] == ":":
             if name is None:
                 name = line[:-1]
                 if entries:
@@ -246,6 +250,7 @@ def parse(lines, root=None):
     name = name or root
     total = total if total is not None else len(entries)
     doc[name] = Directory(name, total, entries)
+    doc.update(error_lines=error_lines) if error_lines else None
     return doc
 
 

--- a/insights/parsers/ls.py
+++ b/insights/parsers/ls.py
@@ -41,10 +41,33 @@ from insights.core.filters import add_filter
 from insights.core.ls_parser import FilePermissions
 from insights.core.plugins import parser
 from insights.specs import Specs
+from insights.util import deprecated
 
 # Required basic filters for `LS` specs that the content needs to be filtered
 add_filter(Specs.ls_la_filtered, ['total '])
 add_filter(Specs.ls_lan_filtered, ['total '])
+
+
+def compose_raw_entry(target):
+    if target:
+        raw_line = ' '.join([target['type'] + target['perms']])
+        if 'links' in target:
+            raw_line += ' ' + str(target['links'])
+        raw_line += ' ' + ' '.join([target['owner'], target['group']])
+        if 'se_user' in target:
+            raw_line += ' ' + ':'.join(
+                [target['se_user'], target['se_role'], target['se_type'], target['se_mls']]
+            )
+        if 'size' in target:
+            raw_line += ' ' + str(target['size'])
+        if 'major' in target:
+            raw_line += ' ' + ', '.join([str(target['major']), str(target['minor'])])
+        if 'date' in target:
+            raw_line += ' ' + target['date']
+        raw_line += ' ' + target['name']
+        if target['type'] == 'l' and 'link' in target:
+            raw_line += ' -> ' + target['link']
+        return raw_line
 
 
 class FileListing(CommandParser, dict):
@@ -276,26 +299,7 @@ class FileListing(CommandParser, dict):
         """
         if directory in self:
             de = self[directory]['entries']
-            if target in de:
-                tgt = de[target]
-                raw_line = ' '.join([tgt['type'] + tgt['perms']])
-                if 'links' in tgt:
-                    raw_line += ' ' + str(tgt['links'])
-                raw_line += ' ' + ' '.join([tgt['owner'], tgt['group']])
-                if 'se_user' in tgt:
-                    raw_line += ' ' + ':'.join(
-                        [tgt['se_user'], tgt['se_role'], tgt['se_type'], tgt['se_mls']]
-                    )
-                if 'size' in tgt:
-                    raw_line += ' ' + str(tgt['size'])
-                if 'major' in tgt:
-                    raw_line += ' ' + ', '.join([str(tgt['major']), str(tgt['minor'])])
-                if 'date' in tgt:
-                    raw_line += ' ' + tgt['date']
-                raw_line += ' ' + tgt['name']
-                if tgt['type'] == 'l' and 'link' in tgt:
-                    raw_line += ' -> ' + tgt['link']
-                return raw_line
+            return compose_raw_entry(de.get(target))
 
     def permissions_of(self, directory, target):
         """
@@ -410,23 +414,22 @@ class LSlHFiles(CommandParser, dict):
     """
     Parses file information of ``ls -lH`` command.
 
+    .. warning::
+        This class is deprecated and will be removed from 3.7.0.
+        Please use the :class:`LSldH` instead.
+
     .. note::
 
         To parse a specific file, its full path should be added to the
         `ls_lH_files` spec via `add_filter`.
         Only paths point to files are acceptable.
 
-    Examples:
-        >>> from insights.core.filters import add_filter
-        >>> from insights.specs import Specs
-        >>> add_filter(Specs.ls_lH_files, ['/etc/redhat-release', '/var/log/messages'])
-        >>> type(ls_files)
-        <class 'insights.parsers.ls.LSlHFiles'>
-        >>> "/etc/redhat-release" in ls_files
-        True
-        >>> ls_files["/etc/redhat-release"].all_zero()
-        False
     """
+    def __init__(self, *args, **kwargs):
+        deprecated(
+            LSlHFiles, "Please use the :class:`LSldH` instead.", "3.7.0"
+        )
+        super(LSlHFiles, self).__init__(*args, **kwargs)
 
     def parse_content(self, content):
         self.error_lines = []
@@ -441,3 +444,129 @@ class LSlHFiles(CommandParser, dict):
                 pass
         if not self:
             raise SkipComponent
+
+
+class FileListingNoHeader(CommandParser, dict):
+    """
+    Parses a flat, long-listing with SELinux context information
+    where each entry represents an absolute path and no directory
+    headers are present. Stores all information for each successfully
+    parsed entry, containing::
+
+        - type:     File type indicator ('d', '-', 'l', 'b', 'c')
+        - perms:    Permission bits, e.g. 'rw-r--r--.'
+        - links:    Number of hard links
+        - owner:    Owner user name
+        - group:    Owner group name
+        - size:     File size in bytes (if applicable)
+        - major:    Device major number (for block/char devices)
+        - minor:    Device minor number (for block/char devices)
+        - se_user:  SELinux user (if applicable)
+        - se_role:  SELinux role (if applicable)
+        - se_type:  SELinux type (if applicable)
+        - se_mls:   SELinux level (if applicable)
+        - name:     Full absolute path to the file
+        - date:     Modification date/time string
+        - link:     Target path (if the entry is a symlink)
+        - dir:      Parent directory (if applicable)
+
+    Attributes::
+
+        entries (dict): A mapping of all parsed entries, keyed by their absolute paths.
+        files (list): The list of all non-special files (i.e. not block or character devices).
+        dirs (list): The list of all directories parsed.
+        specials (list): The list of all special files (block and character devices).
+        error_lines (list): The list of all special files (block and character devices).
+
+    Sample output::
+
+        ls: cannot access '/dev/socketfile': No such file or directory
+        dr-xr-xr-x. 5 root root     4096 May 30 06:57 /boot
+        drwx------. 4 root root       83 Nov  6  2024 /boot/grub2
+        -rw-------. 1 root root     6658 Dec 20  2023 /boot/grub2/grub.cfg
+        crw--w----. 1 root tty  136,   0 Nov 17 01:28 /dev/stderr
+        brw-rw----. 1 root disk 252,   0 Nov 16 03:19 /dev/vda
+        crw-------. 1 root root  10, 137 Nov  6  2024 /dev/vhci
+
+    Examples::
+
+        >>> from insights.core.filters import add_filter
+        >>> from insights.specs import Specs
+        >>> add_filter(Specs.ls_ldH_items, ['/boot', '/boot/grub2/grub.cfg', '/dev/stderr', '/dev/vda', '/dev/vhci'])
+        >>> type(ls_files_no_header)
+        <class 'insights.parsers.ls.FileListingNoHeader'>
+        >>> len(ls_files_no_header.entries.keys())
+        6
+        >>> "/boot/grub2/grub.cfg" in ls_files_no_header.files
+        True
+        >>> ls_files_no_header.dirs
+        ['/boot', '/boot/grub2']
+        >>> "/dev/vda" in ls_files_no_header.specials
+        True
+        >>> ls_files_no_header.entries['/boot']['perms']
+        'r-xr-xr-x.'
+    """
+
+    def parse_content(self, content):
+        """
+        Parses a file/directory listing with SELinux information from the
+        provided content and updates the dictionary with all parsed entries.
+        """
+        result = ls_parser.parse(content, None)
+        self.update(result.get(None))
+        self.error_lines = result.pop('error_lines') if 'error_lines' in result else []
+
+    entries = property(lambda self: self['entries'])
+    files = property(lambda self: self['files'])
+    dirs = property(lambda self: self['dirs'])
+    specials = property(lambda self: self['specials'])
+
+    def raw_entry_of(self, target):
+        """
+        Returns the raw line entry of the ``target`` listed in
+        'ls' command output.
+
+        Parameters:
+            target (string): Name of the directory or file to get
+                information for.
+
+        Returns:
+            str: The re-constructed rough line if found or None if not found.
+
+        .. note::
+            As it's re-constructed according to the serialized items, it's not
+            identical with the original line.
+        """
+        return compose_raw_entry(self['entries'].get(target))
+
+    def permissions_of(self, target):
+        """
+        Returns a FilePermissions object, if found.
+
+        Parameters:
+            directory(string): Full path without trailing slash where to
+                search.
+            target (string): Name of the directory or file to get
+                FilePermissions for.
+
+        Returns:
+            FilePermissions: If found or None if not found.
+        """
+        raw_line = self.raw_entry_of(target)
+        if raw_line:
+            return FilePermissions(raw_line)
+
+
+@parser(Specs.ls_ldH)
+class LSldH(FileListingNoHeader):
+    """
+    Parses output of ``ls -ldH`` command.
+    See :py:class:`FileListingNoHeader` for more information.
+
+    .. note::
+
+        To parse a specific file, its full path should be added to the
+        `ls_ldH_items` spec via `add_filter`.
+
+    """
+    pass

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -431,6 +431,8 @@ class Specs(SpecSet):
     ls_laRZ_dirs = RegistryPoint(filterable=True)
     ls_laZ = RegistryPoint()
     ls_laZ_dirs = RegistryPoint(filterable=True)
+    ls_ldH = RegistryPoint()
+    ls_ldH_items = RegistryPoint(filterable=True)
     # Useful for SoS
     ls_boot = RegistryPoint()
     ls_dev = RegistryPoint()

--- a/insights/specs/datasources/ls.py
+++ b/insights/specs/datasources/ls.py
@@ -162,3 +162,15 @@ def files_dirs_number(broker):
             relative_path='insights_datasources/files_dirs_number',
         )
     raise SkipComponent
+
+
+@datasource(HostContext, optional=[FSTab])
+def list_with_ldH(broker):
+    filters = set(_list_items(Specs.ls_ldH_items))
+    if 'fstab_mounted.dirs' in filters and FSTab in broker:
+        filters.remove('fstab_mounted.dirs')
+        for mntp in broker[FSTab].mounted_on.keys():
+            filters.add(mntp) if mntp.startswith('/') else None
+    if filters:
+        return ' '.join(sorted(filters))
+    raise SkipComponent

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -502,6 +502,7 @@ class DefaultSpecs(Specs):
         '/bin/ls -laRZ %s', ls.list_with_laRZ, save_as='ls_laRZ', keep_rc=True
     )
     ls_laZ = command_with_args('/bin/ls -laZ %s', ls.list_with_laZ, save_as='ls_laZ', keep_rc=True)
+    ls_ldH = command_with_args('/bin/ls -ldH %s', ls.list_with_ldH, save_as='ls_ldH', keep_rc=True)
     lsattr = command_with_args("/bin/lsattr %s", lsattr.paths_to_lsattr)
     lsblk = simple_command("/bin/lsblk")
     lsblk_pairs = simple_command(

--- a/insights/tests/datasources/test_ls.py
+++ b/insights/tests/datasources/test_ls.py
@@ -24,6 +24,7 @@ from insights.specs.datasources.ls import (
     list_with_lanRL,
     list_with_laRZ,
     list_with_laZ,
+    list_with_ldH,
 )
 from insights.tests import context_wrap
 
@@ -58,6 +59,15 @@ PVS_DATA = """
   WARNING: File locking is disabled.
   LVM2_PV_FMT=''|LVM2_PV_UUID=''|LVM2_DEV_SIZE='1.00g'|LVM2_PV_NAME='/dev/vda1'|LVM2_PV_MAJOR='252'|LVM2_PV_MINOR='1'|LVM2_PV_MDA_FREE='0 '|LVM2_PV_MDA_SIZE='0 '|LVM2_PV_EXT_VSN=''|LVM2_PE_START='0 '|LVM2_PV_SIZE='0 '|LVM2_PV_FREE='0 '|LVM2_PV_USED='0 '|LVM2_PV_ATTR='---'|LVM2_PV_ALLOCATABLE=''|LVM2_PV_EXPORTED=''|LVM2_PV_MISSING=''|LVM2_PV_PE_COUNT='0'|LVM2_PV_PE_ALLOC_COUNT='0'|LVM2_PV_TAGS=''|LVM2_PV_MDA_COUNT='0'|LVM2_PV_MDA_USED_COUNT='0'|LVM2_PV_BA_START='0 '|LVM2_PV_BA_SIZE='0 '|LVM2_PV_IN_USE=''|LVM2_PV_DUPLICATE=''|LVM2_PV_DEVICE_ID=''|LVM2_PV_DEVICE_ID_TYPE=''|LVM2_VG_NAME=''
   LVM2_PV_FMT='lvm2'|LVM2_PV_UUID='D0bk3H-NASe-ncYz-L3T0-mPSH-QbzT-xlPTrh'|LVM2_DEV_SIZE='<127.00g'|LVM2_PV_NAME='/dev/vda2'|LVM2_PV_MAJOR='252'|LVM2_PV_MINOR='2'|LVM2_PV_MDA_FREE='507.50k'|LVM2_PV_MDA_SIZE='1020.00k'|LVM2_PV_EXT_VSN='2'|LVM2_PE_START='1.00m'|LVM2_PV_SIZE='<127.00g'|LVM2_PV_FREE='<54.94g'|LVM2_PV_USED='<72.06g'|LVM2_PV_ATTR='a--'|LVM2_PV_ALLOCATABLE='allocatable'|LVM2_PV_EXPORTED=''|LVM2_PV_MISSING=''|LVM2_PV_PE_COUNT='32511'|LVM2_PV_PE_ALLOC_COUNT='18447'|LVM2_PV_TAGS=''|LVM2_PV_MDA_COUNT='1'|LVM2_PV_MDA_USED_COUNT='1'|LVM2_PV_BA_START='0 '|LVM2_PV_BA_SIZE='0 '|LVM2_PV_IN_USE='used'|LVM2_PV_DUPLICATE=''|LVM2_PV_DEVICE_ID=''|LVM2_PV_DEVICE_ID_TYPE=''|LVM2_VG_NAME='rhel_rhel8'
+""".strip()
+
+FSTAB_DUPLICATE_CONTEXT = """
+/dev/mapper/rhel_rhel8-root /                       xfs     defaults        0 0
+/dev/vda1 /boot                   xfs     defaults        0 0
+/dev/mapper/rhel_rhel8-swap none                    swap    defaults        0 0
+/dev/mapper/rhel_rhel7-hana1 /hana/data/rhel7-hana1                       xfs     defaults        0 0
+/dev/mapper/rhel_rhel7-hana2 /hana/data/rhel7-hana1                       xfs     defaults        0 0
+/dev/mapper/rhel_rhel7-hana3 /hana/data/rhel7-hana1                       xfs     defaults        0 0
 """.strip()
 
 
@@ -97,6 +107,8 @@ def setup_function(func):
         filters.add_filter(
             Specs.ls_lH_files, ["/etc/redhat-release", '/var/log/messages', 'fstab_mounted.devices']
         )
+    if func is test_ld_with_fstab_mounted_filter:
+        filters.add_filter(Specs.ls_ldH_items, ["/", '/boot', 'fstab_mounted.dirs'])
 
 
 def teardown_function(func):
@@ -188,3 +200,18 @@ def test_lH_files_fstab_blkid(_):
         ret
         == '/dev/mapper/rhel-home /dev/mapper/rhel-root /dev/mapper/rhel-var /dev/sdb2 /etc/redhat-release /var/log/messages'
     )
+
+
+def test_ld_with_fstab_mounted_filter():
+    ret = list_with_ldH({})
+    assert ret == '/ /boot fstab_mounted.dirs'
+
+    fstab = FSTab(context_wrap(FSTAB_CONTEXT))
+    broker = {FSTab: fstab}
+    ret = list_with_ldH(broker)
+    assert ret == '/ /boot /hana/data/rhel7-hana1 /hana/data/rhel7-hana2 /hana/data/rhel7-hana3'
+
+    fstab = FSTab(context_wrap(FSTAB_DUPLICATE_CONTEXT))
+    broker = {FSTab: fstab}
+    ret = list_with_ldH(broker)
+    assert ret == '/ /boot /hana/data/rhel7-hana1'

--- a/insights/tests/parsers/test_ls.py
+++ b/insights/tests/parsers/test_ls.py
@@ -1,6 +1,6 @@
 from insights.parsers.ls import (
     LSla, LSlaFiltered, LSlan, LSlanFiltered,
-    LSlanL, LSlanR, LSlanRL, LSlaRZ, LSlaZ
+    LSlanL, LSlanR, LSlanRL, LSlaRZ, LSlaZ, LSldH
 )
 from insights.tests import context_wrap
 
@@ -290,6 +290,16 @@ drwxr-xr-x. 19 root root system_u:object_r:device_t:s0         3180 May 10 09:54
 crw-rw-rw-.  1 root root system_u:object_r:vfio_device_t:s0 10, 196 May 10 09:54 vfio -> false_link_2
 """
 
+LS_LDH = """
+ls: cannot access '/dev/socketfile': No such file or directory
+dr-xr-xr-x. 5 root root     4096 May 30 06:57 /boot
+drwx------. 4 root root       83 Nov  6  2024 /boot/grub2
+-rw-------. 1 root root     6658 Dec 20  2023 /boot/grub2/grub.cfg
+crw--w----. 1 root tty  136,   0 Nov 17 01:28 /dev/stderr
+brw-rw----. 1 root disk 252,   0 Nov 16 03:19 /dev/vda
+crw-------. 1 root root  10, 137 Nov  6  2024 /dev/vhci
+"""
+
 
 def test_ls_la():
     ls = LSla(context_wrap(LS_LA))
@@ -537,3 +547,33 @@ def test_ls_laZ_on_dev():
     dev_listings = ls.listing_of('/dev/vfio')
     assert 'vfio' in dev_listings
     assert dev_listings["vfio"]['link'] == 'false_link_2'
+
+
+def test_ls_ldH():
+    ls = LSldH(context_wrap(LS_LDH))
+    assert ls.error_lines == ["ls: cannot access '/dev/socketfile': No such file or directory"]
+    assert ls.dirs == ['/boot', '/boot/grub2']
+    assert '/boot/grub2/grub.cfg' in ls.files
+    assert len(ls.files) == 1
+    assert '/dev/vda' in ls.specials
+
+    assert ls['entries']['/boot/grub2/grub.cfg']['type'] == '-'
+    assert ls['entries']['/boot/grub2/grub.cfg']['perms'] == 'rw-------.'
+    assert ls['entries']['/boot/grub2/grub.cfg']['links'] == 1
+    assert ls['entries']['/boot/grub2/grub.cfg']['owner'] == 'root'
+    assert ls['entries']['/boot/grub2/grub.cfg']['group'] == 'root'
+    assert ls['entries']['/boot/grub2/grub.cfg']['size'] == 6658
+    assert ls['entries']['/boot/grub2/grub.cfg']['name'] == '/boot/grub2/grub.cfg'
+    assert ls['entries']['/boot/grub2/grub.cfg']['date'] == 'Dec 20  2023'
+
+    assert ls.entries['/dev/vda']['type'] == 'b'
+    assert ls.entries['/dev/vda']['owner'] == 'root'
+    assert ls.entries['/dev/vda']['name'] == '/dev/vda'
+
+    assert ls.raw_entry_of(
+        '/dev/vda') == 'brw-rw----. 1 root disk 252, 0 Nov 16 03:19 /dev/vda'
+    assert ls.raw_entry_of('/dev/vdb') is None
+    assert ls.raw_entry_of(
+        '/boot/grub2/grub.cfg') == '-rw-------. 1 root root 6658 Dec 20  2023 /boot/grub2/grub.cfg'
+    assert ls.raw_entry_of(
+        '/dev/stderr') == 'crw--w----. 1 root tty 136, 0 Nov 17 01:28 /dev/stderr'

--- a/insights/tests/parsers/test_ls_file_listing.py
+++ b/insights/tests/parsers/test_ls_file_listing.py
@@ -2,7 +2,7 @@
 import doctest
 
 from insights.parsers import ls as ls_module
-from insights.parsers.ls import FileListing, LSlan, LSlHFiles
+from insights.parsers.ls import FileListing, LSlan, LSlHFiles, FileListingNoHeader
 from insights.tests import context_wrap
 
 SINGLE_DIRECTORY = """
@@ -144,6 +144,16 @@ brw-rw----. 1 root  disk 252, 1 May 16 01:30 /dev/vda1
 # devices without a major/minor number?  Or non-devices that have a comma in
 # the size?  Permissions that don't make sense?  Dates that don't make sense
 # but still fit the patterns?  What should the parser do with such entries?
+
+LS_FILE_NO_HEADER_DOC = '''
+ls: cannot access '/dev/socketfile': No such file or directory
+dr-xr-xr-x. 5 root root     4096 May 30 06:57 /boot
+drwx------. 4 root root       83 Nov  6  2024 /boot/grub2
+-rw-------. 1 root root     6658 Dec 20  2023 /boot/grub2/grub.cfg
+crw--w----. 1 root tty  136,   0 Nov 17 01:28 /dev/stderr
+brw-rw----. 1 root disk 252,   0 Nov 16 03:19 /dev/vda
+crw-------. 1 root root  10, 137 Nov  6  2024 /dev/vhci
+'''
 
 
 def test_single_directory():
@@ -439,6 +449,7 @@ def test_doc_example():
     env = {
         'ls_lan': LSlan(context_wrap(FILE_LISTING_DOC)),
         'ls_files': LSlHFiles(context_wrap(LS_FILE_PERMISSIONS_DOC)),
+        'ls_files_no_header': FileListingNoHeader(context_wrap(LS_FILE_NO_HEADER_DOC)),
     }
     failed, total = doctest.testmod(ls_module, globs=env)
     assert failed == 0

--- a/insights/tests/test_ls_parser.py
+++ b/insights/tests/test_ls_parser.py
@@ -237,7 +237,7 @@ def test_parse_single_directory():
 
 def test_parse_multiple_directories():
     results = parse(MULTIPLE_DIRECTORIES.splitlines(), None)
-    assert len(results) == 2, len(results)
+    assert len(results) == 3, len(results)
     assert results["/etc/sysconfig"]["name"] == "/etc/sysconfig"
     assert results["/etc/sysconfig"]["total"] == 96
     assert results["/etc/rc.d/rc3.d"]["name"] == "/etc/rc.d/rc3.d"
@@ -245,6 +245,7 @@ def test_parse_multiple_directories():
 
     assert results["/etc/sysconfig"]["entries"]["spooler-T"]["perms"] == "-w----r-T"
     assert results["/etc/sysconfig"]["entries"]["spooler-t"]["perms"] == "-w----r-t"
+    assert len(results['error_lines']) == 1
 
     res = results["/etc/sysconfig"]["entries"]["ebtables-config"]
     assert res["type"] == "-"
@@ -259,16 +260,17 @@ def test_parse_multiple_directories():
 
 def test_parse_multiple_directories_with_break():
     results = parse(MULTIPLE_DIRECTORIES_WITH_BREAK.splitlines(), None)
-    assert len(results) == 3, len(results)
-    assert len(results.values()) == 3
-    assert len(results.items()) == 3
-    assert len(list(six.iteritems(results))) == 3
+    assert len(results) == 4, len(results)
+    assert len(results.values()) == 4
+    assert len(results.items()) == 4
+    assert len(list(six.iteritems(results))) == 4
     assert results["/etc"]["name"] == "/etc"
     assert results["/etc"]["total"] == 1652
     assert results["/etc/rc.d/rc3.d"]["name"] == "/etc/rc.d/rc3.d"
     assert results["/etc/rc.d/rc3.d"]["total"] == 4
     assert 'chrony.keys' in results['/etc']['files']
     assert 'cifs-utils' in results['/etc']['dirs']
+    assert len(results['error_lines']) == 1
 
     res = results["/etc"]["entries"]["chrony.conf.20180210135613"]
     assert res["type"] == "-"
@@ -283,7 +285,7 @@ def test_parse_multiple_directories_with_break():
 
 def test_complicated_files():
     results = parse(COMPLICATED_FILES.splitlines(), "/tmp")
-    assert len(results) == 1
+    assert len(results) == 2
     assert results["/tmp"]["total"] == 16, results["/tmp"]["total"]
     assert results["/tmp"]["name"] == "/tmp", results["/tmp"]["name"]
     res = results["/tmp"]["entries"]["dm-10"]
@@ -296,6 +298,7 @@ def test_complicated_files():
     assert res["date"] == "Aug  4 16:56"
     assert res["name"] == "dm-10"
     assert res["dir"] == "/tmp"
+    assert len(results['error_lines']) == 1
 
 
 def test_files_with_selinux_disabled():


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [x] Is this a backport from `master`? Yes, this is a backport of #4620
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

- Add new datasource list_with_ldH
- Add new spec ls_ldH and ls_ldH_dirs
- Add new parser LSldH
- Update ls_parser.parse to support 'error_lines'
- Refactored logic from LSlHFiles into a new base parser, FileListingNoHeader, which supports ls -ld* related specs.
- Deprecate the LSlHFiles
- Jira: RHINENG-20871

