### PR TITLE
feat: Add new datasource spec azure_instance_compute_metadata (#4772)

### DIFF
--- a/insights/parsers/azure_instance.py
+++ b/insights/parsers/azure_instance.py
@@ -13,8 +13,12 @@ AzureInstanceType - 'vmSize' of Azure Instance
 AzureInstancePlan - 'plan' of Azure Instance
 --------------------------------------------
 
+AzureInstanceComputeMetadata - 'compute' metadata of Azure Instance
+--------------------------------------------------------------------
+
 AzurePublicIpv4Addresses - list of public IPv4 addresses
 --------------------------------------------------------
+
 """
 
 import json
@@ -22,9 +26,18 @@ import json
 from uuid import UUID
 
 from insights.core import CommandParser
+from insights.core import JSONParser
 from insights.core.exceptions import ParseException, SkipComponent
+from insights.core.filters import add_filter
 from insights.core.plugins import parser
 from insights.specs import Specs
+from insights.util import deprecated
+
+# TODO: Need to migrate the `add_filter` to filter-requester.
+# Note. Please pay attention to the sensitive data when adding new fields to the filter.
+add_filter(
+    Specs.azure_instance_compute_metadata, ['licenseType', 'vmSize', 'vmId', 'plan', 'offer']
+)
 
 
 def validate_content(content):
@@ -54,6 +67,14 @@ class AzureInstanceID(CommandParser):
         >>> azure_id.id
         'f904ece8-c6c1-4b5c-881f-309b50f25e50'
     """
+
+    def __init__(self, *args, **kwargs):
+        deprecated(
+            AzureInstanceID,
+            "Please use the :py:class:`AzureInstanceComputeMetadata` instead.",
+            "3.9.0",
+        )
+        super(AzureInstanceID, self).__init__(*args, **kwargs)
 
     def parse_content(self, content):
         validate_content(content)
@@ -107,6 +128,14 @@ class AzureInstanceType(CommandParser):
         >>> azure_type.raw
         'Standard_L64s_v2'
     """
+
+    def __init__(self, *args, **kwargs):
+        deprecated(
+            AzureInstanceType,
+            "Please use the :py:class:`AzureInstanceComputeMetadata` instead.",
+            "3.9.0",
+        )
+        super(AzureInstanceType, self).__init__(*args, **kwargs)
 
     def parse_content(self, content):
         validate_content(content)
@@ -164,6 +193,14 @@ class AzureInstancePlan(CommandParser):
         True
     """
 
+    def __init__(self, *args, **kwargs):
+        deprecated(
+            AzureInstancePlan,
+            "Please use the :py:class:`AzureInstanceComputeMetadata` instead.",
+            "3.9.0",
+        )
+        super(AzureInstancePlan, self).__init__(*args, **kwargs)
+
     def parse_content(self, content):
         validate_content(content)
 
@@ -181,6 +218,46 @@ class AzureInstancePlan(CommandParser):
         return "<azure_plan_name: {n}, product: {pr}, publisher: {pu}, raw: {r}".format(
             n=self.name, pr=self.product, pu=self.publisher, r=self.raw
         )
+
+
+@parser(Specs.azure_instance_compute_metadata)
+class AzureInstanceComputeMetadata(JSONParser):
+    """
+    Class for parsing the Azure Instance compute metadata returned by the
+    ``azure_instance_compute_metadata`` datasource.
+
+    The datasource collects filtered fields from the Azure Instance Metadata Service endpoint:
+    ``http://169.254.169.254/metadata/instance/compute?api-version=2021-12-13&format=json``
+
+    This parser extends JSONParser and provides dictionary-style access to the filtered metadata
+    fields. Available fields depend on the configured filters. More fields would be included
+    according to the custom filters. For example:
+    - ``fieldKey1`` - Field value 1
+    - ``fieldKey2`` - Field value 2
+
+    Typical content of the filtered JSON data::
+
+        {
+            "fieldKey1": "Field value 1",
+            "fieldKey2": "Field value 2"
+        }
+
+    Raises:
+        SkipComponent: When content is empty, curl error occurs, or no filters defined.
+
+    Examples:
+        >>> azure_instance_compute_metadata['licenseType']
+        ''
+        >>> azure_instance_compute_metadata['vmId']
+        '3c29e210-0669-496f-812a-2fffffffffff'
+        >>> azure_instance_compute_metadata['plan']
+        {'name': '', 'product': 'planProduct', 'publisher': ''}
+        >>> azure_instance_compute_metadata['plan']['product']
+        'planProduct'
+    """
+
+    def __repr__(self):
+        return "<azure_instance_compute_metadata: vmId:{id}>".format(id=self.data.get("vmId"))
 
 
 @parser(Specs.azure_load_balancer)

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -45,6 +45,9 @@ class Specs(SpecSet):
     awx_manage_check_license_data = RegistryPoint(filterable=True)
     awx_manage_print_settings = RegistryPoint()
     azure_instance_id = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
+    azure_instance_compute_metadata = RegistryPoint(
+        filterable=True, no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac']
+    )
     azure_instance_plan = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     azure_instance_type = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     azure_load_balancer = RegistryPoint()

--- a/insights/specs/datasources/azure.py
+++ b/insights/specs/datasources/azure.py
@@ -1,0 +1,74 @@
+"""
+Custom datasources for azure information
+"""
+
+import json
+
+from insights.components.cloud_provider import IsAzure
+from insights.core.context import HostContext
+from insights.core.exceptions import SkipComponent
+from insights.core.filters import get_filters
+from insights.core.plugins import datasource
+from insights.core.spec_factory import DatasourceProvider, simple_command
+from insights.specs import Specs
+
+
+class LocalSpecs(Specs):
+    """Local specs used only by azure datasources"""
+
+    azure_instance_compute_metadata_raw = simple_command(
+        "/usr/bin/curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute?api-version=2021-12-13&format=json --connect-timeout 5",
+        deps=[IsAzure],
+    )
+    """ Returns the Azure instance compute metadata from Azure Instance Metadata Service """
+
+
+@datasource(LocalSpecs.azure_instance_compute_metadata_raw, HostContext)
+def azure_instance_compute_metadata(broker):
+    """
+    This datasource provides Azure instance compute metadata from the Azure Instance Metadata Service.
+
+    .. note::
+        This datasource filters the full compute metadata JSON to include only the fields
+        specified in the filters. The filters are added to the
+        :mod:`insights.specs.Specs.azure_instance_compute_metadata` Spec.
+
+    Typical content returned by the Azure Instance Metadata Service::
+
+        {"licenseType": "", "plan": {"name": "", "product": "", "publisher": ""}, "tagsList": [], "vmId": "3c29e210-0669-496f-812a-2fffffffffff", ...}
+
+    Returns:
+        DatasourceProvider: JSON string containing only the filtered fields from Azure compute metadata.
+
+    Raises:
+        SkipComponent: When content is empty, curl error occurs, no filters defined,
+                       invalid JSON format, JSON parsing fails, or no matching filters found.
+    """
+
+    filters = get_filters(Specs.azure_instance_compute_metadata)
+    if not filters:
+        raise SkipComponent("No filters defined")
+
+    raw_content = broker[LocalSpecs.azure_instance_compute_metadata_raw].content
+    if not raw_content or 'curl: ' in raw_content[0]:
+        raise SkipComponent("Empty content or curl error")
+
+    try:
+        content = json.loads(raw_content[0])
+    except Exception as e:
+        raise SkipComponent("Failed to parse metadata: {0}".format(e))
+
+    if not isinstance(content, dict):
+        raise SkipComponent("Invalid JSON format")
+
+    result = {key: content[key] for key in filters if key in content}
+    if not result:
+        raise SkipComponent("No matching filters found in metadata")
+
+    return DatasourceProvider(
+        content=json.dumps(result, sort_keys=True),
+        relative_path='insights_datasources/azure_instance_compute_metadata',
+        ds=Specs.azure_instance_compute_metadata,
+        ctx=broker.get(HostContext),
+        cleaner=broker.get("cleaner"),
+    )

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -46,6 +46,7 @@ from insights.specs import Specs
 from insights.specs.datasources import (
     aws,
     awx_manage,
+    azure,
     client_metadata,
     cloud_init,
     corosync as corosync_ds,
@@ -167,6 +168,7 @@ class DefaultSpecs(Specs):
         "/usr/bin/curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/vmId?api-version=2021-12-13&format=text --connect-timeout 5",
         deps=[IsAzure],
     )
+    azure_instance_compute_metadata = azure.azure_instance_compute_metadata
     azure_instance_plan = simple_command(
         "/usr/bin/curl -s -H Metadata:true http://169.254.169.254/metadata/instance/compute/plan?api-version=2021-12-13&format=json --connect-timeout 5",
         deps=[IsAzure],
@@ -931,11 +933,13 @@ class DefaultSpecs(Specs):
         ]
     )  # XML
     teamdctl_config_dump = foreach_execute(
-        ethernet.team_interfaces, "/usr/bin/teamdctl %s config dump",
+        ethernet.team_interfaces,
+        "/usr/bin/teamdctl %s config dump",
         deps=[SELinuxDisabled],
     )  # RHEL-150529
     teamdctl_state_dump = foreach_execute(
-        ethernet.team_interfaces, "/usr/bin/teamdctl %s state dump",
+        ethernet.team_interfaces,
+        "/usr/bin/teamdctl %s state dump",
         deps=[SELinuxDisabled],
     )  # RHEL-150529
     testparm_s = simple_command("/usr/bin/testparm -s")

