### PR TITLE
feat(conftest): Add ALLOW_TYPE_CLASS doctest flag for Py2/Py3 type repr

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,13 @@
+import doctest
 import logging
 import pytest
 import warnings
 from insights.tests import run_test
+from insights.tests.doctest_support import INSIGHTS_DOCTEST_OPTIONFLAGS, InsightsDocTestRunner
 warnings.simplefilter('always', DeprecationWarning)
+
+# testmod() constructs DocTestRunner internally; replace the class for all doctest.testmod() calls.
+doctest.DocTestRunner = InsightsDocTestRunner
 
 
 def pytest_addoption(parser):
@@ -14,6 +19,8 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     level = logging.DEBUG if config.getoption("--appdebug") else logging.ERROR
     logging.basicConfig(level=level)
+    optionflags = getattr(config.option, 'doctest_optionflags', 0)
+    config.option.doctest_optionflags = optionflags | INSIGHTS_DOCTEST_OPTIONFLAGS
 
 
 @pytest.fixture

--- a/insights/tests/doctest_support.py
+++ b/insights/tests/doctest_support.py
@@ -1,0 +1,45 @@
+"""
+Py2/Py3 compatible doctest checker and runner for parser documentation tests.
+"""
+
+import doctest
+import re
+
+DOCTEST_ALLOW_TYPE_CLASS = doctest.register_optionflag('ALLOW_TYPE_CLASS')
+INSIGHTS_DOCTEST_OPTIONFLAGS = DOCTEST_ALLOW_TYPE_CLASS
+
+_TYPE_CLASS_RE = re.compile(r"<type '([^']+)'>")
+
+
+def _normalize_type_class_repr(text):
+    return _TYPE_CLASS_RE.sub(r"<class '\1'>", text)
+
+
+_StandardOutputChecker = doctest.OutputChecker
+
+
+class InsightsDoctestChecker(_StandardOutputChecker):
+    def check_output(self, want, got, optionflags):
+        if _StandardOutputChecker.check_output(self, want, got, optionflags):
+            return True
+
+        if not optionflags & DOCTEST_ALLOW_TYPE_CLASS:
+            return False
+
+        want = _normalize_type_class_repr(want)
+        got = _normalize_type_class_repr(got)
+
+        return _StandardOutputChecker.check_output(self, want, got, optionflags)
+
+
+INSIGHTS_DOCTEST_CHECKER = InsightsDoctestChecker()
+
+_StandardDocTestRunner = doctest.DocTestRunner
+
+
+class InsightsDocTestRunner(_StandardDocTestRunner):
+    def __init__(self, checker=None, verbose=None, optionflags=0):
+        if checker is None:
+            checker = INSIGHTS_DOCTEST_CHECKER
+        optionflags |= INSIGHTS_DOCTEST_OPTIONFLAGS
+        _StandardDocTestRunner.__init__(self, checker, verbose, optionflags)

--- a/insights/tests/test_doctest_support.py
+++ b/insights/tests/test_doctest_support.py
@@ -1,0 +1,63 @@
+import doctest
+import types
+
+import pytest
+
+from insights.tests.doctest_support import (
+    DOCTEST_ALLOW_TYPE_CLASS,
+    INSIGHTS_DOCTEST_OPTIONFLAGS,
+    InsightsDoctestChecker,
+    InsightsDocTestRunner,
+)
+
+
+@pytest.fixture
+def insights_checker():
+    return InsightsDoctestChecker()
+
+
+TYPE_CLASS_TEST_CASES = [
+    ("<class 'list'>\n", "<class 'list'>\n", True, INSIGHTS_DOCTEST_OPTIONFLAGS),
+    ("<class 'list'>\n", "<type 'list'>\n", True, DOCTEST_ALLOW_TYPE_CLASS),
+    ("<type 'list'>\n", "<class 'list'>\n", True, INSIGHTS_DOCTEST_OPTIONFLAGS),
+    ("<class 'dict'>\n", "<type 'list'>\n", False, INSIGHTS_DOCTEST_OPTIONFLAGS),
+    ("<class 'list'>\n", "<type 'list'>\n", False, 0),
+]
+
+
+@pytest.mark.parametrize(
+    "want,got,expected_result,insights_optionflags",
+    TYPE_CLASS_TEST_CASES,
+    ids=[
+        "identical_class_repr",
+        "class_want_type_got",
+        "type_want_class_got",
+        "mismatched_type_names",
+        "insights_checker_without_flag",
+    ],
+)
+def test_type_class_repr_comparison(
+    insights_checker,
+    want,
+    got,
+    expected_result,
+    insights_optionflags,
+):
+    assert insights_checker.check_output(
+        want, got, insights_optionflags
+    ) == expected_result
+
+
+def test_doctest_testmod_uses_insights_runner():
+    assert doctest.DocTestRunner is InsightsDocTestRunner
+
+    module = types.ModuleType('insights_doctest_support_example')
+    module.__doc__ = """
+    >>> type([])
+    <class 'list'>
+    >>> type([])
+    <type 'list'>
+    """
+    failed, total = doctest.testmod(module)
+    assert total == 2
+    assert failed == 0


### PR DESCRIPTION
Normalize <type 'name'> to <class 'name'> when comparing doctest output so type() examples work when doctests are cherry-picked between Python 2 and 3.

Co-authored-by: Cursor <cursoragent@cursor.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### All Pull Requests:

Check all that apply:

* [X] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [X] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [X] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

## Summary by Sourcery

Enable doctests to compare Python 2 and Python 3 type representations consistently.

New Features:
- Add cross-version doctest support for treating Python 2 and Python 3 type representations as equivalent.

Enhancements:
- Configure project doctests to use the enhanced checker and runner with the new comparison option enabled by default.

Tests:
- Add coverage for compatible and incompatible type representations and doctest.testmod integration.