### PR TITLE
feat: exclude insights.client.apps module from rpm building

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,7 +8,8 @@ actions:
     - sed -i -e '/cachecontrol/d' -e '/defusedxml/d' -e '/jinja2/d' -e '/lockfile/d' -e '/redis/d' -e '/setuptools;/d' pyproject.toml setup.py
     - sed -i -e '/insights-.*=/d' -e '/mangle =/d' pyproject.toml setup.py
     - cp insights/tests/filters.yaml insights/filters.yaml
-    - cp MANIFEST.in.client MANIFEST.in
+    # build from the code in PR, exclude playbook_verifier, use test filters
+    - cp MANIFEST.in.rpm MANIFEST.in
   get-current-version:
     - awk '/^Version:/ {print $2;}' insights-core.spec
   create-archive:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+# Use to build sdist and wheel
 include insights/defaults.yaml
 include insights/NAME
 include insights/VERSION

--- a/MANIFEST.in.egg
+++ b/MANIFEST.in.egg
@@ -1,3 +1,5 @@
+# Use to build eggs
+graft insights/client
 include LICENSE
 include NOTICE
 include insights/COMMIT
@@ -8,7 +10,9 @@ include insights/compliance_obfuscations.yaml
 include insights/defaults.yaml
 include insights/filters.yaml
 include insights/revoked_playbooks.yaml
+prune examples
 prune insights/parsr/examples/tests
 prune insights/parsr/query/tests
 prune insights/parsr/tests
+prune insights/plugins
 prune insights/tests

--- a/MANIFEST.in.rpm
+++ b/MANIFEST.in.rpm
@@ -1,3 +1,4 @@
+# Use to build rpm packages
 graft insights/client
 include LICENSE
 include NOTICE
@@ -8,8 +9,9 @@ include insights/VERSION
 include insights/compliance_obfuscations.yaml
 include insights/defaults.yaml
 include insights/filters.yaml
-include insights/revoked_playbooks.yaml
+exclude insights/client/phase/v1.py
 prune examples
+prune insights/client/apps
 prune insights/parsr/examples/tests
 prune insights/parsr/query/tests
 prune insights/parsr/tests

--- a/MANIFEST.in.rpm_legacy
+++ b/MANIFEST.in.rpm_legacy
@@ -1,0 +1,18 @@
+# Use to build rpm packages for RHEL9.8.z and RHEL10.2.z
+graft insights/client
+include LICENSE
+include NOTICE
+include insights/COMMIT
+include insights/NAME
+include insights/RELEASE
+include insights/VERSION
+include insights/compliance_obfuscations.yaml
+include insights/defaults.yaml
+include insights/filters.yaml
+include insights/revoked_playbooks.yaml
+prune examples
+prune insights/parsr/examples/tests
+prune insights/parsr/query/tests
+prune insights/parsr/tests
+prune insights/plugins
+prune insights/tests

--- a/build_client_egg.sh
+++ b/build_client_egg.sh
@@ -17,7 +17,7 @@ fi
 
 rm -f insights.zip
 rm -rf insights_core.egg-info
-cp MANIFEST.in.client MANIFEST.in
+cp MANIFEST.in.egg MANIFEST.in
 # use the insights/tests/filters.yaml for testing
 if [ "$TARGET" == "testing" ]; then
     cp -f insights/tests/filters.yaml insights/filters.yaml

--- a/build_core_rpm.sh
+++ b/build_core_rpm.sh
@@ -19,28 +19,35 @@ if [[ "${PYTHON_VERSION%%.*}" != "3" ]]; then
 fi
 
 # Check build target
+
+# playbook-verifier will be excluded from rpm package by default
+MANIFEST="MANIFEST.in.rpm"
 if [ "$TARGET" == "internal" ]; then
     # backforward compatible with internal RPM building
     echo "Building insights-core RPM for internal usage."
     BUILDTARGET="for_internal 1"
-    MANIFEST="MANIFEST.in.core"
-elif [ "$TARGET" == "release" ] || [ "$TARGET" == "testing" ]; then
+elif [ "$TARGET" == "release" ] || [ "$TARGET" == "testing" ] || [ "$TARGET" == "legacy_release" ]; then
     if [ "$TARGET" == "release" ]; then
         # for RPM release
         echo "Building insights-core RPM for insights-client."
         BUILDTARGET="with_selinux 1"
+    elif [ "$TARGET" == "legacy_release" ]; then
+        # for RHEL10.2.z and RHEL9.8.z RPM release
+        echo "Building insights-core RPM for RHEL10.2.z or RHEL9.8.z."
+        BUILDTARGET="with_selinux 1"
+        # use rpm_legacy MANIFEST file
+        MANIFEST="MANIFEST.in.rpm_legacy"
     else
         # for RPM testing (PR Check)
         echo "Building insights-core RPM for testing with insights-client."
         BUILDTARGET="with_selinux 0"
     fi
-    MANIFEST="MANIFEST.in.client"
     # - remove depedencies for data processing
     sed -i -e '/cachecontrol/d' -e '/defusedxml/d' -e '/jinja2/d' -e '/lockfile/d' -e '/redis/d' -e '/setuptools;/d' pyproject.toml setup.py
     # - remove entrypoints for data processing
     sed -i -e '/insights-.*=/d' -e '/mangle =/d' pyproject.toml setup.py
 else
-    echo "Error: invalid build target: '$TARGET'. Use 'internal', 'release', or 'testing'"
+    echo "Error: invalid build target: '$TARGET'. Use 'internal', 'release', 'legacy_release', or 'testing'"
     exit 1
 fi
 


### PR DESCRIPTION
By default `insights.client.apps` module will not be included in the released rpm packages. To ensure compatibility with the released rpm packages for RHEL 10.2.z and RHEL 9.8.z, this patch has the capability to release rpm packages that contain insights.client.apps.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Introduce separate RPM and egg manifests to exclude insights.client.apps by default while preserving compatibility with legacy RHEL releases.

New Features:
- Add a legacy_release RPM build target to produce packages compatible with RHEL 10.2.z and RHEL 9.8.z.
- Introduce dedicated MANIFEST files for RPM and egg builds to control included modules, excluding playbook_verifier/insights.client.apps by default.

Build:
- Update build_core_rpm.sh to default to an RPM-specific MANIFEST and support the new legacy_release target.
- Adjust Packit configuration to use the RPM manifest during SRPM creation and testing builds.
- Change client egg build script to use an egg-specific MANIFEST instead of the client MANIFEST.