### PR TITLE
fix(data-processing): fix unpredictable behavior of --context

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -52,7 +52,12 @@ from insights.core.context import (
     HostContext,
     SerializedArchiveContext,
 )
-from insights.core.exceptions import InvalidArchive, InvalidContentType, SkipComponent
+from insights.core.exceptions import (
+    InvalidArchive,
+    InvalidContentType,
+    SkipComponent,
+    ContextException,
+)
 from insights.core.filters import add_filter, apply_filters, get_filters
 from insights.core.hydration import create_context, initialize_broker
 from insights.core.plugins import (
@@ -298,9 +303,17 @@ def _load_context(path):
     if path is None:
         return
 
+    tmp_path = path
     if "." not in path:
         path = ".".join(["insights.core.context", path])
-    return dr.get_component(path)
+
+    context = dr.get_component(path)
+    if context is None:
+        raise ContextException(
+            "ERROR: cannot find '{0}', please check the full module name.".format(tmp_path)
+        )
+
+    return context
 
 
 def run(
@@ -349,7 +362,8 @@ def run(
         )
         p.add_argument(
             "--context",
-            help="Execution Context. Defaults to HostContext if an archive isn't passed.",
+            help="Execution context. Defaults to HostContext if an archive is not specified \
+                  and HostArchiveContext if an archive is specified.",
         )
         p.add_argument(
             "--no-load-default", help="Don't load the default plugins.", action="store_true"
@@ -525,6 +539,12 @@ def run(
                 broker = _run(broker, graph, root, context=context, inventory=inventory)
 
         return broker
+    except ContextException as ce:
+        if args and args.context:
+            msg = "{ce}\n\nCannot run with context: '{ctx}'"
+            log.error(msg.format(ce=ce, ctx=args.context))
+        else:
+            raise
     except (InvalidContentType, InvalidArchive):
         if args and args.archive:
             path = args.archive

--- a/insights/core/exceptions.py
+++ b/insights/core/exceptions.py
@@ -48,6 +48,16 @@ class InvalidArchive(Exception):
         self.msg = msg
 
 
+class ContextException(Exception):
+    """
+    Raised when execution context cannot be identified or missing expected context.
+    """
+
+    def __init__(self, msg):
+        super(ContextException, self).__init__(msg)
+        self.msg = msg
+
+
 class InvalidContentType(InvalidArchive):
     """
     Raised when invalid content_type is specified.

--- a/insights/core/hydration.py
+++ b/insights/core/hydration.py
@@ -2,14 +2,19 @@ import logging
 import os
 
 from insights.core import archives, dr
-from insights.core.context import (ClusterArchiveContext, ExecutionContextMeta, HostArchiveContext,
-                                   SerializedArchiveContext)
-from insights.core.exceptions import InvalidArchive
+from insights.core.context import (
+    ClusterArchiveContext,
+    ExecutionContextMeta,
+    HostArchiveContext,
+    SerializedArchiveContext,
+)
+from insights.core.exceptions import ContextException, InvalidArchive
 from insights.core.serde import Hydration
 
 log = logging.getLogger(__name__)
 
 if hasattr(os, "scandir"):
+
     def get_all_files(path):
         with os.scandir(path) as it:
             for ent in it:
@@ -22,8 +27,8 @@ if hasattr(os, "scandir"):
                 except OSError as ex:
                     log.exception(ex)
 
-
 else:
+
     def get_all_files(path):
         for root, _, files in os.walk(path):
             for f in files:
@@ -44,21 +49,60 @@ def identify(files):
     return common_path, HostArchiveContext
 
 
-def create_context(path, context=None):
+def _create_cluster_archive_context(path):
     top = os.listdir(path)
-    arc = [os.path.join(path, f) for f in top
-           if f.endswith(archives.COMPRESSION_TYPES) and
-           os.path.isfile(os.path.join(path, f))]
-    if arc:
-        return ClusterArchiveContext(path, all_files=arc)
+    arc = [
+        os.path.join(path, f)
+        for f in top
+        if f.endswith(archives.COMPRESSION_TYPES) and os.path.isfile(os.path.join(path, f))
+    ]
 
+    return ClusterArchiveContext(path, all_files=arc) if arc else None
+
+
+def create_context(path, context=None):
     all_files = list(get_all_files(path))
     if not all_files:
         raise InvalidArchive("No files in archive")
 
-    common_path, ctx = identify(all_files)
-    context = context or ctx
-    return context(common_path, all_files=all_files)
+    # try given context
+    # this block is unable to select ClusterArchiveContext
+    if context:
+        common_path, ctx = context.handles(all_files)
+        if ctx is not None:
+            return ctx(common_path, all_files=all_files)
+
+    # try ClusterArchiveContext
+    cac_ctx = _create_cluster_archive_context(path)
+    # do not use ClusterArchiveContext if the user specified another execution context
+    if cac_ctx and (context is None or context == ClusterArchiveContext):
+        return cac_ctx
+    # remember that we found ClusterArchiveContext if a user-defined context was not found
+    elif cac_ctx and context is not None:
+        ctx = ClusterArchiveContext
+    # use standard auto-detection (falls back to HostArchiveContext if nothing else is detected)
+    else:
+        common_path, ctx = identify(all_files)
+
+    # The specified context was not found and it is not HostArchiveContext; suggest the
+    # auto-detected one.
+    # `context` and `ctx` will be identical at this point only if both are HostArchiveContext. This
+    # will occur when no execution context is found in the path and identify() falls back to
+    # HostArchiveContext. To maintain consistent behavior between user-defined context and
+    # auto-detected one, we need to allow its creation even though the marker was not found.
+    if context is not None and context is not ctx:
+        raise ContextException(
+            "Cannot find execution context '{0}.{1}' in path: {2}\n  Did you mean '{3}.{4}'?".format(
+                context.__module__,
+                context.__name__,
+                path,
+                ctx.__module__,
+                ctx.__name__,
+            )
+        )
+
+    # we get here only if no specific execution context was requested
+    return ctx(common_path, all_files=all_files)
 
 
 def initialize_broker(path, context=None, broker=None):

--- a/insights/tests/core/test_hydration.py
+++ b/insights/tests/core/test_hydration.py
@@ -2,10 +2,18 @@ import pytest
 import sys
 import tempfile
 
-from insights.core.hydration import get_all_files
 from os import chmod, makedirs
-from os.path import join
+from os.path import dirname, join
 from shutil import rmtree
+
+from insights.core.context import (
+    ClusterArchiveContext,
+    HostArchiveContext,
+    SerializedArchiveContext,
+    SosArchiveContext,
+)
+from insights.core.exceptions import ContextException, InvalidArchive
+from insights.core.hydration import get_all_files, create_context
 
 
 def test_get_all_files():
@@ -44,3 +52,187 @@ def test_get_all_files_oserror(caplog):
     chmod(join(tmp_dir, "sys"), 0o777)
     chmod(d, 0o777)
     rmtree(tmp_dir, ignore_errors=True)
+
+
+def create_file(root, relpath, content=""):
+    file_path = join(root, relpath)
+    # Python 2.7 does not support exist_ok and raises an exception when path exists
+    try:
+        makedirs(dirname(file_path))
+    except FileExistsError:
+        pass
+    fd = open(file_path, "w")
+    fd.write(content)
+    fd.close()
+    return file_path
+
+
+CLUSTER_ARCHIVE_CONTEXT_SAMPLE_ARCHIVE = "cluster_archive_context_archive1.tar.gz"
+
+
+def create_cluster_archive_context(root):
+    create_file(root, CLUSTER_ARCHIVE_CONTEXT_SAMPLE_ARCHIVE)
+
+
+SERIALIZED_ARCHIVE_CONTEXT_ROOT = "serialized_archive_context"
+SERIALIZED_ARCHIVE_CONTEXT_MARKER = "insights_archive.txt"
+
+
+def create_serialized_archive_context(root):
+    create_file(root, join(SERIALIZED_ARCHIVE_CONTEXT_ROOT, SERIALIZED_ARCHIVE_CONTEXT_MARKER))
+
+
+SOS_ARCHIVE_CONTEXT_ROOT = "sos_archive_context"
+SOS_ARCHIVE_CONTEXT_MARKER = "sos_commands/uname_-a"
+
+
+def create_sos_archive_context(root):
+    create_file(root, join(SOS_ARCHIVE_CONTEXT_ROOT, SOS_ARCHIVE_CONTEXT_MARKER))
+
+
+def test_create_context_autodetection_cluster_archive_context(caplog, tmpdir):
+    """Automatic detection selects ClusterArchiveContext whenever present.
+
+    The path contains ClusterArchiveContext, SerializedArchiveContext and SosArchiveContext.
+    In the current implementation, ClusterArchiveContext takes precedence over any other execution
+    context when the automatic detection is used.
+    """
+    create_cluster_archive_context(tmpdir)
+    create_serialized_archive_context(tmpdir)
+    create_sos_archive_context(tmpdir)
+
+    context = create_context(tmpdir)
+    assert type(context) is ClusterArchiveContext
+    assert context.root == tmpdir
+    assert context.all_files == [join(tmpdir, CLUSTER_ARCHIVE_CONTEXT_SAMPLE_ARCHIVE)]
+
+
+def test_create_context_autodetection_other(caplog, tmpdir):
+    """Automatic detection selects the last-defined execution context that matches the path.
+
+    The path contains SerializedArchiveContext and SosArchiveContext. SosArchiveContext gets
+    selected because it is defined after SerializedArchiveContext.
+    """
+    create_serialized_archive_context(tmpdir)
+    create_sos_archive_context(tmpdir)
+
+    context = create_context(tmpdir)
+    assert type(context) is SosArchiveContext
+    assert context.root == join(tmpdir, SOS_ARCHIVE_CONTEXT_ROOT)
+    assert sorted(context.all_files) == [
+        join(tmpdir, SERIALIZED_ARCHIVE_CONTEXT_ROOT, SERIALIZED_ARCHIVE_CONTEXT_MARKER),
+        join(tmpdir, SOS_ARCHIVE_CONTEXT_ROOT, SOS_ARCHIVE_CONTEXT_MARKER),
+    ]
+
+
+def test_create_context_autodetection_fallback(caplog, tmpdir):
+    """HostArchiveContext is used if no other execution context is found.
+
+    The path does not contain data for any loaded execution context. The function creates
+    HostArchiveContext in that case.
+    """
+    # at least one file or directory has to exist otherwise an exception gets raised
+    create_file(tmpdir, "some_file.txt")
+
+    context = create_context(tmpdir)
+    assert type(context) is HostArchiveContext
+    assert context.root == tmpdir
+    assert context.all_files == [join(tmpdir, "some_file.txt")]
+
+
+def test_create_context_user_defined_fallback(caplog, tmpdir):
+    """Use HostArchiveContext even if it is not found when requested.
+
+    The path contains no execution context while the user specified HostArchiveContext.
+
+    The HostArchiveContext was not found in the path, but it is the ultimate fallback that would be
+    selected by auto-detection regardless. We need to create it to remain consistent with
+    auto-detection.
+    """
+    # at least one file or directory has to exist for the auto-detection mechanism to choose
+    # HostArchiveContext
+    create_file(tmpdir, "some_file.txt")
+
+    context = create_context(tmpdir, context=HostArchiveContext)
+    assert type(context) is HostArchiveContext
+    assert context.root == tmpdir
+    assert context.all_files == [join(tmpdir, "some_file.txt")]
+
+
+def test_create_context_user_defined_cluster_archive_context(caplog, tmpdir):
+    """ClusterArchiveContext is selected when requested by the user.
+
+    The path contains ClusterArchiveContext, SerializedArchiveContext and SosArchiveContext and the
+    user requested ClusterArchiveContext. ClusterArchiveContext will be used.
+
+    This test is required because ClusterArchiveContext has custom initialization logic in
+    create_context (bad!).
+    """
+    create_cluster_archive_context(tmpdir)
+    create_serialized_archive_context(tmpdir)
+    create_sos_archive_context(tmpdir)
+
+    context = create_context(tmpdir, context=ClusterArchiveContext)
+    assert type(context) is ClusterArchiveContext
+    assert context.root == tmpdir
+    assert context.all_files == [join(tmpdir, CLUSTER_ARCHIVE_CONTEXT_SAMPLE_ARCHIVE)]
+
+
+def test_create_context_user_defined_other(caplog, tmpdir):
+    """User-defined execution context takes precedence over everything else.
+
+    The path contains ClusterArchiveContext, SerializedArchiveContext and SosArchiveContext.
+    SerializedArchiveContext gets selected because it is requested by the user, despite
+    ClusterArchiveContext taking precedence over everything else otherwise and SosArchiveContext
+    being defined after SerializedArchiveContext.
+    """
+    create_cluster_archive_context(tmpdir)
+    create_serialized_archive_context(tmpdir)
+    create_sos_archive_context(tmpdir)
+
+    context = create_context(tmpdir, context=SerializedArchiveContext)
+    assert type(context) is SerializedArchiveContext
+    assert context.root == join(tmpdir, SERIALIZED_ARCHIVE_CONTEXT_ROOT)
+    assert sorted(context.all_files) == [
+        join(tmpdir, CLUSTER_ARCHIVE_CONTEXT_SAMPLE_ARCHIVE),
+        join(tmpdir, SERIALIZED_ARCHIVE_CONTEXT_ROOT, SERIALIZED_ARCHIVE_CONTEXT_MARKER),
+        join(tmpdir, SOS_ARCHIVE_CONTEXT_ROOT, SOS_ARCHIVE_CONTEXT_MARKER),
+    ]
+
+
+def test_create_context_did_you_mean_cluster_archive_context(caplog, tmpdir):
+    """ClusterArchiveContext is suggested whenever present.
+
+    The path contains ClusterArchiveContext, SerializedArchiveContext and SosArchiveContext while
+    the user specified HostArchiveContext. The function raises an exception and suggests
+    ClusterArchiveContext. In the current implementation ClusterArchiveContext is selected
+    automatically whenever present.
+    """
+    create_cluster_archive_context(tmpdir)
+    create_serialized_archive_context(tmpdir)
+    create_sos_archive_context(tmpdir)
+
+    with pytest.raises(ContextException, match="Did you mean 'insights.core.context.ClusterArchiveContext'"):
+        create_context(tmpdir, context=HostArchiveContext)
+
+
+def test_create_context_did_you_mean_other(caplog, tmpdir):
+    """ClusterArchiveContext is suggested whenever present.
+
+    The path contains SerializedArchiveContext and SosArchiveContext while the user specified
+    HostArchiveContext. The function raises an exception and suggests SosArchiveContext because it
+    was defined after SerializedArchiveContext.
+    """
+    create_serialized_archive_context(tmpdir)
+    create_sos_archive_context(tmpdir)
+
+    with pytest.raises(ContextException, match="Did you mean 'insights.core.context.SosArchiveContext'"):
+        create_context(tmpdir, context=HostArchiveContext)
+
+
+@pytest.mark.parametrize("user_defined_context", [None, HostArchiveContext])
+def test_create_context_empty_path(caplog, tmpdir, user_defined_context):
+    """Raises an exception when the path is empty."""
+    with pytest.raises(InvalidArchive) as ce:
+        create_context(tmpdir, context=user_defined_context)
+    assert "No files in archive" in str(ce)


### PR DESCRIPTION
- Jira: RHINENG-8429

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?
* [ ] Need backport to `3.0_egg`? Yes, refer to [RPM/Egg Delivery](https://github.com/RedHatInsights/insights-core/blob/master/CONTRIBUTING.md#rpmegg-delivery) to open a new PR.
* [ ] Is this a backport from `master`? Yes, this is a backport of #PR-ID
<!--
Replace the "PR-ID", if this PR needs to be backported from the master branch.
-->

**Note:** I do not understand the "need backport" checkbox. I do not know if it needs to be ticked or not.


### Complete Description of Additions/Changes:

* Fix unpredictable behavior of `--context`. The new behavior fulfills the following requirements:
  * A specified execution context is used whenever it is found, regardless of other execution contexts found in the path.
  * If insights-run chooses an execution context automatically when executed without the `--context` option, the same execution context can be specified by the user with the same result.
* Keep execution context selection logic in `create_context` (as much as possible without breaking changes to other existing functions)
* Add comprehensive tests for `create_context`

## Summary by Sourcery

Clarify and harden execution context selection for data processing archives, ensuring predictable behavior for automatic and user-specified contexts and surfacing clear errors when contexts are missing or mismatched.

Bug Fixes:
- Ensure create_context consistently selects the intended execution context when --context is provided or omitted, including proper precedence for ClusterArchiveContext and HostArchiveContext fallbacks.
- Raise explicit errors when a requested execution context component cannot be imported or when the archive path contains no files, avoiding silent misconfiguration.
- Provide user-facing error messages when an invalid or unavailable context is requested via the CLI, instead of failing silently or unpredictably.

Enhancements:
- Add suggestion logic that recommends the most appropriate detected execution context when the requested one is not found, improving usability of context selection.
- Factor out ClusterArchiveContext creation and detection into a dedicated helper to keep context resolution logic clearer and more maintainable.

Tests:
- Add comprehensive tests for create_context covering auto-detection, user-specified contexts, fallbacks, suggestion behavior, and empty-archive errors.