### PR TITLE
FEAT: Add new spec thp_shmem_enabled

### DIFF
--- a/insights/parsers/transparent_hugepage.py
+++ b/insights/parsers/transparent_hugepage.py
@@ -7,40 +7,15 @@ Module for parsing the sysfs settings for transparent_hugepage:
 ThpUseZeroPage - file ``/sys/kernel/mm/transparent_hugepage/use_zero_page``
 ---------------------------------------------------------------------------
 
-Gets the contents of /sys/kernel/mm/transparent_hugepage/use_zero_page, which is either 0 or 1.
-
-Sample input::
-
-    0
-
-Examples:
-
-    >>> shared[ThpUseZeroPage].use_zero_page
-    0
-
-
 ThpEnabled - file ``/sys/kernel/mm/transparent_hugepage/enabled``
 -----------------------------------------------------------------
 
-Gets the contents of  /sys/kernel/mm/transparent_hugepage/enabled, which is something like
-`always [madvise] never` where the active value is in brackets.
-
-If no option is active (that should never happen), `active_option` will contain None.
-
-Sample input::
-
-    always [madvise] never
-
-Examples:
-
-    >>> shared[ThpEnabled].line
-    always [madvise] never
-    >>> shared[ThpEnabled].active_option
-    madvise
-
+ThpShmemEnabled - file ``/sys/kernel/mm/transparent_hugepage/shmem_enabled``
+----------------------------------------------------------------------------
 """
 
 from .. import Parser, parser
+from insights.core.exceptions import ParseException
 from insights.specs import Specs
 
 
@@ -51,6 +26,16 @@ class ThpUseZeroPage(Parser):
 
     Attributes:
         use_zero_page (str): The setting, should be 0 or 1.
+
+    Sample input::
+
+        0
+
+    Examples:
+        >>> type(thp_use_zero_page)
+        <class 'insights.parsers.transparent_hugepage.ThpUseZeroPage'>
+        >>> thp_use_zero_page.use_zero_page
+        '0'
     """
     def parse_content(self, content):
         self.use_zero_page = " ".join(content).strip()
@@ -66,6 +51,19 @@ class ThpEnabled(Parser):
     Attributes:
         line (str): Contents of the input file.
         active_option (str): The active option for transparent huge pages, or `None` if not present.