--- a/insights/tests/datasources/test_azure.py
+++ b/insights/tests/datasources/test_azure.py
@@ -1,0 +1,121 @@
+import json
+import pytest
+
+from collections import defaultdict
+from unittest.mock import Mock
+
+from insights.core import filters
+from insights.core.exceptions import SkipComponent
+from insights.core.spec_factory import DatasourceProvider
+from insights.specs import Specs
+from insights.specs.datasources.azure import LocalSpecs, azure_instance_compute_metadata
+
+AZURE_INSTANCE_COMPUTE_METADATA = """
+{"licenseType": "", "offer": "RHEL", "plan": {"name": "", "product": "", "publisher": ""}, "tagsList": [], "vmId": "3c29e210-0669-496f-812a-2fffffffffff", "vmSize": "Standard_B1s"}
+""".strip()
+
+AZURE_INSTANCE_COMPUTE_METADATA_AB_CURL = """
+curl: (7) Failed to connect to 169.254.169.254 port 80: Connection timed out
+""".strip()
+
+AZURE_INSTANCE_COMPUTE_METADATA_AB_JSON = """
+"some string"
+""".strip()
+
+AZURE_INSTANCE_COMPUTE_METADATA_AB_UNPARSABLE = """
+"keyA": "", "KeyB": "RHEL"}
+""".strip()
+
+AZURE_INSTANCE_COMPUTE_METADATA_MISMATCH = """
+{"keyA": "", "KeyB": "RHEL"}
+""".strip()
+
+AZURE_INSTANCE_COMPUTE_METADATA_FILTERED_JSON = {
+    "licenseType": "",
+    "offer": "RHEL",
+    "plan": {"name": "", "product": "", "publisher": ""},
+    "vmId": "3c29e210-0669-496f-812a-2fffffffffff",
+    "vmSize": "Standard_B1s",
+}
+
+RELATIVE_PATH = 'insights_datasources/azure_instance_compute_metadata'
+
+
+def setup_function(func):
+    if (
+        func is test_azure_instance_compute_metadata_datasource
+        or func is test_azure_instance_compute_metadata_datasource_abnormal_output
+    ):
+        filters.add_filter(
+            Specs.azure_instance_compute_metadata,
+            ["vmSize", "vmId", "plan", "offer", "licenseType", "someRandomKey"],
+        )
+    if func is test_azure_instance_compute_metadata_datasource_no_filter:
+        filters.add_filter(Specs.azure_instance_compute_metadata, [])
+
+
+def teardown_function(func):
+    filters._CACHE = {}
+    filters.FILTERS = defaultdict(dict)
+
+
+def test_azure_instance_compute_metadata_datasource():
+    azure_instance_compute_metadata_data = Mock()
+    azure_instance_compute_metadata_data.content = AZURE_INSTANCE_COMPUTE_METADATA.splitlines()
+    broker = {LocalSpecs.azure_instance_compute_metadata_raw: azure_instance_compute_metadata_data}
+    result = azure_instance_compute_metadata(broker)
+    assert result is not None
+    assert isinstance(result, DatasourceProvider)
+    expected = DatasourceProvider(
+        content=json.dumps(AZURE_INSTANCE_COMPUTE_METADATA_FILTERED_JSON, sort_keys=True),
+        relative_path=RELATIVE_PATH,
+    )
+    assert result.content == expected.content
+    assert result.relative_path == expected.relative_path
+
+
+def test_azure_instance_compute_metadata_datasource_no_filter():
+    azure_instance_compute_metadata_data = Mock()
+    azure_instance_compute_metadata_data.content = AZURE_INSTANCE_COMPUTE_METADATA.splitlines()
+    broker = {LocalSpecs.azure_instance_compute_metadata_raw: azure_instance_compute_metadata_data}
+    with pytest.raises(SkipComponent) as e:
+        azure_instance_compute_metadata(broker)
+    assert 'No filters defined' in str(e)
+
+
+def test_azure_instance_compute_metadata_datasource_abnormal_output():
+    azure_instance_compute_metadata_data = Mock()
+    azure_instance_compute_metadata_data.content = (
+        AZURE_INSTANCE_COMPUTE_METADATA_AB_CURL.splitlines()
+    )
+    broker = {LocalSpecs.azure_instance_compute_metadata_raw: azure_instance_compute_metadata_data}
+    with pytest.raises(SkipComponent) as e:
+        azure_instance_compute_metadata(broker)
+    assert 'Empty content or curl error' in str(e)
+
+    azure_instance_compute_metadata_data = Mock()
+    azure_instance_compute_metadata_data.content = (
+        AZURE_INSTANCE_COMPUTE_METADATA_AB_JSON.splitlines()
+    )
+    broker = {LocalSpecs.azure_instance_compute_metadata_raw: azure_instance_compute_metadata_data}
+    with pytest.raises(SkipComponent) as e:
+        azure_instance_compute_metadata(broker)
+    assert 'Invalid JSON format' in str(e)
+
+    azure_instance_compute_metadata_data = Mock()
+    azure_instance_compute_metadata_data.content = (
+        AZURE_INSTANCE_COMPUTE_METADATA_MISMATCH.splitlines()
+    )
+    broker = {LocalSpecs.azure_instance_compute_metadata_raw: azure_instance_compute_metadata_data}
+    with pytest.raises(SkipComponent) as e:
+        azure_instance_compute_metadata(broker)
+    assert 'No matching filters found in metadata' in str(e)
+
+    azure_instance_compute_metadata_data = Mock()
+    azure_instance_compute_metadata_data.content = (
+        AZURE_INSTANCE_COMPUTE_METADATA_AB_UNPARSABLE.splitlines()
+    )
+    broker = {LocalSpecs.azure_instance_compute_metadata_raw: azure_instance_compute_metadata_data}
+    with pytest.raises(SkipComponent) as e:
+        azure_instance_compute_metadata(broker)
+    assert 'Failed to parse metadata' in str(e)

