### PR TITLE
fix(Syslog): Add leap year handling issue to syslog parser

### DIFF
--- a/insights/core/__init__.py
+++ b/insights/core/__init__.py
@@ -1469,7 +1469,15 @@ class Syslog(LogFileOutput):
                 try:
                     datetime.datetime.strptime(logstamp, self.time_format)
                 except ValueError:
-                    return msg_info
+                    if '%y' not in self.time_format.lower():
+                        try:
+                            # strptime defaults to 1900 (not a leap year), so
+                            # "Feb 29" raises ValueError. Retry with a leap year.
+                            datetime.datetime.strptime("2000 " + logstamp, "%Y " + self.time_format)
+                        except ValueError:
+                            return msg_info
+                    else:
+                        return msg_info
                 msg_info['timestamp'] = logstamp
                 msg_info['hostname'] = info_splits[1]
                 msg_info['procname'] = info_splits[2]

--- a/insights/tests/test_syslog.py
+++ b/insights/tests/test_syslog.py
@@ -17,6 +17,35 @@ May 10 15:36:19 lxc-rhel68-sat56 yum[11954]: Updated: sos-3.2-40.el6.noarch
 """.strip()
 
 
+MSGINFO_FEB29 = """
+Feb 28 12:00:01 testhost CROND[1234]: (root) CMD (/usr/bin/test)
+Feb 29 09:15:42 testhost watchdog[5678]: shutting down the system because of error 1
+Feb 29 10:30:00 testhost sshd[9012]: Accepted publickey for user1
+Mar  1 08:00:01 testhost CROND[3456]: (root) CMD (/usr/bin/test)
+""".strip()
+
+
+def test_syslog_feb29():
+    """Feb 29 log lines must parse correctly despite strptime defaulting to 1900 (not a leap year)."""
+    msg_info = Syslog(context_wrap(MSGINFO_FEB29))
+    feb29_lines = msg_info.get('shutting down')
+    assert len(feb29_lines) == 1
+    assert feb29_lines[0].get('timestamp') == 'Feb 29 09:15:42'
+    assert feb29_lines[0].get('hostname') == 'testhost'
+    assert feb29_lines[0].get('procname') == 'watchdog[5678]'
+    assert feb29_lines[0].get('message') == 'shutting down the system because of error 1'
+
+    sshd_lines = msg_info.get('Accepted publickey')
+    assert len(sshd_lines) == 1
+    assert sshd_lines[0].get('timestamp') == 'Feb 29 10:30:00'
+    assert sshd_lines[0].get('procname') == 'sshd[9012]'
+
+    all_lines = msg_info.get('CMD')
+    assert len(all_lines) == 2
+    assert all_lines[0].get('timestamp') == 'Feb 28 12:00:01'
+    assert all_lines[1].get('timestamp') == 'Mar  1 08:00:01'
+
+
 def test_syslog():
     msg_info = Syslog(context_wrap(MSGINFO))
     bona_list = msg_info.get('(root) LIST (root)')


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] No Sensitive Data in this change?
* [X] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Fix syslog timestamp validation so leap-day entries are parsed correctly.

Bug Fixes:
- Handle February 29 timestamps when parsing syslog entries without a year.

Tests:
- Add coverage for parsing February 29 syslog entries and preserving their metadata.