### PR TITLE
feat(RHINENG-29756): Add containerized Satellite and AAP detection

### DIFF
--- a/docs/shared_combiners_catalog/ansible_containerized.rst
+++ b/docs/shared_combiners_catalog/ansible_containerized.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.combiners.ansible_containerized
+   :members:
+   :show-inheritance:

--- a/docs/shared_combiners_catalog/satellite_containerized.rst
+++ b/docs/shared_combiners_catalog/satellite_containerized.rst
@@ -1,0 +1,3 @@
+.. automodule:: insights.combiners.satellite_containerized
+   :members:
+   :show-inheritance:

--- a/insights/combiners/ansible_containerized.py
+++ b/insights/combiners/ansible_containerized.py
@@ -1,0 +1,44 @@
+"""
+Ansible Containerized
+=====================
+Combiner to collect data about a containerized Ansible Automation Platform
+(AAP) deployment: the AAP containers (those whose image contains
+``ansible-automation-platform``).
+"""
+
+from typing import List
+
+from insights.core.plugins import combiner
+from insights.parsers.podman import PodmanPsAllJson
+
+AAP_IMAGE_MARKER = "ansible-automation-platform"
+
+
+@combiner(PodmanPsAllJson)
+class AnsibleContainerized(object):
+    """
+    Collects the AAP containers from the root-owned podman containers
+    (``PodmanPsAllJson``).
+
+    Containers are matched by image: any container whose image contains
+    ``ansible-automation-platform``. This captures the whole AAP stack
+    (gateway, controller, receptor, eda, hub, metrics, ...) including the
+    execution-node case where ``receptor`` may be the only AAP container.
+
+    ``PodmanPsAllJson`` is a required dependency, so this combiner only runs
+    when the podman containers were collected. When it runs but no AAP
+    containers are present, ``containers`` is an empty list.
+
+    Attributes:
+        containers (list): The raw podman jsons for the AAP containers
+            (empty list if none were found).
+
+    Examples:
+        >>> type(ansible_containerized)
+        <class 'insights.combiners.ansible_containerized.AnsibleContainerized'>
+        >>> len(ansible_containerized.containers)
+        2
+    """
+
+    def __init__(self, podman_ps: PodmanPsAllJson) -> None:
+        self.containers: List[dict] = podman_ps.search_by_image(AAP_IMAGE_MARKER, partial=True)

--- a/insights/combiners/satellite_containerized.py
+++ b/insights/combiners/satellite_containerized.py
@@ -1,0 +1,73 @@
+"""
+Satellite Containerized
+=======================
+Combiner to collect data about a containerized Satellite deployment: the
+``foremanctl`` RPM version and the ``foreman`` / ``foreman-proxy`` containers.
+"""
+
+from typing import List, Optional
+
+from insights.core.exceptions import SkipComponent
+from insights.core.plugins import combiner
+from insights.parsers.installed_rpms import InstalledRpms
+from insights.parsers.podman import PodmanPsAllJson
+
+FOREMANCTL_PKG = "foremanctl"
+FOREMAN_CONTAINER = "foreman"
+FOREMAN_PROXY_CONTAINER = "foreman-proxy"
+
+
+@combiner(optional=[InstalledRpms, PodmanPsAllJson])
+class SatelliteContainerized(object):
+    """
+    Collects data about a containerized Satellite deployment.
+
+    The ``foreman`` and ``foreman-proxy`` containers are located by exact
+    container name. Matching by name (not image) is deliberate: the foreman
+    image is shared by the ``dynflow-sidekiq-*`` containers, so an image match
+    would wrongly capture those too. All matches are kept (a list rather than a
+    single container) because container names are only unique per user, so
+    rootless deployments may expose several containers with the same name.
+
+    Attributes:
+        foremanctl_version (str): Version of the ``foremanctl`` RPM, or ``None``.
+        containers (list): Raw podman jsons for the ``foreman`` and
+            ``foreman-proxy`` containers. ``None`` when the podman containers
+            were not collected, or an empty list when they were collected but
+            no matching containers were found.
+
+    Raises:
+        SkipComponent: When nothing was collected (neither ``InstalledRpms``
+            nor the podman containers).
+
+    Examples:
+        >>> type(satellite_containerized)
+        <class 'insights.combiners.satellite_containerized.SatelliteContainerized'>
+        >>> satellite_containerized.foremanctl_version
+        '1.1.0'
+        >>> len(satellite_containerized.containers)
+        2
+        >>> satellite_containerized.containers[0]["Names"]
+        ['foreman']
+    """
+
+    def __init__(
+        self,
+        rpms: Optional[InstalledRpms],
+        podman_ps: Optional[PodmanPsAllJson],
+    ) -> None:
+        if rpms is None and podman_ps is None:
+            raise SkipComponent("Not a containerized Satellite: nothing collected")
+
+        self.foremanctl_version: Optional[str] = None
+        self.containers: Optional[List[dict]] = None
+
+        if rpms:
+            foremanctl = rpms.get_max(FOREMANCTL_PKG)
+            if foremanctl:
+                self.foremanctl_version = foremanctl.version
+
+        if podman_ps:
+            self.containers = podman_ps.search_by_name(
+                FOREMAN_CONTAINER
+            ) + podman_ps.search_by_name(FOREMAN_PROXY_CONTAINER)

