### PR TITLE
chore(test): replace mock with unittest.mock

### DIFF
--- a/insights/tests/cleaner/test_clean_content_hostname.py
+++ b/insights/tests/cleaner/test_clean_content_hostname.py
@@ -1,4 +1,4 @@
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights.client.config import InsightsConfig
 from insights.cleaner import Cleaner

--- a/insights/tests/cleaner/test_clean_content_ipv4.py
+++ b/insights/tests/cleaner/test_clean_content_ipv4.py
@@ -1,4 +1,4 @@
-from mock.mock import patch
+from unittest.mock import patch
 from pytest import mark
 
 from insights.client.config import InsightsConfig

--- a/insights/tests/cleaner/test_clean_file.py
+++ b/insights/tests/cleaner/test_clean_file.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights.client.archive import InsightsArchive
 from insights.client.config import InsightsConfig

--- a/insights/tests/cleaner/test_max_line_length.py
+++ b/insights/tests/cleaner/test_max_line_length.py
@@ -1,4 +1,4 @@
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights.cleaner import Cleaner
 from insights.client.config import InsightsConfig

--- a/insights/tests/cleaner/test_reports.py
+++ b/insights/tests/cleaner/test_reports.py
@@ -3,7 +3,7 @@ import json
 import os
 import tempfile
 
-from mock.mock import patch
+from unittest.mock import patch
 from pytest import mark
 
 from insights.client.archive import InsightsArchive

--- a/insights/tests/client/apps/test_playbook_verifier.py
+++ b/insights/tests/client/apps/test_playbook_verifier.py
@@ -5,11 +5,11 @@ import collections
 import pkgutil
 import sys
 
-import mock
 import pytest
 import tempfile
 import shutil
-from mock.mock import patch
+from unittest import mock
+from unittest.mock import patch
 from pytest import raises
 
 from insights.client.constants import InsightsConstants as constants

--- a/insights/tests/client/auto_config/test_autoconfig_urls.py
+++ b/insights/tests/client/auto_config/test_autoconfig_urls.py
@@ -1,5 +1,5 @@
 from insights.client.auto_config import set_auto_configuration, _try_satellite6_configuration, try_auto_configuration
-from mock.mock import Mock, patch
+from unittest.mock import Mock, patch
 
 
 @patch("insights.client.auto_config.rhsmCertificate", Mock())

--- a/insights/tests/client/auto_config/test_branch_info_call.py
+++ b/insights/tests/client/auto_config/test_branch_info_call.py
@@ -1,5 +1,5 @@
 from insights.client.auto_config import set_auto_configuration
-from mock.mock import Mock, patch
+from unittest.mock import Mock, patch
 
 
 @patch("insights.client.auto_config.InsightsConnection")

--- a/insights/tests/client/collection_rules/test_get_rm_conf.py
+++ b/insights/tests/client/collection_rules/test_get_rm_conf.py
@@ -1,10 +1,11 @@
 # -*- coding: UTF-8 -*-
 
 import six
-import mock
+import sys
 import pytest
 from .helpers import insights_upload_conf
-from mock.mock import patch, Mock, call
+from unittest import mock
+from unittest.mock import patch, Mock, call
 from insights.client.collection_rules import correct_format, load_yaml, verify_permissions
 
 
@@ -266,7 +267,7 @@ def test_rm_conf_old_nofile(isfile):
     assert result is None
 
 
-@pytest.mark.skipif(mock.version_info < (3, 0, 5), reason="Old mock_open has no iteration control")
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Old mock_open has no iteration control")
 @patch('insights.client.collection_rules.verify_permissions', return_value=True)
 @patch_isfile(True)
 def test_rm_conf_old_emptyfile(isfile, verify):
@@ -281,7 +282,7 @@ def test_rm_conf_old_emptyfile(isfile, verify):
     assert result is None
 
 
-@pytest.mark.skipif(mock.version_info < (3, 0, 5), reason="Old mock_open has no iteration control")
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Old mock_open has no iteration control")
 @patch('insights.client.collection_rules.verify_permissions', return_value=True)
 @patch_isfile(True)
 def test_rm_conf_old_load_bad_invalidsection(isfile, verify):
@@ -297,7 +298,7 @@ def test_rm_conf_old_load_bad_invalidsection(isfile, verify):
     assert 'ERROR: invalid section(s)' in str(e.value)
 
 
-@pytest.mark.skipif(mock.version_info < (3, 0, 5), reason="Old mock_open has no iteration control")
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Old mock_open has no iteration control")
 @patch('insights.client.collection_rules.verify_permissions', return_value=True)
 @patch_isfile(True)
 def test_rm_conf_old_load_bad_keysnosection(isfile, verify):
@@ -313,7 +314,7 @@ def test_rm_conf_old_load_bad_keysnosection(isfile, verify):
     assert 'ERROR: Cannot parse' in str(e.value)
 
 
-@pytest.mark.skipif(mock.version_info < (3, 0, 5), reason="Old mock_open has no iteration control")
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Old mock_open has no iteration control")
 @patch('insights.client.collection_rules.verify_permissions', return_value=True)
 @patch_isfile(True)
 def test_rm_conf_old_load_bad_invalidkey(isfile, verify):
@@ -328,7 +329,7 @@ def test_rm_conf_old_load_bad_invalidkey(isfile, verify):
     assert 'ERROR: Unknown key' in str(e.value)
 
 
-@pytest.mark.skipif(mock.version_info < (3, 0, 5), reason="Old mock_open has no iteration control")
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Old mock_open has no iteration control")
 @patch('insights.client.collection_rules.verify_permissions', return_value=True)
 @patch_isfile(True)
 def test_rm_conf_old_load_ok(isfile, verify):

--- a/insights/tests/client/connection/test_LEGACY_reg_check.py
+++ b/insights/tests/client/connection/test_LEGACY_reg_check.py
@@ -1,7 +1,7 @@
 import requests
 import json
 from insights.client.connection import InsightsConnection
-from mock.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 
 @patch("insights.client.connection.generate_machine_id", return_value='xxxxxx')

--- a/insights/tests/client/connection/test_advisor_report.py
+++ b/insights/tests/client/connection/test_advisor_report.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from mock.mock import patch
+from unittest.mock import patch
 from insights.client.constants import InsightsConstants as constants
 from insights.client.connection import InsightsConnection
 from insights.client.config import InsightsConfig

