### PR TITLE
feat: New spec "podman ps --all --no-trunc --size --format=json"

### DIFF
--- a/docs/shared_parsers_catalog/podman.rst
+++ b/docs/shared_parsers_catalog/podman.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.parsers.podman
+   :members:
+   :show-inheritance:

--- a/insights/parsers/podman.py
+++ b/insights/parsers/podman.py
@@ -1,0 +1,90 @@
+"""
+Parsers for podman
+==================
+
+This module contains the following parsers:
+
+PodmanPsAllJson - command ``podman ps --all --no-trunc --size --format=json``
+-----------------------------------------------------------------------------
+"""
+
+from insights import parser, JSONParser
+from insights.specs import Specs
+
+
+@parser(Specs.podman_ps_all_json)
+class PodmanPsAllJson(JSONParser):
+    """
+    Class for parsing the output of the ``podman ps --all --no-trunc --size --format=json`` command.
+
+    The output is a JSON array containing objects with container information.
+
+    Typical output of this command::
+
+        [
+            {
+                "AutoRemove": false,
+                "Command": [
+                    "/usr/sbin/httpd",
+                    "-DFOREGROUND"
+                ],
+                "Created": "2024-01-15T10:30:45.123456789-05:00",
+                "CreatedAt": "2024-01-15 10:30:45 -0500 EST",
+                "Exited": false,
+                "ExitedAt": -62135596800,
+                "ExitCode": 0,
+                "Id": "03e2861336a76e29155836113ff6560cb70780c32f95062642993b2b3d0fc216",
+                "Image": "rhel7_httpd",
+                "ImageID": "882ab98aae5394aebe91fe6d8a4297fa0387c3cfd421b2d892bddf218ac373b2",
+                "IsInfra": false,
+                "Labels": {
+                    "maintainer": "Red Hat"
+                },
+                "Mounts": [],
+                "Names": [
+                    "angry_saha"
+                ],
+                "Namespaces": {},
+                "Networks": [
+                    "podman"
+                ],
+                "Pid": 12345,
+                "Pod": "",
+                "PodName": "",
+                "Ports": [
+                    {
+                        "host_ip": "0.0.0.0",
+                        "container_port": 80,
+                        "host_port": 8080,
+                        "range": 1,
+                        "protocol": "tcp"
+                    }
+                ],
+                "Size": {
+                    "rootFsSize": 221554338,
+                    "rwSize": 0
+                },
+                "StartedAt": 1705330245,
+                "State": "running",
+                "Status": "Up 37 seconds"
+            }
+        ]
+
+    Attributes:
+        data (list): A list containing the parsed container information as dictionaries
+
+    Examples:
+        >>> type(podman_ps_json.data)
+        <class 'list'>
+        >>> len(podman_ps_json.data)
+        2
+        >>> podman_ps_json.data[0]["Id"]
+        '03e2861336a76e29155836113ff6560cb70780c32f95062642993b2b3d0fc216'
+        >>> podman_ps_json.data[0]["State"]
+        'running'
+        >>> podman_ps_json.data[0]["Names"]
+        ['angry_saha']
+        >>> podman_ps_json.data[0]["Image"]
+        'rhel7_httpd'
+    """
+    pass

--- a/insights/parsers/podman_list.py
+++ b/insights/parsers/podman_list.py
@@ -11,6 +11,7 @@ For more details, please refer to the
 """
 from insights import parser
 from insights.specs import Specs
+from insights.util import deprecated
 from insights.parsers.docker_list import DockerListContainers, DockerListImages
 
 
@@ -45,6 +46,10 @@ class PodmanListImages(DockerListImages):
 @parser(Specs.podman_list_containers)
 class PodmanListContainers(DockerListContainers):
     """
+    .. warning::
+        This class is deprecated and will be removed from 3.8.0.
+        Please use the :class:`insights.parsers.podman.PodmanPsAllJson` instead.
+
     Handle the list of podman containers using the
     `class:insights.parsers.docker_list.DockerListContainers` parser class.
 
