### PR TITLE
feat: add spec and parser for mdadm_detail_platform (RHINENG-27037)

### DIFF
--- a/insights/parsers/mdadm.py
+++ b/insights/parsers/mdadm.py
@@ -64,6 +64,7 @@ class MDAdmMetadata(CommandParser, dict):
         >>> mdadm["Events"]
         60
     """
+
     def parse_content(self, content):
         mdadm_dev = "/mdadm_-E_.dev."
         if mdadm_dev in self.file_path:
@@ -88,6 +89,7 @@ class MDAdmDetailDevice(dict):
     The md device's properties in <property name> : <property value> format
     will be stored seprately, and are accessable via <property name>.
     """
+
     def parse_device(self, content, device_start_index, table_start_index, index):
 
         self['device_name'] = content[device_start_index].split(':')[0]
@@ -235,3 +237,29 @@ class MDAdmDetail(CommandParser, list):
         # Empty prased data
         if len(self) < 1:
             raise SkipComponent('Empty parsed device')
+
+
+@parser(Specs.mdadm_detail_platform)
+class MDAdmDetailPlatform(CommandParser, dict):
+    """
+    Parser for output of ``mdadm --detail-platform``.
+
+    Sample output::
+
+        Platform : Intel(R) Rapid Storage Technology
+        Version : 14.8.0.2377
+        RAID Levels : raid0 raid1 raid10 raid5
+        Chunk Sizes : 4k 8k 16k 32k 64k 128k
+        2TB volumes : supported
+        2TB disks : supported
+        Max Disks : 7
+        Max Volumes : 2 per array, 4 per controller
+        I/O Controller : /sys/devices/pci0000:00/0000:00:1f.2 (SATA)
+        Port4 : /dev/sdd (ZDEEX7A8)
+    """
+
+    def parse_content(self, content):
+        if len(content) == 0:
+            raise SkipComponent("Empty content of command output")
+        for key, val in split_kv_pairs(content, split_on=':').items():
+            self[key] = val

--- a/insights/parsers/mdadm.py
+++ b/insights/parsers/mdadm.py
@@ -256,10 +256,26 @@ class MDAdmDetailPlatform(CommandParser, dict):
         Max Volumes : 2 per array, 4 per controller
         I/O Controller : /sys/devices/pci0000:00/0000:00:1f.2 (SATA)
         Port4 : /dev/sdd (ZDEEX7A8)