--- a/insights/tests/client/connection/test_branch_info.py
+++ b/insights/tests/client/connection/test_branch_info.py
@@ -1,5 +1,5 @@
 from insights.client.connection import InsightsConnection
-from mock.mock import Mock, MagicMock, patch
+from unittest.mock import Mock, MagicMock, patch
 
 
 @patch("insights.client.connection.InsightsConnection._init_session")

--- a/insights/tests/client/connection/test_checkin.py
+++ b/insights/tests/client/connection/test_checkin.py
@@ -1,7 +1,7 @@
 from json import dumps
 from uuid import uuid4
 
-from mock.mock import Mock, patch
+from unittest.mock import Mock, patch
 from pytest import mark
 from pytest import raises
 from requests import ConnectionError

--- a/insights/tests/client/connection/test_diagnosis.py
+++ b/insights/tests/client/connection/test_diagnosis.py
@@ -2,7 +2,7 @@ import json
 from insights.client import InsightsClient
 from insights.client.config import InsightsConfig
 from insights.client.connection import InsightsConnection
-from mock.mock import patch, Mock
+from unittest.mock import patch, Mock
 import pytest
 
 TEST_REMEDIATION_ID = 123456

--- a/insights/tests/client/connection/test_init.py
+++ b/insights/tests/client/connection/test_init.py
@@ -1,8 +1,8 @@
 from insights.client.auto_config import try_auto_configuration
 from insights.client.config import InsightsConfig
 from insights.client.connection import InsightsConnection
-from mock.mock import Mock
-from mock.mock import patch
+from unittest.mock import Mock
+from unittest.mock import patch
 from pytest import mark
 
 

--- a/insights/tests/client/connection/test_init_session.py
+++ b/insights/tests/client/connection/test_init_session.py
@@ -1,5 +1,5 @@
 from insights.client.connection import InsightsConnection
-from mock.mock import Mock, patch
+from unittest.mock import Mock, patch
 from os import environ as os_environ
 
 

--- a/insights/tests/client/connection/test_reg_check.py
+++ b/insights/tests/client/connection/test_reg_check.py
@@ -1,7 +1,7 @@
 import requests
 import json
 from insights.client.connection import InsightsConnection
-from mock.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 
 @patch("insights.client.connection.generate_machine_id", return_value='xxxxxx')

--- a/insights/tests/client/connection/test_test_connection.py
+++ b/insights/tests/client/connection/test_test_connection.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 import requests
-from mock import mock
+from unittest import mock
 
 from insights.client.config import InsightsConfig
 from insights.client.connection import InsightsConnection

--- a/insights/tests/client/connection/test_upload.py
+++ b/insights/tests/client/connection/test_upload.py
@@ -1,4 +1,4 @@
-from mock.mock import Mock, patch
+from unittest.mock import Mock, patch
 from insights.client.connection import InsightsConnection
 
 

--- a/insights/tests/client/connection/test_url_guess.py
+++ b/insights/tests/client/connection/test_url_guess.py
@@ -1,5 +1,5 @@
 from insights.client.connection import InsightsConnection
-from mock.mock import Mock, patch
+from unittest.mock import Mock, patch
 
 
 @patch("insights.client.connection.InsightsConnection._init_session")

--- a/insights/tests/client/core_collector/test_done.py
+++ b/insights/tests/client/core_collector/test_done.py
@@ -1,4 +1,4 @@
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights.client.config import InsightsConfig
 from insights.client.core_collector import CoreCollector

--- a/insights/tests/client/core_collector/test_run_collection.py
+++ b/insights/tests/client/core_collector/test_run_collection.py
@@ -1,4 +1,4 @@
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights.client.config import InsightsConfig
 from insights.client.core_collector import CoreCollector

--- a/insights/tests/client/init/test_fetch.py
+++ b/insights/tests/client/init/test_fetch.py
@@ -1,7 +1,7 @@
 from insights.client import InsightsClient
 from insights.client.config import InsightsConfig
 from insights.client.constants import InsightsConstants as constants
-from mock.mock import Mock, patch
+from unittest.mock import Mock, patch
 from pytest import fixture
 from tempfile import NamedTemporaryFile
 

--- a/insights/tests/client/init/test_write_pidfile.py
+++ b/insights/tests/client/init/test_write_pidfile.py
@@ -2,8 +2,8 @@ import os
 
 from insights.client import InsightsClient
 from insights.client.constants import InsightsConstants
-from mock.mock import call
-from mock.mock import patch
+from unittest.mock import call
+from unittest.mock import patch
 
 
 @patch("insights.client.atexit.register")

--- a/insights/tests/client/phase/test_LEGACY_post_update.py
+++ b/insights/tests/client/phase/test_LEGACY_post_update.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 from insights.client.phase.v1 import post_update
-from mock.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from pytest import raises
 
 

--- a/insights/tests/client/phase/test_collect_and_upload.py
+++ b/insights/tests/client/phase/test_collect_and_upload.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 
 from insights.client.phase.v1 import collect_and_output
-from mock.mock import patch
+from unittest.mock import patch
 from pytest import raises
 
 

--- a/insights/tests/client/phase/test_post_update.py
+++ b/insights/tests/client/phase/test_post_update.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 import os
 from shutil import rmtree
 from insights.client.phase.v1 import post_update
-from mock.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from pytest import raises
 
 

--- a/insights/tests/client/phase/test_pre_update_checkin.py
+++ b/insights/tests/client/phase/test_pre_update_checkin.py
@@ -2,7 +2,7 @@
 
 from insights.client.constants import InsightsConstants
 from insights.client.phase.v1 import pre_update
-from mock.mock import patch
+from unittest.mock import patch
 from pytest import raises
 
 

--- a/insights/tests/client/phase/test_pre_update_support.py
+++ b/insights/tests/client/phase/test_pre_update_support.py
@@ -2,7 +2,7 @@
 
 from insights.client.constants import InsightsConstants
 from insights.client.phase.v1 import pre_update
-from mock.mock import patch
+from unittest.mock import patch
 from pytest import raises, mark
 
 

--- a/insights/tests/client/phase/test_update.py
+++ b/insights/tests/client/phase/test_update.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 
 from insights.client.phase.v1 import update
-from mock.mock import patch
+from unittest.mock import patch
 from pytest import raises
 
 

