### PR TITLE
feat(RHINENG-29756): Add search methods to PodmanPsAllJson

### DIFF
--- a/insights/parsers/podman.py
+++ b/insights/parsers/podman.py
@@ -20,6 +20,24 @@ class PodmanContainerSearch(object):
     container dicts (as produced by ``podman ps ... --format=json``).
     """
 
+    @staticmethod
+    def _validate_search_term(value, arg_name: str) -> None:
+        """
+        Validate a search term.
+
+        Args:
+            value: The value to validate.
+            arg_name (str): The argument name, used in error messages.
+
+        Raises:
+            TypeError: If ``value`` is not a string.
+            ValueError: If ``value`` is an empty string.
+        """
+        if not isinstance(value, str):
+            raise TypeError("{0} must be a string, got {1}".format(arg_name, type(value).__name__))
+        if not value:
+            raise ValueError("{0} must not be empty".format(arg_name))
+
     def search_by_name(self, name: str, partial: bool = False) -> List[dict]:
         """
         Search containers by name.
@@ -31,7 +49,12 @@ class PodmanContainerSearch(object):
 
         Returns:
             list: The matching raw container jsons (empty list if none match).
+
+        Raises:
+            TypeError: If ``name`` is not a string.
+            ValueError: If ``name`` is an empty string.
         """
+        self._validate_search_term(name, "name")
         if partial:
             return [c for c in self.data if any(name in n for n in c.get("Names", []))]
         return [c for c in self.data if name in c.get("Names", [])]
@@ -47,7 +70,12 @@ class PodmanContainerSearch(object):
 
         Returns:
             list: The matching raw container jsons (empty list if none match).
+
+        Raises:
+            TypeError: If ``image`` is not a string.
+            ValueError: If ``image`` is an empty string.
         """
+        self._validate_search_term(image, "image")
         if partial:
             return [c for c in self.data if image in c.get("Image", "")]
         return [c for c in self.data if c.get("Image", "") == image]

--- a/insights/parsers/podman.py
+++ b/insights/parsers/podman.py
@@ -8,12 +8,53 @@ PodmanPsAllJson - command ``podman ps --all --no-trunc --size --format=json``
 -----------------------------------------------------------------------------
 """
 
+from typing import List
+
 from insights import parser, JSONParser
 from insights.specs import Specs
 
 
+class PodmanContainerSearch(object):
+    """
+    Mixin providing container search helpers over a flat ``self.data`` list of
+    container dicts (as produced by ``podman ps ... --format=json``).
+    """
+
+    def search_by_name(self, name: str, partial: bool = False) -> List[dict]:
+        """
+        Search containers by name.
+
+        Args:
+            name (str): The container name to search for.
+            partial (bool): When ``False`` (default) match the name exactly;
+                when ``True`` match containers whose name contains ``name``.
+
+        Returns:
+            list: The matching raw container jsons (empty list if none match).
+        """
+        if partial:
+            return [c for c in self.data if any(name in n for n in c.get("Names", []))]
+        return [c for c in self.data if name in c.get("Names", [])]
+
+    def search_by_image(self, image: str, partial: bool = False) -> List[dict]:
+        """
+        Search containers by image.
+
+        Args:
+            image (str): The image to search for.
+            partial (bool): When ``False`` (default) match the image exactly;
+                when ``True`` match containers whose image contains ``image``.
+
+        Returns:
+            list: The matching raw container jsons (empty list if none match).
+        """
+        if partial:
+            return [c for c in self.data if image in c.get("Image", "")]
+        return [c for c in self.data if c.get("Image", "") == image]
+
+
 @parser(Specs.podman_ps_all_json)
-class PodmanPsAllJson(JSONParser):
+class PodmanPsAllJson(JSONParser, PodmanContainerSearch):
     """
     Class for parsing the output of the ``podman ps --all --no-trunc --size --format=json`` command.
 
@@ -86,5 +127,12 @@ class PodmanPsAllJson(JSONParser):
         ['angry_saha']
         >>> podman_ps_json.data[0]["Image"]
         'rhel7_httpd'
