### PR TITLE
[CCXDEV-15098] Fix memory leak - cleanup broker exception traceback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/RedHatInsights/insights-core/tree/HEAD)
 
+- fix(dr): clear exception tracebacks after run to prevent memory leak from circular references ([PR 4763](https://github.com/RedHatInsights/insights-core/pull/4763))
+
 # [insights-core-3.7.2.2](https://github.com/RedHatInsights/insights-core/releases/tag/insights-core-3.7.2.2) (2026-02-05)
 
 - chore(setup): remove six from the dependencies ([PR 4719](https://github.com/RedHatInsights/insights-core/pull/4719))

--- a/docs/exception_model.rst
+++ b/docs/exception_model.rst
@@ -119,3 +119,37 @@ make it much easier for the engine to identify and quickly deal with known
 conditions versus unanticipated conditions (i.e., other exceptions being raised)
 which could indicate errors in the parsing code, errors in data collection, or
 data errors.
+
+Exception Traceback Lifecycle
+=============================
+
+When the engine catches an exception during component execution, it stores two
+things via ``broker.add_exception()``:
+
+1. The exception object itself (in ``broker.exceptions``).
+2. A formatted traceback **string** (in ``broker.tracebacks``), captured via
+   ``traceback.format_exc()``.
+
+After storing these, the engine clears ``exception.__traceback__`` (sets it to
+``None``).  This is necessary because Python's live traceback object holds a
+reference to the stack frame, which in turn references all local variables —
+including the ``broker``.  Without clearing it, this creates a circular
+reference chain::
+
+    broker.exceptions -> exception -> __traceback__ -> frame -> broker
+
+This cycle prevents CPython's reference-counting collector from freeing the
+broker and all of its component results.  In long-running services, this
+manifests as a steady memory leak.
+
+Clearing ``__traceback__`` breaks the cycle without losing any debugging
+information, because the human-readable traceback string is already preserved
+in ``broker.tracebacks``.
+
+.. note::
+
+   After ``run()`` completes, ``exception.__traceback__`` is ``None``.
+   All traceback information is available as a formatted string via
+   ``broker.tracebacks[exception]``.  All existing code in the codebase
+   (formatters, tools, serializers) already uses ``broker.tracebacks``
+   exclusively.

--- a/insights/core/dr.py
+++ b/insights/core/dr.py
@@ -1093,6 +1093,9 @@ def run_components(ordered_components, components, broker):
             for x in get_registry_points(component):
                 BLACKLISTED_SPECS.append(str(x).split('.')[-1])
             broker.add_exception(component, bs, traceback.format_exc())
+            # CCXDEV-15098: Clear traceback to break circular reference.
+            # See the comment in the ``except Exception`` block below.
+            bs.__traceback__ = None
         except MissingRequirements as mr:
             if log.isEnabledFor(logging.DEBUG):
                 name = get_name(component)
@@ -1103,14 +1106,38 @@ def run_components(ordered_components, components, broker):
             if broker.store_skips:
                 log.debug(sc)
                 broker.add_exception(component, sc, traceback.format_exc())
-            else:
-                pass
+                # CCXDEV-15098: Clear traceback to break circular reference.
+                # See the comment in the ``except Exception`` block below.
+                sc.__traceback__ = None
         except Exception as ex:
             log.debug(ex)
             tb = traceback.format_exc()
             broker.add_exception(component, ex, tb)
             for reg_spec in get_registry_points(component):
                 broker.add_exception(reg_spec, ex, tb)
+            # CCXDEV-15098: Clear the traceback reference to break a circular
+            # reference chain that prevents the broker from being GC'd.
+            #
+            # When Python catches an exception, it attaches the live
+            # traceback object to ``ex.__traceback__``.  That traceback
+            # holds a reference to the stack frame, which in turn
+            # references all local variables — including ``broker``.
+            # This creates a circular reference chain:
+            #
+            #   broker.exceptions -> exception -> __traceback__ -> frame
+            #          -> local vars (including 'broker') -> broker
+            #
+            # CPython's reference-counting collector cannot break cycles,
+            # so the broker (with its ``instances`` dict containing ~500
+            # component results) stays alive until the cyclic GC runs —
+            # if it runs at all.  In long-running services this manifests
+            # as a steady memory leak (~8 MB/hr in production).
+            #
+            # The formatted traceback *string* is already captured above
+            # via ``traceback.format_exc()`` and stored in
+            # ``broker.tracebacks``, so clearing ``__traceback__`` loses
+            # no debugging information.
+            ex.__traceback__ = None
         finally:
             broker.exec_times[component] = time.time() - start
             broker.fire_observers(component)

--- a/insights/tests/test_traceback_leak.py
+++ b/insights/tests/test_traceback_leak.py
@@ -1,0 +1,252 @@
+"""
+Regression test for CCXDEV-15098: Memory leak from circular references
+in exception traceback handling.
+
+When a component raises an exception during ``run()``, Python attaches the
+live traceback object to ``exception.__traceback__``.  That traceback holds
+a reference to the stack frame, which references local variables — including
+the ``broker``.  This creates a circular reference chain::
+
+    Broker -> exceptions -> exception -> __traceback__ -> frame -> Broker
+
+CPython's reference-counting collector cannot break cycles, so the broker
+and all of its data (the ``instances`` dict with ~500 component results)
+stays alive until the cyclic GC runs.  In long-running services this
+manifests as a steady memory leak.
+
+The fix in ``dr.run_components()`` clears ``ex.__traceback__`` after the
+formatted traceback string has been saved in ``broker.tracebacks``,
+breaking the cycle without losing any debugging information.
+
+These tests cover all exception types that store tracebacks:
+
+- Generic ``Exception``  (caught by ``except Exception``)
+- ``SkipComponent``       (caught separately, stores tb when store_skips=True)
+- ``BlacklistedSpec``     (caught separately, always stores tb)
+"""
+
+import gc
+import platform
+import weakref
+
+import pytest
+
+from insights.core import dr
+from insights.core.exceptions import BlacklistedSpec, SkipComponent
+from insights.core.plugins import datasource, rule, make_info
+from insights.core.spec_factory import RegistryPoint, SpecSet
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures: components that raise different exception types
+# ---------------------------------------------------------------------------
+
+EXPECTED_MSG = "traceback leak test exception"
+EXPECTED_SKIP_MSG = "traceback leak skip test"
+EXPECTED_BLACKLIST_MSG = "traceback leak blacklist test"
+
+
+class LeakTestSpecs(SpecSet):
+    failing_data = RegistryPoint()
+    skipped_data = RegistryPoint()
+    blacklisted_data = RegistryPoint()
+
+
+class LeakTestImpl(LeakTestSpecs):
+    @datasource()
+    def failing_data(broker):
+        raise Exception(EXPECTED_MSG)
+
+    @datasource()
+    def skipped_data(broker):
+        raise SkipComponent(EXPECTED_SKIP_MSG)
+
+    @datasource()
+    def blacklisted_data(broker):
+        raise BlacklistedSpec(EXPECTED_BLACKLIST_MSG)
+
+
+@rule(LeakTestSpecs.failing_data)
+def leak_test_rule(data):
+    return make_info("LEAK_TEST")
+
+
+@rule(LeakTestSpecs.skipped_data)
+def skip_test_rule(data):
+    return make_info("SKIP_TEST")
+
+
+@rule(LeakTestSpecs.blacklisted_data)
+def blacklist_test_rule(data):
+    return make_info("BLACKLIST_TEST")
+
+
+# ---------------------------------------------------------------------------
+# Helper: find exceptions of a given type in the broker
+# ---------------------------------------------------------------------------
+
+def _find_exceptions(broker, exc_type):
+    """Return all exceptions of exc_type from any component in the broker.
+
+    Exceptions may be keyed by the implementation function rather than
+    the RegistryPoint (e.g. BlacklistedSpec and SkipComponent are only
+    stored under the implementation key).  This helper searches all
+    components to avoid false-pass from a missed key lookup.
+    """
+    found = []
+    for comp, ex_list in broker.exceptions.items():
+        for ex in ex_list:
+            if isinstance(ex, exc_type):
+                found.append(ex)
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Tests for generic Exception
+# ---------------------------------------------------------------------------
+
+def test_traceback_cleared_after_run():
+    """Verify that __traceback__ is None for generic exceptions after run().
+
+    Without the fix, the exception retains a __traceback__ reference to the
+    stack frame, creating a circular reference that prevents the broker from
+    being garbage collected.
+    """
+    broker = dr.run(leak_test_rule)
+
+    exceptions = _find_exceptions(broker, Exception)
+    # Filter to our specific test exception (not SkipComponent etc.)
+    exceptions = [e for e in exceptions
+                  if type(e) is Exception and str(e) == EXPECTED_MSG]
+    assert len(exceptions) >= 1, (
+        "Expected at least one Exception with message %r in broker.exceptions, "
+        "found none. Keys: %s" % (EXPECTED_MSG, list(broker.exceptions.keys()))
+    )
+
+    for ex in exceptions:
+        # Formatted traceback string is preserved (functionality not broken)
+        tb = broker.tracebacks[ex]
+        assert tb is not None
+        assert EXPECTED_MSG in tb
+        assert "Traceback" in tb
+
+        # The fix: __traceback__ must be cleared to break the circular ref
+        assert ex.__traceback__ is None, (
+            "ex.__traceback__ should be None after run() to prevent "
+            "circular reference: Broker -> exceptions -> ex -> "
+            "__traceback__ -> frame -> Broker"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests for SkipComponent
+# ---------------------------------------------------------------------------
+
+def test_traceback_cleared_for_skip_component():
+    """Verify that __traceback__ is None for SkipComponent exceptions.
+
+    SkipComponent exceptions store tracebacks when broker.store_skips is True.
+    The same circular reference pattern applies.
+    """
+    broker = dr.Broker()
+    broker.store_skips = True
+    broker = dr.run(skip_test_rule, broker=broker)
+
+    exceptions = _find_exceptions(broker, SkipComponent)
+    assert len(exceptions) >= 1, (
+        "Expected at least one SkipComponent in broker.exceptions, "
+        "found none. store_skips=%s, keys: %s"
+        % (broker.store_skips, list(broker.exceptions.keys()))
+    )
+
+    for ex in exceptions:
+        # Formatted traceback string is preserved
+        tb = broker.tracebacks[ex]
+        assert tb is not None
+        assert EXPECTED_SKIP_MSG in tb
+
+        # __traceback__ must be cleared
+        assert ex.__traceback__ is None, (
+            "SkipComponent.__traceback__ should be None after run() "
+            "to prevent circular reference"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests for BlacklistedSpec
+# ---------------------------------------------------------------------------
+
+def test_traceback_cleared_for_blacklisted_spec():
+    """Verify that __traceback__ is None for BlacklistedSpec exceptions.
+
+    BlacklistedSpec exceptions always store tracebacks.  The same circular
+    reference pattern applies.
+    """
+    broker = dr.run(blacklist_test_rule)
+
+    exceptions = _find_exceptions(broker, BlacklistedSpec)
+    assert len(exceptions) >= 1, (
+        "Expected at least one BlacklistedSpec in broker.exceptions, "
+        "found none. Keys: %s" % list(broker.exceptions.keys())
+    )
+
+    for ex in exceptions:
+        # Formatted traceback string is preserved
+        tb = broker.tracebacks[ex]
+        assert tb is not None
+        assert EXPECTED_BLACKLIST_MSG in tb
+
+        # __traceback__ must be cleared
+        assert ex.__traceback__ is None, (
+            "BlacklistedSpec.__traceback__ should be None after run() "
+            "to prevent circular reference"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GC collection test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    platform.python_implementation() != "CPython",
+    reason="Relies on CPython reference-counting semantics"
+)
+def test_broker_collected_after_run():
+    """Verify that brokers are garbage collected after processing.
+
+    Without the fix, circular references from exception.__traceback__ keep
+    brokers alive indefinitely, causing memory to grow over time.
+
+    We disable the cyclic GC during the test so that only reference-counting
+    frees the brokers.  With the fix, clearing __traceback__ breaks the
+    cycle and reference counting alone is sufficient.  Without the fix,
+    the circular reference keeps the broker alive.
+    """
+    n_runs = 5
+    refs = []
+
+    # Disable cyclic GC so circular references are NOT collected.
+    # This makes the test deterministic: brokers survive IFF there
+    # is a reference cycle.
+    gc.collect()
+    was_enabled = gc.isenabled()
+    gc.disable()
+
+    try:
+        for _ in range(n_runs):
+            broker = dr.run(leak_test_rule)
+            refs.append(weakref.ref(broker))
+            del broker
+
+        collected = sum(1 for ref in refs if ref() is None)
+        assert collected >= n_runs - 1, (
+            f"Only {collected}/{n_runs} brokers were garbage collected "
+            "by reference counting alone (cyclic GC disabled). "
+            "Remaining brokers are held by circular references "
+            "from exception.__traceback__ -> frame -> broker."
+        )
+    finally:
+        # Restore GC state exactly as it was before the test.
+        if was_enabled:
+            gc.enable()
+        gc.collect()


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This PR fixes a memory leak in `insights/core/dr.py` that affects long-running services using insights-core. When components raise exceptions during `run_components()`, Python attaches a live traceback object to the exception. This traceback holds a reference back to the stack frame's local variables — including the `broker` — creating a circular reference chain that prevents garbage collection via reference counting. Over time, this causes steady memory growth (observed in production).

The fix clears `exception.__traceback__` immediately after the formatted traceback string has been captured via `traceback.format_exc()`. This breaks the circular reference without losing any debugging information, since all existing code in the codebase accesses tracebacks through `broker.tracebacks` (the formatted string), not `exception.__traceback__`.

In `run_components()`, caught exceptions are stored in `broker.exceptions` along with their formatted traceback string via `broker.add_exception(component, ex, tb)`. However, the exception's `__traceback__` attribute still holds a reference to the live stack frame, which references all local variables — including `broker`. This creates a circular reference chain:

```
broker.exceptions -> exception -> __traceback__ -> frame -> local vars (broker) -> broker
```

CPython's reference-counting collector cannot break cycles. The cyclic GC may eventually collect them, but in long-running services this is unreliable and the memory grows steadily before collection occurs.

## Summary by Sourcery

Prevent memory leaks in long-running services by clearing stored exception tracebacks after component execution and documenting the change.

Bug Fixes:
- Break circular references by clearing exception __traceback__ after capturing formatted tracebacks in run_components, covering generic, skip, and blacklisted spec exceptions.

Documentation:
- Note the traceback cleanup behavior and memory leak fix in the changelog.

Tests:
- Add regression tests ensuring exception __traceback__ is cleared, tracebacks remain available as strings, and brokers are garbage-collected without cyclic GC.