--- a/insights/tests/client/support/test_collect_support_info.py
+++ b/insights/tests/client/support/test_collect_support_info.py
@@ -4,7 +4,7 @@ from insights.client.config import InsightsConfig
 from insights.client.connection import InsightsConnection
 from insights.client.support import InsightsSupport, registration_check
 from insights.client.constants import InsightsConstants as constants
-from mock.mock import Mock, patch
+from unittest.mock import Mock, patch
 
 
 TEMP_TEST_REG_DIR = "/tmp/insights-client-registration"

--- a/insights/tests/client/test_ansiblehost.py
+++ b/insights/tests/client/test_ansiblehost.py
@@ -1,7 +1,7 @@
 import pytest
 from insights.client.config import InsightsConfig
 from insights.client.connection import InsightsConnection
-from mock.mock import patch
+from unittest.mock import patch
 
 
 class MockSession(object):

--- a/insights/tests/client/test_archive.py
+++ b/insights/tests/client/test_archive.py
@@ -1,7 +1,7 @@
 import time
 from insights.client.archive import InsightsArchive
 from insights.client.config import InsightsConfig
-from mock.mock import patch, Mock, call
+from unittest.mock import patch, Mock, call
 from unittest import TestCase
 from pytest import raises
 from insights.client.constants import InsightsConstants as constants

--- a/insights/tests/client/test_client.py
+++ b/insights/tests/client/test_client.py
@@ -16,7 +16,7 @@ from insights.client.config import InsightsConfig
 from insights.client.connection import InsightsConnection
 from insights import package_info
 from insights.client.constants import InsightsConstants as constants
-from mock.mock import patch, Mock, call, ANY
+from unittest.mock import patch, Mock, call, ANY
 from pytest import mark
 from pytest import raises
 

--- a/insights/tests/client/test_collect.py
+++ b/insights/tests/client/test_collect.py
@@ -1,5 +1,5 @@
 # -*- coding: UTF-8 -*-
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights.client.client import collect
 from insights.client.config import InsightsConfig

--- a/insights/tests/client/test_config.py
+++ b/insights/tests/client/test_config.py
@@ -2,7 +2,7 @@ import pytest
 import os
 from io import TextIOWrapper, BytesIO
 from insights.client.config import InsightsConfig, DEFAULT_OPTS
-from mock.mock import patch, Mock
+from unittest.mock import patch, Mock
 from pytest import mark
 
 

--- a/insights/tests/client/test_config_validate_obfuscation_options.py
+++ b/insights/tests/client/test_config_validate_obfuscation_options.py
@@ -1,9 +1,6 @@
 import pytest
 
-try:
-    from unittest.mock import patch, call
-except Exception:
-    from mock import patch, call
+from unittest.mock import patch, call
 
 from insights.client.config import InsightsConfig
 

--- a/insights/tests/client/test_connection_clean_facts.py
+++ b/insights/tests/client/test_connection_clean_facts.py
@@ -1,8 +1,4 @@
-try:
-    from unittest.mock import patch
-except Exception:
-    from mock import patch
-
+from unittest.mock import patch
 from copy import deepcopy
 
 from insights.client.connection import InsightsConnection

--- a/insights/tests/client/test_crypto.py
+++ b/insights/tests/client/test_crypto.py
@@ -3,7 +3,7 @@ import shutil
 import subprocess
 import tempfile
 
-import mock
+from unittest import mock
 import pytest
 
 from insights.client import crypto

--- a/insights/tests/client/test_displayname.py
+++ b/insights/tests/client/test_displayname.py
@@ -1,7 +1,7 @@
 import pytest
 from insights.client.config import InsightsConfig
 from insights.client.connection import InsightsConnection
-from mock.mock import patch
+from unittest.mock import patch
 
 
 class MockSession(object):

--- a/insights/tests/client/test_log_messages.py
+++ b/insights/tests/client/test_log_messages.py
@@ -1,8 +1,5 @@
 # -*- coding: UTF-8 -*-
-try:
-    from unittest.mock import patch
-except Exception:
-    from mock import patch
+from unittest.mock import patch
 
 from insights.client.client import collect
 from insights.client.config import InsightsConfig

--- a/insights/tests/client/test_net_comm.py
+++ b/insights/tests/client/test_net_comm.py
@@ -2,7 +2,7 @@
 
 from insights.client.phase import v1
 from insights.tests.helpers import dummy_requests_session, getenv_bool, Timeout
-from mock.mock import patch
+from unittest.mock import patch
 from pytest import mark
 
 

--- a/insights/tests/client/test_platform.py
+++ b/insights/tests/client/test_platform.py
@@ -1,7 +1,7 @@
 import json
 from insights.client.config import InsightsConfig
 from insights.client.connection import InsightsConnection
-from mock.mock import patch, mock_open, ANY
+from unittest.mock import patch, mock_open, ANY
 from pytest import raises
 
 

--- a/insights/tests/client/test_schedule.py
+++ b/insights/tests/client/test_schedule.py
@@ -1,6 +1,6 @@
 import tempfile
 
-from mock.mock import call, patch
+from unittest.mock import call, patch
 from pytest import mark
 
 import insights.client.schedule as sched

--- a/insights/tests/client/test_upload_archive_cfacts.py
+++ b/insights/tests/client/test_upload_archive_cfacts.py
@@ -1,12 +1,6 @@
 import json
 
-try:
-    from unittest.mock import patch, mock_open
-    builtin_open = "builtins.open"
-except Exception:
-    from mock import patch
-    from mock.mock import mock_open
-    builtin_open = "__builtin__.open"
+from unittest.mock import patch, mock_open
 
 from insights.client.connection import InsightsConnection
 from insights.util.hostname import determine_hostname
@@ -36,7 +30,7 @@ def test_cfacts_no_cleaning_1(legacy_upload):
 
 @patch('insights.client.connection.InsightsConnection._init_session', mock_init_session)
 @patch('insights.client.connection.InsightsConnection.post', return_value=MockSession())
-@patch(builtin_open, new_callable=mock_open, read_data='')
+@patch('builtins.open', new_callable=mock_open, read_data='')
 @patch('insights.client.connection.InsightsUploadConf.get_rm_conf', return_value={})
 @patch("insights.client.connection.get_canonical_facts", return_value={'hostname': determine_hostname()})
 @patch("insights.client.connection.logger")
@@ -58,7 +52,7 @@ def test_cfacts_no_cleaning_2(logger, facts, rm_conf, _open, post):
 
 @patch('insights.client.connection.InsightsConnection._init_session', mock_init_session)
 @patch('insights.client.connection.InsightsConnection.post', return_value=MockSession())