+
+    Sample input::
+
+        always [madvise] never
+
+    Examples:
+        >>> type(thp_enabled)
+        <class 'insights.parsers.transparent_hugepage.ThpEnabled'>
+        >>> thp_enabled.line
+        'always [madvise] never'
+        >>> thp_enabled.active_option
+        'madvise'
+
     """
     def parse_content(self, content):
         self.line = " ".join(content).strip()
@@ -73,3 +71,35 @@ class ThpEnabled(Parser):
         for w in self.line.split():
             if w.startswith("[") and w.endswith("]"):
                 self.active_option = w[1:-1]
+
+
+@parser(Specs.thp_shmem_enabled)
+class ThpShmemEnabled(Parser):
+    """
+    Class for parsing the ``/sys/kernel/mm/transparent_hugepage/shmem_enabled`` files..
+
+    Attributes:
+        line (str): Contents of the input file.
+        active_option (str): The active option for shmem_enabled of transparent huge pages, or `None` if not present.
+
+    Typical content of the file is::
+
+        always within_size advise [never] deny force
+
+    Examples:
+        >>> type(thp_shmem_enabled)
+        <class 'insights.parsers.transparent_hugepage.ThpShmemEnabled'>
+        >>> thp_shmem_enabled.line
+        'always within_size advise [never] deny force'
+        >>> thp_shmem_enabled.active_option
+        'never'
+    """
+    def parse_content(self, content):
+        self.line = " ".join(content).strip()
+        self.active_option = None
+        for w in self.line.split():
+            if w.startswith("[") and w.endswith("]") and w[1:-1]:
+                self.active_option = w[1:-1]
+                break
+        if not (self.line or self.active_option):
+            raise ParseException('Error: {0}'.format(content or 'empty file'))

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -888,6 +888,7 @@ class Specs(SpecSet):
     testparm_s = RegistryPoint(filterable=True)
     testparm_v_s = RegistryPoint(filterable=True)
     thp_enabled = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
+    thp_shmem_enabled = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     thp_use_zero_page = RegistryPoint()
     timedatectl_status = RegistryPoint()
     tmpfilesd = RegistryPoint(multi_output=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -940,6 +940,7 @@ class DefaultSpecs(Specs):
     testparm_s = simple_command("/usr/bin/testparm -s")
     testparm_v_s = simple_command("/usr/bin/testparm -v -s")
     thp_enabled = simple_file("/sys/kernel/mm/transparent_hugepage/enabled")
+    thp_shmem_enabled = simple_file("/sys/kernel/mm/transparent_hugepage/shmem_enabled")
     thp_use_zero_page = simple_file("/sys/kernel/mm/transparent_hugepage/use_zero_page")
     timedatectl_status = simple_command('/usr/bin/timedatectl status')
     tmpfilesd = glob_file(

--- a/insights/tests/parsers/test_transparent_hugepage.py
+++ b/insights/tests/parsers/test_transparent_hugepage.py
@@ -1,4 +1,9 @@
-from insights.parsers.transparent_hugepage import ThpEnabled, ThpUseZeroPage
+import doctest
+import pytest
+
+from insights.core.exceptions import ParseException
+from insights.parsers import transparent_hugepage
+from insights.parsers.transparent_hugepage import ThpEnabled, ThpUseZeroPage, ThpShmemEnabled
 from insights.tests import context_wrap
 
 ZEROPAGE_0 = "0"
@@ -26,6 +31,13 @@ always madvise [never]
 
 # testing without newlines
 ENABLED_ALWAYS = """[always] madvise never"""
+
+THP_SHMEM_ENABLED_ALWAYS = """[always] within_size advise never deny force"""
+THP_SHMEM_ENABLED_NEVER = """always within_size advise [never] deny force"""
+THP_SHMEM_ENABLED_ENABLE_EMPTY = """always within_size advise [] deny force"""
+THP_SHMEM_ENABLED_ENABLE_EMPTY2 = """always within_size advise [ ] deny force"""
+THP_SHMEM_ENABLED_ENABLE_EMPTY3 = """always within_size advise deny force"""
+THP_SHMEM_ENABLED_EMPTY = """ """
 
 
 def test_zeropage():
@@ -62,3 +74,44 @@ def test_enabled():
     assert conf is not None
     assert "always" == conf.active_option
     assert ENABLED_ALWAYS.strip() == conf.line
+
+
+def test_thp_shmem_enabled():
+    conf = ThpShmemEnabled(context_wrap(THP_SHMEM_ENABLED_ALWAYS))
+    assert conf is not None
+    assert "always" == conf.active_option
+    assert THP_SHMEM_ENABLED_ALWAYS.strip() == conf.line
+
+    conf = ThpShmemEnabled(context_wrap(THP_SHMEM_ENABLED_NEVER))
+    assert conf is not None
+    assert "never" == conf.active_option
+    assert THP_SHMEM_ENABLED_NEVER.strip() == conf.line
+
+    conf = ThpShmemEnabled(context_wrap(THP_SHMEM_ENABLED_ENABLE_EMPTY))
+    assert conf is not None
+    assert conf.active_option is None
+    assert THP_SHMEM_ENABLED_ENABLE_EMPTY.strip() == conf.line
+
+    conf = ThpShmemEnabled(context_wrap(THP_SHMEM_ENABLED_ENABLE_EMPTY2))
+    assert conf is not None
+    assert conf.active_option is None
+    assert THP_SHMEM_ENABLED_ENABLE_EMPTY2.strip() == conf.line
+
+    conf = ThpShmemEnabled(context_wrap(THP_SHMEM_ENABLED_ENABLE_EMPTY3))
+    assert conf is not None
+    assert conf.active_option is None
+    assert THP_SHMEM_ENABLED_ENABLE_EMPTY3.strip() == conf.line
+
+    with pytest.raises(ParseException) as e:
+        transparent_hugepage.ThpShmemEnabled(context_wrap(THP_SHMEM_ENABLED_EMPTY))
+    assert "Error: " in str(e)
+
+
+def test_transparent_hugepage_doc_examples():
+    env = {
+        'thp_use_zero_page': transparent_hugepage.ThpUseZeroPage(context_wrap(ZEROPAGE_0)),
+        'thp_enabled': transparent_hugepage.ThpEnabled(context_wrap(ENABLED_MADVISE)),
+        'thp_shmem_enabled': transparent_hugepage.ThpShmemEnabled(context_wrap(THP_SHMEM_ENABLED_NEVER)),
+    }
+    failed, total = doctest.testmod(transparent_hugepage, globs=env)
+    assert failed == 0


### PR DESCRIPTION
Signed-off-by: Xinting Li <xintli@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
RHINENG-24776

Add new spec thp_shmem_enabled and new parser ThpShmemEnabled

## Summary by Sourcery

Add support for parsing the transparent hugepage shmem_enabled setting and expose it as a new spec.

New Features:
- Introduce the ThpShmemEnabled parser to read the transparent hugepage shmem_enabled configuration.
- Add a new thp_shmem_enabled spec pointing to /sys/kernel/mm/transparent_hugepage/shmem_enabled.

Tests:
- Extend transparent hugepage parser tests to cover the new ThpShmemEnabled parser.

## Summary by Sourcery

Add support for collecting and parsing the transparent hugepage shmem_enabled setting as a new spec and parser, and expand documentation and tests for transparent hugepage parsers.

New Features:
- Add a ThpShmemEnabled parser to expose the active transparent hugepage shmem_enabled option.
- Introduce a thp_shmem_enabled spec mapped to /sys/kernel/mm/transparent_hugepage/shmem_enabled.

Enhancements:
- Improve transparent hugepage parser documentation and doctest coverage for existing parsers.

Tests:
- Extend transparent hugepage parser tests to cover ThpShmemEnabled, including empty and malformed input cases.
- Add doctest-based tests to validate documented examples for transparent hugepage parsers.