### PR TITLE
fix: add retry for fetching tailoring file

### DIFF
--- a/insights/specs/datasources/compliance/__init__.py
+++ b/insights/specs/datasources/compliance/__init__.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import tempfile
+import time
 
 from glob import glob
 from logging import getLogger
@@ -21,6 +22,8 @@ SCAP_DATASTREAMS_PATH = '/usr/share/xml/scap/'
 SSG_PACKAGE = 'scap-security-guide'
 REQUIRED_PACKAGES = [SSG_PACKAGE, 'openscap-scanner', 'openscap']
 OOM_ERROR_LINK = 'https://access.redhat.com/articles/6999111'
+TAILORING_FETCH_ATTEMPTS = 3
+TAILORING_FETCH_RETRY_DELAY_SEC = 10
 
 # SSG versions that need the <version> in XML repaired
 VERSIONS_FOR_REPAIR = '0.1.18 0.1.19 0.1.21 0.1.25'.split()
@@ -50,28 +53,45 @@ class ComplianceClient:
                 policy['ref_id']
             )
         )
-        response = self.conn.session.get(
-            "{0}/compliance/v2/policies/{1}/tailorings/{2}/tailoring_file".format(
-                self.conn.base_url, policy['id'], self.os_minor
-            )
+        url = "{0}/compliance/v2/policies/{1}/tailorings/{2}/tailoring_file".format(
+            self.conn.base_url, policy['id'], self.os_minor
         )
-        logger.debug("Response code: {0}".format(response.status_code))
-
-        if response.status_code == 204:
+        response = None
+        for attempt in range(1, TAILORING_FETCH_ATTEMPTS + 1):
+            response = self.conn.session.get(url)
             logger.debug(
-                "Policy {0} is not tailored, continuing with default rule and value selections...".format(
-                    policy['ref_id']
+                "Response code: {0} (attempt {1}/{2})".format(
+                    response.status_code, attempt, TAILORING_FETCH_ATTEMPTS
                 )
             )
-            return None
 
-        if not response.ok:
-            logger.debug(
-                "Something went wrong during downloading the tailoring file of {0}. The expected status code is 200, got {1}".format(
-                    policy['ref_id'], response.status_code
+            if response.status_code == 204:
+                logger.debug(
+                    "Policy {0} is not tailored, continuing with default rule and value selections...".format(
+                        policy['ref_id']
+                    )
+                )
+                return None
+
+            if 200 <= response.status_code < 300:
+                break
+
+            logger.warning(
+                "Something went wrong during downloading the tailoring file of {0}. "
+                "The expected status code is 200, got {1} (attempt {2} of {3}).".format(
+                    policy['ref_id'], response.status_code, attempt, TAILORING_FETCH_ATTEMPTS
                 )
             )
-            return None
+            if attempt < TAILORING_FETCH_ATTEMPTS:
+                time.sleep(TAILORING_FETCH_RETRY_DELAY_SEC)
+        else:
+            logger.error(
+                "Failed to download tailoring file for policy {0} after {1} attempts (last HTTP status {2}). "
+                "Refusing to run the scan without a definitive tailoring response from the service.".format(
+                    policy['ref_id'], TAILORING_FETCH_ATTEMPTS, response.status_code
+                )
+            )
+            exit(constants.sig_kill_bad)
 
         if response.content is None or response.headers['Content-Type'] != "application/xml":
             logger.debug(response.content)

--- a/insights/tests/datasources/compliance/test_compliance.py
+++ b/insights/tests/datasources/compliance/test_compliance.py
@@ -239,19 +239,23 @@ def test_tailored_file_is_downloaded_if_needed(config, call):
     )
 
 
+@patch("insights.specs.datasources.compliance.time.sleep")
 @patch("insights.specs.datasources.compliance.open", new_callable=mock_open)
 @patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
-def test_tailored_file_fails_to_download(config, call):
+def test_tailored_file_fails_to_download(config, call, sleep_mock):
     compliance_client = ComplianceClient(config=config)
-    compliance_client.conn.session.get = Mock(
-        return_value=Mock(
-            status_code=403,
-            ok=False,
-            headers={"Content-Type": "application/xml"},
-            json=Mock(return_value={'data': []}),
-        )
+    bad_response = Mock(
+        status_code=403,
+        ok=False,
+        headers={"Content-Type": "application/xml"},
+        json=Mock(return_value={'data': []}),
     )
-    assert compliance_client.download_tailoring_file({'id': 'foo', 'ref_id': 'aaaaa'}) is None
+    compliance_client.conn.session.get = Mock(return_value=bad_response)
+    with raises(SystemExit) as exc:
+        compliance_client.download_tailoring_file({'id': 'foo', 'ref_id': 'aaaaa'})
+    assert exc.value.code == constants.sig_kill_bad
+    assert compliance_client.conn.session.get.call_count == 3
+    assert sleep_mock.call_count == 2
 
     compliance_client.conn.session.get = Mock(
         return_value=Mock(
@@ -271,6 +275,26 @@ def test_tailored_file_fails_to_download(config, call):
         )
     )
     assert compliance_client.download_tailoring_file({'id': 'foo', 'ref_id': 'aaaaa'}) is None
+
+
+@patch("insights.specs.datasources.compliance.time.sleep")
+@patch("insights.specs.datasources.compliance.open", new_callable=mock_open)
+@patch("insights.client.config.InsightsConfig", base_url='localhost.com/app')
+def test_tailoring_file_retries_transient_errors_then_succeeds(config, mock_open_file, sleep_mock):
+    compliance_client = ComplianceClient(os_version=['6', '5'], config=config)
+    fail = Mock(status_code=504, ok=False, headers={})
+    ok_response = Mock(
+        status_code=200,
+        content=b"<Tailoring/>",
+        headers={"Content-Type": "application/xml"},
+    )
+    compliance_client.conn.session.get = Mock(side_effect=[fail, fail, ok_response])
+    path = compliance_client.download_tailoring_file(
+        {'id': 'foo', 'ref_id': 'aaaaa', 'os_minor_version': '5'}
+    )
+    assert 'oscap_tailoring_file-aaaaa' in path
+    assert compliance_client.conn.session.get.call_count == 3
+    assert sleep_mock.call_count == 2
 
 
 @patch("insights.specs.datasources.compliance.open", new_callable=mock_open)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Add retry logic and stricter failure handling when downloading compliance tailoring files, and extend tests to cover retry behavior and failure scenarios.

Bug Fixes:
- Retry fetching compliance tailoring files on transient HTTP failures instead of immediately proceeding without them.
- Treat repeated tailoring download failures as fatal and abort the scan when no definitive tailoring response is obtained.

Tests:
- Extend compliance tailoring download tests to cover retry attempts, fatal failure exits, and successful recovery after transient errors.