-@patch(builtin_open, new_callable=mock_open, read_data='')
+@patch('builtins.open', new_callable=mock_open, read_data='')
 @patch('insights.client.connection.InsightsUploadConf.get_rm_conf', return_value={})
 @patch("insights.client.connection.get_canonical_facts", return_value={'hostname': determine_hostname(), 'ip': '10.0.0.1'})
 @patch("insights.client.connection.logger")

--- a/insights/tests/client/test_utilities.py
+++ b/insights/tests/client/test_utilities.py
@@ -7,12 +7,8 @@ import insights.client.utilities as util
 import insights.client.cert_auth
 from insights.client.constants import InsightsConstants as constants
 import re
-try:
-    from unittest import mock
-    from unittest.mock import patch
-except ImportError:
-    import mock
-    from mock.mock import patch
+from unittest import mock
+from unittest.mock import patch
 import six
 import pytest
 import errno

--- a/insights/tests/core/spec_factory/test_content_provider_load.py
+++ b/insights/tests/core/spec_factory/test_content_provider_load.py
@@ -2,7 +2,7 @@ import os
 from collections import defaultdict
 
 import pytest
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights.core import dr
 from insights.core import filters

--- a/insights/tests/core/test_dr_run.py
+++ b/insights/tests/core/test_dr_run.py
@@ -4,7 +4,7 @@ from insights import run, make_fail, make_pass
 from insights.core import dr
 from insights.plugins import always_fires, never_fires
 from insights.specs import Specs
-from mock import patch
+from unittest.mock import patch
 from insights.tests.spec_tests import report_multioutput, report_nonexistent, report_raw
 
 

--- a/insights/tests/datasources/compliance/test_compliance.py
+++ b/insights/tests/datasources/compliance/test_compliance.py
@@ -2,12 +2,8 @@
 import os
 import six
 
-try:
-    from unittest.mock import patch, Mock, mock_open
-except Exception:
-    from mock import patch, Mock, mock_open
-
 from pytest import raises, mark
+from unittest.mock import patch, Mock, mock_open
 
 from insights.client.config import InsightsConfig
 from insights.client.constants import InsightsConstants as constants

--- a/insights/tests/datasources/compliance/test_compliance_ds.py
+++ b/insights/tests/datasources/compliance/test_compliance_ds.py
@@ -2,13 +2,9 @@
 import os
 import json
 
-try:
-    from unittest.mock import patch
-except Exception:
-    from mock import patch
-
 from pytest import raises
 from tempfile import NamedTemporaryFile
+from unittest.mock import patch
 
 from insights.core.exceptions import SkipComponent
 from insights.client.config import InsightsConfig

--- a/insights/tests/datasources/container/test_containers_inspect.py
+++ b/insights/tests/datasources/container/test_containers_inspect.py
@@ -2,7 +2,7 @@ import json
 import pytest
 
 from collections import defaultdict
-from mock.mock import Mock
+from unittest.mock import Mock
 
 from insights.core import dr, filters
 from insights.core.exceptions import SkipComponent

--- a/insights/tests/datasources/container/test_nginx_conf.py
+++ b/insights/tests/datasources/container/test_nginx_conf.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock.mock import patch, PropertyMock
+from unittest.mock import patch, PropertyMock
 
 from insights.core.context import HostContext
 from insights.core.exceptions import SkipComponent, ContentException

--- a/insights/tests/datasources/container/test_running_rhel_containers.py
+++ b/insights/tests/datasources/container/test_running_rhel_containers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights.core.context import HostContext
 from insights.core.exceptions import SkipComponent

--- a/insights/tests/datasources/malware_detection/test_malware_detection.py
+++ b/insights/tests/datasources/malware_detection/test_malware_detection.py
@@ -11,7 +11,7 @@ import random
 import fileinput
 
 from datetime import datetime
-from mock.mock import patch, Mock, ANY
+from unittest.mock import patch, Mock, ANY
 
 try:
     from urllib import quote as urlencode  # python 2
@@ -2302,7 +2302,7 @@ class TestsUtilizingFakeYara:
             mdc = MalwareDetectionClient(InsightsConfig())
             assert mdc.remote_rules_location == remote_rules_location
             assert mdc.graphql_url == expected_graphql_url
-            assert post.called_with(expected_graphql_url, ANY, ANY, verify=True, stream=True)
+            post.assert_called_with(expected_graphql_url, json=ANY, headers=ANY, verify=True, stream=True)
             assert mdc.disabled_rules == []
 
             # Test with one disabled rule
@@ -2335,7 +2335,7 @@ class TestsUtilizingFakeYara:
             mdc = MalwareDetectionClient(InsightsConfig())
             assert mdc.remote_rules_location == remote_rules_location
             assert mdc.graphql_url == expected_graphql_url
-            assert post.called_with(expected_graphql_url, ANY, ANY, verify=True, stream=True)
+            post.assert_called_with(expected_graphql_url, json=ANY, headers=ANY, verify=True, stream=True)
             assert mdc.disabled_rules == ['abc', 'rule1', 'rule2', 'xyz']
 
         @pytest.mark.skipif(
@@ -2368,7 +2368,7 @@ class TestsUtilizingFakeYara:
             )
             log.debug.assert_any_call("Unable to get disabled rules list.  Skipping ...")
             log.debug.assert_called_with("Disabled rules: %s", [])
-            assert post.called_with(expected_graphql_url, ANY, ANY, verify=True, stream=True)
+            post.assert_called_with(expected_graphql_url, json=ANY, headers=ANY, verify=True, stream=True)
             assert post.call_count == 2
             assert mdc.disabled_rules == []
 
@@ -2386,7 +2386,7 @@ class TestsUtilizingFakeYara:
             )
             log.debug.assert_any_call("Unable to get disabled rules list.  Skipping ...")
             log.debug.assert_called_with("Disabled rules: %s", [])
-            assert post.called_with(expected_graphql_url, ANY, ANY, verify=True, stream=True)
+            post.assert_called_with(expected_graphql_url, json=ANY, headers=ANY, verify=True, stream=True)
             assert post.call_count == 3
             assert mdc.disabled_rules == []
 

--- a/insights/tests/datasources/test_aws.py
+++ b/insights/tests/datasources/test_aws.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock.mock import Mock
+from unittest.mock import Mock
 
 from insights.core.exceptions import SkipComponent
 from insights.specs.datasources.aws import LocalSpecs, aws_imdsv2_token

