### PR TITLE
fix(RHINENG-22265): Fix broken documentation links in code-comments

### DIFF
--- a/insights/cleaner/hostname.py
+++ b/insights/cleaner/hostname.py
@@ -20,7 +20,7 @@ class Hostname(object):
     .. note::
 
         Currently, only the system hostname will be obfuscated, see:
-        - https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-data-obfuscation#proc-obfuscating-hostname_insights-cg-obfuscation
+        - https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html/client_configuration_guide_for_red_hat_lightspeed_with_fedramp/client-data-obfuscation#proc-obfuscating-hostname
 
     """
 

--- a/insights/util/posix_regex.py
+++ b/insights/util/posix_regex.py
@@ -5,7 +5,7 @@ Utilities for POSIX Bracket Expressions
 
 Per the Insights Client Configuration Guide, the "POSIX Bracket Expressions",
 is also supported by the "file-content-redaction.yaml":
--  https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/client_configuration_guide_for_red_hat_insights/con-insights-client-data-redaction_insights-cg-data-redaction#proc-insights-client-cg-redact-pattern-keyword-yaml_insights-cg-data-redaction
+-  https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html/client_configuration_guide_for_red_hat_lightspeed_with_fedramp/client-data-redaction#proc-insights-client-cg-redact-pattern-keyword-yaml
 
 
 This module provides a method to convert the "POSIX Bracket Expressions" to


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

This PR updates documentation links that got broken after the Insights->Red Hat Lightspeed rebrand. The links are only within code comments.

## Summary by Sourcery

Documentation:
- Refresh code comment links to hostname obfuscation and POSIX bracket expression redaction documentation to use the current Red Hat Lightspeed URLs.