### PR TITLE
Add new spec sys_block_queue_discard_max_bytes

### DIFF
--- a/insights/parsers/sys_block.py
+++ b/insights/parsers/sys_block.py
@@ -9,6 +9,9 @@ StableWrites - file ``/sys/block/*/queue/stable_writes``
 
 MaxSegmentSize - file ``/sys/block/*/queue/max_segment_size``
 -------------------------------------------------------------
+
+DiscardMaxBytes - file ``/sys/block/*/queue/discard_max_bytes``
+---------------------------------------------------------------
 """
 from insights import Parser, parser
 from insights.core.exceptions import ParseException
@@ -87,4 +90,38 @@ class MaxSegmentSize(Parser):
             raise ParseException("Error: unparsable content: {0}".format(content[0]))
 
     max_segment_size = property(lambda self: self._max_segment_size)
+    device = property(lambda self: self._device)
+
+
+@parser(Specs.sys_block_queue_discard_max_bytes)
+class DiscardMaxBytes(Parser):
+    """
+    Class for parsing the ``/sys/block/*/queue/discard_max_bytes`` files.
+
+    Typical content of the file is::
+
+        0
+
+    Examples:
+        >>> type(discard_max_bytes)
+        <class 'insights.parsers.sys_block.DiscardMaxBytes'>
+        >>> discard_max_bytes.discard_max_bytes
+        0
+        >>> discard_max_bytes.device
+        'sda'
+
+    Raises:
+        ParseException: When content is empty or unparsable
+    """
+
+    def parse_content(self, content):
+        if len(content) != 1:
+            raise ParseException('Error: {0}'.format(content or 'empty file'))
+        try:
+            self._discard_max_bytes = int(content[0].strip())
+            self._device = self.file_path.split('/')[-3]
+        except ValueError:
+            raise ParseException("Error: unparsable content: {0}".format(content[0]))
+
+    discard_max_bytes = property(lambda self: self._discard_max_bytes)
     device = property(lambda self: self._device)

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -832,6 +832,7 @@ class Specs(SpecSet):
     swift_object_expirer_conf = RegistryPoint()
     swift_proxy_server_conf = RegistryPoint()
     sys_block_queue_stable_writes = RegistryPoint(multi_output=True)
+    sys_block_queue_discard_max_bytes = RegistryPoint(multi_output=True)
     sys_block_queue_max_segment_size = RegistryPoint(multi_output=True)
     sys_fs_cgroup_memory_tasks_number = RegistryPoint()  # No need to clean
     sys_fs_cgroup_uniq_memory_swappiness = RegistryPoint()  # No need to clean

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -887,6 +887,7 @@ class DefaultSpecs(Specs):
         ]
     )
     sys_block_queue_stable_writes = glob_file("/sys/block/*/queue/stable_writes")
+    sys_block_queue_discard_max_bytes = glob_file("/sys/block/*/queue/discard_max_bytes")
     sys_block_queue_max_segment_size = glob_file("/sys/block/*/queue/max_segment_size")
     sys_fs_cgroup_memory_tasks_number = sys_fs_cgroup_memory.tasks_number
     sys_fs_cgroup_uniq_memory_swappiness = sys_fs_cgroup_memory.uniq_memory_swappiness

--- a/insights/tests/parsers/test_sys_block.py
+++ b/insights/tests/parsers/test_sys_block.py
@@ -20,9 +20,15 @@ MAX_SEGMENT_SIZE = """
 4294967295
 """.strip()
 
+DISCARD_MAX_BYTES = """
+0
+""".strip()
+
 FILE_PATH_SDA = "/sys/block/sda/queue/scheduler"
 MAX_SEGMENT_SIZE_PATH_SDA = "/sys/block/sda/queue/max_segment_size"
 SPECIAL_DEVICE_PATH = "/sys/block/sd@!$/queue/max_segment_size"
+DISCARD_MAX_BYTES_PATH_SDA = "/sys/block/sda/queue/discard_max_bytes"
+SPECIAL_DEVICE_PATH_DISCARD_MAX_BYTES = "/sys/block/sd@!$/queue/discard_max_bytes"
 
 
 def test_stable_writes():
@@ -61,10 +67,31 @@ def test_invalid_max_segment_size():
     assert "Error: " in str(e)
 
 
+def test_discard_max_bytes():
+    res = sys_block.DiscardMaxBytes(context_wrap(DISCARD_MAX_BYTES, DISCARD_MAX_BYTES_PATH_SDA))
+    assert res.discard_max_bytes == 0
+    assert res.device == 'sda'
+
+    res_special = sys_block.DiscardMaxBytes(context_wrap(DISCARD_MAX_BYTES, SPECIAL_DEVICE_PATH_DISCARD_MAX_BYTES))
+    assert res_special.discard_max_bytes == 0
+    assert res_special.device == 'sd@!$'
+
+
+def test_invalid_discard_max_bytes():
+    with pytest.raises(ParseException) as e:
+        sys_block.DiscardMaxBytes(context_wrap(CONTENT_INVALID, DISCARD_MAX_BYTES_PATH_SDA))
+    assert "Error: " in str(e)
+
+    with pytest.raises(ParseException) as e:
+        sys_block.DiscardMaxBytes(context_wrap(CONTENT_EMPTY))
+    assert "Error: " in str(e)
+
+
 def test_stable_writes_doc_examples():
     env = {
         'block_stable_writes': sys_block.StableWrites(context_wrap(STABLE_WRITES, FILE_PATH_SDA)),
         'max_segment_size': sys_block.MaxSegmentSize(context_wrap(MAX_SEGMENT_SIZE, MAX_SEGMENT_SIZE_PATH_SDA)),
+        'discard_max_bytes': sys_block.DiscardMaxBytes(context_wrap(DISCARD_MAX_BYTES, DISCARD_MAX_BYTES_PATH_SDA)),
     }
     failed, total = doctest.testmod(sys_block, globs=env)
     assert failed == 0


### PR DESCRIPTION
Signed-off-by: Xinting Li <xintli@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
RHINENG-25469

Add new spec sys_block_queue_discard_max_bytes and new parser DiscardMaxBytes

## Summary by Sourcery

Introduce parsing and collection support for block device discard_max_bytes queue settings.

New Features:
- Add DiscardMaxBytes parser for /sys/block/*/queue/discard_max_bytes exposing discard_max_bytes and device attributes.
- Register a new sys_block_queue_discard_max_bytes spec that globs discard_max_bytes files for all block devices.

Tests:
- Extend sys_block parser tests and doctest environment to cover the new DiscardMaxBytes parser, including error handling for invalid and empty content.