--- a/insights/tests/datasources/test_awx_manage.py
+++ b/insights/tests/datasources/test_awx_manage.py
@@ -2,7 +2,7 @@ import json
 import pytest
 
 from collections import defaultdict, OrderedDict
-from mock.mock import Mock
+from unittest.mock import Mock
 
 from insights.core import filters
 from insights.core.exceptions import SkipComponent

--- a/insights/tests/datasources/test_candlepin.py
+++ b/insights/tests/datasources/test_candlepin.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock.mock import Mock
+from unittest.mock import Mock
 
 from insights.core import ET
 from insights.core.exceptions import SkipComponent

--- a/insights/tests/datasources/test_client_metadata.py
+++ b/insights/tests/datasources/test_client_metadata.py
@@ -2,14 +2,7 @@ import yaml
 import json
 import pytest
 
-try:
-    from unittest.mock import patch, mock_open
-
-    builtin_open = "builtins.open"
-except Exception:
-    from mock import patch, mock_open
-
-    builtin_open = "__builtin__.open"
+from unittest.mock import patch, mock_open
 
 from insights import package_info
 from insights.client.config import InsightsConfig
@@ -154,7 +147,7 @@ def test_display_name():
 
 @patch("yaml.safe_load", return_value=yaml.load(TAGS_YAML, Loader=yaml.Loader))
 @patch("os.path.isfile", return_value=True)
-@patch(builtin_open)
+@patch("builtins.open")
 def test_tags_ok(m_open, m_isfile, m_load):
     result = tags({})
     result_json = json.loads(''.join(result.content).strip())
@@ -171,7 +164,7 @@ def test_tags_ok(m_open, m_isfile, m_load):
 
 
 @patch("os.path.isfile", return_value=True)
-@patch(builtin_open, mock_open(read_data='---\ntest\n---'))
+@patch("builtins.open", mock_open(read_data='---\ntest\n---'))
 def test_invalid_yaml(m_isfile):
     with pytest.raises(ContentException) as ce:
         tags({})
@@ -180,7 +173,7 @@ def test_invalid_yaml(m_isfile):
 
 @patch("yaml.safe_load", return_value=None)
 @patch("os.path.isfile", return_value=True)
-@patch(builtin_open)
+@patch("builtins.open")
 def test_empty_yaml(m_open, m_isfile, m_load):
     with pytest.raises(ContentException) as ce:
         tags({})

--- a/insights/tests/datasources/test_cloud_init.py
+++ b/insights/tests/datasources/test_cloud_init.py
@@ -2,7 +2,7 @@ import pytest
 import yaml
 
 from collections import defaultdict
-from mock.mock import Mock
+from unittest.mock import Mock
 
 from insights.core import filters
 from insights.core.exceptions import SkipComponent

--- a/insights/tests/datasources/test_corosync.py
+++ b/insights/tests/datasources/test_corosync.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights.combiners.redhat_release import RedHatRelease
 from insights.core.exceptions import SkipComponent

--- a/insights/tests/datasources/test_db2.py
+++ b/insights/tests/datasources/test_db2.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock.mock import Mock
+from unittest.mock import Mock
 from insights.core.exceptions import SkipComponent
 from insights.specs.datasources.db2 import LocalSpecs, db2_users, db2_databases_info
 from insights.parsers.ps import PsAuxcww

--- a/insights/tests/datasources/test_env.py
+++ b/insights/tests/datasources/test_env.py
@@ -1,5 +1,5 @@
 import pytest
-from mock.mock import patch, mock_open
+from unittest.mock import patch, mock_open
 from insights.core.dr import SkipComponent
 from insights.core.spec_factory import DatasourceProvider
 from insights.specs.datasources.env import ld_library_path_global_conf

--- a/insights/tests/datasources/test_ethernet.py
+++ b/insights/tests/datasources/test_ethernet.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock.mock import Mock
+from unittest.mock import Mock
 
 from insights.core.exceptions import SkipComponent
 from insights.parsers.nmcli import NmcliConnShow

--- a/insights/tests/datasources/test_httpd.py
+++ b/insights/tests/datasources/test_httpd.py
@@ -1,20 +1,12 @@
 import pytest
 
-from mock.mock import mock_open
+from unittest.mock import mock_open, patch
 from insights.combiners.ps import Ps
 from insights.core.context import HostContext
 from insights.core.exceptions import SkipComponent
 from insights.parsers.mount import ProcMounts
 from insights.specs.datasources.httpd import httpd_cmds, httpd_on_nfs, httpd_configuration_files, httpd24_scl_configuration_files, httpd24_scl_jbcs_configuration_files
 from insights.tests import context_wrap
