### PR TITLE
chore(ci/cd): remove py27 pipeline tests for master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Insights Core Test
 
 on:
   push:
-    branches: [ master, '3.0']
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         python-versions: ["3.9", "3.11", "3.12"]
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-versions }}
@@ -43,7 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: python:3.6.15-buster
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.6
@@ -60,30 +58,8 @@ jobs:
         pip install -e .[testing]
         pytest
 
-  python27-test:
-    runs-on: ubuntu-latest
-    container:
-      image: python:2.7.18-buster
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 2.7
-      uses: actions/setup-python@v5
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-    - name: flake8
-      run: |
-        pip install -e .[linting]
-        flake8 .
-    - name: pytest
-      run: |
-        pip install -e .[testing]
-        pytest
-
   docs-test:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.12
@@ -101,7 +77,6 @@ jobs:
 
   gitleaks:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
       with:
@@ -116,7 +91,6 @@ jobs:
 
   greeting:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/first-interaction@v1
       with:


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->

Jira RHINENG-20876

## Summary by Sourcery

Update CI workflow configuration for the main branch.

CI:
- Stop running the main GitHub Actions workflow on the 3.0 branch so it only triggers for master.
- Remove the Python 2.7 test job from the GitHub Actions workflow.