### PR TITLE
fix(parsers): support platform_firmware_information in dmidecode

### DIFF
--- a/insights/parsers/dmidecode.py
+++ b/insights/parsers/dmidecode.py
@@ -23,9 +23,13 @@ The common information retrieved from dmidecode is available in several
 convenience properties:
 
 * **system_info** - Information about the machine itself
-* **bios** - the BIOS information
-* **bios_vendor** - the BIOS's 'Vendor' attribute
-* **bios_date** - the BIOS's 'Release Date' attribute
+* **bios** - the BIOS / Platform Firmware information
+* **bios_vendor** - the BIOS's / Platform Firmware's 'Vendor' attribute
+* **bios_date** - the BIOS's / Platform Firmware's 'Release Date' attribute
+* **platform_firmware** - alias of ``bios``, for dmidecode 3.6+ where the
+  'BIOS Information' section was renamed to 'Platform Firmware Information'
+* **platform_firmware_vendor** - alias of ``bios_vendor``
+* **platform_firmware_date** - alias of ``bios_date``
 * **processor_manufacturer** - the processor's 'Manufacturer' attribute
 * **is_present** - this indicates whether dmidecode information was found.
 
@@ -84,7 +88,11 @@ Examples:
     1
     >>> dmi['bios_information'][0]['vendor']
     'HP'
+    >>> dmi['platform_firmware_information'][0]['vendor']
+    'HP'
     >>> dmi.bios_vendor
+    'HP'
+    >>> dmi.platform_firmware_vendor
     'HP'
     >>> dmi.bios_date
     datetime.date(2008, 9, 27)
@@ -113,6 +121,17 @@ class DMIDecode(CommandParser, LegacyItemAccess):
     def parse_content(self, content):
         self.data = parse_dmidecode(content, pythonic_keys=True)
 
+        # If bios_info exists one of the keys was present in parsed data,
+        # assign its value to the missing key for access with both keys.
+        bios_info = self._get_bios_info()
+        if bios_info:
+            self.data.setdefault("platform_firmware_information", bios_info)
+            self.data.setdefault("bios_information", bios_info)
+
+    def _get_bios_info(self):
+        """(list): Helper to fetch the BIOS or Platform Firmware Information block list."""
+        return self.data.get("platform_firmware_information") or self.data.get("bios_information")
+
     @property
     def system_info(self):
         """(str): Convenience method to get system information"""
@@ -127,21 +146,43 @@ class DMIDecode(CommandParser, LegacyItemAccess):
 
     @property
     def bios(self):
-        """(str): Convenience method to get BIOS information"""
-        return self["bios_information"][0] if "bios_information" in self else None
+        """(dict): Convenience method to get BIOS / Platform Firmware information"""
+        bios_info = self._get_bios_info()
+        return bios_info[0] if bios_info else None
 
     @property
     @defaults()
     def bios_vendor(self):
-        """(str): Convenience method to get BIOS vendor"""
-        return self["bios_information"][0]["vendor"]
+        """(str): Convenience method to get BIOS / Platform Firmware vendor"""
+        bios_section = self.bios
+        return bios_section.get("vendor") if bios_section else None
 
     @property
     @defaults()
     def bios_date(self):
-        """(datetime.date): Get the BIOS release date in datetime.date format"""
-        month, day, year = map(int, self["bios_information"][0]["release_date"].split("/"))
-        return date(year, month, day)
+        """(datetime.date): Get the BIOS / Platform Firmware release date in datetime.date format"""
+        bios_section = self.bios
+        if bios_section and "release_date" in bios_section:
+            month, day, year = map(int, bios_section["release_date"].split("/"))
+            return date(year, month, day)
+        return None
+
+    @property
+    def platform_firmware(self):
+        """(dict): Convenience method to get BIOS / Platform Firmware information"""
+        return self.bios
+
+    @property
+    @defaults()
+    def platform_firmware_vendor(self):
+        """(str): Convenience method to get BIOS / Platform Firmware vendor"""
+        return self.bios_vendor
+
+    @property
+    @defaults()
+    def platform_firmware_date(self):
+        """(datetime.date): Get the BIOS / Platform Firmware release date in datetime.date format"""
+        return self.bios_date
 
     @property
     @defaults()

