### PR TITLE
fix: prevent default plugins from blocking warning control (RHINENG-26113)

### DIFF
--- a/insights/client/connection.py
+++ b/insights/client/connection.py
@@ -9,7 +9,6 @@ import json
 import logging
 import platform
 import sys
-import warnings
 import errno
 # import io
 from tempfile import TemporaryFile
@@ -32,7 +31,6 @@ from insights import cleaner, package_info
 from insights.client.collection_rules import InsightsUploadConf
 from insights.util.canonical_facts import get_canonical_facts
 
-warnings.simplefilter('ignore')
 APP_NAME = constants.app_name
 NETWORK = constants.custom_network_log_level
 logger = logging.getLogger(__name__)

--- a/insights/tests/client/connection/test_warnings.py
+++ b/insights/tests/client/connection/test_warnings.py
@@ -16,5 +16,8 @@ def test_load_default_plugins_does_not_disable_warnings():
             DeprecationWarning,
         )
 
-    assert len(caught) == 1
-    assert issubclass(caught[0].category, DeprecationWarning)
+    dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert any(
+        "SampleCondition has been deprecated" in str(w.message)
+        for w in dep_warnings
+    )

--- a/insights/tests/client/connection/test_warnings.py
+++ b/insights/tests/client/connection/test_warnings.py
@@ -1,0 +1,20 @@
+import warnings
+
+from insights import load_default_plugins
+
+
+def test_load_default_plugins_does_not_disable_warnings():
+    """
+    Default plugins import insights.client.connection, which must not
+    globally suppress warnings.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        load_default_plugins()
+        warnings.warn(
+            "SampleCondition has been deprecated. Use AnotherCondition.",
+            DeprecationWarning,
+        )
+
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, DeprecationWarning)


### PR DESCRIPTION
fix: prevent default plugins from blocking warning control (RHINENG-26113)

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Default plugins import `insights.client.connection`, which previously called
`warnings.simplefilter('ignore')` at import time. That globally suppressed
warnings for the whole process, so applications could not use `PYTHONWARNINGS`
when running `insights run` with default plugins loaded.

**Changes**
- Remove `warnings.simplefilter('ignore')` from `insights/client/connection.py`
- Add unit test `insights/tests/client/connection/test_warnings.py`

urllib3 verbosity is still handled via logger level in the same file; only the global warning suppression was removed.

## Summary by Sourcery

Remove global warning suppression from the client connection module to allow applications to control Python warnings when default plugins are loaded.

Bug Fixes:
- Ensure loading default plugins no longer disables Python warnings globally, preserving PYTHONWARNINGS behavior.

Tests:
- Add a unit test verifying that loading default plugins does not suppress DeprecationWarning emissions.