### PR TITLE
Add pesign datasource with email filtering for UEFI Secure Boot data collection

### DIFF
--- a/docs/custom_datasources_index.rst
+++ b/docs/custom_datasources_index.rst
@@ -251,6 +251,14 @@ insights.specs.datasources.pcp
     :show-inheritance:
     :undoc-members:
 
+insights.specs.datasources.pesign
+---------------------------------
+
+.. automodule:: insights.specs.datasources.pesign
+    :members: pesign_show_signature_shimx64
+    :show-inheritance:
+    :undoc-members:
+
 insights.specs.datasources.ps
 -----------------------------
 

--- a/insights/specs/__init__.py
+++ b/insights/specs/__init__.py
@@ -629,6 +629,7 @@ class Specs(SpecSet):
     pcs_config = RegistryPoint()
     pcs_quorum_status = RegistryPoint()
     pcs_status = RegistryPoint()
+    pesign_show_signature_shimx64 = RegistryPoint()
     php_ini = RegistryPoint(filterable=True)
     pidstat = RegistryPoint()
     pluginconf_d = RegistryPoint(multi_output=True)

--- a/insights/specs/datasources/pesign.py
+++ b/insights/specs/datasources/pesign.py
@@ -1,0 +1,64 @@
+"""
+Custom datasources for ``pesign`` command outputs
+"""
+
+from insights.core.exceptions import SkipComponent
+from insights.core.plugins import datasource
+from insights.core.spec_factory import DatasourceProvider, simple_command
+from insights.specs import Specs
+
+
+class LocalSpecs(Specs):
+    """Local specs used only by pesign datasources"""
+
+    pesign_show_signature_shimx64_raw = simple_command("/usr/bin/pesign --show-signature --in=/boot/efi/EFI/redhat/shimx64.efi")
+
+
+@datasource(LocalSpecs.pesign_show_signature_shimx64_raw)
+def pesign_show_signature_shimx64(broker):
+    """
+    Filter pesign --show-signature output to remove email address lines.
+
+    This datasource processes signing certificate information while excluding
+    email addresses to prevent exposure of customer personal/internal emails
+    from custom-signed binaries.
+
+    Collects:
+        - Signer's common name (e.g., "Microsoft Corporation UEFI CA 2011")
+        - Signing time (e.g., "Jul 7, 2011")
+        - Signature validation status (e.g., "There is a valid signature")
+        - Cryptographic algorithms (e.g., "SHA256", "RSA pkcs1 padding")
+        - Output delimiters
+
+    Filters out:
+        - Email address lines (privacy concern with custom-signed binaries)
+
+    Arguments:
+        broker: the broker object for the current session
+
+    Returns:
+        DatasourceProvider: Filtered pesign output without email lines
+
+    Raises:
+        SkipComponent: When no output after filtering email lines
+    """
+    raw_output = broker[LocalSpecs.pesign_show_signature_shimx64_raw]
+
+    if not raw_output or not raw_output.content:
+        raise SkipComponent("No pesign output available")
+
+    # Filter out email address lines (case-insensitive)
+    filtered_lines = []
+    for line in raw_output.content:
+        if "email address" not in line.lower():
+            filtered_lines.append(line)
+
+    if not filtered_lines:
+        raise SkipComponent("No output after filtering email lines")
+
+    content = "\n".join(filtered_lines)
+
+    return DatasourceProvider(
+        content=content,
+        relative_path="insights_commands/pesign_show_signature_shimx64"
+    )

--- a/insights/specs/default.py
+++ b/insights/specs/default.py
@@ -71,6 +71,7 @@ from insights.specs.datasources import (
     mdadm,
     mount as mount_ds,
     package_provides,
+    pesign,
     ps,
     rpm,
     sap,
@@ -658,6 +659,7 @@ class DefaultSpecs(Specs):
     )
     pcs_quorum_status = simple_command("/usr/sbin/pcs quorum status")
     pcs_status = simple_command("/usr/sbin/pcs status")
+    pesign_show_signature_shimx64 = pesign.pesign_show_signature_shimx64
     pidstat = simple_command("/usr/bin/pidstat")
     php_ini = first_file(["/etc/opt/rh/php73/php.ini", "/etc/opt/rh/php72/php.ini", "/etc/php.ini"])
     pluginconf_d = glob_file("/etc/yum/pluginconf.d/*.conf")

