### PR TITLE
Add new parser & datasource for ls -ldZ

### DIFF
--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -172,7 +172,7 @@ insights.specs.datasources.ls
 -----------------------------
 
 .. automodule:: insights.specs.datasources.ls
-    :members: list_with_la, list_with_la_filtered, list_with_lan, list_with_lan_filtered, list_with_lanL, list_with_lanR, list_with_lanRL, list_with_laRZ, list_with_laZ, files_dirs_number, list_with_ldH
+    :members: list_with_la, list_with_la_filtered, list_with_lan, list_with_lan_filtered, list_with_lanL, list_with_lanR, list_with_lanRL, list_with_laRZ, list_with_laZ, files_dirs_number, list_with_ldH, list_with_ldZ
     :show-inheritance:
     :undoc-members:
 

--- a/insights/parsers/ls.py
+++ b/insights/parsers/ls.py
@@ -31,6 +31,12 @@ LSlaRZ - command ``ls -lanRZ <dirs>``
 LSlaZ - command ``ls -lanZ <dirs>``
 -----------------------------------
 
+LSldH - command ``ls -ldH <items>``
+-----------------------------------
+
+LSldZ - command ``ls -ldZ <items>``
+-----------------------------------
+
 LSlHFiles - spec ``ls_files`` -  command ``ls -lH  <files>``
 ------------------------------------------------------------
 """
@@ -567,6 +573,21 @@ class LSldH(FileListingNoHeader):
 
         To parse a specific file, its full path should be added to the
         `ls_ldH_items` spec via `add_filter`.
+
+    """
+    pass
+
+
+@parser(Specs.ls_ldZ)
+class LSldZ(FileListingNoHeader):
+    """
+    Parses output of ``ls -ldZ`` command.
+    See :py:class:`FileListingNoHeadSelinux` for more information.
+
+    .. note::
+
+        To parse a specific file, its full path should be added to the
+        `ls_ldZ_items` spec via `add_filter`.
 
     """
     pass

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -433,6 +433,8 @@ class Specs(SpecSet):
     ls_laZ_dirs = RegistryPoint(filterable=True)
     ls_ldH = RegistryPoint()
     ls_ldH_items = RegistryPoint(filterable=True)
+    ls_ldZ = RegistryPoint()
+    ls_ldZ_items = RegistryPoint(filterable=True)
     # Useful for SoS
     ls_boot = RegistryPoint()
     ls_dev = RegistryPoint()

--- a/insights/specs/datasources/ls.py
+++ b/insights/specs/datasources/ls.py
@@ -164,9 +164,27 @@ def files_dirs_number(broker):
     raise SkipComponent
 
 
-@datasource(HostContext, optional=[FSTab])
+@datasource(HostContext, optional=[FSTab, BlockIDInfo, Pvs])
 def list_with_ldH(broker):
     filters = set(_list_items(Specs.ls_ldH_items))
+    files = set(_f for _f in filters if not os.path.isdir(_f))
+    if 'fstab_mounted.devices' in filters and FSTab in broker and BlockIDInfo in broker:
+        files.remove('fstab_mounted.devices')
+        fstab_mounts = broker[FSTab]
+        blkid_info = broker[BlockIDInfo]
+        files.update(_get_fstab_mounted_device_files(fstab_mounts, blkid_info))
+    if 'pvs.devices' in filters and Pvs in broker:
+        files.remove('pvs.devices')
+        pvs_info = broker[Pvs]
+        files.update(set([item['PV'] for item in pvs_info]))
+    if files:
+        return ' '.join(sorted(files))
+    raise SkipComponent
+
+
+@datasource(HostContext)
+def list_with_ldZ(broker):
+    filters = set(_list_items(Specs.ls_ldZ_items))
     if 'fstab_mounted.dirs' in filters and FSTab in broker:
         filters.remove('fstab_mounted.dirs')
         for mntp in broker[FSTab].mounted_on.keys():

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -503,6 +503,7 @@ class DefaultSpecs(Specs):
     )
     ls_laZ = command_with_args('/bin/ls -laZ %s', ls.list_with_laZ, save_as='ls_laZ', keep_rc=True)
     ls_ldH = command_with_args('/bin/ls -ldH %s', ls.list_with_ldH, save_as='ls_ldH', keep_rc=True)
+    ls_ldZ = command_with_args('/bin/ls -ldZ %s', ls.list_with_ldZ, save_as='ls_ldZ', keep_rc=True)
     lsattr = command_with_args("/bin/lsattr %s", lsattr.paths_to_lsattr)
     lsblk = simple_command("/bin/lsblk")
     lsblk_pairs = simple_command(


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [x] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

- Add new datasource list_with_ldZ
- Add new spec ls_ldZ and ls_ldZ_items
- Add new parser LSldZ
- RHINENG-20974

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