@@ -67,4 +72,7 @@ class PodmanListContainers(DockerListContainers):
         >>> containers.containers['tender_rosalind']['STATUS']
         'Exited (137) 18 hours ago'
     """
-    pass
+
+    def __init__(self, *args, **kwargs):
+        deprecated(PodmanListContainers, "Please use the :class:`insights.parsers.podman.PodmanPsAllJson` instead.", "3.8.0")
+        super(PodmanListContainers, self).__init__(*args, **kwargs)

--- a/insights/parsers/podman_list.py
+++ b/insights/parsers/podman_list.py
@@ -47,7 +47,7 @@ class PodmanListImages(DockerListImages):
 class PodmanListContainers(DockerListContainers):
     """
     .. warning::
-        This class is deprecated and will be removed from 3.8.0.
+        This class is deprecated and will be removed from 3.9.0.
         Please use the :class:`insights.parsers.podman.PodmanPsAllJson` instead.
 
     Handle the list of podman containers using the

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -639,6 +639,7 @@ class Specs(SpecSet):
     pmrep_metrics = RegistryPoint()
     podman_list_containers = RegistryPoint()
     podman_list_images = RegistryPoint()
+    podman_ps_all_json = RegistryPoint()
     podman_system_info = RegistryPoint()
     postconf = RegistryPoint(filterable=True)
     postconf_builtin = RegistryPoint(filterable=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -671,6 +671,7 @@ class DefaultSpecs(Specs):
         "/usr/bin/pmrep -t 1s -T 1s network.interface.out.packets network.interface.collisions swap.pagesout mssql.memory_manager.stolen_server_memory mssql.memory_manager.total_server_memory -o csv"
     )
     podman_list_containers = simple_command("/usr/bin/podman ps --all --no-trunc")
+    podman_ps_all_json = simple_command("/usr/bin/podman ps --all --no-trunc --size --format=json")
     podman_system_info = simple_command("/usr/bin/podman system info --format=json")
     postconf = simple_command("/usr/sbin/postconf")
     postconf_builtin = simple_command("/usr/sbin/postconf -C builtin")