+
+    Examples:
+        >>> mdadm_plat["Platform"]
+        'Intel(R) Rapid Storage Technology'
+        >>> mdadm_plat["Version"]
+        '14.8.0.2377'
+        >>> mdadm_plat["Max Disks"]
+        '7'
+
+    Raises:
+        SkipComponent: When content is empty or no platform data is found.
     """
 
     def parse_content(self, content):
         if len(content) == 0:
             raise SkipComponent("Empty content of command output")
+
         for key, val in split_kv_pairs(content, split_on=':').items():
             self[key] = val
+
+        # If no data was parsed, skip
+        if len(self) == 0:
+            raise SkipComponent("No platform data found")

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -477,7 +477,7 @@ class Specs(SpecSet):
     md5chk_files = RegistryPoint(multi_output=True)
     mdadm_D = RegistryPoint()
     mdadm_E = RegistryPoint(multi_output=True)
-    mdadm_detail_platform = RegistryPoint()
+    mdadm_detail_platform = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     mdatp_managed = RegistryPoint()
     mdstat = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     meminfo = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -477,6 +477,7 @@ class Specs(SpecSet):
     md5chk_files = RegistryPoint(multi_output=True)
     mdadm_D = RegistryPoint()
     mdadm_E = RegistryPoint(multi_output=True)
+    mdadm_detail_platform = RegistryPoint()
     mdatp_managed = RegistryPoint()
     mdstat = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])
     meminfo = RegistryPoint(no_obfuscate=['hostname', 'ipv4', 'ipv6', 'mac'])

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -536,7 +536,7 @@ class DefaultSpecs(Specs):
     )
     md5chk_files = foreach_execute(md5chk.files, "/usr/bin/md5sum %s", keep_rc=True)
     mdadm_D = command_with_args("/usr/sbin/mdadm -D %s", mdadm.raid_devices, keep_rc=True)
-    mdadm_detail_platform = simple_command("/usr/sbin/mdadm --detail-platform", keep_rc=True)
+    mdadm_detail_platform = simple_command("/usr/sbin/mdadm --detail-platform")
     mdatp_managed = simple_file("/etc/opt/microsoft/mdatp/managed/mdatp_managed.json")
     mdstat = simple_file("/proc/mdstat")
     meminfo = first_file(["/proc/meminfo", "/meminfo"])

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -536,6 +536,7 @@ class DefaultSpecs(Specs):
     )
     md5chk_files = foreach_execute(md5chk.files, "/usr/bin/md5sum %s", keep_rc=True)
     mdadm_D = command_with_args("/usr/sbin/mdadm -D %s", mdadm.raid_devices, keep_rc=True)
+    mdadm_detail_platform = simple_command("/usr/sbin/mdadm --detail-platform", keep_rc=True)
     mdatp_managed = simple_file("/etc/opt/microsoft/mdatp/managed/mdatp_managed.json")
     mdstat = simple_file("/proc/mdstat")
     meminfo = first_file(["/proc/meminfo", "/meminfo"])

--- a/insights/specs/insights_archive.py
+++ b/insights/specs/insights_archive.py
@@ -219,6 +219,7 @@ class InsightsArchiveSpecs(Specs):
     max_uid = simple_file("insights_commands/awk_-F_if_3_max_max_3_END_print_max_.etc.passwd")
     md5chk_files = glob_file("insights_commands/md5sum_*")
     mdadm_D = simple_file("insights_commands/mdadm_-D_.dev.md")
+    mdadm_detail_platform = simple_file("insights_commands/mdadm_--detail-platform")
     mount = simple_file("insights_commands/mount")
     mokutil_sbstate = simple_file("insights_commands/mokutil_--sb-state")
     multicast_querier = simple_file(

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -168,7 +168,6 @@ class SosSpecs(Specs):
     manila_conf = first_file(["/var/lib/config-data/puppet-generated/manila/etc/manila/manila.conf", "/etc/manila/manila.conf"])
     mdadm_D = simple_file("sos_commands/md/mdadm_-D_.dev.md")
     mdadm_E = glob_file("sos_commands/md/mdadm_-E_*")
-    mdadm_detail_platform = simple_file("sos_commands/md/mdadm_--detail-platform")
     mistral_executor_log = simple_file("/var/log/mistral/executor.log")
     mlx4_port = glob_file("/sys/bus/pci/devices/*/mlx4_port[0-9]")
     modinfo_filtered_modules = simple_file("sos_commands/kernel/modinfo_ALL_MODULES")

--- a/insights/specs/sos_archive.py
+++ b/insights/specs/sos_archive.py
@@ -168,6 +168,7 @@ class SosSpecs(Specs):
     manila_conf = first_file(["/var/lib/config-data/puppet-generated/manila/etc/manila/manila.conf", "/etc/manila/manila.conf"])
     mdadm_D = simple_file("sos_commands/md/mdadm_-D_.dev.md")
     mdadm_E = glob_file("sos_commands/md/mdadm_-E_*")
+    mdadm_detail_platform = simple_file("sos_commands/md/mdadm_--detail-platform")
     mistral_executor_log = simple_file("/var/log/mistral/executor.log")
     mlx4_port = glob_file("/sys/bus/pci/devices/*/mlx4_port[0-9]")
     modinfo_filtered_modules = simple_file("sos_commands/kernel/modinfo_ALL_MODULES")

--- a/insights/tests/parsers/test_mdadm.py
+++ b/insights/tests/parsers/test_mdadm.py
@@ -1,5 +1,5 @@
 from insights.parsers import mdadm
-from insights.parsers.mdadm import MDAdmMetadata, MDAdmDetail
+from insights.parsers.mdadm import MDAdmMetadata, MDAdmDetail, MDAdmDetailPlatform
 from insights.core.exceptions import SkipComponent
 from insights.tests import context_wrap
 
@@ -380,6 +380,26 @@ def test_mdadm_d_exceptions():
                       MDADM_D_CONTENT_EMPTY_DATA_1,
                       MDADM_D_CONTENT_EMPTY_DATA_2])))
     assert 'Empty parsed device' in str(exc)
+
+
+MDADM_DETAIL_PLATFORM_CONTENT = """
+       Platform : Intel(R) Rapid Storage Technology
+        Version : 14.8.0.2377
+    RAID Levels : raid0 raid1 raid10 raid5
+    Chunk Sizes : 4k 8k 16k 32k 64k 128k
+      Max Disks : 7
+""".strip()
+
+
+def test_mdadm_detail_platform():
+    mdadm = MDAdmDetailPlatform(context_wrap(MDADM_DETAIL_PLATFORM_CONTENT))
+    assert mdadm["Platform"] == "Intel(R) Rapid Storage Technology"
+
+
+def test_mdadm_detail_platform_empty():
+    with pytest.raises(SkipComponent) as exc:
+        MDAdmDetailPlatform(context_wrap(""))
+    assert "Empty content of command output" in str(exc)
 
 
 def test_doc_examples():

--- a/insights/tests/parsers/test_mdadm.py
+++ b/insights/tests/parsers/test_mdadm.py
@@ -393,7 +393,12 @@ MDADM_DETAIL_PLATFORM_CONTENT = """
 
 def test_mdadm_detail_platform():
     mdadm = MDAdmDetailPlatform(context_wrap(MDADM_DETAIL_PLATFORM_CONTENT))
