### PR TITLE
chore: Uname supports RHEL 10.1

### DIFF
--- a/insights/parsers/uname.py
+++ b/insights/parsers/uname.py
@@ -133,6 +133,7 @@ rhel_release_map = {
     "5.14.0-611": "9.7",
     # RHEL 10
     "6.12.0-55": "10.0",
+    "6.12.0-124": "10.1",
 }
 
 release_to_kernel_map = dict((v, k) for k, v in rhel_release_map.items())


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [x] Is this a backport from `master`? Yes, this is a backport of #4643 
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Enhancements:
- Add mapping for kernel release 6.12.0-124 to RHEL 10.1 in the rhel_release_map.