### PR TITLE
Add new spec ethtool_priv_flags

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -216,6 +216,7 @@ class Specs(SpecSet):
     ethtool_g = RegistryPoint(multi_output=True, no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     ethtool_i = RegistryPoint(multi_output=True, no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     ethtool_k = RegistryPoint(multi_output=True, no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
+    ethtool_priv_flags = RegistryPoint(multi_output=True, no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     facter = RegistryPoint()
     falconctl_aid = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     falconctl_backend = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -312,6 +312,7 @@ class DefaultSpecs(Specs):
     ethtool_g = foreach_execute(ethernet.interfaces, "/sbin/ethtool -g %s")
     ethtool_i = foreach_execute(ethernet.interfaces, "/sbin/ethtool -i %s")
     ethtool_k = foreach_execute(ethernet.interfaces, "/sbin/ethtool -k %s")
+    ethtool_priv_flags = foreach_execute(ethernet.interfaces, "/sbin/ethtool --show-priv-flags %s")
     falconctl_aid = simple_command("/opt/CrowdStrike/falconctl -g --aid")
     falconctl_backend = simple_command("/opt/CrowdStrike/falconctl -g --backend")
     falconctl_rfm = simple_command("/opt/CrowdStrike/falconctl -g --rfm-state")


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED


(cherry picked from commit 906f7f3f412b919895373ec45d20b0bd441677db)

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [x] Is this a backport from `master`? Yes, this is a backport of #4666
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
* Add spec ethtool_priv_flags
* Add related parser PrivFlags
* JIRA 22663

## Summary by Sourcery

Add support for collecting and parsing ethtool private flags for all network interfaces.

New Features:
- Introduce the ethtool_priv_flags spec to run `ethtool --show-priv-flags` on each network interface.
- Add the PrivFlags parser to expose interface name and private flag key/value pairs from ethtool output.

Tests:
- Add unit tests and doctest wiring for the new PrivFlags parser, including handling unsupported-command errors.