+
     assert mdadm["Platform"] == "Intel(R) Rapid Storage Technology"
+    assert mdadm["Version"] == "14.8.0.2377"
+    assert mdadm["RAID Levels"] == "raid0 raid1 raid10 raid5"
+    assert mdadm["Chunk Sizes"] == "4k 8k 16k 32k 64k 128k"
+    assert mdadm["Max Disks"] == "7"
 
 
 def test_mdadm_detail_platform_empty():
@@ -402,12 +407,21 @@ def test_mdadm_detail_platform_empty():
     assert "Empty content of command output" in str(exc)
 
 
+def test_mdadm_detail_platform_no_data():
+    # Test when content exists but no valid key-value pairs are found
+    invalid_content = "Some random output without proper format"
+    with pytest.raises(SkipComponent) as exc:
+        MDAdmDetailPlatform(context_wrap(invalid_content))
+    assert "No platform data found" in str(exc)
+
+
 def test_doc_examples():
     env = {
         'mdadm': MDAdmMetadata(context_wrap(
             MDADM_CONTENT, path='insights_commands/mdadm_-E_.dev.loop0'
         )),
-        'mdadm_d': MDAdmDetail(context_wrap('\n'.join([MDADM_D_CONTENT_MD2, MDADM_D_CONTENT_MD1])))
+        'mdadm_d': MDAdmDetail(context_wrap('\n'.join([MDADM_D_CONTENT_MD2, MDADM_D_CONTENT_MD1]))),
+        'mdadm_plat': MDAdmDetailPlatform(context_wrap(MDADM_DETAIL_PLATFORM_CONTENT))
     }
     failed, total = doctest.testmod(mdadm, globs=env)
     assert failed == 0


### PR DESCRIPTION
All Pull Requests:
Check all that apply:

[x ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
[x ] No Sensitive Data in this change?
 Is this PR to correct an issue?
[x ] Is this PR an enhancement?
Complete Description of Additions/Changes:
This PR adds support for collecting and parsing the output of:

mdadm --detail-platform

The command is required for RHINENG-27037 to identify systems that use Intel(R) Rapid Storage Technology.

Changes included:

- Added a new spec mdadm_detail_platform
- Added command collection for mdadm --detail-platform
- Added MDAdmDetailPlatform parser
- Added tests for the new parser
The parser stores the command output as key/value pairs for use by customers.
If the command returns no output, the parser skips processing by raising SkipComponent.

## Summary by Sourcery

Add support for collecting and parsing mdadm --detail-platform output into structured key/value data.

New Features:
- Introduce MDAdmDetailPlatform parser for mdadm --detail-platform output.
- Add mdadm_detail_platform spec and command collection for the new mdadm detail platform data.

Enhancements:
- Wire the new mdadm detail platform spec into default and archive specs for data collection.

Tests:
- Add unit tests covering normal, empty, and invalid mdadm --detail-platform output for the new parser.
- Extend doctest coverage to include mdadm detail platform parsing.