### PR TITLE
feat(RHINENG-28024, RHINENG-28023): extend AnsibleInfo combiner with receptor, runner, eda-controller, and gateway packages

### DIFF
--- a/insights/combiners/ansible_info.py
+++ b/insights/combiners/ansible_info.py
@@ -3,6 +3,7 @@ Ansible Info
 ============
 Provide information about the Ansible packages installed on a system.
 """
+
 from insights.core.plugins import combiner
 from insights.parsers.installed_rpms import InstalledRpms
 
@@ -10,11 +11,19 @@ ANSIBLE_TOWER_PKG = "ansible-tower"
 ANSIBLE_AUTOMATION_HUB_PKG = "automation-hub"
 ANSIBLE_CATALOG_WORKER_PKG = "catalog-worker"
 ANSIBLE_AUTOMATION_CONTROLLER_PKG = "automation-controller"
+ANSIBLE_RECEPTOR_PKG = "receptor"
+ANSIBLE_RUNNER_PKG = "ansible-runner"
+ANSIBLE_EDA_CONTROLLER_PKG = "automation-eda-controller"
+ANSIBLE_AUTOMATION_GATEWAY_PKG = "automation-gateway"
 ANSIBLE_PACKAGES = [
     ANSIBLE_TOWER_PKG,
     ANSIBLE_AUTOMATION_HUB_PKG,
     ANSIBLE_CATALOG_WORKER_PKG,
     ANSIBLE_AUTOMATION_CONTROLLER_PKG,
+    ANSIBLE_RECEPTOR_PKG,
+    ANSIBLE_RUNNER_PKG,
+    ANSIBLE_EDA_CONTROLLER_PKG,
+    ANSIBLE_AUTOMATION_GATEWAY_PKG,
 ]
 
 
@@ -43,19 +52,26 @@ class AnsibleInfo(dict):
         True
         >>> info.controller_version
         '1.0.0'
+        >>> info.is_receptor
+        False
+        >>> info.receptor_version is None
+        True
     """
+
     def __init__(self, rpms):
-        pkg_versions = dict([(pkg, rpms.get_max(pkg)) for pkg in ANSIBLE_PACKAGES if rpms.get_max(pkg) is not None])
+        pkg_versions = dict(
+            [(pkg, rpms.get_max(pkg)) for pkg in ANSIBLE_PACKAGES if rpms.get_max(pkg) is not None]
+        )
         self.update(pkg_versions)
 
     @property
     def is_tower(self):
-        """ bool: Whether or not this system has ``ansible-tower`` installed """
+        """bool: Whether or not this system has ``ansible-tower`` installed"""
         return ANSIBLE_TOWER_PKG in self
 
     @property
     def tower_version(self):
-        """ str: Version of ansible-tower installed or ``None``"""
+        """str: Version of ansible-tower installed or ``None``"""
         return self[ANSIBLE_TOWER_PKG].version if ANSIBLE_TOWER_PKG in self else None
 
     @property
@@ -79,20 +95,70 @@ class AnsibleInfo(dict):
 
     @property
     def is_hub(self):
-        """ bool: Whether or not this system has ``automation-hub`` installed """
+        """bool: Whether or not this system has ``automation-hub`` installed"""
         return ANSIBLE_AUTOMATION_HUB_PKG in self
 
     @property
     def hub_version(self):
-        """ str: Version of automation-hub installed or ``None``"""
-        return self[ANSIBLE_AUTOMATION_HUB_PKG].version if ANSIBLE_AUTOMATION_HUB_PKG in self else None
+        """str: Version of automation-hub installed or ``None``"""
+        return (
+            self[ANSIBLE_AUTOMATION_HUB_PKG].version if ANSIBLE_AUTOMATION_HUB_PKG in self else None
+        )
 
     @property
     def is_catalog_worker(self):
-        """ bool: Whether or not this system has ``catalog-worker`` installed """
+        """bool: Whether or not this system has ``catalog-worker`` installed"""
         return ANSIBLE_CATALOG_WORKER_PKG in self
 
     @property
     def catalog_worker_version(self):
