### PR TITLE
fix: don't import FileListing in insights

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 ignore = E203,E501,E126,E127,E128,E722,E741,W503,W504
 exclude = insights/contrib,bin,docs,include,lib,lib64,.git,.collections.py,insights/parsers/tests/lvm_test_data.py,insights/client/apps/ansible/playbook_verifier/contrib,insights/tools/coverage.py
+per-file-ignores = insights/__init__.py: F401


### PR DESCRIPTION
FileListing is now a base Praser which imports 'insights.specs' indiretly.  It's not good approach to import all Specs when using the `insights.core.dr` API.

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [x] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Avoid importing FileListing from the top-level insights package to prevent unnecessary loading of specs when using the core APIs.

Bug Fixes:
- Stop indirect loading of insights.specs via FileListing when importing insights, reducing unintended side effects for consumers.

Enhancements:
- Reformat insights.__init__ for improved readability and alignment with style guidelines.