### PR TITLE
chore(rpmbuild): refine the RPM spec file

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,7 +5,7 @@ specfile_path: insights-core.spec
 actions:
   post-upstream-clone:
     - sed -i -e '/cachecontrol/d' -e '/defusedxml/d' -e '/jinja2/d' -e '/lockfile/d' -e '/redis/d' -e '/setuptools;/d' pyproject.toml setup.py
-    - sed -i -e '/insights =/d' -e '/insights-dupkey/d' -e '/insights-run/d' -e '/insights-inspect/d' -e '/mangle =/d' pyproject.toml setup.py
+    - sed -i -e '/insights-.*=/d' -e '/mangle =/d' pyproject.toml setup.py
     - echo "dev" > insights/RELEASE
     - cp MANIFEST.in.client MANIFEST.in
     # - python3 -m pip3 install build

--- a/build_core_rpm.sh
+++ b/build_core_rpm.sh
@@ -38,7 +38,7 @@ elif [ "$TARGET" == "release" ] || [ "$TARGET" == "testing" ]; then
     # - remove depedencies for data processing
     sed -i -e '/cachecontrol/d' -e '/defusedxml/d' -e '/jinja2/d' -e '/lockfile/d' -e '/redis/d' -e '/setuptools;/d' pyproject.toml setup.py
     # - remove entrypoints for data processing
-    sed -i -e '/insights =/d' -e '/insights-dupkey/d' -e '/insights-run/d' -e '/insights-inspect/d' -e '/mangle =/d' pyproject.toml setup.py
+    sed -i -e '/insights-.*=/d' -e '/mangle =/d' pyproject.toml setup.py
 else
     echo "Error: invalid build target: '$TARGET'. Use 'internal', 'release', or 'testing'"
     exit 1

--- a/insights-core.spec
+++ b/insights-core.spec
@@ -30,31 +30,6 @@ BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 
-Requires: python3
-%if 0%{?rhel} == 7
-Requires:       python36-CacheControl
-Requires:       python36-colorama
-Requires:       python36-defusedxml
-Requires:       python36-jinja2
-Requires:       python36-lockfile
-Requires:       python36-PyYAML
-Requires:       python36-requests
-Requires:       python36-six
-%else
-%if 0%{?for_internal}
-Requires:       python3-CacheControl
-Requires:       python3-colorama
-Requires:       python3-defusedxml
-Requires:       python3-jinja2
-Requires:       python3-lockfile
-Requires:       python3-redis
-%endif
-Requires:       python3-pyyaml
-Requires:       python3-requests
-Requires:       python3-rpm
-Requires:       python3-six
-%endif
-
 %if 0%{?with_selinux}
 Requires:       ((%{name}-selinux >= %{version}-%{release}) if selinux-policy-%{selinuxtype})
 %endif
@@ -101,16 +76,26 @@ if [ $1 -eq 0 ]; then
     %selinux_modules_uninstall -s %{selinuxtype} %{modulename}
     %selinux_relabel_post -s %{selinuxtype}
 fi
+%endif
 
 %build
+%if 0%{?with_selinux}
 make -f %{_datadir}/selinux/devel/Makefile %{modulename}.pp
 bzip2 -9 %{modulename}.pp
 %endif
 
 %install
-rm -rf $RPM_BUILD_ROOT
-%{__python3} setup.py install -O1 --root $RPM_BUILD_ROOT
-rm -rf $RPM_BUILD_ROOT/usr/bin
+rm -rf %{buildroot}
+# %{__python3} -m pip install --upgrade pip
+# %{__python3} -m pip install . --root %{buildroot}
+%{__python3} setup.py install -O1 --root %{buildroot}
+mkdir -p %{buildroot}/%{_libexecdir}
+mv %{buildroot}%{_bindir}/insights %{buildroot}%{_libexecdir}
+
+%if 0%{?for_internal}
+mv %{buildroot}%{_bindir}/insights-* %{buildroot}%{_libexecdir}
+mv %{buildroot}%{_bindir}/mangle %{buildroot}%{_libexecdir}
+%endif
 
 %if 0%{?with_selinux}
 install -D -p -m 0644 %{modulename}.pp.bz2 %{buildroot}%{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp.bz2
@@ -120,11 +105,17 @@ install -D -p -m 0644 %{name}-selinux-%{version}/%{modulename}.if %{buildroot}%{
 %files
 # For noarch packages: sitelib
 %{python3_sitelib}/*
+%{_libexecdir}/insights
+
+%if 0%{?for_internal}
+%{_libexecdir}/insights-*
+%{_libexecdir}/mangle
+%endif
+
 %license LICENSE
 
 %if 0%{?with_selinux}
 %files selinux
-%license LICENSE
 %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp.*
 %{_datadir}/selinux/devel/include/distributed/%{modulename}.if
 %ghost %verify(not md5 size mode mtime) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}


### PR DESCRIPTION
- Remove the useless 'Requires'
- Add binary entry command 'insights'

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Refine the RPM packaging for insights-core by simplifying runtime dependencies and adjusting how CLI entrypoints are installed and shipped.

Enhancements:
- Remove explicit Python runtime package requirements from the RPM spec in favor of a leaner dependency set.
- Install the main insights and related internal CLI binaries under libexec instead of the standard bin directory, updating file listings accordingly.
- Relax sed patterns in Packit and RPM build scripts to generically strip all insights-* entrypoints while preserving the primary insights command.