-        """ str: Version of catalog-worker installed or ``None``"""
-        return self[ANSIBLE_CATALOG_WORKER_PKG].version if ANSIBLE_CATALOG_WORKER_PKG in self else None
+        """str: Version of catalog-worker installed or ``None``"""
+        return (
+            self[ANSIBLE_CATALOG_WORKER_PKG].version if ANSIBLE_CATALOG_WORKER_PKG in self else None
+        )
+
+    @property
+    def is_receptor(self):
+        """bool: Whether or not this system has ``receptor`` installed"""
+        return ANSIBLE_RECEPTOR_PKG in self
+
+    @property
+    def receptor_version(self):
+        """str: Version of receptor installed or ``None``"""
+        return self[ANSIBLE_RECEPTOR_PKG].version if ANSIBLE_RECEPTOR_PKG in self else None
+
+    @property
+    def is_runner(self):
+        """bool: Whether or not this system has ``ansible-runner`` installed"""
+        return ANSIBLE_RUNNER_PKG in self
+
+    @property
+    def runner_version(self):
+        """str: Version of ansible-runner installed or ``None``"""
+        return self[ANSIBLE_RUNNER_PKG].version if ANSIBLE_RUNNER_PKG in self else None
+
+    @property
+    def is_eda_controller(self):
+        """bool: Whether or not this system has ``automation-eda-controller`` installed"""
+        return ANSIBLE_EDA_CONTROLLER_PKG in self
+
+    @property
+    def eda_controller_version(self):
+        """str: Version of automation-eda-controller installed or ``None``"""
+        return (
+            self[ANSIBLE_EDA_CONTROLLER_PKG].version if ANSIBLE_EDA_CONTROLLER_PKG in self else None
+        )
+
+    @property
+    def is_gateway(self):
+        """bool: Whether or not this system has ``automation-gateway`` installed"""
+        return ANSIBLE_AUTOMATION_GATEWAY_PKG in self
+
+    @property
+    def gateway_version(self):
+        """str: Version of automation-gateway installed or ``None``"""
+        return (
+            self[ANSIBLE_AUTOMATION_GATEWAY_PKG].version
+            if ANSIBLE_AUTOMATION_GATEWAY_PKG in self
+            else None
+        )

--- a/insights/tests/combiners/test_ansible_info.py
+++ b/insights/tests/combiners/test_ansible_info.py
@@ -1,8 +1,16 @@
 from insights.parsers.installed_rpms import InstalledRpms
 from insights.combiners import ansible_info
 from insights.combiners.ansible_info import (
-    AnsibleInfo, ANSIBLE_AUTOMATION_CONTROLLER_PKG, ANSIBLE_CATALOG_WORKER_PKG, ANSIBLE_TOWER_PKG,
-    ANSIBLE_AUTOMATION_HUB_PKG)
+    AnsibleInfo,
+    ANSIBLE_AUTOMATION_CONTROLLER_PKG,
+    ANSIBLE_CATALOG_WORKER_PKG,
+    ANSIBLE_TOWER_PKG,
+    ANSIBLE_AUTOMATION_HUB_PKG,
+    ANSIBLE_RECEPTOR_PKG,
+    ANSIBLE_RUNNER_PKG,
+    ANSIBLE_EDA_CONTROLLER_PKG,
+    ANSIBLE_AUTOMATION_GATEWAY_PKG,
+)
 from insights.tests import context_wrap
 import doctest
 
@@ -10,16 +18,29 @@ TOWER_RPM = ANSIBLE_TOWER_PKG + "-1.0.0-1"
 AUTO_CONTROLLER_RPM = ANSIBLE_AUTOMATION_CONTROLLER_PKG + "-1.0.1-1"
 CATALOG_WORKER_RPM = ANSIBLE_CATALOG_WORKER_PKG + "-1.0.2-1"
 HUB_RPM = ANSIBLE_AUTOMATION_HUB_PKG + "-1.0.3-1"
+RECEPTOR_RPM = ANSIBLE_RECEPTOR_PKG + "-1.6.6-1"
+RUNNER_RPM = ANSIBLE_RUNNER_PKG + "-2.4.2-3"
+EDA_CONTROLLER_RPM = ANSIBLE_EDA_CONTROLLER_PKG + "-1.2.3-1"
+GATEWAY_RPM = ANSIBLE_AUTOMATION_GATEWAY_PKG + "-2.5.20260422-3"
 ALL_RPMS = '''
 {controller}
 {cworker}
 {tower}
 {hub}
+{receptor}
+{runner}
+{eda_controller}
+{gateway}
 '''.format(
     controller=AUTO_CONTROLLER_RPM,
     cworker=CATALOG_WORKER_RPM,
     tower=TOWER_RPM,
-    hub=HUB_RPM).strip()
+    hub=HUB_RPM,
+    receptor=RECEPTOR_RPM,
+    runner=RUNNER_RPM,
+    eda_controller=EDA_CONTROLLER_RPM,
+    gateway=GATEWAY_RPM,
+).strip()
 
 
 def test_ansible_info_all():
@@ -38,6 +59,18 @@ def test_ansible_info_all():
     assert comb.is_catalog_worker
     assert comb.catalog_worker_version == '1.0.2'
     assert comb[ANSIBLE_CATALOG_WORKER_PKG].nvr == CATALOG_WORKER_RPM
+    assert comb.is_receptor
+    assert comb.receptor_version == '1.6.6'
+    assert comb[ANSIBLE_RECEPTOR_PKG].nvr == RECEPTOR_RPM
+    assert comb.is_runner
+    assert comb.runner_version == '2.4.2'
+    assert comb[ANSIBLE_RUNNER_PKG].nvr == RUNNER_RPM
+    assert comb.is_eda_controller
+    assert comb.eda_controller_version == '1.2.3'
+    assert comb[ANSIBLE_EDA_CONTROLLER_PKG].nvr == EDA_CONTROLLER_RPM
+    assert comb.is_gateway
+    assert comb.gateway_version == '2.5.20260422'
+    assert comb[ANSIBLE_AUTOMATION_GATEWAY_PKG].nvr == GATEWAY_RPM
 
 
 def test_ansible_info_tower():
