### PR TITLE
fix(compliance): distinguish "already assigned" from "not found" on policy_link failure

### DIFF
--- a/insights/specs/datasources/compliance/__init__.py
+++ b/insights/specs/datasources/compliance/__init__.py
@@ -266,15 +266,23 @@ class ComplianceClient:
         if response.status_code == 202:
             logger.info("Successfully {0} policy (ID {1}).\n".format(operation, policy_id))
             return 0
+
+        try:
+            system_policy_ids = [p['id'] for p in self.get_system_policies() if isinstance(p, dict)]
+        except Exception:
+            system_policy_ids = []
+
+        if policy_id in system_policy_ids:
+            reason = "is already associated to this host"
         else:
-            logger.error(
-                "Policy ID {0} can not be {1}. "
-                "Refer to the /var/log/insights-client/insights-client.log for more details.".format(
-                    policy_id,
-                    operation,
-                )
+            reason = "does not exist or is not accessible"
+        logger.error(
+            "Policy {0} {1}. "
+            "Refer to the /var/log/insights-client/insights-client.log for more details.".format(
+                policy_id, reason
             )
-            return constants.sig_kill_bad
+        )
+        return constants.sig_kill_bad
 
     def get_system_policies(self):
         if self.inventory_id is None:

--- a/insights/tests/datasources/compliance/test_compliance.py
+++ b/insights/tests/datasources/compliance/test_compliance.py
@@ -456,13 +456,14 @@ def test_policy_link_assign_invalid_policy_id(config, log):
     compliance_client.conn.session.patch = Mock(
         return_value=Mock(status_code=404, json=Mock(return_value={}))
     )
+    compliance_client.get_system_policies = Mock(return_value=[])
     assert compliance_client.policy_link(policy_id, 'patch') == constants.sig_kill_bad
     url = "https://localhost/app/compliance/v2/policies/{0}/systems/{1}".format(
         policy_id, compliance_client.inventory_id
     )
     compliance_client.conn.session.patch.assert_called_with(url)
     log.error.assert_called_with(
-        "Policy ID {0} can not be assigned. "
+        "Policy {0} does not exist or is not accessible. "
         "Refer to the /var/log/insights-client/insights-client.log for more details.".format(
             policy_id
         )
@@ -495,13 +496,54 @@ def test_policy_link_unassign_invalid_policy_id(config, log):
     )
     compliance_client._inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
     policy_id = "________-ab56-420b-9e71-878795375af5"
+    compliance_client.get_system_policies = Mock(return_value=[])
     assert compliance_client.policy_link(policy_id, 'delete') == constants.sig_kill_bad
     url = "https://localhost/app/compliance/v2/policies/{0}/systems/{1}".format(
         policy_id, compliance_client.inventory_id
     )
     compliance_client.conn.session.delete.assert_called_with(url)
     log.error.assert_called_with(
-        "Policy ID {0} can not be unassigned. "
+        "Policy {0} does not exist or is not accessible. "
+        "Refer to the /var/log/insights-client/insights-client.log for more details.".format(
+            policy_id
+        )
+    )
+
+
+@patch('insights.specs.datasources.compliance.logger')
+@patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
+def test_policy_link_assign_already_assigned(config, log):
+    compliance_client = ComplianceClient(config=config)
+    compliance_client._inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
+    policy_id = "d83ddbac-ab56-420b-9e71-878795375af5"
+    compliance_client.conn.session.patch = Mock(
+        return_value=Mock(status_code=404, json=Mock(return_value={}))
+    )
+    compliance_client.get_system_policies = Mock(
+        return_value=[{'id': policy_id, 'title': 'Already assigned policy'}]
+    )
+    assert compliance_client.policy_link(policy_id, 'patch') == constants.sig_kill_bad
+    log.error.assert_called_with(
+        "Policy {0} is already associated to this host. "
+        "Refer to the /var/log/insights-client/insights-client.log for more details.".format(
+            policy_id
+        )
+    )
+
+
+@patch('insights.specs.datasources.compliance.logger')
+@patch("insights.client.config.InsightsConfig", base_url='localhost/app', systemid='', proxy=None)
+def test_policy_link_assign_lookup_failure(config, log):
+    compliance_client = ComplianceClient(config=config)
+    compliance_client._inventory_id = '068040f1-08c8-43e4-949f-7d6470e9111c'
+    policy_id = "d83ddbac-ab56-420b-9e71-878795375af5"
+    compliance_client.conn.session.patch = Mock(
+        return_value=Mock(status_code=404, json=Mock(return_value={}))
+    )
+    compliance_client.get_system_policies = Mock(side_effect=Exception("connection error"))
+    assert compliance_client.policy_link(policy_id, 'patch') == constants.sig_kill_bad
+    log.error.assert_called_with(
+        "Policy {0} does not exist or is not accessible. "
         "Refer to the /var/log/insights-client/insights-client.log for more details.".format(
             policy_id
         )


### PR DESCRIPTION
### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [x] No Sensitive Data in this change?
* [x] Is this PR to correct an issue?
* [x] Is this PR an enhancement?

### Complete Description of Additions/Changes:

Ref: [RHINENG-28976](https://redhat.atlassian.net/browse/RHINENG-28976)


[RHINENG-28976]: https://redhat.atlassian.net/browse/RHINENG-28976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Improve compliance policy-link failure reporting to identify whether a policy is already assigned or unavailable.

Bug Fixes:
- Distinguish policies that are already associated with a host from policies that do not exist or are inaccessible when policy linking fails.

Tests:
- Add coverage for already-assigned policies and failures while looking up existing system policies.