### PR TITLE
[CCXDEV-16685] Add python3.14 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-versions: ["3.9", "3.11", "3.12"]
+        python-versions: ["3.9", "3.11", "3.12", "3.14"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-versions }}

--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,6 @@ share/
 .vscode
 insights/filters.yaml
 .nox/
+.tox/
 .venv/
 

--- a/insights/tests/datasources/malware_detection/test_malware_detection.py
+++ b/insights/tests/datasources/malware_detection/test_malware_detection.py
@@ -57,7 +57,7 @@ TEMP_CONFIG_FILE = os.path.join(TEMP_TEST_DIR, 'malware-detection-config.yml')
 TEST_PID = str(os.getpid())  # This running processes ID
 
 # Get the number of CPU threads to run yara
-CPUS = 1 if int(call('nproc').strip()) <= 2 else 2
+CPUS = 1 if (os.cpu_count() or 1) <= 2 else 2
 
 # Some of the toplevel directories that will be included/excluded by default when listing root (/)
 TLDS = ['/boot', '/dev', '/etc', '/home', '/opt', '/proc', '/root', '/sys', '/tmp', '/usr', '/var']
@@ -105,8 +105,12 @@ SKIP_IF_RHEL6_REASON = "The malware-detection client isn't supported on RHEL6 / 
 IS_CONTAINER = (
     os.path.exists("/.dockerenv")
     or os.path.exists("/run/.containerenv")
-    or '1' not in call('pidof init systemd').strip().split()
 )
+if not IS_CONTAINER:
+    try:
+        IS_CONTAINER = '1' not in call('pidof init systemd').strip().split()
+    except (FileNotFoundError, CalledProcessError):
+        pass
 SKIP_IF_CONTAINER_REASON = (
     "This test uses running process that may not exist when run in a container"
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.14",
 ]
 license = {file = "LICENSE"}
 dynamic = ["version", "readme"]
@@ -86,3 +87,10 @@ readme = {file = ["README.rst"]}
 [tool.pytest.ini_options]
 addopts = "-rsxXfE --ignore=./build/"
 testpaths = ["insights"]
+python_files = [
+    "insights/tests/*",
+    "insights/parsr/tests/*",
+    "insights/parsr/examples/tests/*",
+    "insights/parsr/query/tests/*",
+    "insights/archive/test.py",
+]

--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ if __name__ == "__main__":
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: 3.12',
+            'Programming Language :: Python :: 3.14',
         ],
         entry_points=entry_points,
         include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,43 @@
+[tox]
+requires = tox-uv
+envlist = unit-py39,unit-py311,unit-py312,unit-py314
+
+[testenv:unit-py39]
+basepython = python3.9
+usedevelop = true
+deps = .[testing]
+commands =
+    pytest {posargs:--cov --cov-branch --cov-report=}
+
+[testenv:unit-py311]
+basepython = python3.11
+usedevelop = true
+deps = .[testing]
+commands =
+    pytest {posargs:--cov --cov-branch --cov-report=}
+
+[testenv:unit-py312]
+basepython = python3.12
+usedevelop = true
+deps = .[testing]
+commands =
+    pytest {posargs:--cov --cov-branch --cov-report=}
+
+[testenv:unit-py314]
+basepython = python3.14
+usedevelop = true
+deps = .[testing]
+commands =
+    pytest {posargs:--cov --cov-branch --cov-report=}
+
+[testenv:lint]
+deps = .[linting]
+commands =
+    flake8 .
+
+[testenv:docs]
+deps = .[docs]
+allowlist_externals =
+    pandoc
+commands =
+    sphinx-build -W -b html -qa -E docs docs/_build/html


### PR DESCRIPTION
## Summary by Sourcery

Add Python 3.13 support across tooling and metadata while improving environment-dependent test behavior.

New Features:
- Add Python 3.13 to the supported versions in packaging metadata and CI workflows.
- Introduce a tox configuration with unit test, lint, and docs environments aligned to supported Python versions.

Bug Fixes:
- Make CPU thread detection and container detection in malware detection tests more robust and compatible with newer Python versions.

Tests:
- Adjust malware detection tests to use os.cpu_count and to handle container detection failures more safely.