--- a/insights/parsers/podman.py
+++ b/insights/parsers/podman.py
@@ -8,12 +8,53 @@ PodmanPsAllJson - command ``podman ps --all --no-trunc --size --format=json``
 -----------------------------------------------------------------------------
 """
 
+from typing import List
+
 from insights import parser, JSONParser
 from insights.specs import Specs
 
 
+class PodmanContainerSearch(object):
+    """
+    Mixin providing container search helpers over a flat ``self.data`` list of
+    container dicts (as produced by ``podman ps ... --format=json``).
+    """
+
+    def search_by_name(self, name: str, partial: bool = False) -> List[dict]:
+        """
+        Search containers by name.
+
+        Args:
+            name (str): The container name to search for.
+            partial (bool): When ``False`` (default) match the name exactly;
+                when ``True`` match containers whose name contains ``name``.
+
+        Returns:
+            list: The matching raw container jsons (empty list if none match).
+        """
+        if partial:
+            return [c for c in self.data if any(name in n for n in c.get("Names", []))]
+        return [c for c in self.data if name in c.get("Names", [])]
+
+    def search_by_image(self, image: str, partial: bool = False) -> List[dict]:
+        """
+        Search containers by image.
+
+        Args:
+            image (str): The image to search for.
+            partial (bool): When ``False`` (default) match the image exactly;
+                when ``True`` match containers whose image contains ``image``.
+
+        Returns:
+            list: The matching raw container jsons (empty list if none match).
+        """
+        if partial:
+            return [c for c in self.data if image in c.get("Image", "")]
+        return [c for c in self.data if c.get("Image", "") == image]
+
+
 @parser(Specs.podman_ps_all_json)
-class PodmanPsAllJson(JSONParser):
+class PodmanPsAllJson(JSONParser, PodmanContainerSearch):
     """
     Class for parsing the output of the ``podman ps --all --no-trunc --size --format=json`` command.
 
@@ -86,5 +127,12 @@ class PodmanPsAllJson(JSONParser):
         ['angry_saha']
         >>> podman_ps_json.data[0]["Image"]
         'rhel7_httpd'