-
-
-try:
-    from unittest.mock import patch
-    builtin_open = "builtins.open"
-except Exception:
-    from mock import patch
-    builtin_open = "__builtin__.open"
 
 
 MOUNT_DATA = """
@@ -153,7 +145,7 @@ SecAction \
 @patch("os.path.isfile", return_value=True)
 @patch("os.path.isdir", return_value=True)
 @patch("glob.glob", return_value=["/etc/httpd/conf.d/ssl.conf"])
-@patch(builtin_open, new_callable=mock_open, read_data=data_lines_httpd_conf)
+@patch("builtins.open", new_callable=mock_open, read_data=data_lines_httpd_conf)
 def test_httpd_conf_files(m_open, m_glob, m_isdir, m_isfile):
     handlers = (m_open.return_value, mock_open(read_data=data_lines_ssl_conf).return_value)
     m_open.side_effect = handlers
@@ -165,7 +157,7 @@ def test_httpd_conf_files(m_open, m_glob, m_isdir, m_isfile):
 @patch("os.path.isfile", return_value=True)
 @patch("os.path.isdir", return_value=True)
 @patch("glob.glob", return_value=["/etc/httpd/conf.d/ssl.conf"])
-@patch(builtin_open, new_callable=mock_open, read_data=data_lines_httpd_conf_lower_case)
+@patch("builtins.open", new_callable=mock_open, read_data=data_lines_httpd_conf_lower_case)
 def test_httpd_conf_files_lower_case(m_open, m_glob, m_isdir, m_isfile):
     handlers = (m_open.return_value, mock_open(read_data=data_lines_ssl_conf_lower_case).return_value)
     m_open.side_effect = handlers
@@ -177,7 +169,7 @@ def test_httpd_conf_files_lower_case(m_open, m_glob, m_isdir, m_isfile):
 @patch("os.path.isfile", return_value=True)
 @patch("os.path.isdir", return_value=True)
 @patch("glob.glob", return_value=["/etc/httpd/modsecurity.d/crs-setup.conf"])
-@patch(builtin_open, new_callable=mock_open, read_data=data_lines_httpd_conf_section_test)
+@patch("builtins.open", new_callable=mock_open, read_data=data_lines_httpd_conf_section_test)
 def test_httpd_conf_files_section(m_open, m_glob, m_isdir, m_isfile):
     handlers = (m_open.return_value, mock_open(read_data=data_lines_crs_setup_conf).return_value)
     m_open.side_effect = handlers
@@ -189,7 +181,7 @@ def test_httpd_conf_files_section(m_open, m_glob, m_isdir, m_isfile):
 @patch("os.path.isfile", return_value=False)
 @patch("os.path.isdir", return_value=False)
 @patch("glob.glob", return_value=["/etc/httpd/conf.d/ssl.conf"])
-@patch(builtin_open, new_callable=mock_open, read_data=data_lines_httpd_conf)
+@patch("builtins.open", new_callable=mock_open, read_data=data_lines_httpd_conf)
 def test_httpd_conf_files_ssl_miss(m_open, m_glob, m_isdir, m_isfile):
     handlers = (m_open.return_value, mock_open(read_data=data_lines_ssl_conf).return_value)
     m_open.side_effect = handlers
@@ -211,7 +203,7 @@ def test_httpd_conf_files_main_miss(m_glob, m_isdir, m_isfile, m_join):
 @patch("os.path.isfile", return_value=True)
 @patch("os.path.isdir", return_value=True)
 @patch("glob.glob", return_value=["/opt/rh/httpd24/root/etc/httpd/conf.d/ssl.conf"])
-@patch(builtin_open, new_callable=mock_open, read_data=data_lines_httpd24_scl_conf)
+@patch("builtins.open", new_callable=mock_open, read_data=data_lines_httpd24_scl_conf)
 def test_httpd24_scl_conf_files(m_open, m_glob, m_isdir, m_isfile):
     handlers = (m_open.return_value, mock_open(read_data=data_lines_ssl_conf).return_value)
     m_open.side_effect = handlers
@@ -223,7 +215,7 @@ def test_httpd24_scl_conf_files(m_open, m_glob, m_isdir, m_isfile):
 @patch("os.path.isfile", return_value=True)
 @patch("os.path.isdir", return_value=True)
 @patch("glob.glob", return_value=["/opt/rh/jbcs-httpd24/root/etc/httpd/conf.d/ssl.conf"])
-@patch(builtin_open, new_callable=mock_open, read_data=data_lines_httpd24_scl_jbcs_conf)
+@patch("builtins.open", new_callable=mock_open, read_data=data_lines_httpd24_scl_jbcs_conf)
 def test_httpd24_scl_jbs_conf_files(m_open, m_glob, m_isdir, m_isfile):
     handlers = (m_open.return_value, mock_open(read_data=data_lines_ssl_conf).return_value)
     m_open.side_effect = handlers

--- a/insights/tests/datasources/test_intersystems.py
+++ b/insights/tests/datasources/test_intersystems.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock.mock import patch
+from unittest.mock import patch
 from insights.core.exceptions import SkipComponent
 from insights.parsers.iris import IrisList, IrisCpf
 from insights.specs.datasources.intersystems import iris_working_configuration, iris_working_messages_log

--- a/insights/tests/datasources/test_ipcs.py
+++ b/insights/tests/datasources/test_ipcs.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock.mock import Mock
+from unittest.mock import Mock
 
 from insights.core.exceptions import SkipComponent
 from insights.specs import Specs

--- a/insights/tests/datasources/test_kernel.py
+++ b/insights/tests/datasources/test_kernel.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock.mock import Mock
+from unittest.mock import Mock
 
 from insights.core.exceptions import SkipComponent
 from insights.specs.datasources.kernel import current_version, default_version

--- a/insights/tests/datasources/test_leapp.py
+++ b/insights/tests/datasources/test_leapp.py
@@ -1,14 +1,8 @@
 import json
 import pytest
 
-try:
-    from unittest.mock import patch
-    builtin_open = "builtins.open"
-except Exception:
-    from mock import patch
-    builtin_open = "__builtin__.open"
-
 from os import path
+from unittest.mock import patch
 
 from insights.core.exceptions import SkipComponent, ContentException
 from insights.specs.datasources.leapp import leapp_report, migration_results
@@ -249,7 +243,7 @@ MIGRATION_RESULTS_NG_1 = json.loads("""
 
 @patch("json.load", return_value=LEAPP_REPORT_OK)
 @patch("os.path.isfile", return_value=True)
-@patch(builtin_open)
+@patch("builtins.open")
 def test_leapp_report_ok(m_open, m_isfile, m_load):
     result = leapp_report({})
     result_json = json.loads(''.join(result.content).strip())
@@ -260,7 +254,7 @@ def test_leapp_report_ok(m_open, m_isfile, m_load):
 
 @patch("json.load", return_value=LEAPP_REPORT_NG_1)
 @patch("os.path.isfile", return_value=True)
-@patch(builtin_open)
+@patch("builtins.open")
 def test_leapp_report_nothing(m_open, m_isfile, m_load):
     with pytest.raises(SkipComponent) as ce:
         leapp_report({})
@@ -269,7 +263,7 @@ def test_leapp_report_nothing(m_open, m_isfile, m_load):
 
 @patch("json.load", return_value=LEAPP_REPORT_NG_2)
 @patch("os.path.isfile", return_value=True)
-@patch(builtin_open)
+@patch("builtins.open")
 def test_leapp_report_ng_2(m_open, m_isfile, m_load):
     with pytest.raises(ContentException) as ce:
         leapp_report({})
@@ -284,7 +278,7 @@ def test_leapp_report_no_file(isfile):
 
 @patch("json.load", return_value=MIGRATION_RESULTS_OK_1)
 @patch("os.path.isfile", return_value=True)
-@patch(builtin_open)
+@patch("builtins.open")
 def test_leapp_migration_results_ok(m_open, m_isfile, m_load):
     result = migration_results({})
     result_json = json.loads(''.join(result.content).strip())