--- a/insights/tests/datasources/test_pesign.py
+++ b/insights/tests/datasources/test_pesign.py
@@ -1,0 +1,180 @@
+import pytest
+
+from insights.core.exceptions import SkipComponent
+from insights.core.spec_factory import DatasourceProvider
+from insights.specs.datasources.pesign import LocalSpecs, pesign_show_signature_shimx64
+
+
+# Template for multi-cert output
+PESIGN_OUTPUT_MULTI_CERT_TEMP = """
+---------------------------------------------
+The signer's common name is Microsoft Corporation UEFI CA 2011{sign_email_1}
+Signing time: Jul  7, 2011
+There is a valid signature.
+MD: SHA256   Signature: RSA pkcs1 padding
+---------------------------------------------
+The signer's common name is Microsoft Corporation UEFI CA 2023{sign_email_2}
+Signing time: Sep 21, 2015
+There is a valid signature.
+MD: SHA256   Signature: RSA pkcs1 padding
+---------------------------------------------
+""".strip()
+
+PESIGN_OUTPUT_MULTI_CERT_ORG = PESIGN_OUTPUT_MULTI_CERT_TEMP.format(
+    sign_email_1="\nThe signer's email address is secure@microsoft.com",
+    sign_email_2="\nThe signer's email address is secure@microsoft.com"
+)
+
+PESIGN_OUTPUT_MULTI_CERT_FILTERED = PESIGN_OUTPUT_MULTI_CERT_TEMP.format(
+    sign_email_1="",
+    sign_email_2=""
+)
+
+# Template for single-cert output
+PESIGN_OUTPUT_SINGLE_CERT_TEMP = """
+---------------------------------------------
+The signer's common name is Red Hat Secure Boot (CA key 1){sign_email}
+Signing time: May 12, 2020
+There is a valid signature.
+MD: SHA256   Signature: RSA pkcs1 padding
+---------------------------------------------
+""".strip()
+
+PESIGN_OUTPUT_SINGLE_CERT_ORG = PESIGN_OUTPUT_SINGLE_CERT_TEMP.format(
+    sign_email="\nThe signer's email address is secalert@redhat.com"
+)
+
+PESIGN_OUTPUT_SINGLE_CERT_FILTERED = PESIGN_OUTPUT_SINGLE_CERT_TEMP.format(
+    sign_email=""
+)
+
+# Template for custom cert output
+PESIGN_OUTPUT_CUSTOM_CERT_TEMP = """
+---------------------------------------------
+The signer's common name is Custom Enterprise CA{sign_email}
+Signing time: Jan 15, 2023
+There is a valid signature.
+MD: SHA256   Signature: RSA pkcs1 padding
+---------------------------------------------
+""".strip()
+
+PESIGN_OUTPUT_CUSTOM_CERT_ORG = PESIGN_OUTPUT_CUSTOM_CERT_TEMP.format(
+    sign_email="\nThe signer's email address is john.doe@customcompany.com"
+)
+
+PESIGN_OUTPUT_CUSTOM_CERT_FILTERED = PESIGN_OUTPUT_CUSTOM_CERT_TEMP.format(
+    sign_email=""
+)
+
+# Only email lines (edge case)
+PESIGN_OUTPUT_ONLY_EMAIL = """
+The signer's email address is test@example.com
+""".strip()
+
+
+class MockRawOutput:
+    """Mock raw command output"""
+    def __init__(self, output):
+        self.content = output.splitlines() if output else []
+
+
+def test_pesign_success_multi_cert():
+    """Test successful filtering with multiple certificates"""
+    raw_output = MockRawOutput(PESIGN_OUTPUT_MULTI_CERT_ORG)
+    broker = {LocalSpecs.pesign_show_signature_shimx64_raw: raw_output}
+
+    result = pesign_show_signature_shimx64(broker)
+
+    assert result is not None
+    assert isinstance(result, DatasourceProvider)
+
+    content_str = "\n".join(result.content)
+    assert content_str == PESIGN_OUTPUT_MULTI_CERT_FILTERED
+
+
+def test_pesign_success_single_cert():
+    """Test successful filtering with single certificate"""
+    raw_output = MockRawOutput(PESIGN_OUTPUT_SINGLE_CERT_ORG)
+    broker = {LocalSpecs.pesign_show_signature_shimx64_raw: raw_output}
+
+    result = pesign_show_signature_shimx64(broker)
+
+    assert result is not None
+    assert isinstance(result, DatasourceProvider)
+
+    content_str = "\n".join(result.content)
+    assert content_str == PESIGN_OUTPUT_SINGLE_CERT_FILTERED
+
+
+def test_pesign_filters_custom_email():
+    """Test that custom/private email addresses are filtered"""
+    raw_output = MockRawOutput(PESIGN_OUTPUT_CUSTOM_CERT_ORG)
+    broker = {LocalSpecs.pesign_show_signature_shimx64_raw: raw_output}
+
+    result = pesign_show_signature_shimx64(broker)
+
+    assert result is not None
+    assert isinstance(result, DatasourceProvider)
+
+    content_str = "\n".join(result.content)
+    assert content_str == PESIGN_OUTPUT_CUSTOM_CERT_FILTERED
+
+
+def test_pesign_no_output():
+    """Test SkipComponent when no raw output available"""
+    raw_output = MockRawOutput(None)
+    broker = {LocalSpecs.pesign_show_signature_shimx64_raw: raw_output}
+
+    with pytest.raises(SkipComponent) as exc:
+        pesign_show_signature_shimx64(broker)
+
+    assert "No pesign output available" in str(exc.value)
+
+
+def test_pesign_empty_output():
+    """Test SkipComponent when raw output is empty"""
+    raw_output = MockRawOutput("")
+    broker = {LocalSpecs.pesign_show_signature_shimx64_raw: raw_output}
+
+    with pytest.raises(SkipComponent) as exc:
+        pesign_show_signature_shimx64(broker)
+
+    assert "No pesign output available" in str(exc.value)
+
+
+def test_pesign_only_email_lines():
+    """Test SkipComponent when only email lines present (all filtered out)"""
+    raw_output = MockRawOutput(PESIGN_OUTPUT_ONLY_EMAIL)
+    broker = {LocalSpecs.pesign_show_signature_shimx64_raw: raw_output}
+
+    with pytest.raises(SkipComponent) as exc:
+        pesign_show_signature_shimx64(broker)
+
+    assert "No output after filtering email lines" in str(exc.value)
+
+
+def test_pesign_case_insensitive_filtering():
+    """Test that email filtering is case-insensitive"""
+    output_org = """The signer's EMAIL ADDRESS is test@example.com
+The signer's Email Address is another@example.com
+Some other line"""
+
+    output_expected = "Some other line"
+
+    raw_output = MockRawOutput(output_org)
+    broker = {LocalSpecs.pesign_show_signature_shimx64_raw: raw_output}
+
+    result = pesign_show_signature_shimx64(broker)
+
+    content_str = "\n".join(result.content)
+    assert content_str == output_expected
+
+
+def test_pesign_relative_path():
+    """Test that the correct relative path is set"""
+    raw_output = MockRawOutput(PESIGN_OUTPUT_SINGLE_CERT_ORG)
+    broker = {LocalSpecs.pesign_show_signature_shimx64_raw: raw_output}
+
+    result = pesign_show_signature_shimx64(broker)
+
+    assert result.relative_path == "insights_commands/pesign_show_signature_shimx64"


