### PR TITLE
fix(test): update the check of obfuscation warnings

### DIFF
--- a/insights/tests/client/test_config_validate_obfuscation_options.py
+++ b/insights/tests/client/test_config_validate_obfuscation_options.py
@@ -1,9 +1,9 @@
 import pytest
 
 try:
-    from unittest.mock import patch
+    from unittest.mock import patch, call
 except Exception:
-    from mock import patch
+    from mock import patch, call
 
 from insights.client.config import InsightsConfig
 
@@ -48,7 +48,7 @@ def test_validate_obfuscation_options_conflict_old_warning(egg, rhel, logger):
     with pytest.raises(ValueError) as ve:
         InsightsConfig(obfuscate=False, obfuscate_hostname=True, _print_errors=True)
     assert 'Option `obfuscate_hostname` requires `obfuscate`' in str(ve.value)
-    logger.warning.assert_called_once_with(
+    logger.warning.assert_called_with(
         'WARNING: `obfuscate` and `obfuscate_hostname` are deprecated, please use `obfuscation_list` instead.'
     )
 
@@ -92,12 +92,19 @@ def test_validate_obfuscation_options_conflict_new(
         obfuscation_list=obfuscation_list,
         _print_errors=True,
     )
-    assert c.obfuscation_list == expected_opt
-    logger.warning.assert_called_once_with(
-        'WARNING: Conflicting options: `obfuscation_list` and `obfuscate`, using: "obfuscation_list={0}".'.format(
-            obfuscation_list
+    logger.warning.assert_has_calls(
+        (
+            call(
+                'WARNING: `obfuscate` and `obfuscate_hostname` are deprecated, please use `obfuscation_list` instead.'
+            ),
+            call(
+                'WARNING: Conflicting options: `obfuscation_list` and `obfuscate`, using: "obfuscation_list={0}".'.format(
+                    obfuscation_list
+                )
+            ),
         )
     )
+    assert c.obfuscation_list == expected_opt
 
 
 @patch('insights.client.config.logger')


### PR DESCRIPTION
- after 3.6.10, both conflicts and deprecations will be checked.


(cherry picked from commit 808a73346518afd5f5657a330390ee9c7d4f1782)

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [x] Is this a backport from `master`? Yes, this is a backport of #4648 
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Tests:
- Update obfuscation options validation tests to expect both deprecation and conflict warnings from the logger instead of a single warning.