--- a/insights/tests/parsers/test_podman.py
+++ b/insights/tests/parsers/test_podman.py
@@ -1,0 +1,137 @@
+import doctest
+
+from insights.parsers import podman
+from insights.parsers.podman import PodmanPsAllJson
+from insights.tests import context_wrap
+
+
+PODMAN_PS_ALL_JSON = """
+[
+    {
+        "AutoRemove": false,
+        "Command": [
+            "/usr/sbin/httpd",
+            "-DFOREGROUND"
+        ],
+        "Created": "2024-01-15T10:30:45.123456789-05:00",
+        "CreatedAt": "2024-01-15 10:30:45 -0500 EST",
+        "Exited": false,
+        "ExitedAt": -62135596800,
+        "ExitCode": 0,
+        "Id": "03e2861336a76e29155836113ff6560cb70780c32f95062642993b2b3d0fc216",
+        "Image": "rhel7_httpd",
+        "ImageID": "882ab98aae5394aebe91fe6d8a4297fa0387c3cfd421b2d892bddf218ac373b2",
+        "IsInfra": false,
+        "Labels": {
+            "maintainer": "Red Hat"
+        },
+        "Mounts": [],
+        "Names": [
+            "angry_saha"
+        ],
+        "Namespaces": {},
+        "Networks": [
+            "podman"
+        ],
+        "Pid": 12345,
+        "Pod": "",
+        "PodName": "",
+        "Ports": [
+            {
+                "host_ip": "0.0.0.0",
+                "container_port": 80,
+                "host_port": 8080,
+                "range": 1,
+                "protocol": "tcp"
+            }
+        ],
+        "Size": null,
+        "StartedAt": 1705330245,
+        "State": "running",
+        "Status": "Up 37 seconds"
+    },
+    {
+        "AutoRemove": false,
+        "Command": [
+            "/bin/sh",
+            "-c",
+            "yum install -y vsftpd-2.2.2-6.el6"
+        ],
+        "Created": "2024-01-15T09:30:00.123456789-05:00",
+        "CreatedAt": "2024-01-15 09:30:00 -0500 EST",
+        "Exited": true,
+        "ExitedAt": 1705326600,
+        "ExitCode": 137,
+        "Id": "95516ea08b565e37e2a4bca3333af40a240c368131b77276da8dec629b7fe102",
+        "Image": "bd8638c869ea40a9269d87e9af6741574562af9ee013e03ac2745fb5f59e2478",
+        "ImageID": "bd8638c869ea40a9269d87e9af6741574562af9ee013e03ac2745fb5f59e2478",
+        "IsInfra": false,
+        "Labels": null,
+        "Mounts": [],
+        "Names": [
+            "tender_rosalind"
+        ],
+        "Namespaces": {},
+        "Networks": [],
+        "Pid": 0,
+        "Pod": "",
+        "PodName": "",
+        "Ports": [],
+        "Size": {
+            "rootFsSize": 221554338,
+            "rwSize": 0
+        },
+        "StartedAt": 1705326605,
+        "State": "exited",
+        "Status": "Exited (137) 18 hours ago"
+    }
+]
+""".strip()
+
+PODMAN_PS_JSON_EMPTY = """
+[]
+""".strip()
+
+
+def test_podman_ps_json():
+    result = PodmanPsAllJson(context_wrap(PODMAN_PS_ALL_JSON))
+    assert isinstance(result.data, list)
+    assert len(result.data) == 2
+
+    # Test first container
+    assert result.data[0]["Id"] == "03e2861336a76e29155836113ff6560cb70780c32f95062642993b2b3d0fc216"
+    assert result.data[0]["State"] == "running"
+    assert result.data[0]["Status"] == "Up 37 seconds"
+    assert result.data[0]["Image"] == "rhel7_httpd"
+    assert result.data[0]["Names"] == ["angry_saha"]
+    assert result.data[0]["Command"] == ["/usr/sbin/httpd", "-DFOREGROUND"]
+    assert result.data[0]["Pid"] == 12345
+    assert result.data[0]["ExitCode"] == 0
+    assert result.data[0]["Ports"][0]["host_port"] == 8080
+    assert result.data[0]["Ports"][0]["container_port"] == 80
+
+    # Test second container
+    assert result.data[1]["Id"] == "95516ea08b565e37e2a4bca3333af40a240c368131b77276da8dec629b7fe102"
+    assert result.data[1]["State"] == "exited"
+    assert result.data[1]["Status"] == "Exited (137) 18 hours ago"
+    assert result.data[1]["Names"] == ["tender_rosalind"]
+    assert result.data[1]["ExitCode"] == 137
+    assert result.data[1]["Pid"] == 0
+    assert result.data[1]["Ports"] == []
+    assert result.data[1]["Size"] == {
+        "rootFsSize": 221554338,
+        "rwSize": 0}
+
+
+def test_podman_ps_json_empty():
+    result = PodmanPsAllJson(context_wrap(PODMAN_PS_JSON_EMPTY))
+    assert isinstance(result.data, list)
+    assert len(result.data) == 0
+
+
+def test_podman_ps_json_documentation():
+    failed_count, _ = doctest.testmod(
+        podman,
+        globs={'podman_ps_json': PodmanPsAllJson(context_wrap(PODMAN_PS_ALL_JSON))}
+    )
+    assert failed_count == 0


### PR DESCRIPTION
This spec is added by Huanhuan Li <huali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
This PR is same with https://github.com/RedHatInsights/insights-core/pull/4760, created a new one to fix the commit signature issue.

## Summary by Sourcery

Add a new JSON-based podman container listing spec and parser while deprecating the legacy text-based podman container list parser.

New Features:
- Introduce the podman_ps_all_json spec for `podman ps --all --no-trunc --size --format=json` output.
- Add the PodmanPsAllJson parser to expose container details from the JSON-formatted podman ps output.

Enhancements:
- Deprecate PodmanListContainers in favor of the new PodmanPsAllJson parser and emit a deprecation warning on initialization.

Tests:
- Add unit and doctest-based tests to validate parsing of populated and empty JSON outputs from `podman ps --all --no-trunc --size --format=json`.