@@ -295,7 +289,7 @@ def test_leapp_migration_results_ok(m_open, m_isfile, m_load):
 
 @patch("json.load", return_value=MIGRATION_RESULTS_OK_2)
 @patch("os.path.isfile", return_value=True)
-@patch(builtin_open)
+@patch("builtins.open")
 def test_c2r_migration_results_ok(m_open, m_isfile, m_load):
     result = migration_results({})
     result_json = json.loads(''.join(result.content).strip())
@@ -306,7 +300,7 @@ def test_c2r_migration_results_ok(m_open, m_isfile, m_load):
 
 @patch("json.load", return_value=MIGRATION_RESULTS_NG_1)
 @patch("os.path.isfile", return_value=True)
-@patch(builtin_open)
+@patch("builtins.open")
 def test_leapp_migration_results_nothing(m_open, m_isfile, m_load):
     with pytest.raises(SkipComponent) as ce:
         migration_results({})
@@ -315,7 +309,7 @@ def test_leapp_migration_results_nothing(m_open, m_isfile, m_load):
 
 @patch("json.load", return_value=MIGRATION_RESULTS_NG_2)
 @patch("os.path.isfile", return_value=True)
-@patch(builtin_open)
+@patch("builtins.open")
 def test_leapp_migration_results_ng_2(m_open, m_isfile, m_load):
     with pytest.raises(ContentException) as ce:
         migration_results({})

--- a/insights/tests/datasources/test_logrotate.py
+++ b/insights/tests/datasources/test_logrotate.py
@@ -1,8 +1,4 @@
-try:
-    from unittest.mock import patch
-except Exception:
-    from mock import patch
-
+from unittest.mock import patch
 
 from insights.specs.datasources.logrotate import logrotate_conf_list
 

--- a/insights/tests/datasources/test_lpstat.py
+++ b/insights/tests/datasources/test_lpstat.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock.mock import Mock
+from unittest.mock import Mock
 
 from insights.core.exceptions import SkipComponent
 from insights.core.spec_factory import DatasourceProvider

--- a/insights/tests/datasources/test_ls.py
+++ b/insights/tests/datasources/test_ls.py
@@ -1,11 +1,7 @@
 import pytest
 
 from collections import defaultdict
-
-try:
-    from unittest.mock import patch
-except Exception:
-    from mock import patch
+from unittest.mock import patch
 
 from insights.core import filters
 from insights.core.exceptions import SkipComponent

--- a/insights/tests/datasources/test_luks.py
+++ b/insights/tests/datasources/test_luks.py
@@ -1,5 +1,5 @@
 import pytest
-from mock.mock import Mock
+from unittest.mock import Mock
 
 from insights import SkipComponent
 from insights.parsers.blkid import BlockIDInfo

--- a/insights/tests/datasources/test_machine_id.py
+++ b/insights/tests/datasources/test_machine_id.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from mock.mock import patch
+from unittest.mock import patch
 from collections import defaultdict
 
 from insights.client.config import InsightsConfig

--- a/insights/tests/datasources/test_mdadm.py
+++ b/insights/tests/datasources/test_mdadm.py
@@ -1,5 +1,5 @@
 import pytest
-from mock.mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from insights.core.exceptions import SkipComponent
 from insights.specs.datasources.mdadm import raid_devices

--- a/insights/tests/datasources/test_pcp.py
+++ b/insights/tests/datasources/test_pcp.py
@@ -1,7 +1,7 @@
 import datetime
 import pytest
 
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights.client.config import InsightsConfig
 from insights.combiners.ps import Ps

--- a/insights/tests/datasources/test_ps.py
+++ b/insights/tests/datasources/test_ps.py
@@ -3,7 +3,7 @@ import pytest
 import shutil
 import tempfile
 
-from mock.mock import Mock
+from unittest.mock import Mock
 
 from insights.core.exceptions import SkipComponent
 from insights.core.spec_factory import DatasourceProvider

--- a/insights/tests/datasources/test_rpm.py
+++ b/insights/tests/datasources/test_rpm.py
@@ -1,7 +1,7 @@
-import mock
 import pytest
 
-from mock.mock import Mock
+from unittest import mock
+from unittest.mock import Mock
 from collections import defaultdict
 
 from insights.core import filters

--- a/insights/tests/datasources/test_satellite.py
+++ b/insights/tests/datasources/test_satellite.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock.mock import Mock
+from unittest.mock import Mock
 
 from insights.core.exceptions import SkipComponent
 from insights.core.spec_factory import DatasourceProvider

--- a/insights/tests/datasources/test_semanage.py
+++ b/insights/tests/datasources/test_semanage.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from mock.mock import Mock
+from unittest.mock import Mock
 from collections import defaultdict
 
 from insights.core import filters

--- a/insights/tests/datasources/test_ssl_certificate.py
+++ b/insights/tests/datasources/test_ssl_certificate.py
@@ -1,12 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-try:
-    from unittest.mock import patch, mock_open
-    builtin_open = "builtins.open"
-except Exception:
-    from mock import patch, mock_open
-    builtin_open = "__builtin__.open"
+
+from unittest.mock import patch, mock_open
 
 from insights.combiners.rsyslog_confs import RsyslogAllConf
 from insights.core.exceptions import SkipComponent
@@ -315,7 +311,7 @@ queue.type = "LinkedList"
 
 
 @patch("os.path.exists", return_value=True)
