### PR TITLE
spec: do hostname obfuscation for bootctl_status

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -61,7 +61,7 @@ class Specs(SpecSet):
     )
     boot_loader_entries = RegistryPoint(multi_output=True)
     bootc_status = RegistryPoint(no_obfuscate=['hostname'])
-    bootctl_status = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
+    bootctl_status = RegistryPoint(no_obfuscate=['ipv4', 'ipv6', 'mac'])
     brctl_show = RegistryPoint()
     buddyinfo = RegistryPoint()
     candlepin_broker = RegistryPoint()


### PR DESCRIPTION
- As on some hosts, hostname might be appeared in its output, it's necessary to do the hostname obfuscation in that case.
- Jira: RHINENG-22308

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [x] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Bug Fixes:
- Ensure bootctl_status output no longer exempts hostnames from obfuscation, preventing potential leakage of sensitive host information.