+        >>> len(podman_ps_json.search_by_name("angry_saha"))
+        1
+        >>> podman_ps_json.search_by_image("rhel7_httpd")[0]["Names"]
+        ['angry_saha']
+        >>> len(podman_ps_json.search_by_image("httpd", partial=True))
+        1
     """
+
     pass

--- a/insights/tests/combiners/test_ansible_containerized.py
+++ b/insights/tests/combiners/test_ansible_containerized.py
@@ -1,0 +1,91 @@
+import doctest
+
+from insights.parsers.podman import PodmanPsAllJson
+from insights.combiners import ansible_containerized
+from insights.combiners.ansible_containerized import AnsibleContainerized
+from insights.tests import context_wrap
+
+PODMAN_PS_AAP = """
+[
+    {
+        "Id": "pg",
+        "Image": "registry.redhat.io/rhel9/postgresql-15:latest",
+        "Names": ["postgresql"],
+        "State": "running",
+        "Status": "Up 38 minutes"
+    },
+    {
+        "Id": "gw",
+        "Image": "registry.redhat.io/ansible-automation-platform-27/gateway-rhel9:latest",
+        "Names": ["automation-gateway"],
+        "State": "running",
+        "Status": "Up 36 minutes"
+    },
+    {
+        "Id": "rc",
+        "Image": "registry.redhat.io/ansible-automation-platform-27/receptor-rhel9:latest",
+        "Names": ["receptor"],
+        "State": "running",
+        "Status": "Up 34 minutes"
+    }
+]
+""".strip()
+
+PODMAN_PS_EXEC_NODE = """
+[
+    {
+        "Id": "rc",
+        "Image": "registry.redhat.io/ansible-automation-platform-27/receptor-rhel9:latest",
+        "Names": ["receptor"],
+        "State": "running",
+        "Status": "Up 41 minutes"
+    }
+]
+""".strip()
+
+PODMAN_PS_NO_AAP = """
+[
+    {
+        "Id": "pg",
+        "Image": "registry.redhat.io/rhel9/postgresql-15:latest",
+        "Names": ["postgresql"],
+        "State": "running",
+        "Status": "Up 38 minutes"
+    }
+]
+""".strip()
+
+
+def test_ansible_containerized_mixed():
+    podman = PodmanPsAllJson(context_wrap(PODMAN_PS_AAP))
+    comb = AnsibleContainerized(podman)
+    # postgresql excluded; gateway + receptor captured
+    assert len(comb.containers) == 2
+    names = sorted(c["Names"][0] for c in comb.containers)
+    assert names == ["automation-gateway", "receptor"]
+
+
+def test_ansible_containerized_exec_node():
+    podman = PodmanPsAllJson(context_wrap(PODMAN_PS_EXEC_NODE))
+    comb = AnsibleContainerized(podman)
+    assert len(comb.containers) == 1
+    assert comb.containers[0]["Names"] == ["receptor"]
+    assert comb.containers[0]["State"] == "running"
+
+
+def test_ansible_containerized_no_aap():
+    # podman was collected but no AAP containers are present -> empty list,
+    # no SkipComponent (the required PodmanPsAllJson dependency was satisfied)
+    podman = PodmanPsAllJson(context_wrap(PODMAN_PS_NO_AAP))
+    comb = AnsibleContainerized(podman)
+    assert comb.containers == []
+
+
+def test_ansible_containerized_docs():
+    podman = PodmanPsAllJson(context_wrap(PODMAN_PS_AAP))
+    comb = AnsibleContainerized(podman)
+    failed, _ = doctest.testmod(
+        ansible_containerized,
+        globs={"ansible_containerized": comb},
+    )
+    assert failed == 0

--- a/insights/tests/combiners/test_satellite_containerized.py
+++ b/insights/tests/combiners/test_satellite_containerized.py
@@ -1,0 +1,161 @@
+import doctest
+import pytest
+
+from insights.core.exceptions import SkipComponent
+from insights.parsers.installed_rpms import InstalledRpms
+from insights.parsers.podman import PodmanPsAllJson
+from insights.combiners import satellite_containerized
+from insights.combiners.satellite_containerized import SatelliteContainerized
+from insights.tests import context_wrap
+
+FOREMANCTL_RPM = "foremanctl-1.1.0-1.el9.noarch"
+
+PODMAN_PS_SATELLITE = """
+[
+    {
+        "Id": "aaa",
+        "Image": "quay.io/foreman/foreman:3.16",
+        "Names": ["dynflow-sidekiq-worker"],
+        "State": "running",
+        "Status": "Up 59 minutes"
+    },
+    {
+        "Id": "bbb",
+        "Image": "quay.io/sclorg/postgresql-13-c9s:latest",
+        "Names": ["postgresql"],
+        "State": "running",
+        "Status": "Up 2 hours"
+    },
+    {
+        "Id": "ccc",
+        "Image": "quay.io/foreman/foreman:3.16",
+        "Names": ["foreman"],
+        "State": "running",
+        "Status": "Up 41 minutes"
+    },
+    {
+        "Id": "ddd",
+        "Image": "quay.io/foreman/foreman-proxy:3.16",
+        "Names": ["foreman-proxy"],
+        "State": "exited",
+        "Status": "Exited (0) 5 minutes ago"
+    }
+]
+""".strip()
+
+PODMAN_PS_SERVER_ONLY = """
+[
+    {
+        "Id": "ccc",
+        "Image": "quay.io/foreman/foreman:3.16",
+        "Names": ["foreman"],
+        "State": "running",
+        "Status": "Up 41 minutes"
+    }
+]
+""".strip()
+
+PODMAN_PS_CAPSULE_ONLY = """
+[
+    {
+        "Id": "ddd",
+        "Image": "quay.io/foreman/foreman-proxy:3.16",
+        "Names": ["foreman-proxy"],
+        "State": "running",
+        "Status": "Up 30 minutes"
+    }
+]
+""".strip()
+
+PODMAN_PS_NO_FOREMAN = """
+[
+    {
+        "Id": "bbb",
+        "Image": "quay.io/sclorg/postgresql-13-c9s:latest",
+        "Names": ["postgresql"],
+        "State": "running",
+        "Status": "Up 2 hours"
+    }
+]
+""".strip()
+
+
+def test_satellite_containerized_both():
+    rpms = InstalledRpms(context_wrap(FOREMANCTL_RPM))
+    podman = PodmanPsAllJson(context_wrap(PODMAN_PS_SATELLITE))
+    comb = SatelliteContainerized(rpms, podman)
+    assert comb.foremanctl_version == "1.1.0"
+    # exact name match isolates foreman from the dynflow-sidekiq container
+    assert [c["Id"] for c in comb.containers] == ["ccc", "ddd"]
+
+
+def test_satellite_containerized_rpm_only():
+    # podman not collected -> containers is None (distinct from "not found")
+    rpms = InstalledRpms(context_wrap(FOREMANCTL_RPM))
+    comb = SatelliteContainerized(rpms, None)
+    assert comb.foremanctl_version == "1.1.0"
+    assert comb.containers is None
+
+
+def test_satellite_containerized_podman_only():
+    podman = PodmanPsAllJson(context_wrap(PODMAN_PS_SATELLITE))
+    comb = SatelliteContainerized(None, podman)
+    assert comb.foremanctl_version is None
+    assert [c["Id"] for c in comb.containers] == ["ccc", "ddd"]
+
+
+def test_satellite_containerized_server_only_with_rpm():
+    rpms = InstalledRpms(context_wrap(FOREMANCTL_RPM))
+    podman = PodmanPsAllJson(context_wrap(PODMAN_PS_SERVER_ONLY))
+    comb = SatelliteContainerized(rpms, podman)
+    assert comb.foremanctl_version == "1.1.0"
+    assert [c["Id"] for c in comb.containers] == ["ccc"]
+
+
+def test_satellite_containerized_server_only_without_rpm():
+    podman = PodmanPsAllJson(context_wrap(PODMAN_PS_SERVER_ONLY))
+    comb = SatelliteContainerized(None, podman)
+    assert comb.foremanctl_version is None
+    assert [c["Id"] for c in comb.containers] == ["ccc"]
+
+
+def test_satellite_containerized_capsule_only_with_rpm():
+    rpms = InstalledRpms(context_wrap(FOREMANCTL_RPM))
+    podman = PodmanPsAllJson(context_wrap(PODMAN_PS_CAPSULE_ONLY))
+    comb = SatelliteContainerized(rpms, podman)
+    assert comb.foremanctl_version == "1.1.0"
+    assert [c["Id"] for c in comb.containers] == ["ddd"]
+
+
+def test_satellite_containerized_capsule_only_without_rpm():
+    podman = PodmanPsAllJson(context_wrap(PODMAN_PS_CAPSULE_ONLY))
+    comb = SatelliteContainerized(None, podman)
+    assert comb.foremanctl_version is None
+    assert [c["Id"] for c in comb.containers] == ["ddd"]
+
+
+def test_satellite_containerized_skip_no_data():
+    # nothing collected at all -> SkipComponent
+    with pytest.raises(SkipComponent):
+        SatelliteContainerized(None, None)
+
+
+def test_satellite_containerized_no_foreman():
+    # podman was collected but has no foreman containers -> empty list, and
+    # no foremanctl RPM; the combiner still fires (podman was collected)
+    rpms = InstalledRpms(context_wrap("bash-5.1.8-6.el9"))
+    podman = PodmanPsAllJson(context_wrap(PODMAN_PS_NO_FOREMAN))
+    comb = SatelliteContainerized(rpms, podman)
+    assert comb.foremanctl_version is None
+    assert comb.containers == []
+
+
+def test_satellite_containerized_docs():
+    rpms = InstalledRpms(context_wrap(FOREMANCTL_RPM))
+    podman = PodmanPsAllJson(context_wrap(PODMAN_PS_SATELLITE))
+    comb = SatelliteContainerized(rpms, podman)
+    failed, _ = doctest.testmod(
+        satellite_containerized,
+        globs={"satellite_containerized": comb},
+    )
+    assert failed == 0

--- a/insights/tests/parsers/test_podman.py
+++ b/insights/tests/parsers/test_podman.py
@@ -4,7 +4,6 @@ from insights.parsers import podman
 from insights.parsers.podman import PodmanPsAllJson
 from insights.tests import context_wrap
 
-
 PODMAN_PS_ALL_JSON = """
 [
     {
@@ -99,7 +98,9 @@ def test_podman_ps_json():
     assert len(result.data) == 2
 
     # Test first container
-    assert result.data[0]["Id"] == "03e2861336a76e29155836113ff6560cb70780c32f95062642993b2b3d0fc216"
+    assert (
+        result.data[0]["Id"] == "03e2861336a76e29155836113ff6560cb70780c32f95062642993b2b3d0fc216"
+    )
     assert result.data[0]["State"] == "running"
     assert result.data[0]["Status"] == "Up 37 seconds"
     assert result.data[0]["Image"] == "rhel7_httpd"
@@ -111,16 +112,16 @@ def test_podman_ps_json():
     assert result.data[0]["Ports"][0]["container_port"] == 80
 
     # Test second container
-    assert result.data[1]["Id"] == "95516ea08b565e37e2a4bca3333af40a240c368131b77276da8dec629b7fe102"
+    assert (
+        result.data[1]["Id"] == "95516ea08b565e37e2a4bca3333af40a240c368131b77276da8dec629b7fe102"
+    )
     assert result.data[1]["State"] == "exited"
     assert result.data[1]["Status"] == "Exited (137) 18 hours ago"
     assert result.data[1]["Names"] == ["tender_rosalind"]
     assert result.data[1]["ExitCode"] == 137
     assert result.data[1]["Pid"] == 0
     assert result.data[1]["Ports"] == []
-    assert result.data[1]["Size"] == {
-        "rootFsSize": 221554338,
-        "rwSize": 0}
+    assert result.data[1]["Size"] == {"rootFsSize": 221554338, "rwSize": 0}
 
 
 def test_podman_ps_json_empty():
@@ -129,9 +130,101 @@ def test_podman_ps_json_empty():
     assert len(result.data) == 0
 
 
+PODMAN_PS_MULTI_JSON = """
+[
+    {
+        "Id": "aaa",
+        "Image": "quay.io/foreman/foreman:3.16",
+        "Names": ["foreman"],
+        "State": "running"
+    },
+    {
+        "Id": "bbb",
+        "Image": "quay.io/foreman/foreman:3.16",
+        "Names": ["dynflow-sidekiq-worker"],
+        "State": "running"
+    },
+    {
+        "Id": "ccc",
+        "Image": "quay.io/foreman/foreman-proxy:3.16",
+        "Names": ["foreman-proxy"],
+        "State": "exited"
+    }
+]
+""".strip()
+
+
+def test_podman_ps_search_by_name():
+    result = PodmanPsAllJson(context_wrap(PODMAN_PS_ALL_JSON))
+
+    # exact match (default)
+    exact = result.search_by_name("angry_saha")
+    assert len(exact) == 1
+    assert exact[0]["Names"] == ["angry_saha"]
+
+    # exact match must not match a substring
+    assert result.search_by_name("angry") == []
+
+    # partial match
+    partial = result.search_by_name("rosalind", partial=True)
+    assert len(partial) == 1
+    assert partial[0]["Names"] == ["tender_rosalind"]
+
+    # no match
+    assert result.search_by_name("does_not_exist") == []
+
+
+def test_podman_ps_search_by_name_multiple():
+    result = PodmanPsAllJson(context_wrap(PODMAN_PS_MULTI_JSON))
+
+    # partial match returns multiple containers
+    matches = result.search_by_name("foreman", partial=True)
+    assert len(matches) == 2
+    ids = sorted(c["Id"] for c in matches)
+    assert ids == ["aaa", "ccc"]
+
+    # exact match returns only the one named "foreman"
+    exact = result.search_by_name("foreman")
+    assert len(exact) == 1
+    assert exact[0]["Id"] == "aaa"
+
+
+def test_podman_ps_search_by_image():
+    result = PodmanPsAllJson(context_wrap(PODMAN_PS_ALL_JSON))
+
+    # exact match (default)
+    exact = result.search_by_image("rhel7_httpd")
+    assert len(exact) == 1
+    assert exact[0]["Names"] == ["angry_saha"]
+
+    # exact match must not match a substring
+    assert result.search_by_image("httpd") == []
+
+    # partial match
+    partial = result.search_by_image("httpd", partial=True)
+    assert len(partial) == 1
+    assert partial[0]["Image"] == "rhel7_httpd"
+
+    # no match
+    assert result.search_by_image("nonexistent") == []
+
+
+def test_podman_ps_search_by_image_multiple():
+    result = PodmanPsAllJson(context_wrap(PODMAN_PS_MULTI_JSON))
+
+    # exact match returns both containers sharing the same image
+    exact = result.search_by_image("quay.io/foreman/foreman:3.16")
+    assert len(exact) == 2
+    ids = sorted(c["Id"] for c in exact)
+    assert ids == ["aaa", "bbb"]
+
+    # partial match on "foreman" returns all three
+    partial = result.search_by_image("foreman", partial=True)
+    assert len(partial) == 3
+
+
 def test_podman_ps_json_documentation():
     failed_count, _ = doctest.testmod(
-        podman,
-        globs={'podman_ps_json': PodmanPsAllJson(context_wrap(PODMAN_PS_ALL_JSON))}
+        podman, globs={'podman_ps_json': PodmanPsAllJson(context_wrap(PODMAN_PS_ALL_JSON))}
     )
     assert failed_count == 0


### PR DESCRIPTION
### Jira
[RHINENG-29756](https://redhat.atlassian.net/browse/RHINENG-29756)

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

#### Summary

Detect containerized Satellite and Ansible Automation Platform (AAP) deployments.

- Shared search — search_by_name/search_by_image (exact and partial) implemented in a new PodmanContainerSearch mixin reused by the parsers and the combiner.
- SatelliteContainerized — locates the foreman / foreman-proxy containers and the foremanctl RPM version.
- AnsibleContainerized — matches containers whose image contains ansible-automation-platform.

#### Tests

- SatelliteContainerized / AnsibleContainerized: positive scenarios, skip scenarios, doctests

#### Dependencies

There is already a followup for this PR open, which will add rootless containers detection: https://github.com/RedHatInsights/insights-core/pull/4811


## Summary by Sourcery

Add container-aware Podman collection and product detection for Satellite and Ansible Automation Platform.

New Features:
- Add unified detection and reporting for containerized Satellite deployments, including foremanctl version and Foreman containers.
- Add detection and reporting for Ansible Automation Platform containers, including execution-node deployments.
- Collect and unify rootful and rootless Podman containers across local users.
- Provide exact and partial Podman container name and image search capabilities.

Enhancements:
- Track rootless container ownership while preserving a flat searchable container view.
- Skip containerized product components when no relevant deployment data is available.

Documentation:
- Add catalog entries for the new Podman, Satellite containerized, and Ansible containerized combiners.

Tests:
- Add coverage for rootless Podman collection and parsing, container aggregation, search helpers, and Satellite and AAP detection scenarios.

## Summary by Sourcery

Detect containerized Satellite and Ansible Automation Platform deployments across rootful and rootless Podman containers.

New Features:
- Add detection and reporting for containerized Satellite deployments, including foremanctl version and Foreman containers.
- Add detection and reporting for containerized Ansible Automation Platform deployments, including execution-node deployments.
- Collect and unify rootful and rootless Podman containers across local users.

Enhancements:
- Provide reusable exact and partial container name and image searches while preserving rootless container ownership.

Documentation:
- Add catalog entries for the containerized Satellite and Ansible Automation Platform combiners.

Tests:
- Add coverage for Podman search helpers and containerized Satellite and AAP detection scenarios.

[RHINENG-29756]: https://redhat.atlassian.net/browse/RHINENG-29756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