@@ -51,6 +84,14 @@ def test_ansible_info_tower():
     assert comb.controller_version == '1.0.0'
     assert comb.hub_version is None
     assert comb.catalog_worker_version is None
+    assert not comb.is_receptor
+    assert not comb.is_runner
+    assert not comb.is_eda_controller
+    assert not comb.is_gateway
+    assert comb.receptor_version is None
+    assert comb.runner_version is None
+    assert comb.eda_controller_version is None
+    assert comb.gateway_version is None
 
 
 def test_ansible_info_auto_controller():
@@ -64,6 +105,98 @@ def test_ansible_info_auto_controller():
     assert comb.controller_version == '1.0.1'
     assert comb.hub_version is None
     assert comb.catalog_worker_version is None
+    assert not comb.is_receptor
+    assert not comb.is_runner
+    assert not comb.is_eda_controller
+    assert not comb.is_gateway
+    assert comb.receptor_version is None
+    assert comb.runner_version is None
+    assert comb.eda_controller_version is None
+    assert comb.gateway_version is None
+
+
+def test_ansible_info_receptor():
+    rpms = InstalledRpms(context_wrap(RECEPTOR_RPM))
+    comb = AnsibleInfo(rpms)
+    assert not comb.is_tower
+    assert not comb.is_controller
+    assert not comb.is_hub
+    assert not comb.is_catalog_worker
+    assert comb.is_receptor
+    assert not comb.is_runner
+    assert not comb.is_eda_controller
+    assert not comb.is_gateway
+    assert comb.receptor_version == '1.6.6'
+    assert comb.tower_version is None
+    assert comb.controller_version is None
+    assert comb.hub_version is None
+    assert comb.catalog_worker_version is None
+    assert comb.runner_version is None
+    assert comb.eda_controller_version is None
+    assert comb.gateway_version is None
+
+
+def test_ansible_info_runner():
+    rpms = InstalledRpms(context_wrap(RUNNER_RPM))
+    comb = AnsibleInfo(rpms)
+    assert not comb.is_tower
+    assert not comb.is_controller
+    assert not comb.is_hub
+    assert not comb.is_catalog_worker
+    assert not comb.is_receptor
+    assert comb.is_runner
+    assert not comb.is_eda_controller
+    assert not comb.is_gateway
+    assert comb.runner_version == '2.4.2'
+    assert comb.tower_version is None
+    assert comb.controller_version is None
+    assert comb.hub_version is None
+    assert comb.catalog_worker_version is None
+    assert comb.receptor_version is None
+    assert comb.eda_controller_version is None
+    assert comb.gateway_version is None
+
+
+def test_ansible_info_eda_controller():
+    rpms = InstalledRpms(context_wrap(EDA_CONTROLLER_RPM))
+    comb = AnsibleInfo(rpms)
+    assert not comb.is_tower
+    assert not comb.is_controller
+    assert not comb.is_hub
+    assert not comb.is_catalog_worker
+    assert not comb.is_receptor
+    assert not comb.is_runner
+    assert comb.is_eda_controller
+    assert not comb.is_gateway
+    assert comb.eda_controller_version == '1.2.3'
+    assert comb.tower_version is None
+    assert comb.controller_version is None
+    assert comb.hub_version is None
+    assert comb.catalog_worker_version is None
+    assert comb.receptor_version is None
+    assert comb.runner_version is None
+    assert comb.gateway_version is None
+
+
+def test_ansible_info_gateway():
+    rpms = InstalledRpms(context_wrap(GATEWAY_RPM))
+    comb = AnsibleInfo(rpms)
+    assert not comb.is_tower
+    assert not comb.is_controller
+    assert not comb.is_hub
+    assert not comb.is_catalog_worker
+    assert not comb.is_receptor
+    assert not comb.is_runner
+    assert not comb.is_eda_controller
+    assert comb.is_gateway
+    assert comb.gateway_version == '2.5.20260422'
+    assert comb.tower_version is None
+    assert comb.controller_version is None
+    assert comb.hub_version is None
+    assert comb.catalog_worker_version is None
+    assert comb.receptor_version is None
+    assert comb.runner_version is None
+    assert comb.eda_controller_version is None
 
 
 def test_ansible_info_docs():


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

  - Adds 4 new Ansible packages to the `AnsibleInfo` combiner: `receptor`, `ansible-runner`, `automation-eda-controller`, and `automation-gateway`
  - Each package gets a module-level constant, an entry in `ANSIBLE_PACKAGES`, and `is_*`/`*_version` property pairs following the existing pattern
  - The constructor already iterates `ANSIBLE_PACKAGES`, so no constructor changes were needed
  - Added test coverage for the changes
 
This PR is a blocker for https://github.com/RedHatInsights/insights-puptoo/pull/868

## Summary by Sourcery

Extend the AnsibleInfo combiner to recognize additional Ansible ecosystem packages and expose their presence and versions.

New Features:
- Add support in AnsibleInfo for receptor, ansible-runner, automation-eda-controller, and automation-gateway packages, including presence flags and version accessors.

Tests:
- Expand ansible_info combiner tests to cover the new packages in both combined and single-package scenarios.