### PR TITLE
RHINENG-28888 Add pesign --show-signature spec for shim signature collection

### DIFF
--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -629,6 +629,7 @@ class Specs(SpecSet):
     pcs_config = RegistryPoint()
     pcs_quorum_status = RegistryPoint()
     pcs_status = RegistryPoint()
+    pesign_show_signature_shimx64 = RegistryPoint()
     php_ini = RegistryPoint(filterable=True)
     pidstat = RegistryPoint()
     pluginconf_d = RegistryPoint(multi_output=True)

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -658,6 +658,7 @@ class DefaultSpecs(Specs):
     )
     pcs_quorum_status = simple_command("/usr/sbin/pcs quorum status")
     pcs_status = simple_command("/usr/sbin/pcs status")
+    pesign_show_signature_shimx64 = simple_command("/usr/bin/pesign --show-signature --in=/boot/efi/EFI/redhat/shimx64.efi")
     pidstat = simple_command("/usr/bin/pidstat")
     php_ini = first_file(["/etc/opt/rh/php73/php.ini", "/etc/opt/rh/php72/php.ini", "/etc/php.ini"])
     pluginconf_d = glob_file("/etc/yum/pluginconf.d/*.conf")


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

## Summary

  - Add pesign_show_signature_shimx64 RegistryPoint to insights/specs/__init__.py (alphabetically between pcs_status and php_ini)
  - Add simple_command("/usr/bin/pesign --show-signature --in=/boot/efi/EFI/redhat/shimx64.efi") to insights/specs/default.py
  - Enables collection of PE signature metadata from the shim binary, required by the UEFI Secure Boot cert enrollment analysis epic
  
## Files Changed

  - insights/specs/__init__.py — 1 line added
  - insights/specs/default.py — 1 line added

## Summary by Sourcery

Add a new Insights spec to collect pesign signature metadata from the shimx64 UEFI bootloader binary.

New Features:
- Introduce pesign_show_signature_shimx64 spec for collecting PE signature information from /boot/efi/EFI/redhat/shimx64.efi.

Enhancements:
- Extend the default specs set with a pesign --show-signature command to support Secure Boot certificate enrollment analysis.