### PR DESCRIPTION
## Problem

The `pesign --show-signature` command outputs email addresses from code signing certificates. While standard Red Hat/Microsoft binaries contain public emails, customers with custom UEFI signing infrastructure may use personal or internal email addresses (e.g., `john.doe@company.com`, `security-team@enterprise.local`), creating a privacy/GDPR risk.

The insights-core framework only supports obfuscation for `hostname`, `ipv4`, `ipv6`, and `mac` - email obfuscation is not available.

## Solution

Created a custom datasource that:
- Runs `pesign --show-signature` command via `ctx.shell_out()`
- Filters out lines containing "email address" (case-insensitive)
- Collects all other certificate data (common name, signing time, validation status, cryptographic algorithms)
- Returns filtered output via `DatasourceProvider`
- Raises `SkipComponent` on command failure or empty output after filtering


## What Gets Collected
- Signer's common name (e.g., "Microsoft Corporation UEFI CA 2011")
- Signing time (e.g., "Jul 7, 2011")
- Signature validation status (e.g., "There is a valid signature")
- Cryptographic algorithms (SHA256, RSA pkcs1 padding, etc.)
- Output delimiters

## What Gets Filtered (Privacy Protection)
- Lines containing "email address" (any case)
- Email addresses from certificates (both public and private)

##Checklist

Check all that apply:

- [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
- [x] No Sensitive Data in this change?
- [ ] Is this PR to correct an issue?
- [x] Is this PR an enhancement?

## Summary by Sourcery

Add privacy-preserving collection of UEFI Secure Boot signature data by filtering email addresses from pesign output.

New Features:
- Add a pesign datasource that collects UEFI signing certificate metadata while excluding certificate email-address lines.
- Register the filtered pesign output as a standard datasource for shimx64 Secure Boot signatures.

Enhancements:
- Skip collection when pesign produces no usable output after privacy filtering.

Documentation:
- Document the new custom datasource.

Tests:
- Add coverage for certificate output filtering, private email removal, empty results, case-insensitive matching, and datasource metadata.