+        >>> len(podman_ps_json.search_by_name("angry_saha"))
+        1
+        >>> podman_ps_json.search_by_image("rhel7_httpd")[0]["Names"]
+        ['angry_saha']
+        >>> len(podman_ps_json.search_by_image("httpd", partial=True))
+        1
     """
+
     pass

--- a/insights/tests/parsers/test_podman.py
+++ b/insights/tests/parsers/test_podman.py
@@ -4,7 +4,6 @@ from insights.parsers import podman
 from insights.parsers.podman import PodmanPsAllJson
 from insights.tests import context_wrap
 
-
 PODMAN_PS_ALL_JSON = """
 [
     {
@@ -92,6 +91,29 @@ PODMAN_PS_JSON_EMPTY = """
 []
 """.strip()
 
+PODMAN_PS_MULTI_JSON = """
+[
+    {
+        "Id": "aaa",
+        "Image": "quay.io/foreman/foreman:3.16",
+        "Names": ["foreman"],
+        "State": "running"
+    },
+    {
+        "Id": "bbb",
+        "Image": "quay.io/foreman/foreman:3.16",
+        "Names": ["dynflow-sidekiq-worker"],
+        "State": "running"
+    },
+    {
+        "Id": "ccc",
+        "Image": "quay.io/foreman/foreman-proxy:3.16",
+        "Names": ["foreman-proxy"],
+        "State": "exited"
+    }
+]
+""".strip()
+
 
 def test_podman_ps_json():
     result = PodmanPsAllJson(context_wrap(PODMAN_PS_ALL_JSON))
@@ -99,7 +121,9 @@ def test_podman_ps_json():
     assert len(result.data) == 2
 
     # Test first container
-    assert result.data[0]["Id"] == "03e2861336a76e29155836113ff6560cb70780c32f95062642993b2b3d0fc216"
+    assert (
+        result.data[0]["Id"] == "03e2861336a76e29155836113ff6560cb70780c32f95062642993b2b3d0fc216"
+    )
     assert result.data[0]["State"] == "running"
     assert result.data[0]["Status"] == "Up 37 seconds"
     assert result.data[0]["Image"] == "rhel7_httpd"
@@ -111,16 +135,16 @@ def test_podman_ps_json():
     assert result.data[0]["Ports"][0]["container_port"] == 80
 
     # Test second container
-    assert result.data[1]["Id"] == "95516ea08b565e37e2a4bca3333af40a240c368131b77276da8dec629b7fe102"
+    assert (
+        result.data[1]["Id"] == "95516ea08b565e37e2a4bca3333af40a240c368131b77276da8dec629b7fe102"
+    )
     assert result.data[1]["State"] == "exited"
     assert result.data[1]["Status"] == "Exited (137) 18 hours ago"
     assert result.data[1]["Names"] == ["tender_rosalind"]
     assert result.data[1]["ExitCode"] == 137
     assert result.data[1]["Pid"] == 0
     assert result.data[1]["Ports"] == []
-    assert result.data[1]["Size"] == {
-        "rootFsSize": 221554338,
-        "rwSize": 0}
+    assert result.data[1]["Size"] == {"rootFsSize": 221554338, "rwSize": 0}
 
 
 def test_podman_ps_json_empty():
@@ -129,9 +153,77 @@ def test_podman_ps_json_empty():
     assert len(result.data) == 0
 
 
+def test_podman_ps_search_by_name():
+    result = PodmanPsAllJson(context_wrap(PODMAN_PS_ALL_JSON))
+
+    # exact match (default)
+    exact = result.search_by_name("angry_saha")
+    assert len(exact) == 1
+    assert exact[0]["Names"] == ["angry_saha"]
+
+    # exact match must not match a substring
+    assert result.search_by_name("angry") == []
+
+    # partial match
+    partial = result.search_by_name("rosalind", partial=True)
+    assert len(partial) == 1
+    assert partial[0]["Names"] == ["tender_rosalind"]
+
+    # no match
+    assert result.search_by_name("does_not_exist") == []
+
+
+def test_podman_ps_search_by_name_multiple():
+    result = PodmanPsAllJson(context_wrap(PODMAN_PS_MULTI_JSON))
+
+    # partial match returns multiple containers
+    matches = result.search_by_name("foreman", partial=True)
+    assert len(matches) == 2
+    ids = sorted(c["Id"] for c in matches)
+    assert ids == ["aaa", "ccc"]
+
+    # exact match returns only the one named "foreman"
+    exact = result.search_by_name("foreman")
+    assert len(exact) == 1
+    assert exact[0]["Id"] == "aaa"
+
+
+def test_podman_ps_search_by_image():
+    result = PodmanPsAllJson(context_wrap(PODMAN_PS_ALL_JSON))
+
+    # exact match (default)
+    exact = result.search_by_image("rhel7_httpd")
+    assert len(exact) == 1
+    assert exact[0]["Names"] == ["angry_saha"]
+
+    # exact match must not match a substring
+    assert result.search_by_image("httpd") == []
+
+    # partial match
+    partial = result.search_by_image("httpd", partial=True)
+    assert len(partial) == 1
+    assert partial[0]["Image"] == "rhel7_httpd"
+
+    # no match
+    assert result.search_by_image("nonexistent") == []
+
+
+def test_podman_ps_search_by_image_multiple():
+    result = PodmanPsAllJson(context_wrap(PODMAN_PS_MULTI_JSON))
+
+    # exact match returns both containers sharing the same image
+    exact = result.search_by_image("quay.io/foreman/foreman:3.16")
+    assert len(exact) == 2
+    ids = sorted(c["Id"] for c in exact)
+    assert ids == ["aaa", "bbb"]
+
+    # partial match on "foreman" returns all three
+    partial = result.search_by_image("foreman", partial=True)
+    assert len(partial) == 3
+
+
 def test_podman_ps_json_documentation():
     failed_count, _ = doctest.testmod(
-        podman,
-        globs={'podman_ps_json': PodmanPsAllJson(context_wrap(PODMAN_PS_ALL_JSON))}
+        podman, globs={'podman_ps_json': PodmanPsAllJson(context_wrap(PODMAN_PS_ALL_JSON))}
     )
     assert failed_count == 0

--- a/insights/tests/parsers/test_podman.py
+++ b/insights/tests/parsers/test_podman.py
@@ -1,5 +1,7 @@
 import doctest
 
+import pytest
+
 from insights.parsers import podman
 from insights.parsers.podman import PodmanPsAllJson
 from insights.tests import context_wrap
@@ -220,6 +222,23 @@ def test_podman_ps_search_by_image_multiple():
     # partial match on "foreman" returns all three
     partial = result.search_by_image("foreman", partial=True)
     assert len(partial) == 3
+
+
+def test_podman_ps_search_invalid_argument():
+    result = PodmanPsAllJson(context_wrap(PODMAN_PS_ALL_JSON))
+
+    # non-string search terms raise TypeError
+    for bad in (None, 123, ["angry_saha"]):
+        with pytest.raises(TypeError):
+            result.search_by_name(bad)
+        with pytest.raises(TypeError):
+            result.search_by_image(bad)
+
+    # empty search terms raise ValueError
+    with pytest.raises(ValueError):
+        result.search_by_name("")
+    with pytest.raises(ValueError):
+        result.search_by_image("")
 
 
 def test_podman_ps_json_documentation():


### PR DESCRIPTION
### Jira
[RHINENG-29756](https://redhat.atlassian.net/browse/RHINENG-29756)

### All Pull Requests:

Check all that apply:

* [x] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Add the `PodmanContainerSearch` class that can be reused in container specs, and it allows us to filter the containers by name and image.


[RHINENG-29756]: https://redhat.atlassian.net/browse/RHINENG-29756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add name and image search capabilities to PodmanPsAllJson.

New Features:
- Add reusable container search helpers to filter Podman containers by exact or partial name and image.

Enhancements:
- Expose the search functionality through PodmanPsAllJson with validation for invalid search terms.

Tests:
- Add coverage for exact and partial name/image searches, multiple matches, empty results, and invalid arguments.