-@patch(builtin_open, new_callable=mock_open, read_data=HTTPD_CONF)
+@patch("builtins.open", new_callable=mock_open, read_data=HTTPD_CONF)
 def test_httpd_certificate(m_open, m_exist):
     m_open.side_effect = [m_open.return_value, mock_open(read_data=HTTPD_SSL_CONF).return_value]
     broker = {
@@ -354,7 +350,7 @@ def test_nginx_certificate():
 
 
 @patch("os.path.exists", return_value=True)
-@patch(builtin_open, new_callable=mock_open, read_data=HTTPD_CONF)
+@patch("builtins.open", new_callable=mock_open, read_data=HTTPD_CONF)
 def test_httpd_ssl_cert_exception(m_open, m_exists):
     m_open.side_effect = [m_open.return_value, mock_open(read_data=HTTPD_CONF_WITHOUT_SSL).return_value]
     broker1 = {
@@ -400,7 +396,7 @@ def test_mssql_tls_no_cert_exception():
 
 
 @patch("os.path.exists", return_value=True)
-@patch(builtin_open, new_callable=mock_open, read_data=HTTPD_CONF)
+@patch("builtins.open", new_callable=mock_open, read_data=HTTPD_CONF)
 def test_httpd_certificate_info_in_nss(m_open, m_exists):
     m_open.side_effect = [m_open.return_value, mock_open(read_data=HTTPD_WITH_NSS).return_value]
     broker = {
@@ -411,7 +407,7 @@ def test_httpd_certificate_info_in_nss(m_open, m_exists):
 
 
 @patch("os.path.exists", return_value=True)
-@patch(builtin_open, new_callable=mock_open, read_data=HTTPD_CONF)
+@patch("builtins.open", new_callable=mock_open, read_data=HTTPD_CONF)
 def test_httpd_certificate_info_in_nss_exception(m_open, m_exists):
     m_open.side_effect = [m_open.return_value, mock_open(read_data=HTTPD_WITH_NSS_OFF).return_value]
     broker = {

--- a/insights/tests/datasources/test_sys_fs_cgroup_memory.py
+++ b/insights/tests/datasources/test_sys_fs_cgroup_memory.py
@@ -1,5 +1,5 @@
 import pytest
-from mock.mock import patch, mock_open, Mock
+from unittest.mock import patch, mock_open, Mock
 from insights.core.dr import SkipComponent
 from insights.core.spec_factory import DatasourceProvider
 from insights.specs.datasources.sys_fs_cgroup_memory import (

--- a/insights/tests/datasources/test_yum_updates.py
+++ b/insights/tests/datasources/test_yum_updates.py
@@ -2,7 +2,7 @@ import json
 
 from insights.core.spec_factory import DatasourceProvider
 from insights.specs.datasources import yum_updates
-from mock.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 
 # Verify that the yum_updates broker correctly executes.

--- a/insights/tests/parsers/test_uname.py
+++ b/insights/tests/parsers/test_uname.py
@@ -1,10 +1,7 @@
 import doctest
 import pytest
 
-try:
-    from unittest.mock import patch
-except Exception:
-    from mock import patch
+from unittest.mock import patch
 
 from insights.parsers import uname
 from insights.tests import context_wrap

--- a/insights/tests/specs/test_specs.py
+++ b/insights/tests/specs/test_specs.py
@@ -5,7 +5,7 @@ import pytest
 import tempfile
 
 from collections import defaultdict
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights import collect
 from insights.cleaner import Cleaner

--- a/insights/tests/specs/test_specs_content_redaction_empty.py
+++ b/insights/tests/specs/test_specs_content_redaction_empty.py
@@ -2,7 +2,7 @@ import json
 import os
 from collections import defaultdict
 
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights import collect
 from insights.client.archive import InsightsArchive

--- a/insights/tests/specs/test_specs_filters.py
+++ b/insights/tests/specs/test_specs_filters.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from collections import defaultdict
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights import collect
 from insights.cleaner import Cleaner

--- a/insights/tests/specs/test_specs_runtime_ds_obfuscation.py
+++ b/insights/tests/specs/test_specs_runtime_ds_obfuscation.py
@@ -3,7 +3,7 @@ import os
 from collections import defaultdict
 
 import pytest
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights import collect
 from insights.client.archive import InsightsArchive

--- a/insights/tests/specs/test_specs_save_as.py
+++ b/insights/tests/specs/test_specs_save_as.py
@@ -2,7 +2,7 @@ import os
 import json
 
 from collections import defaultdict
-from mock.mock import patch, Mock
+from unittest.mock import patch, Mock
 from pytest import mark
 
 from insights import collect

--- a/insights/tests/specs/test_specs_special_content.py
+++ b/insights/tests/specs/test_specs_special_content.py
@@ -4,7 +4,7 @@ import os
 from collections import defaultdict
 
 import pytest
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights import collect
 from insights.client.archive import InsightsArchive

--- a/insights/tests/test_collect.py
+++ b/insights/tests/test_collect.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import yaml
 
-from mock.mock import Mock
+from unittest.mock import Mock
 
 from insights.collect import load_manifest, generate_archive_name, _parse_broker_exceptions
 from insights.core.dr import Broker

--- a/insights/tests/test_collect_apply_blacklist.py
+++ b/insights/tests/test_collect_apply_blacklist.py
@@ -1,4 +1,4 @@
-from mock.mock import patch
+from unittest.mock import patch
 
 from insights import dr
 from insights.collect import apply_blacklist

--- a/insights/tests/test_command_parser.py
+++ b/insights/tests/test_command_parser.py
@@ -2,7 +2,7 @@ import sys
 from insights import get_nvr
 from insights.command_parser import InsightsCli
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 VERSION_OUT = get_nvr() + '\n'
 

--- a/insights/tests/test_remote_resource.py
+++ b/insights/tests/test_remote_resource.py
@@ -1,4 +1,4 @@
-from mock.mock import patch
+from unittest.mock import patch
 from cachecontrol.cache import DictCache
 from insights.core.remote_resource import RemoteResource, CachedRemoteResource
 from insights.tests.mock_web_server import TestMockServer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ optional = [
 ]
 testing = [
     "coverage",
-    "mock==2.0.0",  # FIXME: remove for python 3.6 and newer
     "pytest-cov",
     "pytest; python_version >= '3'",
     "pytest~=4.6.0; python_version == '2.7'",

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,6 @@ testing = set(
         'pytest~=4.6.0; python_version == "2.7"',
         'pytest; python_version >= "3"',
         'pytest-cov',
-        'mock==2.0.0',
     ]
 )
 


### PR DESCRIPTION
### All Pull Requests:

- As Python2 is not supported in RPM, remove the using of mock module
- And replace all old mock in test to unittest.mock
- Jira RHINENG-22254

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Modernize test suite to rely on Python standard library mocking utilities and drop legacy mock module usage.

Enhancements:
- Standardize tests on unittest.mock by replacing imports and decorators that previously used the external mock package.
- Simplify test helpers by removing Python 2 compatibility shims around builtins.open handling and legacy mock_open limitations.

Build:
- Remove the external mock dependency from test-related dependencies in pyproject.toml and setup.py.

Tests:
- Update various tests to patch builtins.open directly instead of using version-dependent aliases.
- Adjust malware detection client tests to use assert_called_with on mocked HTTP calls for clearer and more accurate verification.