--- a/insights/tests/filters.yaml
+++ b/insights/tests/filters.yaml
@@ -6,6 +6,8 @@ insights.specs.Specs.audit_log:
   type=AVC: 10
 insights.specs.Specs.awx_manage_check_license_data:
   product_name: 10
+insights.specs.Specs.azure_instance_compute_metadata:
+  offer: 1
 insights.specs.Specs.candlepin_error_log:
   WARNING: 1
 insights.specs.Specs.candlepin_log:

--- a/insights/tests/parsers/test_azure_instance.py
+++ b/insights/tests/parsers/test_azure_instance.py
@@ -5,6 +5,7 @@ from insights.core.exceptions import ContentException, ParseException, SkipCompo
 from insights.parsers import azure_instance
 from insights.parsers.azure_instance import (
     AzureInstanceID,
+    AzureInstanceComputeMetadata,
     AzureInstancePlan,
     AzureInstanceType,
     AzurePublicIpv4Addresses,
@@ -74,6 +75,11 @@ curl: (7) couldn't connect to host
 """.strip()
 AZURE_PLAN_AB_3 = """
 curl: (28) connect() timed out!
+""".strip()
+
+# For AzureInstanceComputeMetadata
+AZURE_INSTANCE_COMPUTE_METADATA = """
+{"licenseType": "", "offer": "RHEL", "plan": {"name": "", "product": "planProduct", "publisher": ""}, "vmId": "3c29e210-0669-496f-812a-2fffffffffff", "vmSize": "Standard_B1s"}
 """.strip()
 
 # For AzurePublicIpv4Addresses and AzurePublicHostname
@@ -239,9 +245,33 @@ def test_azure_instance_plan():
     assert azure.raw == '{"name": "", "product": "", "publisher": ""}'
 
 
+# Test AzureInstanceComputeMetadata
+def test_azure_instance_compute_metadata_empty():
+    with pytest.raises(SkipComponent):
+        AzureInstanceComputeMetadata(context_wrap(""))
+
+
+def test_azure_instance_compute_metadata():
+    azure = AzureInstanceComputeMetadata(context_wrap(AZURE_INSTANCE_COMPUTE_METADATA))
+    assert "licenseType" in azure
+    assert azure["licenseType"] == ""
+    assert azure["vmSize"] == "Standard_B1s"
+    assert azure["vmId"] == "3c29e210-0669-496f-812a-2fffffffffff"
+    assert azure["plan"] == {"name": "", "product": "planProduct", "publisher": ""}
+    assert azure["plan"]["name"] == ""
+    assert azure["offer"] == "RHEL"
+    assert azure.get("offer") == "RHEL"
+    assert "someRandomKey" not in azure
+    assert azure.get("someRandomKey") is None
+    assert repr(azure) == "<azure_instance_compute_metadata: vmId:3c29e210-0669-496f-812a-2fffffffffff>"
+
+
 def test_doc_examples():
     env = {
         'azure_id': AzureInstanceID(context_wrap(AZURE_ID_1)),
+        'azure_instance_compute_metadata': AzureInstanceComputeMetadata(
+            context_wrap(AZURE_INSTANCE_COMPUTE_METADATA)
+        ),
         'azure_plan': AzureInstancePlan(context_wrap(AZURE_PLAN_DOC)),
         'azure_type': AzureInstanceType(context_wrap(AZURE_TYPE_DOC)),
     }


### PR DESCRIPTION
- Add a filterable datasource spec to filter on target fields of the output of azure instance metadata compute endpoint. Avoid seperate specs collection call to this same compute metadata for diff fields.
 - Deprecate seperate parsers: AzureInstanceID, AzureInstanceType and AzureInstancePlan

Signed-off-by: Xiaoxue Wang <xiaoxwan@redhat.com>

Co-authored-by: Xiaoxue Wang <xiaoxwan@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Introduce a filterable Azure instance compute metadata datasource and parser to consolidate access to Azure VM metadata while deprecating older field-specific parsers.

New Features:
- Add a JSON-based AzureInstanceComputeMetadata parser backed by a new filterable azure_instance_compute_metadata spec and datasource to expose selected Azure VM compute metadata fields.

Enhancements:
- Mark AzureInstanceID, AzureInstanceType, and AzureInstancePlan parsers as deprecated in favor of the consolidated compute metadata parser.
- Wire the new azure_instance_compute_metadata spec into the default specs and register default filters for commonly used fields.
- Add tests for the new Azure compute metadata datasource, parser, and filters, including handling of abnormal and error conditions.

Tests:
- Extend parser and datasource tests to validate filtered Azure compute metadata handling, error scenarios, and documentation examples.