--- a/insights/tests/parsers/test_dmidecode.py
+++ b/insights/tests/parsers/test_dmidecode.py
@@ -350,6 +350,28 @@ OEM-specific Type
 
 """
 
+DMIDECODE_3_6 = """
+# dmidecode 3.6
+Getting SMBIOS data from sysfs.
+SMBIOS 2.8 present.
+10 structures occupying 561 bytes.
+Table at 0x000F5960.
+
+Handle 0x0000, DMI type 0, 24 bytes
+Platform Firmware Information
+\tVendor: SeaBIOS
+\tVersion: 1.16.1-1.el9
+\tRelease Date: 04/01/2014
+\tAddress: 0xE8000
+\tRuntime Size: 96 KiB
+\tROM Size: 64 KiB
+\tCharacteristics:
+\t\tFirmware characteristics not supported
+\t\tTargeted content distribution is supported
+\tPlatform Firmware Revision: 0.0
+
+"""
+
 
 def test_get_dmidecode():
     '''
@@ -430,6 +452,15 @@ def test_get_dmidecode():
     assert ret.bios_date == date(2013, 3, 1)
     assert ret.processor_manufacturer == 'Bochs'
 
+    # Verify forward-compatibility to check if new key 'platform_firmware_information' can parse old dmidecode data (for parse_content() method)
+    assert 'platform_firmware_information' in ret
+    assert ret['platform_firmware_information'][0]['vendor'] == 'HP'
+
+    # Test platform_firmware_* properties also work when given older dmidecode output
+    assert ret.platform_firmware == ret['bios_information'][0]
+    assert ret.platform_firmware_vendor == 'HP'
+    assert ret.platform_firmware_date == date(2013, 3, 1)
+
 
 def test_get_dmidecode_fail():
     '''
@@ -440,6 +471,14 @@ def test_get_dmidecode_fail():
 
     assert ret.is_present is False
     assert ret.system_uuid is None
+
+    # When the data is not accessible the properties should return None
+    assert ret.bios is None
+    assert ret.bios_vendor is None
+    assert ret.bios_date is None
+    assert ret.platform_firmware is None
+    assert ret.platform_firmware_vendor is None
+    assert ret.platform_firmware_date is None
 
 
 # def test_virt_what_1():
@@ -551,3 +590,43 @@ def test_dmidecode_oddities():
         'installable_languages': ['1', 'en-US'],
         'currently_installed_language': 'en-US'
     }
+
+
+def test_get_dmidecode_platform_firmware():
+    """
+    Test for dmidecode 3.6+ output format using 'Platform Firmware Information'
+    """
+    context = context_wrap(DMIDECODE_3_6)
+    ret = DMIDecode(context)
+
+    # Verify new key 'platform_firmware_information' parsing
+    assert "platform_firmware_information" in ret
+    assert len(ret.get("platform_firmware_information")) == 1
+    assert ret.get("platform_firmware_information")[0].get("vendor") == "SeaBIOS"
+    assert ret.get("platform_firmware_information")[0].get("version") == "1.16.1-1.el9"
+    assert ret.get("platform_firmware_information")[0].get("release_date") == "04/01/2014"
+    assert ret.get("platform_firmware_information")[0].get("address") == "0xE8000"
+    assert ret.get("platform_firmware_information")[0].get("runtime_size") == "96 KiB"
+    assert ret.get("platform_firmware_information")[0].get("rom_size") == "64 KiB"
+
+    tmp = [
+        "Firmware characteristics not supported",
+        "Targeted content distribution is supported",
+    ]
+
+    assert ret.get("platform_firmware_information")[0].get("characteristics") == tmp
+    assert ret.get("platform_firmware_information")[0].get("platform_firmware_revision") == "0.0"
+
+    # Verify backward-compatibility to check if old key 'bios_information' can parse new dmidecode data (for parse_content() method)
+    assert "bios_information" in ret
+    assert ret["bios_information"][0]["vendor"] == "SeaBIOS"
+
+    # Verify exist bios* properties return data correctly on dmidecode 3.6+
+    assert ret.bios == ret["platform_firmware_information"][0]
+    assert ret.bios_vendor == "SeaBIOS"
+    assert ret.bios_date == date(2014, 4, 1)
+
+    # Verify new platform_firmware_* properties return data correctly on dmidecode 3.6+
+    assert ret.platform_firmware == ret["platform_firmware_information"][0]
+    assert ret.platform_firmware_vendor == "SeaBIOS"
+    assert ret.platform_firmware_date == date(2014, 4, 1)


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:
dmidecode 3.6+ renamed "BIOS Information" to "Platform Firmware Information", causing KeyError and missing properties on newer systems.

~~~
- Support both 'platform_firmware_information' and 'bios_information' in properties.
- Add forward/backward compatibility of both keys access in parse_content.
- Add platform_firmware, platform_firmware_vendor, and platform_firmware_date properties.
- Update unit tests with dmidecode 3.6+ test case.

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED
~~~

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references.

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*

Due to this the downstream `extraction_rules` had failure when it attempted to access the keys inside property `bios` due to which it resulted in exception.
This change will help access `bios` or `platform_firmware` keys interchangeably and will not cause exception for accessing any of  its properties. If the section for `bios` or `platform_firmware` and key in them does not exist, it will return `None`

## Summary by Sourcery

Support renamed platform firmware sections in dmidecode while preserving compatible BIOS data access.

New Features:
- Add platform firmware aliases for BIOS information, vendor, and release date properties.

Bug Fixes:
- Maintain BIOS data access across dmidecode versions that use either BIOS Information or Platform Firmware Information, preventing missing-key failures.

Enhancements:
- Return None safely when firmware sections or requested properties are unavailable.

Documentation:
- Update dmidecode parser documentation and examples for platform firmware naming.

Tests:
- Add coverage for dmidecode 3.6+ output and backward- and forward-compatible BIOS/platform firmware access.